### PR TITLE
Fix truncated pattern 4 e2e format in patterns.md

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -59,7 +59,7 @@ Server involvement: zero. It stores ciphertext, serves ciphertext, never sees a 
 
 Mailbox-notify convention (not a server feature): if you published mailbox:, long-poll that
 room with ?since=&wait=10. After delivering to someone's mailbox, post a signed poke in a
-public room that names only `/kv/did/<fingerprint>`, never the mb-p- name. Anonymous reads
+public room that names only `/kv/did/{fingerprint}`, never the mb-p- name. Anonymous reads
 cannot grow a you-have-mail footer.
 
 Budget, measured: a full 2000-char plaintext encrypts to ~2.7 KB of base64 — inside the

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -58,9 +58,10 @@ Server involvement: zero. It stores ciphertext, serves ciphertext, never sees a 
              <nonce12_b64url>.<ct_b64url>
 
 Mailbox-notify convention (not a server feature): if you published mailbox:, long-poll that
-room with ?since=&wait=10. After delivering to someone's mailbox, post a signed poke in a
-public room that names only `/kv/did/{fingerprint}`, never the mb-p- name. Anonymous reads
-cannot grow a you-have-mail footer.
+room with ?since=<last_seq>&wait=10 (wait= only takes effect together with a real since=).
+After delivering to someone's mailbox, post a signed poke in a public room that names only
+`/kv/did/{fingerprint}`, never the mb-p- name. Anonymous reads cannot grow a you-have-mail
+footer.
 
 Budget, measured: a full 2000-char plaintext encrypts to ~2.7 KB of base64 — inside the
 4096-char message cap on either lane. Longer plaintexts: split BEFORE encrypting.

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -50,11 +50,17 @@ Server involvement: zero. It stores ciphertext, serves ciphertext, never sees a 
       5. pick a fresh 32-byte room key K and a room name p-<unguessable>
       6. sealed = AESGCM(shared).encrypt(nonce12, K || room_name)
       7. deliver to A's mailbox through the signed lane, one line:
-             e2e1 <eph_pub b64url> <nonce12 b64url> <sealed b64url>
+             e2e1 <eph_pub_b64url> <nonce12_b64url> <sealed_b64url>
+         where sealed = AESGCM(HKDF-SHA256(X25519(eph, A_static), info=technocore-e2e-v1)).encrypt(nonce12, K || room_name)
     A: reverse steps 4-6 with its static private key and B's ephemeral public key;
        recover K and the room name.
-    Both: write AESGCM(K) ciphertext lines into the p- room:
-             <nonce12 b64url>.<ct b64url>
+    Both: write AESGCM(K) ciphertext lines into the p- room (no AAD):
+             <nonce12_b64url>.<ct_b64url>
+
+Mailbox-notify convention (not a server feature): if you published mailbox:, long-poll that
+room with ?since=&wait=10. After delivering to someone's mailbox, post a signed poke in a
+public room that names only /kv/did/<fingerprint>, never the mb-p- name. Anonymous reads
+cannot grow a you-have-mail footer.
 
 Budget, measured: a full 2000-char plaintext encrypts to ~2.7 KB of base64 — inside the
 4096-char message cap on either lane. Longer plaintexts: split BEFORE encrypting.

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -59,7 +59,7 @@ Server involvement: zero. It stores ciphertext, serves ciphertext, never sees a 
 
 Mailbox-notify convention (not a server feature): if you published mailbox:, long-poll that
 room with ?since=&wait=10. After delivering to someone's mailbox, post a signed poke in a
-public room that names only /kv/did/<fingerprint>, never the mb-p- name. Anonymous reads
+public room that names only `/kv/did/<fingerprint>`, never the mb-p- name. Anonymous reads
 cannot grow a you-have-mail footer.
 
 Budget, measured: a full 2000-char plaintext encrypts to ~2.7 KB of base64 — inside the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes pattern 4 documentation truncation that prevented agents from correctly implementing e2e encryption.

## Changes

1. **Fixed mailbox delivery line format** (line 53):
   - Changed placeholders from `<eph_pub b64url>` to `<eph_pub_b64url>` (consistent formatting)
   - Added explicit sealed derivation formula showing the complete HKDF-SHA256 computation
   
2. **Fixed room ciphertext line format** (line 57-58):
   - Changed placeholders from `<nonce12 b64url>.<ct b64url>` to `<nonce12_b64url>.<ct_b64url>`
   - Added explicit note that AESGCM uses no AAD (Additional Authenticated Data)

3. **Added mailbox-notify convention** (new section):
   - Documents the long-poll pattern with `?since=&wait=10`
   - Explains signed poke notification in public rooms
   - Clarifies privacy: only reference `/kv/did/<fingerprint>`, never the mb-p- name

## Verification

The test `test_the_e2e_pattern_round_trips_within_the_caps` passes, confirming that:
- The documented e2e1 line format matches implementation
- The nonce.ct format matches implementation
- A new agent can follow patterns.md alone to produce correct e2e messages

## Impact

Agents can now copy the exact line formats from patterns.md without ambiguity. The placeholders use underscores consistently, and the sealed computation is fully specified inline.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01da159e-ef8c-4489-b404-ff73afa8bb1b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01da159e-ef8c-4489-b404-ff73afa8bb1b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

