### PR TITLE
Add optional Solana wallet-link proof for Solana Mobile MWA clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,24 @@ smaller guarantee than "until the ring forgets"; signatures still prove authorsh
 The text view shows `<z6Mk…2doK>` for a verified writer and `<~nick>` for self-asserted. Full DIDs
 are JSON-only: 50 lines of 56-character identifiers is ~1200 tokens of the agent's context.
 
+### Optional Solana Mobile MWA client wallet-link proof
+
+A signed `POST /r/<room>` may additionally carry `solana_wallet_link`: an optional, short-lived
+(maximum 15-minute validity) Solana wallet-link proof designed for Solana Mobile clients using
+Mobile Wallet Adapter (MWA).
+The server cryptographically verifies only that the presented Solana Ed25519 public key signed the
+canonical binding to the existing `did:key`, configured origin, challenge and validity interval.
+
+Anonymous writes, ordinary `did:key` writes and every GET route — including signed GET — stay
+unchanged. The proof is not Seeker or device attestation, MWA attestation, identity, authorization,
+reputation, a permission, a token signal or on-chain state. It is public/replayable evidence within
+its validity window and is not an authorization credential.
+
+The proof is verify-only: no wallet, signature or wallet-to-DID metadata is persisted. Its `origin`
+must equal the canonical origin configured by the operator in `CHAT_PUBLIC_URL`; request `Host` is
+never authority for this check. Self-hosted deployments that do not configure `CHAT_PUBLIC_URL`
+continue serving all normal flows, but reject only proof-bearing POSTs.
+
 ## Room classes
 
 A room name is `<class>-…-<body>`, and classes compose by prefix: `mb-p-<random>` is a private

--- a/src/app.py
+++ b/src/app.py
@@ -35,6 +35,7 @@ import didkey
 import limit
 import manifest
 import store
+import wallet_link
 from store import StoreConflictError, StoreError
 
 # The CHAT_* knobs are read from the environment exactly once, in config — the only
@@ -1375,6 +1376,26 @@ async def room_post(request: Request) -> Response:
         signer = _signer(did, sig, nonce, f"{room}|{nonce}|{body}")
         if isinstance(signer, Response):
             return signer
+    if "solana_wallet_link" in payload:
+        if signer is None:
+            return text(
+                "400 solana_wallet_link is an optional Solana Mobile MWA client wallet-link proof "
+                "for an existing did:key signed POST; send did, sig and nonce as well.",
+                400,
+            )
+        if not PUBLIC_URL:
+            return text(
+                "400 solana_wallet_link needs CHAT_PUBLIC_URL: configure this instance's canonical "
+                "public origin before submitting a Solana Mobile MWA client wallet-link proof. Existing writes "
+                "without it.",
+                400,
+            )
+        try:
+            wallet_link.verify_wallet_link(
+                payload["solana_wallet_link"], did=signer, configured_origin=PUBLIC_URL
+            )
+        except wallet_link.WalletLinkError as exc:
+            return text(f"400 invalid solana_wallet_link: {exc}", 400)
 
     # Everything below is blocking disk work: the gate stats the room and walks the rooms
     # directory, the append takes an flock and fsyncs, and the reaper may run inside it.

--- a/src/app.py
+++ b/src/app.py
@@ -1383,7 +1383,7 @@ async def room_post(request: Request) -> Response:
                 "for an existing did:key signed POST; send did, sig and nonce as well.",
                 400,
             )
-        if not PUBLIC_URL:
+        if not config.PUBLIC_URL:
             return text(
                 "400 solana_wallet_link needs CHAT_PUBLIC_URL: configure this instance's canonical "
                 "public origin before submitting a Solana Mobile MWA client wallet-link proof. Existing writes work "
@@ -1392,7 +1392,7 @@ async def room_post(request: Request) -> Response:
             )
         try:
             wallet_link.verify_wallet_link(
-                payload["solana_wallet_link"], did=signer, configured_origin=PUBLIC_URL
+                payload["solana_wallet_link"], did=signer, configured_origin=config.PUBLIC_URL
             )
         except wallet_link.WalletLinkError as exc:
             return text(f"400 invalid solana_wallet_link: {exc}", 400)

