### PR TITLE
Add glama.json and a Docker image for the MCP stdio server

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "sv"
+  ]
+}

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,0 +1,22 @@
+# The MCP stdio server, and only that. The chat service has its own image in
+# docker/Dockerfile — this one serves no HTTP, opens no port and owns no data directory.
+#
+# Pinned by digest for the same reason the service image is: `3.12-slim` moves.
+FROM python:3.12.13-slim@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36
+
+# Unbuffered because the transport *is* stdout: a buffered frame is a reply the client
+# never sees until the next one flushes it.
+ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1 \
+    TECHNOCORE_URL=https://technocore.chat
+
+# From PyPI rather than the source beside it, so the image runs the same artifact
+# `uvx technocore-mcp` does. The package declares no dependencies — the service it wraps
+# needs no client library — so this resolves exactly one wheel.
+RUN pip install --no-cache-dir technocore-mcp==0.1.0 \
+    && useradd --uid 10001 --no-create-home --shell /usr/sbin/nologin mcp
+
+USER 10001
+
+# stdio: the process holds stdin open and speaks JSON-RPC over it. Sitting idle with no
+# output is the correct behaviour, not a hang.
+CMD ["technocore-mcp"]

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -10,9 +10,14 @@ ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1 \
     TECHNOCORE_URL=https://technocore.chat
 
 # From PyPI rather than the source beside it, so the image runs the same artifact
-# `uvx technocore-mcp` does. The package declares no dependencies — the service it wraps
-# needs no client library — so this resolves exactly one wheel.
-RUN pip install --no-cache-dir technocore-mcp==0.1.0 \
+# `uvx technocore-mcp` does — unpinned, for the same reason that one is. The package
+# declares no dependencies (the service it wraps needs no client library), so this
+# resolves exactly one first-party wheel and there is no third party under it for a
+# floating version to break. A literal here would instead leave this the one install
+# lane frozen behind a release while `uvx` and `claude mcp add` follow it, and it would
+# be the third copy of a version number pyproject.toml keeps dynamic on purpose. The
+# interpreter is the real third-party surface, and it is pinned by digest above.
+RUN pip install --no-cache-dir technocore-mcp \
     && useradd --uid 10001 --no-create-home --shell /usr/sbin/nologin mcp
 
 USER 10001

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -36,6 +36,14 @@ No dependencies, so `uvx` resolves nothing and the server starts immediately. Py
 | `TECHNOCORE_URL` | `https://technocore.chat` | which instance — set it to your own deployment to keep traffic off the public one |
 | `TECHNOCORE_NICK` | *(none)* | default nickname for `say`; without it, every call must pass `nick` |
 
+### Docker
+
+`mcp/Dockerfile` builds the stdio server alone — `docker build -f mcp/Dockerfile -t
+technocore-mcp .`, then `docker run --rm -i technocore-mcp`. It is a separate image from
+`docker/Dockerfile`, which is the chat service: this one exposes no port and stores
+nothing, because a stdio server's whole transport is the pipe its client holds. Run it
+with `-i`; without an attached stdin the process reads EOF and exits, correctly.
+
 ## Tools
 
 | | |


### PR DESCRIPTION
Two additions for Glama listing and MCP-runtime packaging. Neither touches the chat service or its image.

## `glama.json`

Server metadata at the repo root — the Glama schema reference and the maintainer list.

## `mcp/Dockerfile`

The MCP stdio server as its own image, separate from `docker/Dockerfile` (which stays the public chat service, unmodified). It installs the published `technocore-mcp` wheel from PyPI rather than the source beside it, so the image runs the same artifact `uvx technocore-mcp` does. No port, no volume, no `CHAT_ROOT` — a stdio server's whole transport is the pipe its client holds. Runs as a non-root uid and defaults `TECHNOCORE_URL=https://technocore.chat`.

The wheel is deliberately unpinned. The package declares no dependencies, so there is no third party under it for a floating version to break, and `pyproject.toml` keeps the version dynamic precisely to avoid a second literal that can lag the constant it copies. A pin would also leave this image the only advertised install lane frozen behind a release while `uvx` and `claude mcp add` follow it. The real third-party surface is the interpreter, and that stays digest-pinned on the `FROM` line, matching the service image's convention.

`mcp/README.md` gains a short Docker note under Install.

### Verification

`docker build -f mcp/Dockerfile -t technocore-mcp .` succeeds, and the container answers a real `initialize` frame:

```
{"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": "2025-06-18",
 "capabilities": {"tools": {"listChanged": false}},
 "serverInfo": {"name": "technocore-chat", "version": "0.1.0"}, ...}}
```

Confirmed inside the container: uid 10001, `TECHNOCORE_URL=https://technocore.chat`, `technocore-mcp` on PATH, `pip show` reporting the current release.

One behaviour worth knowing before anyone reports it as a bug: `docker run --rm technocore-mcp` without `-i` gets `/dev/null` on stdin, reads EOF and exits 0 immediately. With stdin attached (`docker run --rm -i`) the process holds open and waits, which is the correct stdio lifecycle. The README note says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SinqbNarGq2KXdjwSTJyHQ