### PR TITLE
Add signed did:key client and signature test

### DIFF
--- a/signed_client.py
+++ b/signed_client.py
@@ -1,0 +1,102 @@
+import base64
+import urllib.parse
+import urllib.request
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+
+# Base58btc alphabet used by did:key.
+B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+# multicodec prefix for Ed25519 public keys.
+MULTICODEC_ED25519 = b"\xed\x01"
+
+
+def base58_encode(data: bytes) -> str:
+    n = int.from_bytes(data, "big")
+    result = ""
+
+    while n:
+        n, remainder = divmod(n, 58)
+        result = B58[remainder] + result
+
+    # Preserve leading zero bytes.
+    zeros = len(data) - len(data.lstrip(b"\x00"))
+    return "1" * zeros + result
+
+
+def make_did(private_key: Ed25519PrivateKey) -> str:
+    public_key = private_key.public_key().public_bytes_raw()
+    encoded = base58_encode(MULTICODEC_ED25519 + public_key)
+    return "did:key:z" + encoded
+
+
+def sign(private_key: Ed25519PrivateKey, message: str) -> str:
+    signature = private_key.sign(message.encode("utf-8"))
+    return base64.urlsafe_b64encode(signature).decode().rstrip("=")
+
+
+# ------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------
+
+BASE_URL = "http://127.0.0.1:8000"
+ROOM = "lobby"
+NONCE = 1
+TEXT = "hello from my tiny signed client"
+
+
+# ------------------------------------------------------------
+# Generate key + DID
+# ------------------------------------------------------------
+
+private_key = Ed25519PrivateKey.generate()
+did = make_did(private_key)
+
+print("DID:")
+print(did)
+print()
+
+
+# ------------------------------------------------------------
+# Build the exact message that Technocore signs
+# ------------------------------------------------------------
+
+canonical = f"{ROOM}|{NONCE}|{TEXT}"
+
+print("Canonical message:")
+print(canonical)
+print()
+
+
+# ------------------------------------------------------------
+# Sign it
+# ------------------------------------------------------------
+
+signature = sign(private_key, canonical)
+
+print("Signature:")
+print(signature)
+print()
+
+
+# ------------------------------------------------------------
+# Call say-signed
+# ------------------------------------------------------------
+
+url = (
+    f"{BASE_URL}/r/{urllib.parse.quote(ROOM, safe='')}"
+    f"/say-signed/{urllib.parse.quote(did, safe='')}"
+    f"/{urllib.parse.quote(signature, safe='')}"
+    f"/{NONCE}"
+    f"/{urllib.parse.quote(TEXT, safe='')}"
+)
+
+print("Request URL:")
+print(url)
+print()
+
+with urllib.request.urlopen(url) as response:
+    print("HTTP status:", response.status)
+    print("Server response:")
+    print(response.read().decode())

--- a/test_bad_signature.py
+++ b/test_bad_signature.py
@@ -1,0 +1,59 @@
+import base64
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+MULTICODEC_ED25519 = b"\xed\x01"
+
+BASE_URL = "http://127.0.0.1:8000"
+
+
+def base58_encode(data: bytes) -> str:
+    n = int.from_bytes(data, "big")
+    result = ""
+
+    while n:
+        n, remainder = divmod(n, 58)
+        result = B58[remainder] + result
+
+    zeros = len(data) - len(data.lstrip(b"\x00"))
+    return "1" * zeros + result
+
+
+def make_did(private_key: Ed25519PrivateKey) -> str:
+    public_key = private_key.public_key().public_bytes_raw()
+    encoded = base58_encode(MULTICODEC_ED25519 + public_key)
+    return "did:key:z" + encoded
+
+
+private_key = Ed25519PrivateKey.generate()
+did = make_did(private_key)
+
+room = "lobby"
+nonce = 1
+original_text = "hello from the signed client"
+modified_text = "hello from the hacked client"
+
+canonical = f"{room}|{nonce}|{original_text}"
+signature = base64.urlsafe_b64encode(
+    private_key.sign(canonical.encode("utf-8"))
+).decode().rstrip("=")
+
+url = (
+    f"{BASE_URL}/r/{urllib.parse.quote(room, safe='')}"
+    f"/say-signed/{urllib.parse.quote(did, safe='')}"
+    f"/{urllib.parse.quote(signature, safe='')}"
+    f"/{nonce}"
+    f"/{urllib.parse.quote(modified_text, safe='')}"
+)
+
+try:
+    urllib.request.urlopen(url)
+except urllib.error.HTTPError as exc:
+    assert exc.code == 403, f"expected 403, got {exc.code}"
+    print("PASS: modified signed content was rejected with HTTP 403")
+else:
+    raise AssertionError("server accepted content that was not covered by the signature")

--- a/uv.lock
+++ b/uv.lock
@@ -420,7 +420,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.3.3"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
SUMMARY

Adds a small Ed25519 `did:key` client and a negative signature-verification test for the signed write lane.

WHAT I CHANGED

- Added `signed_client.py`
  - Generates an Ed25519 keypair.
  - Creates a `did:key` using the Ed25519 multicodec.
  - Builds the canonical `<room>|<nonce>|<text>` payload.
  - Signs the payload using Ed25519.
  - Sends the signed request to `/say-signed`.

- Added `test_bad_signature.py`
  - Reuses a valid DID/signature.
  - Modifies the signed message content.
  - Confirms the server rejects the modified content with HTTP 403.

- Updated `uv.lock` to reflect the current `0.4.0` project version.

VERIFICATION

The signed client successfully received HTTP 200.

The modified-content test returned:

`PASS: modified signed content was rejected with HTTP 403`

This confirms that changing the message after signing causes signature verification to fail.