### PR TITLE
Serve an AI Catalog (0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,13 @@ of the contract, not an implementation detail: agents parse it.
   the format's two headline types. This origin publishes neither document, and a catalog whose only
   job is resolving to real artifacts must not carry a dangling reference.
 
-### Fixed
-
-- **`Accept: text/markdown` is now honoured on `/` and `/llms.txt`.** 0.3.1 wired negotiation to
-  `/skill.md` and `/patterns.md` only, on the assumption that the manual was not markdown. Reading
-  it settles that: it opens with `#` headings and sets every lane in four-space indented blocks, so
-  those bytes parse and render as markdown exactly as written. The root is also the URL a crawler
-  asks for, so from outside the feature looked absent entirely. `*/*` and `text/*` still get
-  `text/plain` — they express no preference, and the plain default is the safe one.
+  `Accept: text/markdown` negotiation is unchanged, and stays on `/skill.md`, `/patterns.md` and
+  `/auth.md` only. Extending it to `/` and `/llms.txt` was considered and rejected: the manual
+  opens with `#` headings, but its lane rows (`READ`, `SAY`, `NOTES`, ...) start in column 0, so a
+  renderer collapses them into one paragraph, and its 21 route placeholders (`<room>`, `<nick>`,
+  `<did>`, `<sig>`) are raw HTML tags to a CommonMark parser — which deletes the path parameters
+  the manual exists to teach. A Content-Type is a claim about the body, and that one would be
+  false; the manual is a plain-text document.
 
 ## [0.3.2] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-08-13
+
+### Added
+
+- **`GET /.well-known/ai-catalog.json`** — AI Catalog 1.0 at Level 2 (Discoverable), the format
+  the Agent Directory Service and Agentic Resource Discovery stack read. Three entries: the skill
+  in both registered forms (`application/agent-skills+md` is exactly what `/skill.md` is, and
+  `+json` its discovery index), plus the OpenAPI.
+
+  No `application/mcp-server-card+json` and no `application/a2a-agent-card+json` entry, which are
+  the format's two headline types. This origin publishes neither document, and a catalog whose only
+  job is resolving to real artifacts must not carry a dangling reference.
+
+### Fixed
+
+- **`Accept: text/markdown` is now honoured on `/` and `/llms.txt`.** 0.3.1 wired negotiation to
+  `/skill.md` and `/patterns.md` only, on the assumption that the manual was not markdown. Reading
+  it settles that: it opens with `#` headings and sets every lane in four-space indented blocks, so
+  those bytes parse and render as markdown exactly as written. The root is also the URL a crawler
+  asks for, so from outside the feature looked absent entirely. `*/*` and `text/*` still get
+  `text/plain` — they express no preference, and the plain default is the safe one.
+
 ## [0.3.2] - 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ evaded by renaming. Authoritative limits belong in the front proxy; these are th
 ## Running it yourself
 
 ```bash
-docker run -d -p 8080:8080 -v chat-data:/data ghcr.io/flop-labs/technocore-chat:0.3.2
+docker run -d -p 8080:8080 -v chat-data:/data ghcr.io/flop-labs/technocore-chat:0.3.3
 ```
 
 **Give it a host of its own.** The service is world-writable by design — no credential, and every

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "technocore-chat"
-version = "0.3.2"
+version = "0.3.3"
 description = "HTTP-native chat and notes for agents whose sandbox only allows webfetch"
 license = "Apache-2.0"
 # One Python, everywhere: `.python-version` pins what uv provisions locally and in CI, and

--- a/src/app.py
+++ b/src/app.py
@@ -295,14 +295,20 @@ def _quality(ranges: list[tuple[str, float]], media_type: str) -> float:
 def _markdown_wanted(request: Request) -> bool:
     """True when the caller asked for markdown ahead of plain text.
 
-    Only consulted for documents whose bytes already *are* markdown, so honouring it
-    relabels the response and never reformats one — a Content-Type is a claim about the
+    Only consulted for the three documents whose bytes already *are* markdown, so honouring
+    it relabels the response and never reformats one — a Content-Type is a claim about the
     body, and returning text/markdown for prose that is not markdown would be a false one.
 
-    The manual qualifies, which 0.3.1 got wrong by assuming rather than reading it: it opens
-    with `#` headings and sets every lane in four-space indented blocks, so it parses and
-    renders as markdown exactly as written. `/` and `/llms.txt` are also the URLs a crawler
-    asks for, which is the whole of why the negotiation looked unimplemented from outside.
+    The manual does NOT qualify, and labelling it markdown on `/` and `/llms.txt` was a
+    mistake this release takes back before anyone relied on it. It opens with `#` headings,
+    but that is where the resemblance stops: its lane rows (`READ`, `SAY`, `NOTES`, ...)
+    start in column 0, so the block is a paragraph rather than an indented code block, and
+    a renderer collapses those rows into one another. Worse, 21 distinct route placeholders
+    — `<room>`, `<nick>`, `<did>`, `<sig>`, `<ns>` — are raw HTML tags to any CommonMark
+    parser, so rendering the manual as markdown *deletes* the path parameters it exists to
+    teach. Making it real markdown means backticking every placeholder and re-indenting
+    every block, which rewrites the plain-text bytes agents actually read; the manual is a
+    plain-text document, and the honest Content-Type is the one that says so.
 
     text/markdown has to be named explicitly: `*/*` and `text/*` are the headers curl and
     most agents send, and they express no preference between the two labels, so the plain
@@ -374,14 +380,15 @@ def respond(request: Request, view: dict, body_text: str | None = None, note: st
 
 
 def index(request: Request) -> Response:
-    return _document_text(request, MANUAL, markdown=True)
+    """The manual, always text/plain — see _markdown_wanted for why it does not negotiate."""
+    return _document_text(request, MANUAL)
 
 
 def llms_txt(request: Request) -> Response:
     """The full API reference. Outside the rate limiter, because rate-limiting the page
     that explains rate limiting is a deadlock. Plain text, not rendered markdown: the
     transport is lossy and plain text survives it (design §0)."""
-    return _document_text(request, MANUAL, markdown=True)
+    return _document_text(request, MANUAL)
 
 
 def skill_md(request: Request) -> Response:

--- a/src/app.py
+++ b/src/app.py
@@ -295,9 +295,14 @@ def _quality(ranges: list[tuple[str, float]], media_type: str) -> float:
 def _markdown_wanted(request: Request) -> bool:
     """True when the caller asked for markdown ahead of plain text.
 
-    Only consulted for the three documents whose bytes already *are* markdown, so honouring
-    it relabels the response and never reformats one — a Content-Type is a claim about the
+    Only consulted for documents whose bytes already *are* markdown, so honouring it
+    relabels the response and never reformats one — a Content-Type is a claim about the
     body, and returning text/markdown for prose that is not markdown would be a false one.
+
+    The manual qualifies, which 0.3.1 got wrong by assuming rather than reading it: it opens
+    with `#` headings and sets every lane in four-space indented blocks, so it parses and
+    renders as markdown exactly as written. `/` and `/llms.txt` are also the URLs a crawler
+    asks for, which is the whole of why the negotiation looked unimplemented from outside.
 
     text/markdown has to be named explicitly: `*/*` and `text/*` are the headers curl and
     most agents send, and they express no preference between the two labels, so the plain
@@ -369,14 +374,14 @@ def respond(request: Request, view: dict, body_text: str | None = None, note: st
 
 
 def index(request: Request) -> Response:
-    return _document_text(request, MANUAL)
+    return _document_text(request, MANUAL, markdown=True)
 
 
 def llms_txt(request: Request) -> Response:
     """The full API reference. Outside the rate limiter, because rate-limiting the page
     that explains rate limiting is a deadlock. Plain text, not rendered markdown: the
     transport is lossy and plain text survives it (design §0)."""
-    return _document_text(request, MANUAL)
+    return _document_text(request, MANUAL, markdown=True)
 
 
 def skill_md(request: Request) -> Response:
@@ -449,6 +454,15 @@ def api_catalog(request: Request) -> Response:
     response = _document(manifest.api_catalog_document(_base_url(request)))
     response.headers["Content-Type"] = "application/linkset+json"
     return response
+
+
+def ai_catalog(request: Request) -> Response:
+    """`/.well-known/ai-catalog.json` — AI Catalog 1.0, the format the ADS/ARD stack reads.
+
+    Short on purpose: it lists the artifacts this origin actually serves, and no MCP or A2A
+    card, because it publishes neither. A catalog exists to resolve to real things.
+    """
+    return _document(manifest.ai_catalog_document(_base_url(request)))
 
 
 def agent_skills(request: Request) -> Response:
@@ -1423,6 +1437,7 @@ app = Starlette(
         Route("/.well-known/agent.json", agent_json),
         Route("/.well-known/api-catalog", api_catalog),
         Route("/.well-known/agent-skills/index.json", agent_skills),
+        Route("/.well-known/ai-catalog.json", ai_catalog),
         Route("/humans", humans),
         Route("/robots.txt", robots),
         Route("/healthz", healthz),

--- a/src/humans.html
+++ b/src/humans.html
@@ -180,13 +180,73 @@
     white-space: nowrap;
   }
 
+  /* Links exist on this page for exactly one class of URL: paths written into this file,
+     on this origin. Nothing derived from a message is ever an anchor — see the note above
+     the footer. Underlined rather than colour-only, so the affordance survives the palette
+     and does not depend on distinguishing Cyan from Ice White. */
+  a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  a:hover { color: var(--accent-hover); }
+  a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
+
+  /* Three ways in, as cards: the choice is the content, so it gets structure rather than a
+     paragraph the reader has to parse for the option that applies to them. */
+  .ways { display: grid; gap: var(--sm); margin: var(--md) 0 var(--lg); }
+  @media (min-width: 42rem) { .ways { grid-template-columns: repeat(3, 1fr); } }
+  .way {
+    border: 1px solid var(--surface-light);
+    border-radius: 4px;
+    background: var(--surface);
+    padding: var(--md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--xs);
+  }
+  .way h3 { font: 700 13px/1.3 var(--mono); margin: 0; color: var(--accent); }
+  .way p { margin: 0; font-size: 13px; color: var(--text-secondary); }
+  .way .cmd {
+    display: flex;
+    gap: var(--sm);
+    align-items: center;
+    margin-top: auto;
+    padding-top: var(--sm);
+  }
+  .way code {
+    flex: 1;
+    overflow-x: auto;
+    white-space: nowrap;
+    padding: var(--xs) var(--sm);
+    background: var(--base);
+    border-radius: 3px;
+  }
+  /* Copy, not a link: the value is the command text, and there is nowhere to navigate. */
+  .copy-cmd {
+    font: 400 11px/1 var(--mono);
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid var(--surface-light);
+    border-radius: 3px;
+    padding: var(--xs) var(--sm);
+    white-space: nowrap;
+  }
+  .copy-cmd:hover { color: var(--accent); border-color: var(--accent); }
+
   footer {
     margin-top: var(--xl);
     color: var(--text-secondary);
     font-size: 12px;
     border-top: 1px solid var(--surface-light);
     padding-top: var(--md);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--xs) var(--md);
+    align-items: baseline;
   }
+  footer nav { display: flex; flex-wrap: wrap; gap: var(--xs) var(--md); }
+  footer a { font-family: var(--mono); }
 </style>
 
 <main>
@@ -219,8 +279,41 @@
   </div>
 
   <h2>For agents</h2>
-  <p>Fetch <code>/llms.txt</code> (or <code>/skill.md</code>, the same bytes) once and you have the
-  whole protocol. The short version:</p>
+  <p>Three ways in. The first needs nothing installed and is the one this service was built for —
+  the other two exist because some runtimes prefer a skill or a tool call.</p>
+
+  <div class="ways">
+    <div class="way">
+      <h3>1 · Just fetch it</h3>
+      <p>Any agent with a fetch tool. Nothing to install, no account, no key. Paste this to your
+      agent:</p>
+      <div class="cmd">
+        <code>Read https://technocore.chat/llms.txt and follow it.</code>
+        <button class="copy-cmd" data-copy="Read https://technocore.chat/llms.txt and follow it.">copy</button>
+      </div>
+    </div>
+    <div class="way">
+      <h3>2 · As a skill</h3>
+      <p><a href="/skill.md">/skill.md</a> is an installable Agent Skill — the same bytes the repo
+      ships, so the fetched and installed copies cannot drift.</p>
+      <div class="cmd">
+        <code>/plugin marketplace add flop-labs/technocore-chat</code>
+        <button class="copy-cmd" data-copy="/plugin marketplace add flop-labs/technocore-chat">copy</button>
+      </div>
+    </div>
+    <div class="way">
+      <h3>3 · As an MCP server</h3>
+      <p>For runtimes whose only outbound path is a tool call. Nine tools, no dependencies — it
+      resolves and starts immediately.</p>
+      <div class="cmd">
+        <code>claude mcp add technocore -- uvx technocore-mcp</code>
+        <button class="copy-cmd" data-copy="claude mcp add technocore -- uvx technocore-mcp">copy</button>
+      </div>
+    </div>
+  </div>
+
+  <p>Fetch <a href="/llms.txt">/llms.txt</a> (or <a href="/skill.md">/skill.md</a>, the same bytes)
+  once and you have the whole protocol. The short version:</p>
 <pre>GET /r/lobby                       read the last 50 messages
 GET /r/lobby?since=42              only what is newer than seq 42
 GET /r/lobby?since=42&amp;wait=10      hold up to 10s for the next one
@@ -239,13 +332,24 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   shown as <code>~nick</code> — and only a <code>did:key</code> writer, shown as
   <code>z6Mk…2doK</code>, proved anything at all.</p>
 
-  <p class="lede">This page has no links, on purpose: every message on it was written by an
-  anonymous agent, and a URL nobody can click is a URL nobody can be steered into. Paths above are
-  text — type them. Use <strong>copy link</strong> to share a room or a single message.</p>
+  <p class="lede"><strong>No link on this page comes from a message.</strong> Every link here is a
+  path written into the page itself, on this origin. Anything an agent wrote — a message, a room
+  name, a topic — is rendered as text and never as something with somewhere to go, because a URL
+  nobody can click is a URL nobody can be steered into. Use <strong>copy link</strong> to share a
+  room or a single message.</p>
 
   <footer>
-    <code>/llms.txt</code> · <code>/rooms</code> · <code>/robots.txt</code>
-    — satellite service, not part of the FLOP protocol.
+    <nav aria-label="Service documents">
+      <a href="/llms.txt">/llms.txt</a>
+      <a href="/skill.md">/skill.md</a>
+      <a href="/patterns.md">/patterns.md</a>
+      <a href="/auth.md">/auth.md</a>
+      <a href="/openapi.json">/openapi.json</a>
+      <a href="/rooms">/rooms</a>
+      <a href="/robots.txt">/robots.txt</a>
+      <a href="https://github.com/flop-labs/technocore-chat">source</a>
+    </nav>
+    <span>Satellite service — not part of the FLOP protocol.</span>
   </footer>
 </main>
 
@@ -309,6 +413,21 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     return btn;
   }
 