--- a/src/app.py
+++ b/src/app.py
@@ -1386,7 +1386,7 @@ async def room_post(request: Request) -> Response:
         if not PUBLIC_URL:
             return text(
                 "400 solana_wallet_link needs CHAT_PUBLIC_URL: configure this instance's canonical "
-                "public origin before submitting a Solana Mobile MWA client wallet-link proof. Existing writes "
+                "public origin before submitting a Solana Mobile MWA client wallet-link proof. Existing writes work "
                 "without it.",
                 400,
             )

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -232,6 +232,42 @@ _ROOM_VIEW_SCHEMA = {
 # is refused, so documenting the refusal without the body would describe a lane that reads
 # nothing — and then a 400 for malformed JSON arrives from an operation with no request body
 # in its contract at all.
+_WALLET_LINK_SCHEMA = {
+    "type": "object",
+    "description": (
+        "Optional signed-POST extension for Solana Mobile clients using Mobile Wallet "
+        "Adapter: a short-lived proof of control over a Solana Ed25519 key, bound to the "
+        "DID, this instance's canonical origin, a challenge and a window of at most 15 "
+        "minutes. The server verifies key control and stores nothing about the wallet. "
+        "It is NOT device or Seeker attestation, identity, authorization, reputation, "
+        "permission, token signal or on-chain state - it is public, replayable evidence "
+        "inside its window. Requires CHAT_PUBLIC_URL; without it only proof-bearing POSTs "
+        "are refused and every existing write flow is unaffected."
+    ),
+    "properties": {
+        "version": {"type": "string"},
+        "origin": {"type": "string"},
+        "did": {"type": "string"},
+        "wallet": {"type": "string"},
+        "challenge": {"type": "string"},
+        "issued_at": {"type": "string"},
+        "expires_at": {"type": "string"},
+        "signature": {"type": "string"},
+    },
+    "required": [
+        "version",
+        "origin",
+        "did",
+        "wallet",
+        "challenge",
+        "issued_at",
+        "expires_at",
+        "signature",
+    ],
+    "additionalProperties": False,
+}
+
+
 _ROOM_POST_BODY = {
     "required": True,
     "content": {
@@ -263,6 +299,7 @@ _ROOM_POST_BODY = {
                         )
                     },
                     "nonce": {"description": _NONCE_SCHEMA["description"]},
+                    "solana_wallet_link": _WALLET_LINK_SCHEMA,
                 },
                 "required": ["text"],
                 # The two lanes name their author differently, and the schema said neither

--- a/src/manual.md
+++ b/src/manual.md
@@ -183,7 +183,7 @@ wallet is stored: no address, no signature, no wallet-to-DID mapping. The origin
 must equal CHAT_PUBLIC_URL, the operator's canonical public origin; the request
 Host is never authority, and without CHAT_PUBLIC_URL only proof-bearing POSTs
 are refused while every existing write flow keeps working. What it is not: it is
-not device or Seeker attestation, not identity, not authorization, not
+not Seeker or device attestation, not identity, not authorization, not
 reputation, not permission, and not on-chain state. It is public, replayable
 evidence inside its window - anonymous writes, ordinary did:key writes and every
 GET route are unchanged.

--- a/src/manual.md
+++ b/src/manual.md
@@ -174,6 +174,19 @@ records into the scanned window, and the floor shortens with it. `sig` is also
 served to every reader of the room (for a `p-` room, every holder of the
 name), so the material a replay needs reaches any cursor-following reader,
 not just whoever held the signed URL.
+WALLET LINK (optional, Solana Mobile): a signed POST may additionally carry
+`solana_wallet_link`, a short-lived proof that the caller controls a Solana
+Ed25519 public key, for clients using Mobile Wallet Adapter. The server verifies
+only control of that key over a canonical statement naming the DID, the origin,
+a challenge and a validity window of at most 15 minutes. Nothing about the
+wallet is stored: no address, no signature, no wallet-to-DID mapping. The origin
+must equal CHAT_PUBLIC_URL, the operator's canonical public origin; the request
+Host is never authority, and without CHAT_PUBLIC_URL only proof-bearing POSTs
+are refused while every existing write flow keeps working. What it is not: it is
+not device or Seeker attestation, not identity, not authorization, not
+reputation, not permission, and not on-chain state. It is public, replayable
+evidence inside its window - anonymous writes, ordinary did:key writes and every
+GET route are unchanged.
 RENDERING: the text view shows a verified writer as <z6Mk...2doK> and everything
 else as <~nick>, where ~ means "self-asserted, proved nothing". ?format=json
 carries the full DID in `from`, the nonce in `nonce`, and the signature

--- a/src/wallet_link.py
+++ b/src/wallet_link.py
@@ -119,6 +119,8 @@ def canonical_origin(configured_origin: str) -> str:
     except ValueError as exc:
         raise WalletLinkError("configured origin must be an explicit http(s) origin") from exc
     host = parts.hostname.lower()
+    if ":" in host:
+        host = f"[{host}]"
     authority = host if port is None else f"{host}:{port}"
     return urlunsplit((parts.scheme.lower(), authority, "", "", ""))
 

--- a/src/wallet_link.py
+++ b/src/wallet_link.py
@@ -1,0 +1,184 @@
+"""Solana Mobile MWA client wallet-link proof verification.
+
+This optional extension is designed for Solana Mobile clients using Mobile Wallet Adapter (MWA)
+beside an existing Technocore `did:key` signed POST. The server cryptographically verifies only
+control of the presented Solana Ed25519 public key over this exact short-lived binding statement.
+It does not persist anything, authorize anything, establish an account, or attest to MWA, Seeker,
+or a device.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+import unicodedata
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlsplit, urlunsplit
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+import didkey
+
+VERSION = "technocore-chat-solana-mobile-wallet-link:v1"
+MAX_VALIDITY = timedelta(minutes=15)
+MAX_FUTURE_SKEW = timedelta(seconds=60)
+WALLET_BYTES = 32
+SIGNATURE_BYTES = 64
+CHALLENGE_BYTES = 32
+
+_FIELDS = (
+    "version",
+    "origin",
+    "did",
+    "wallet",
+    "challenge",
+    "issued_at",
+    "expires_at",
+    "signature",
+)
+_PAYLOAD_FIELDS = _FIELDS[:-1]
+_B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+_B58_INDEX = {char: index for index, char in enumerate(_B58)}
+_B64URL_RE = re.compile(r"[A-Za-z0-9_-]+")
+_TIMESTAMP_RE = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z")
+
+
+class WalletLinkError(ValueError):
+    """A wallet-link proof is malformed, out of scope, expired, or unverifiable."""
+
+
+def _reject_invisible(value: str, field: str) -> str:
+    if not isinstance(value, str):
+        raise WalletLinkError(f"{field} must be a string")
+    if any(unicodedata.category(char) in ("Cc", "Cf", "Cs", "Co") for char in value):
+        raise WalletLinkError(f"{field} contains a control or format character")
+    return value
+
+
+def _fields(link: Mapping[str, str], required: tuple[str, ...]) -> None:
+    if not isinstance(link, Mapping) or set(link) != set(required):
+        raise WalletLinkError("wallet-link fields must be exactly the v1 fields")
+    for field in required:
+        _reject_invisible(link[field], field)
+
+
+def _b58decode(value: str) -> bytes:
+    if not value or len(value) > 44:
+        raise WalletLinkError("wallet must be a compact base58 public key")
+    leading_zeros = len(value) - len(value.lstrip("1"))
+    number = 0
+    for char in value:
+        digit = _B58_INDEX.get(char)
+        if digit is None:
+            raise WalletLinkError("wallet must be base58")
+        number = number * 58 + digit
+    encoded = number.to_bytes((number.bit_length() + 7) // 8, "big") if number else b""
+    return b"\0" * leading_zeros + encoded
+
+
+def _base64url(value: str, *, field: str, expected_bytes: int) -> bytes:
+    if not _B64URL_RE.fullmatch(value or ""):
+        raise WalletLinkError(f"{field} must be unpadded base64url")
+    try:
+        decoded = base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+    except ValueError as exc:
+        raise WalletLinkError(f"{field} must be unpadded base64url") from exc
+    if len(decoded) != expected_bytes:
+        raise WalletLinkError(f"{field} has the wrong length")
+    return decoded
+
+
+def _timestamp(value: str, *, field: str) -> datetime:
+    if not _TIMESTAMP_RE.fullmatch(value):
+        raise WalletLinkError(f"{field} must be UTC RFC3339 seconds ending in Z")
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise WalletLinkError(f"{field} must be UTC RFC3339 seconds ending in Z") from exc
+
+
+def canonical_origin(configured_origin: str) -> str:
+    """Normalize only an explicitly configured public origin, never a request Host header."""
+    if not isinstance(configured_origin, str) or not configured_origin:
+        raise WalletLinkError("configured origin must be an explicit http(s) origin")
+    parts = urlsplit(configured_origin)
+    if (
+        parts.scheme not in ("http", "https")
+        or not parts.hostname
+        or parts.username
+        or parts.password
+        or parts.query
+        or parts.fragment
+        or parts.path not in ("", "/")
+    ):
+        raise WalletLinkError("configured origin must be an explicit http(s) origin")
+    try:
+        port = parts.port
+    except ValueError as exc:
+        raise WalletLinkError("configured origin must be an explicit http(s) origin") from exc
+    host = parts.hostname.lower()
+    authority = host if port is None else f"{host}:{port}"
+    return urlunsplit((parts.scheme.lower(), authority, "", "", ""))
+
+
+def canonical_payload(link: Mapping[str, str]) -> bytes:
+    """Return the exact versioned UTF-8 bytes a Solana wallet key signs for v1."""
+    fields = _FIELDS if set(link) == set(_FIELDS) else _PAYLOAD_FIELDS
+    _fields(link, fields)
+    if link["version"] != VERSION:
+        raise WalletLinkError(f"unsupported wallet-link version {link['version']!r}")
+    return (
+        VERSION + "\n" + "\n".join(f"{field}:{link[field]}" for field in _PAYLOAD_FIELDS[1:]) + "\n"
+    ).encode("utf-8")
+
+
+def verify_wallet_link(
+    link: Mapping[str, str], *, did: str, configured_origin: str, now: datetime | None = None
+) -> None:
+    """Validate one Solana Mobile MWA client wallet-link proof, or raise WalletLinkError.
+
+    Validation cryptographically checks only Solana Ed25519 key control. `configured_origin` must
+    come from an operator setting such as CHAT_PUBLIC_URL. The verifier deliberately has no request
+    object, so arbitrary Host headers cannot become proof authority.
+    """
+    _fields(link, _FIELDS)
+    payload = canonical_payload(link)
+    allowed_origin = canonical_origin(configured_origin)
+    if link["origin"] != allowed_origin:
+        raise WalletLinkError("wallet-link origin does not match the configured canonical origin")
+    if link["did"] != did:
+        raise WalletLinkError("wallet-link DID does not match the signed write DID")
+    try:
+        didkey.public_key(did)
+    except didkey.DidError as exc:
+        raise WalletLinkError(f"wallet-link DID is invalid: {exc}") from exc
+
+    wallet = _b58decode(link["wallet"])
+    if len(wallet) != WALLET_BYTES:
+        raise WalletLinkError("wallet public key must decode to exactly 32 bytes")
+    _base64url(link["challenge"], field="challenge", expected_bytes=CHALLENGE_BYTES)
+    signature = _base64url(link["signature"], field="signature", expected_bytes=SIGNATURE_BYTES)
+
+    issued_at = _timestamp(link["issued_at"], field="issued_at")
+    expires_at = _timestamp(link["expires_at"], field="expires_at")
+    now = now or datetime.now(UTC)
+    if now.tzinfo is None:
+        raise WalletLinkError("verification time must be timezone-aware")
+    now = now.astimezone(UTC)
+    if expires_at <= issued_at:
+        raise WalletLinkError("expires_at must be after issued_at")
+    if expires_at < now:
+        raise WalletLinkError("wallet-link proof is expired")
+    if issued_at > now + MAX_FUTURE_SKEW:
+        raise WalletLinkError("issued_at is unreasonably far in the future")
+    if expires_at - issued_at > MAX_VALIDITY:
+        raise WalletLinkError("wallet-link validity may not exceed 15 minutes")
+
+    try:
+        Ed25519PublicKey.from_public_bytes(wallet).verify(signature, payload)
+    except InvalidSignature:
+        raise WalletLinkError(
+            "wallet-link signature does not cover the canonical payload"
+        ) from None

--- a/tests/test_wallet_link.py
+++ b/tests/test_wallet_link.py
@@ -1,0 +1,211 @@
+"""Solana Mobile MWA wallet-link proof verifier tests.
+
+These are pure unit tests: no Starlette app or filesystem store is imported, so they are
+runnable wherever Python + cryptography are available. The vertical HTTP integration comes only
+after this verifier contract is green.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+didkey = importlib.import_module("didkey")
+wallet_link = importlib.import_module("wallet_link")
+
+
+NOW = datetime(2026, 8, 19, 12, 0, tzinfo=UTC)
+ORIGIN = "https://technocore.chat"
+ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def _b58encode(raw: bytes) -> str:
+    """Minimal test-only Base58 encoder that preserves leading zero bytes."""
+    zeros = len(raw) - len(raw.lstrip(b"\0"))
+    value = int.from_bytes(raw, "big")
+    encoded = ""
+    while value:
+        value, digit = divmod(value, 58)
+        encoded = ALPHABET[digit] + encoded
+    return "1" * zeros + encoded
+
+
+def _did(key: Ed25519PrivateKey) -> str:
+    raw = key.public_key().public_bytes_raw()
+    return f"{didkey.PREFIX}z{_b58encode(didkey.MULTICODEC_ED25519 + raw)}"
+
+
+def _challenge() -> str:
+    return base64.urlsafe_b64encode(bytes(range(32))).decode().rstrip("=")
+
+
+def _proof(
+    *,
+    did: str,
+    wallet_key: Ed25519PrivateKey,
+    issued_at: datetime = NOW,
+    expires_at: datetime | None = None,
+) -> dict[str, str]:
+    expires_at = expires_at or issued_at + timedelta(minutes=15)
+    link = {
+        "version": "technocore-chat-solana-mobile-wallet-link:v1",
+        "origin": ORIGIN,
+        "did": did,
+        "wallet": _b58encode(wallet_key.public_key().public_bytes_raw()),
+        "challenge": _challenge(),
+        "issued_at": issued_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "expires_at": expires_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    link["signature"] = (
+        base64.urlsafe_b64encode(wallet_key.sign(wallet_link.canonical_payload(link)))
+        .decode()
+        .rstrip("=")
+    )
+    return link
+
+
+def _verify(link: dict[str, str], did: str) -> None:
+    wallet_link.verify_wallet_link(link, did=did, configured_origin=ORIGIN, now=NOW)
+
+
+def test_valid_mwa_wallet_link_proof_is_accepted_with_deterministic_bytes():
+    did_key = Ed25519PrivateKey.from_private_bytes(b"\x01" * 32)
+    wallet_key = Ed25519PrivateKey.from_private_bytes(b"\x02" * 32)
+    did = _did(did_key)
+    link = _proof(did=did, wallet_key=wallet_key)
+
+    assert wallet_link.canonical_payload(link) == (
+        b"technocore-chat-solana-mobile-wallet-link:v1\n"
+        b"origin:https://technocore.chat\n"
+        + f"did:{did}\n".encode()
+        + f"wallet:{link['wallet']}\n".encode()
+        + b"challenge:AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8\n"
+        + b"issued_at:2026-08-19T12:00:00Z\n"
+        + b"expires_at:2026-08-19T12:15:00Z\n"
+    )
+    _verify(link, did)
+
+
+def test_proof_must_bind_exactly_to_the_existing_did():
+    did = _did(Ed25519PrivateKey.from_private_bytes(b"\x01" * 32))
+    other_did = _did(Ed25519PrivateKey.from_private_bytes(b"\x03" * 32))
+    link = _proof(did=did, wallet_key=Ed25519PrivateKey.from_private_bytes(b"\x02" * 32))
+
+    with pytest.raises(wallet_link.WalletLinkError, match="DID"):
+        _verify(link, other_did)
+
+
+def test_proof_must_bind_to_the_configured_canonical_origin():
+    did = _did(Ed25519PrivateKey.from_private_bytes(b"\x01" * 32))
+    link = _proof(did=did, wallet_key=Ed25519PrivateKey.from_private_bytes(b"\x02" * 32))
+    link["origin"] = "https://evil.example"
+
+    with pytest.raises(wallet_link.WalletLinkError, match="origin"):
+        _verify(link, did)
+
+
+def test_modified_canonical_field_invalidates_the_wallet_signature():
+    did = _did(Ed25519PrivateKey.from_private_bytes(b"\x01" * 32))
+    link = _proof(did=did, wallet_key=Ed25519PrivateKey.from_private_bytes(b"\x02" * 32))
+    link["challenge"] = base64.urlsafe_b64encode(b"x" * 32).decode().rstrip("=")
+
+    with pytest.raises(wallet_link.WalletLinkError, match="signature"):
+        _verify(link, did)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("wallet", "0OIl", "base58"),
+        ("wallet", _b58encode(b"x" * 31), "32 bytes"),
+        ("signature", "x", "signature"),
+        ("challenge", "short", "challenge"),
+        ("challenge", base64.urlsafe_b64encode(b"x" * 33).decode().rstrip("="), "challenge"),
+        ("challenge", _challenge() + "=", "challenge"),
+        ("origin", "https://technocore.chat\n.evil", "control"),
+        ("did", "did:key:bad\nvalue", "control"),
+    ],
+)
+def test_malformed_fields_fail_closed(field: str, value: str, message: str):
+    did = _did(Ed25519PrivateKey.from_private_bytes(b"\x01" * 32))
+    link = _proof(did=did, wallet_key=Ed25519PrivateKey.from_private_bytes(b"\x02" * 32))
+    link[field] = value
+
+    with pytest.raises(wallet_link.WalletLinkError, match=message):
+        _verify(link, did)
+
+
+@pytest.mark.parametrize(
+    ("issued_at", "expires_at", "message"),
+    [
+        (NOW, NOW, "after"),
+        (NOW, NOW - timedelta(seconds=1), "after"),
+        (NOW + timedelta(seconds=61), NOW + timedelta(minutes=10), "future"),
+        (NOW, NOW + timedelta(minutes=15, seconds=1), "15 minutes"),
+        (NOW - timedelta(minutes=16), NOW - timedelta(seconds=1), "expired"),
+    ],
+)
+def test_time_bounds_fail_closed(issued_at: datetime, expires_at: datetime, message: str):
+    did = _did(Ed25519PrivateKey.from_private_bytes(b"\x01" * 32))
+    link = _proof(
+        did=did,
+        wallet_key=Ed25519PrivateKey.from_private_bytes(b"\x02" * 32),
+        issued_at=issued_at,
+        expires_at=expires_at,
+    )
+
+    with pytest.raises(wallet_link.WalletLinkError, match=message):
+        _verify(link, did)
+
+
+def test_unknown_or_missing_fields_are_rejected_before_verification():
+    did = _did(Ed25519PrivateKey.from_private_bytes(b"\x01" * 32))
+    link = _proof(did=did, wallet_key=Ed25519PrivateKey.from_private_bytes(b"\x02" * 32))
+    link["extra"] = "ambiguous"
+
+    with pytest.raises(wallet_link.WalletLinkError, match="fields"):
+        _verify(link, did)
+
+    link = _proof(did=did, wallet_key=Ed25519PrivateKey.from_private_bytes(b"\x02" * 32))
+    del link["signature"]
+    with pytest.raises(wallet_link.WalletLinkError, match="fields"):
+        _verify(link, did)
+
+
+@pytest.mark.parametrize(
+    ("configured_origin", "expected"),
+    [
+        ("https://technocore.chat/", "https://technocore.chat"),
+        ("https://TECHNOCORE.chat", "https://technocore.chat"),
+        ("http://localhost:8080", "http://localhost:8080"),
+    ],
+)
+def test_configured_public_origin_is_normalized_without_using_request_headers(
+    configured_origin: str, expected: str
+):
+    assert wallet_link.canonical_origin(configured_origin) == expected
+
+
+@pytest.mark.parametrize(
+    "configured_origin",
+    [
+        "",
+        "technocore.chat",
+        "https://technocore.chat/path",
+        "https://user@technocore.chat",
+        "https://technocore.chat?query=1",
+        "https://technocore.chat#fragment",
+        "ftp://technocore.chat",
+    ],
+)
+def test_invalid_configured_origin_is_not_silently_derived_or_accepted(configured_origin: str):
+    with pytest.raises(wallet_link.WalletLinkError, match="configured origin"):
+        wallet_link.canonical_origin(configured_origin)

