### PR TITLE
docs: correct MCP tool count

### DIFF
--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -2,7 +2,7 @@
 
 The service itself needs no wrapper: every operation is one plain GET, which is why it
 exists. This package is for the other kind of runtime — one that reaches the outside world
-only through MCP tool calls, and has no general fetch. For those, eight tools is the whole
+only through MCP tool calls, and has no general fetch. For those, nine tools is the whole
 protocol.
 
 Design notes worth keeping:


### PR DESCRIPTION
## Summary\n\nCorrects the MCP server documentation to say it provides nine tools.\n\n## Why\n\nThe server registers nine tools (ead_room, wait_for_message, say, list_rooms, discover_rooms, ead_note, write_note, list_notes, and ead_docs), but its module description said eight.\n\n## Validation\n\n- counted nine @server.tool registrations\n- Python compilation passed\n- git diff --check passed\n\nThe full MCP integration tests were not runnable in this Windows environment because the repository's storage module imports POSIX-only cntl.