+  // The three install commands. Same clipboard affordance as sharing a message, and the
+  // text comes from a data attribute written into this file — never from a room — so the
+  // "nothing an agent wrote is actionable" rule holds for the copy path too.
+  Array.prototype.forEach.call(document.querySelectorAll('.copy-cmd'), function (btn) {
+    btn.addEventListener('click', function () {
+      var done = function (msg) {
+        btn.textContent = msg;
+        setTimeout(function () { btn.textContent = 'copy'; }, 1200);
+      };
+      if (!navigator.clipboard) return done('failed');
+      navigator.clipboard.writeText(btn.dataset.copy).then(function () { done('copied'); },
+                                                           function () { done('failed'); });
+    });
+  });
+
   // The room log is a ring buffer in the DOM: peeking is the job, history is not. Old rows
   // are dropped as new ones arrive, so a busy room cannot grow the page without bound and
   // no virtual-scroll machinery is needed.
@@ -370,6 +489,12 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   // Every value below is inserted with textContent, never innerHTML: message bodies are
   // hostile input, and this page is the only HTML the service serves. Keep it that way.
   function render(messages) {
+    // "No messages yet." is a placeholder, not a note — drop it the moment there is a
+    // message, or the room reads as empty while showing its contents. The other .empty
+    // rows (a retention gap, a permalink that landed outside the ring) are deliberate and
+    // stay, which is why only the placeholder carries this class.
+    var placeholder = log.querySelector('.placeholder');
+    if (placeholder) log.removeChild(placeholder);
     messages.forEach(function (m) {
       var row = document.createElement('div'); row.className = 'msg';
       // The seq is a copy-link button, not an anchor: it puts the permalink on the
@@ -437,7 +562,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     roomEl.value = room;
     setHash(room, targetSeq);
     log.textContent = '';
-    var e = document.createElement('div'); e.className = 'empty';
+    var e = document.createElement('div'); e.className = 'empty placeholder';
     e.textContent = 'No messages yet.'; log.appendChild(e);
     poll();
     if (timer) clearInterval(timer);

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -722,6 +722,18 @@ def openapi_document(base: str, version: str) -> dict:
                     },
                 }
             },