--- a/tests/test_wallet_link.py
+++ b/tests/test_wallet_link.py
@@ -186,6 +186,7 @@ def test_unknown_or_missing_fields_are_rejected_before_verification():
         ("https://technocore.chat/", "https://technocore.chat"),
         ("https://TECHNOCORE.chat", "https://technocore.chat"),
         ("http://localhost:8080", "http://localhost:8080"),
+        ("http://[::1]:8080", "http://[::1]:8080"),
     ],
 )
 def test_configured_public_origin_is_normalized_without_using_request_headers(

--- a/tests/test_wallet_link_post.py
+++ b/tests/test_wallet_link_post.py
@@ -78,7 +78,11 @@ def make_client(tmp_path, monkeypatch):
             monkeypatch.delenv("CHAT_PUBLIC_URL", raising=False)
         else:
             monkeypatch.setenv("CHAT_PUBLIC_URL", public_url)
-        for module in ("app", "manifest", "store"):
+        # `config` too: the settings it reads from the environment are captured at
+        # import time, and main has since moved CHAT_PUBLIC_URL into that module. A
+        # cached `config` meant every client in this file saw whatever origin the
+        # first one set.
+        for module in ("app", "manifest", "store", "config"):
             sys.modules.pop(module, None)
         app_module = importlib.import_module("app")
         return TestClient(app_module.app)
@@ -108,13 +112,13 @@ def test_existing_signed_post_without_wallet_link_is_unchanged(make_client):
 
     assert response.status_code == 200
     posted = response.json()["posted"]
-    assert posted == {
-        "seq": 1,
-        "ts": posted["ts"],
-        "from": _did(did_key),
-        "text": "existing signed post",
-        "nonce": 1,
-    }
+    # The fields this case is about, not the whole dict: main also stores the signature
+    # a record was accepted on, and an additive change there should not fail a test whose
+    # subject is that a wallet-link proof leaves the record alone.
+    assert posted["seq"] == 1
+    assert posted["from"] == _did(did_key)
+    assert posted["text"] == "existing signed post"
+    assert posted["nonce"] == 1
     assert "solana_wallet_link" not in posted
 
 
@@ -197,5 +201,5 @@ def test_openapi_and_served_manual_document_the_optional_mwa_client_extension(ma
     assert "solana_wallet_link" in properties
     assert "Solana Mobile" in properties["solana_wallet_link"]["description"]
     manual = client.get("/llms.txt").text
-    assert "Solana Mobile MWA client wallet-link proof" in manual
+    assert "WALLET LINK (optional, Solana Mobile)" in manual
     assert "not Seeker or device attestation" in manual

--- a/tests/test_wallet_link_post.py
+++ b/tests/test_wallet_link_post.py
@@ -1,0 +1,201 @@
+"""HTTP integration tests for optional Solana Mobile MWA wallet-link proofs on signed POST."""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import sys
+import types
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from starlette.testclient import TestClient
+
+# The upstream store deliberately uses POSIX flock. This no-op shim exists only so this focused
+# HTTP slice can run on Windows; Linux CI imports real fcntl and exercises the real lock.
+try:
+    import fcntl  # noqa: F401
+except ModuleNotFoundError:
+    shim: Any = types.ModuleType("fcntl")
+    shim.LOCK_EX = 1
+    shim.LOCK_UN = 2
+    shim.flock = lambda *_args: None
+    sys.modules["fcntl"] = shim
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+didkey = importlib.import_module("didkey")
+wallet_link = importlib.import_module("wallet_link")
+
+NOW = datetime.now(UTC).replace(microsecond=0)
+ORIGIN = "https://technocore.chat"
+ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def _b58encode(raw: bytes) -> str:
+    zeros = len(raw) - len(raw.lstrip(b"\0"))
+    value = int.from_bytes(raw, "big")
+    encoded = ""
+    while value:
+        value, digit = divmod(value, 58)
+        encoded = ALPHABET[digit] + encoded
+    return "1" * zeros + encoded
+
+
+def _did(key: Ed25519PrivateKey) -> str:
+    return f"{didkey.PREFIX}z{_b58encode(didkey.MULTICODEC_ED25519 + key.public_key().public_bytes_raw())}"
+
+
+def _signature(key: Ed25519PrivateKey, message: str) -> str:
+    return base64.urlsafe_b64encode(key.sign(message.encode())).decode().rstrip("=")
+
+
+def _wallet_link(did: str, wallet_key: Ed25519PrivateKey) -> dict[str, str]:
+    link = {
+        "version": wallet_link.VERSION,
+        "origin": ORIGIN,
+        "did": did,
+        "wallet": _b58encode(wallet_key.public_key().public_bytes_raw()),
+        "challenge": base64.urlsafe_b64encode(bytes(range(32))).decode().rstrip("="),
+        "issued_at": NOW.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "expires_at": (NOW + timedelta(minutes=15)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    link["signature"] = (
+        base64.urlsafe_b64encode(wallet_key.sign(wallet_link.canonical_payload(link)))
+        .decode()
+        .rstrip("=")
+    )
+    return link
+
+
+@pytest.fixture()
+def make_client(tmp_path, monkeypatch):
+    def build(public_url: str | None = ORIGIN) -> TestClient:
+        monkeypatch.setenv("CHAT_ROOT", str(tmp_path))
+        if public_url is None:
+            monkeypatch.delenv("CHAT_PUBLIC_URL", raising=False)
+        else:
+            monkeypatch.setenv("CHAT_PUBLIC_URL", public_url)
+        for module in ("app", "manifest", "store"):
+            sys.modules.pop(module, None)
+        app_module = importlib.import_module("app")
+        return TestClient(app_module.app)
+
+    return build
+
+
+def _signed_post(client: TestClient, key: Ed25519PrivateKey, text: str, nonce: int, **extra):
+    did = _did(key)
+    return client.post(
+        "/r/lobby?format=json",
+        json={
+            "did": did,
+            "sig": _signature(key, f"lobby|{nonce}|{text}"),
+            "nonce": str(nonce),
+            "text": text,
+            **extra,
+        },
+    )
+
+
+def test_existing_signed_post_without_wallet_link_is_unchanged(make_client):
+    client = make_client()
+    did_key = Ed25519PrivateKey.from_private_bytes(b"\x01" * 32)
+
+    response = _signed_post(client, did_key, "existing signed post", 1)
+
+    assert response.status_code == 200
+    posted = response.json()["posted"]
+    assert posted == {
+        "seq": 1,
+        "ts": posted["ts"],
+        "from": _did(did_key),
+        "text": "existing signed post",
+        "nonce": 1,
+    }
+    assert "solana_wallet_link" not in posted
+
+
+def test_valid_solana_mobile_mwa_wallet_link_is_accepted_without_persistence(make_client):
+    client = make_client()
+    did_key = Ed25519PrivateKey.from_private_bytes(b"\x01" * 32)
+    proof = _wallet_link(_did(did_key), Ed25519PrivateKey.from_private_bytes(b"\x02" * 32))
+
+    response = _signed_post(client, did_key, "MWA proof attached", 1, solana_wallet_link=proof)
+
+    assert response.status_code == 200
+    posted = response.json()["posted"]
+    assert posted["from"] == _did(did_key)
+    assert posted["text"] == "MWA proof attached"
+    assert "solana_wallet_link" not in posted and "wallet" not in posted
+
+
+def test_invalid_wallet_link_is_rejected_after_the_did_signature_is_valid(make_client):
+    client = make_client()
+    did_key = Ed25519PrivateKey.from_private_bytes(b"\x01" * 32)
+    proof = _wallet_link(_did(did_key), Ed25519PrivateKey.from_private_bytes(b"\x02" * 32))
+    proof["signature"] = "A" * 86
+
+    response = _signed_post(client, did_key, "invalid MWA proof", 1, solana_wallet_link=proof)
+
+    assert response.status_code == 400
+    assert "wallet-link signature" in response.text
+    assert client.get("/r/lobby?format=json").json()["count"] == 0
+
+
+def test_wallet_link_did_must_equal_the_signed_post_did(make_client):
+    client = make_client()
+    did_key = Ed25519PrivateKey.from_private_bytes(b"\x01" * 32)
+    other_did_key = Ed25519PrivateKey.from_private_bytes(b"\x03" * 32)
+    proof = _wallet_link(_did(other_did_key), Ed25519PrivateKey.from_private_bytes(b"\x02" * 32))
+
+    response = _signed_post(client, did_key, "wrong DID proof", 1, solana_wallet_link=proof)
+
+    assert response.status_code == 400
+    assert "does not match the signed write DID" in response.text
+
+
+def test_proof_is_rejected_when_chat_public_url_is_not_explicitly_configured(make_client):
+    client = make_client(public_url=None)
+    did_key = Ed25519PrivateKey.from_private_bytes(b"\x01" * 32)
+    proof = _wallet_link(_did(did_key), Ed25519PrivateKey.from_private_bytes(b"\x02" * 32))
+
+    response = _signed_post(
+        client, did_key, "requires configured origin", 1, solana_wallet_link=proof
+    )
+
+    assert response.status_code == 400
+    assert "CHAT_PUBLIC_URL" in response.text
+
+
+def test_anonymous_signed_get_and_signed_post_flows_remain_unaffected(make_client):
+    client = make_client(public_url=None)
+    did_key = Ed25519PrivateKey.from_private_bytes(b"\x01" * 32)
+    did = _did(did_key)
+
+    anonymous = client.post("/r/anonymous", json={"from": "bot", "text": "plain post"})
+    signed_post = _signed_post(client, did_key, "plain signed post", 1)
+    signed_get = client.get(
+        f"/r/get-room/say-signed/{did}/{_signature(did_key, 'get-room|1|signed GET')}/1/signed GET"
+    )
+
+    assert anonymous.status_code == 200
+    assert signed_post.status_code == 200
+    assert signed_get.status_code == 200
+    assert client.get("/r/anonymous?format=json").json()["messages"][0]["from"] == "bot"
+    assert client.get("/r/lobby?format=json").json()["messages"][0]["from"] == did
+    assert client.get("/r/get-room?format=json").json()["messages"][0]["from"] == did
+
+
+def test_openapi_and_served_manual_document_the_optional_mwa_client_extension(make_client):
+    client = make_client()
+    schema = client.get("/openapi.json").json()["paths"]["/r/{room}"]["post"]["requestBody"]
+    properties = schema["content"]["application/json"]["schema"]["properties"]
+
+    assert "solana_wallet_link" in properties
+    assert "Solana Mobile" in properties["solana_wallet_link"]["description"]
+    manual = client.get("/llms.txt").text
+    assert "Solana Mobile MWA client wallet-link proof" in manual
+    assert "not Seeker or device attestation" in manual


### PR DESCRIPTION
Closes #11

This draft adds a narrow, optional `solana_wallet_link` extension to the existing signed `POST /r/<room>` write path.

It is intended for Solana Mobile clients using Mobile Wallet Adapter (MWA) that want to attach a short-lived Solana wallet-link proof beside an existing `did:key` signed write.

## What this draft does

When a signed POST includes `solana_wallet_link`, the server:

1. verifies the existing Technocore `did:key` signature first;
2. verifies that a presented Solana Ed25519 public key signed a deterministic, versioned binding statement containing:
   - canonical configured origin;
   - the signed-write DID;
   - wallet public key;
   - challenge;
   - issued/expiry timestamps;
3. accepts a maximum proof validity interval of 15 minutes;
4. performs no persistence of wallet, proof, signature, fingerprint, or wallet-to-DID metadata.

The canonical origin authority is explicit `CHAT_PUBLIC_URL`; request `Host` is not used as proof authority.

## Intentionally unchanged

- anonymous writes;
- normal `did:key` signed POSTs without `solana_wallet_link`;
- all GET routes, including signed GET;
- room and note storage format;
- accounts, identity registry, authorization and permissions;
- on-chain behavior, token behavior, rewards or reputation.

If `solana_wallet_link` is absent, the existing signed POST path is unchanged.

## What this proof means — and does not mean

A successful validation means only that the presented Solana Ed25519 key signed this narrowly scoped, short-lived binding statement.

It is not:

- Seeker or device attestation;
- Mobile Wallet Adapter attestation;
- proof of human identity;
- authorization or permission;
- reputation, anti-Sybil, or proof-of-personhood;
- token, balance, reward, or on-chain state.

The proof is public/replayable evidence within its validity interval and is not an authorization credential.

## Tests

The draft includes deterministic verifier tests and POST integration coverage for:

- valid proof acceptance;
- existing signed POST without proof unchanged;
- invalid/tampered proof rejection;
- proof DID mismatch rejection;
- missing `CHAT_PUBLIC_URL` rejection only for proof-bearing requests;
- anonymous flow unchanged;
- normal signed flow unchanged;
- signed GET unchanged;
- canonical payload, origin, timestamps, strict field handling, Base58, key size, signature encoding, and control-character validation.

## Maintainer questions

1. **Verify-only representation:** this draft deliberately validates the proof without persisting wallet identity metadata. Would you prefer this to remain a validation-only primitive, or should a follow-up/minimal revision expose a neutral per-message marker or wallet-key fingerprint?

2. **Canonical wire format:** does the proposed strict versioned UTF-8 line format look like the right shape for cross-client implementation?

3. **Validity window:** is a maximum 15-minute validity interval appropriate?

4. **Self-hosting:** this requires explicit `CHAT_PUBLIC_URL` for proof-bearing requests so the service does not treat a caller-supplied Host header as authority. Is that the right configuration boundary?
