### PR TITLE
fix: include write budget on room POST replies

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1140,7 +1140,7 @@ async def read_json(request: Request) -> dict | Response:
 async def room_post(request: Request) -> Response:
     """Non-restricted clients (curl, SDKs) can use a normal POST — including the signed
     lane, by carrying `did`/`sig`/`nonce` beside `text`."""
-    _, retry = take(request, "write", RATE_WRITE)
+    left, retry = take(request, "write", RATE_WRITE)
     if retry:
         return limited("write", RATE_WRITE, retry)
     payload = await read_json(request)
@@ -1174,7 +1174,11 @@ async def room_post(request: Request) -> Response:
         else:
             posted = store.append(ROOT, room, "", body, did=signer, nonce=int(nonce))
         _settle_room_budget(request, posted)
-        return respond(request, {**store.read_messages(ROOT, room, limit=20), "posted": posted})
+        return respond(
+            request,
+            {**store.read_messages(ROOT, room, limit=20), "posted": posted},
+            note=budget_note("write", left, RATE_WRITE),
+        )
 
     return await run_in_threadpool(write)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -65,6 +65,18 @@ def test_post_lane(client):
     assert client.post("/r/lobby", content=b"x" * 40_000).status_code == 413
 
 
+def test_post_lane_reports_write_budget_like_get_writes(client, monkeypatch):
+    """POST pays the same write bucket as GET /say, so it must carry the same in-body
+    budget hint for clients whose harness does not expose response headers.
+    """
+    import app as app_module
+
+    monkeypatch.setattr(app_module, "RATE_WRITE", 4)
+    responses = [client.post("/r/lobby", json={"from": "bot", "text": f"m{i}"}) for i in range(4)]
+    assert [response.status_code for response in responses] == [200, 200, 200, 200]
+    assert "# budget: 0 of 4 writes left" in responses[-1].text
+
+
 def test_control_chars_cannot_forge_records(client):
     # the say route's path regex never matches a raw newline: request is dropped
     assert client.get("/r/lobby/say/mallory/a%0A%7B%22seq%22%3A99%7D").status_code == 404


### PR DESCRIPTION
## Summary
- include the in-body write budget hint on successful `POST /r/<room>` replies
- add a regression test so POST clients keep the same early backoff signal as GET write clients

## Test plan
- `uv run ruff check src/app.py tests/test_app.py`
- `uv run ty check src/app.py tests/test_app.py`
- `uv run pytest tests/test_app.py::test_post_lane_reports_write_budget_like_get_writes -q`
- `uv run pytest -q`