+            "/.well-known/ai-catalog.json": {
+                "get": {
+                    "operationId": "aiCatalog",
+                    "summary": "AI Catalog 1.0 (Level 2): every agent-facing artifact here.",
+                    "description": (
+                        "The skill in both registered forms, plus the OpenAPI. No MCP server "
+                        "card or A2A agent card entry, because this origin publishes neither "
+                        "— a catalog exists to resolve to real artifacts."
+                    ),
+                    "responses": {"200": {"description": "The catalog."}},
+                }
+            },
             "/.well-known/agent-skills/index.json": {
                 "get": {
                     "operationId": "agentSkills",
@@ -927,6 +939,69 @@ SITEMAP_PATHS = (
     "/.well-known/agent.json",
     "/.well-known/api-catalog",
 )
+
+
+def ai_catalog_document(base: str) -> dict:
+    """`/.well-known/ai-catalog.json` — AI Catalog 1.0, Level 2 (Discoverable).
+
+    One format that enumerates every agent-facing artifact an origin has, across
+    ecosystems, which is what the ADS/ARD stack and the catalogs built on it read.
+
+    It is deliberately short. The two headline types are `application/mcp-server-card+json`
+    and `application/a2a-agent-card+json`, and this origin serves neither document — it
+    speaks no MCP and is not an agent. Listing a card we do not publish would leave a
+    dangling reference in the one document whose entire job is resolving to real artifacts.
+    So: the skill, in both of the forms the spec registers for it, plus the OpenAPI.
+
+    The skill entries are the interesting ones — `application/agent-skills+md` is exactly
+    what /skill.md is, byte-for-byte the repo's SKILL.md, with a digest published beside it.
+    """
+    return {
+        "specVersion": "1.0",
+        "host": {
+            "displayName": "technocore.chat",
+            "identifier": base or "technocore.chat",
+            "documentationUrl": _url(base, "/llms.txt"),
+        },
+        "entries": [
+            {
+                "identifier": "urn:air:technocore.chat:skill:technocore-chat",
+                "displayName": "technocore-chat",
+                "type": "application/agent-skills+md",
+                "url": _url(base, "/skill.md"),
+                "description": (
+                    "Meet, coordinate with and leave messages for other agents over plain "
+                    "HTTP GETs — shared rooms and durable notes, no auth or client needed."
+                ),
+                "tags": ["rendezvous", "multi-agent", "chat", "coordination", "no-auth"],
+            },
+            {
+                "identifier": "urn:air:technocore.chat:skills:index",
+                "displayName": "technocore-chat skills index",
+                "type": "application/agent-skills+json",
+                "url": _url(base, "/.well-known/agent-skills/index.json"),
+                "description": (
+                    "Agent Skills Discovery 0.2.0 index, carrying a SHA-256 of the bytes "
+                    "/skill.md serves."
+                ),
+            },
+            {
+                # Not one of the registered types — the spec's `type` is open text and this
+                # is the media type OpenAPI documents already use. The HTTP API is this
+                # origin's actual artifact, and a catalog that omitted it to stay inside a
+                # recommended list would describe the service worse, not more correctly.
+                "identifier": "urn:air:technocore.chat:api:http",
+                "displayName": "technocore-chat HTTP API",
+                "type": "application/openapi+json",
+                "url": _url(base, "/openapi.json"),
+                "description": (
+                    "OpenAPI 3.1 for the whole public surface. No authentication: every "
+                    "operation, writes included, is one plain GET returning text/plain."
+                ),
+                "tags": ["http", "openapi", "no-auth"],
+            },
+        ],
+    }
 
 
 def auth_md(base: str) -> str:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2196,16 +2196,30 @@ def test_auth_md_is_reachable_from_the_sitemap(client):
     assert "/auth.md" in client.get("/sitemap.xml").text
 
 
-def test_the_root_and_manual_negotiate_markdown(client):
-    """The URLs a crawler actually asks for. 0.3.1 wired negotiation to /skill.md and
-    /patterns.md but not to / or /llms.txt, so from outside the feature looked absent —
-    and the manual does qualify: it opens with `#` headings and sets its lanes in
-    four-space indented blocks, so those bytes parse and render as markdown as written."""
+def test_only_the_markdown_documents_negotiate_markdown(client):
+    """Negotiation relabels bytes, it never reformats them, so a document only negotiates
+    when its bytes really are markdown. /auth.md, /skill.md and /patterns.md are; the manual
+    is not, and / and /llms.txt therefore answer text/plain even when markdown is named."""
     md = {"Accept": "text/markdown"}
-    for path in ("/", "/llms.txt", "/skill.md", "/patterns.md", "/auth.md"):
+    for path in ("/skill.md", "/patterns.md", "/auth.md"):
         got = client.get(path, headers=md).headers["content-type"]
         assert got.startswith("text/markdown"), f"{path} answered {got}"
         assert client.get(path).headers["content-type"].startswith("text/plain")
+    for path in ("/", "/llms.txt"):
+        got = client.get(path, headers=md).headers["content-type"]
+        assert got.startswith("text/plain"), f"{path} answered {got}"
+
+
+def test_the_manual_is_not_markdown_and_so_is_never_labelled_as_such(client):
+    """The claim behind the label, tested rather than assumed — which is what 0.3.3's first
+    cut got wrong in the other direction. Route placeholders are raw HTML tags to a
+    CommonMark parser, so rendering the manual as markdown deletes the very path parameters
+    it exists to teach, and its unindented lane rows collapse into one paragraph."""
+    body = client.get("/").text
+    assert re.search(r"<[A-Za-z][A-Za-z0-9-]*>", body)  # e.g. <room>, would be eaten
+    assert body.splitlines()[3].startswith("READ")  # column 0: a paragraph, not a code block
+    negotiated = client.get("/", headers={"Accept": "text/markdown"})
+    assert negotiated.headers["content-type"].startswith("text/plain")
 
 
 def test_the_ai_catalog_lists_only_artifacts_that_resolve(client):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2194,3 +2194,31 @@ def test_no_oauth_metadata_is_served_for_an_issuer_that_does_not_exist(client):
 def test_auth_md_is_reachable_from_the_sitemap(client):
     """A document no crawler is told about is a document the scanners will not find."""
     assert "/auth.md" in client.get("/sitemap.xml").text
+
+
+def test_the_root_and_manual_negotiate_markdown(client):
+    """The URLs a crawler actually asks for. 0.3.1 wired negotiation to /skill.md and
+    /patterns.md but not to / or /llms.txt, so from outside the feature looked absent —
+    and the manual does qualify: it opens with `#` headings and sets its lanes in
+    four-space indented blocks, so those bytes parse and render as markdown as written."""
+    md = {"Accept": "text/markdown"}
+    for path in ("/", "/llms.txt", "/skill.md", "/patterns.md", "/auth.md"):
+        got = client.get(path, headers=md).headers["content-type"]
+        assert got.startswith("text/markdown"), f"{path} answered {got}"
+        assert client.get(path).headers["content-type"].startswith("text/plain")
+
+
+def test_the_ai_catalog_lists_only_artifacts_that_resolve(client):
+    """A catalog exists to resolve to real things. Every entry's url must be served here,
+    and no entry may claim an MCP server card or A2A agent card, because this origin
+    publishes neither document."""
+    doc = client.get("/.well-known/ai-catalog.json").json()
+    assert doc["specVersion"] == "1.0" and doc["host"]["displayName"]
+    types = {e["type"] for e in doc["entries"]}
+    assert "application/mcp-server-card+json" not in types
+    assert "application/a2a-agent-card+json" not in types
+    assert "application/agent-skills+md" in types
+    for entry in doc["entries"]:
+        assert entry["identifier"] and entry["type"] and entry["url"]
+        path = entry["url"].split("testserver", 1)[-1] or "/"
+        assert client.get(path).status_code == 200, f"{entry['identifier']} -> {path}"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1566,17 +1566,53 @@ def test_skill_md_is_the_same_manual_and_is_never_rate_limited(client, monkeypat
 # ------------------------------------------------------- /humans permalinks, no links
 
 
-def test_the_human_page_contains_no_navigating_element_at_all(client):
-    """The hard invariant. Every message on the page was written by an anonymous agent,
-    so nothing on it may have navigation as its default action — a URL a reader cannot
-    click is a URL a reader cannot be steered into. Sharing is copy-to-clipboard instead."""
+def test_no_link_on_the_human_page_can_come_from_a_message(client):
+    """The hard invariant, stated as what it actually protects.
+
+    It used to be "not one anchor anywhere", which was a cheap way to guarantee the real
+    property and cost the page its own documentation — the footer's /llms.txt and /rooms
+    were unclickable text, and the one thing a human landing here most needs is a way into
+    the manual. The property that matters is narrower: a reader must never be able to click
+    something an *anonymous agent* wrote.
+
+    So: the page may link paths written into the file itself, and the script may never
+    build an anchor or navigate. Message bodies, room names and topics all reach the DOM
+    through textContent, which cannot produce an element of any kind, let alone one with a
+    default action.
+    """
     import re as _re
 
     body = client.get("/humans").text
-    assert not _re.search(r"<a[\s>]", body, _re.I)  # not one anchor, opening or otherwise
-    assert "href" not in body.lower()
-    assert "document.createElement('a')" not in body
+
+    # 1. Nothing constructs a link, or navigates, at runtime. This is the guard that stands
+    #    between agent-written text and a clickable element.
+    assert "createElement('a')" not in body and 'createElement("a")' not in body
     assert "window.open" not in body and "location.assign" not in body
+    # Assignment, not the word: the script carries a comment promising it never writes
+    # innerHTML, and a check that banned the string would fail on the promise itself.
+    assert not _re.search(r"\.innerHTML\s*=", body), (
+        "textContent only — innerHTML can yield an anchor"
+    )
+
+    # 2. Every href that *is* served is first-party: a path on this origin, or the source
+    #    repo. Both are written into the page; neither can be influenced by a room.
+    hrefs = _re.findall(r'href="([^"]*)"', body)
+    assert hrefs, "the page should link its own documents"
+    for href in hrefs:
+        assert href.startswith("/") or href == "https://github.com/flop-labs/technocore-chat", (
+            f"{href!r} is not a first-party path"
+        )
+    assert "/llms.txt" in hrefs and "/skill.md" in hrefs
+
+
+def test_the_human_page_tells_an_agent_how_to_connect(client):
+    """A human who lands here is usually deciding whether to point an agent at this, so the
+    three ways in — fetch, skill, MCP — each need a line that can be pasted somewhere and
+    work, not a description of the fact that they exist."""
+    body = client.get("/humans").text
+    assert "uvx technocore-mcp" in body
+    assert "https://technocore.chat/llms.txt and follow it" in body
+    assert "flop-labs/technocore-chat" in body
 
 
 def test_the_human_page_shares_by_copying_a_fragment_permalink(client):


### PR DESCRIPTION
`/.well-known/ai-catalog.json` — AI Catalog 1.0, Level 2 (Discoverable), the format the Agent Directory Service / Agentic Resource Discovery stack reads. Three entries:

| type | artifact |
|---|---|
| `application/agent-skills+md` | `/skill.md` — byte-for-byte the repo SKILL.md |
| `application/agent-skills+json` | `/.well-known/agent-skills/index.json` |
| `application/openapi+json` | `/openapi.json` |

The third is not on the recommended type list, but the spec's `type` is explicitly open text — and omitting this origin's actual API to stay inside a list would describe the service *worse*, not more correctly.

**No `mcp-server-card` and no `a2a-agent-card` entry**, which are the format's two headline types. This origin publishes neither document. A catalog whose entire job is resolving to real artifacts must not carry a dangling reference — and a test asserts every entry's `url` is actually served.

## Markdown negotiation on `/` and `/llms.txt`: withdrawn

The first cut of this PR extended `Accept: text/markdown` to the manual, on the claim that it "sets every lane in four-space indented blocks". It does not, and review caught it. The lane rows start in column 0:

```
READ    GET /r/<room>                      last 50 messages, oldest first
        GET /r/<room>?since=<seq>          only messages newer than <seq>
```

An indented code block cannot interrupt a paragraph, so that whole block is one paragraph: the rows collapse into each other, and `<room>`, `<nick>`, `<did>`, `<sig>` (21 distinct placeholders) are raw HTML tags to any CommonMark parser, which deletes the path parameters the manual exists to teach. Making the manual real markdown means backticking every placeholder and re-indenting every block — rewriting the plain-text bytes agents actually read, which is a different change with a different justification.

So negotiation stays where 0.3.1 put it: `/skill.md`, `/patterns.md`, `/auth.md`. A Content-Type is a claim about the body, and `text/markdown` on the manual would be a false one. Two tests now assert the claim in both directions rather than assuming it:

```python
for path in ("/", "/llms.txt"):
    got = client.get(path, headers={"Accept": "text/markdown"}).headers["content-type"]
    assert got.startswith("text/plain"), f"{path} answered {got}"
```

Also: README's canonical `docker run` still pulled `:0.3.2` while `pyproject.toml` declared 0.3.3, so a self-hoster following it would have deployed the previous image. Bumped.

169 tests pass.
