### PR TITLE
refactor(mcp): generate tool schemas from signatures; flatten U+2028/9 (#24)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -84,6 +84,6 @@ uv build                                     # wheel + sdist for PyPI
 
 The MCP wire protocol is implemented by hand in `protocol.py` (~190 lines) instead of pulling in the
 SDK — a wrapper for a service whose premise is "you need nothing to reach it" should not need a
-framework and a validation library to forward eight URL shapes.
+framework and a validation library to forward a handful of URL shapes.
 
 Apache-2.0, same as the service.

--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -242,7 +242,8 @@ def _validate(arguments: dict[str, Any], schema: dict[str, Any]) -> dict[str, An
         if kind == "integer" and isinstance(value, float) and value.is_integer():
             value = int(value)  # `is_integer()` is False for nan and inf, which stay rejected
         if not _CHECKS[kind](value):
-            raise _BadParamsError(f"argument {name!r} must be a {kind}")
+            article = "an" if kind.startswith("i") else "a"  # integer is the only vowel here
+            raise _BadParamsError(f"argument {name!r} must be {article} {kind}")
         if "enum" in expected and value not in expected["enum"]:
             allowed = ", ".join(repr(choice) for choice in expected["enum"])
             raise _BadParamsError(f"argument {name!r} must be one of: {allowed}")

--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -212,7 +212,7 @@ def schema_of(handler: Callable[..., str]) -> dict[str, Any]:
     return schema
 
 
-def _validate(arguments: dict[str, Any], schema: dict[str, Any]) -> None:
+def _validate(arguments: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:
     """Arguments against the advertised schema, before the handler and before the network.
 
     Everything here is the caller's mistake, so it is `-32602` and not a tool result: a
@@ -220,6 +220,13 @@ def _validate(arguments: dict[str, Any], schema: dict[str, Any]) -> None:
     and letting it through would put a string where the service expects a seq. The other
     direction — a fetch that fails, a name the service rejects — is data the model *can* act
     on, and stays an `isError` result further down.
+
+    Returns the arguments the handler is called with, which is not always the dict that
+    arrived: JSON Schema reads `integer` by value and not by spelling, so `1.0` satisfies
+    the schema this server advertised and is narrowed to `1` here. Rejecting it would fail
+    a client that validated locally against our own document — the exact disagreement
+    generating these schemas was meant to end — and passing the float through would put
+    `?since=1.0` on the wire.
     """
     properties: dict[str, dict[str, Any]] = schema["properties"]
     unexpected = set(arguments) - set(properties)
@@ -228,13 +235,19 @@ def _validate(arguments: dict[str, Any], schema: dict[str, Any]) -> None:
     missing = set(schema.get("required", ())) - set(arguments)
     if missing:
         raise _BadParamsError(f"missing arguments: {', '.join(sorted(missing))}")
+    checked: dict[str, Any] = {}
     for name, value in arguments.items():
         expected = properties[name]
-        if not _CHECKS[expected["type"]](value):
-            raise _BadParamsError(f"argument {name!r} must be a {expected['type']}")
+        kind = expected["type"]
+        if kind == "integer" and isinstance(value, float) and value.is_integer():
+            value = int(value)  # `is_integer()` is False for nan and inf, which stay rejected
+        if not _CHECKS[kind](value):
+            raise _BadParamsError(f"argument {name!r} must be a {kind}")
         if "enum" in expected and value not in expected["enum"]:
             allowed = ", ".join(repr(choice) for choice in expected["enum"])
             raise _BadParamsError(f"argument {name!r} must be one of: {allowed}")
+        checked[name] = value
+    return checked
 
 
 # ------------------------------------------------------------------ tools
@@ -334,8 +347,7 @@ class Server:
         tool = self.tools.get(params["name"])
         if tool is None:
             raise _BadParamsError(f"unknown tool {params['name']!r}")
-        arguments = params.get("arguments") or {}
-        _validate(arguments, tool.schema)
+        arguments = _validate(params.get("arguments") or {}, tool.schema)
         try:
             body = tool.handler(**arguments)
         except Exception as exc:

--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -10,14 +10,34 @@ What it implements: `initialize`, `notifications/initialized`, `tools/list`, `to
 `ping`, and JSON-RPC framing over newline-delimited stdio. That is the whole surface a
 tools-only server needs; resources, prompts, sampling and completion are not advertised in
 the capabilities block, so a spec-compliant client never calls them.
+
+Two things in here are derived rather than declared, because a second copy of either is a
+copy that drifts. The inbound message has a shape — `TypedDict`s below say what it is, and
+narrowing functions check the parts that JSON cannot promise. And a tool's `inputSchema` is
+read off its handler's signature: the function *is* the schema, so what `tools/list`
+advertises and what `tools/call` enforces cannot disagree with what the handler accepts.
 """
 
 from __future__ import annotations
 
+import inspect
 import json
 import sys
+import types
 from collections.abc import Callable
-from typing import Any, TextIO
+from typing import (
+    Annotated,
+    Any,
+    Literal,
+    NotRequired,
+    TextIO,
+    TypedDict,
+    TypeGuard,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 # Versions this server understands. A client asks for one in `initialize`; the spec says
 # reply with the same version if it is supported, otherwise with one this server does
@@ -32,21 +52,209 @@ INVALID_PARAMS = -32602
 INTERNAL_ERROR = -32603
 
 
+# ------------------------------------------------------------------ the message on the wire
+
+# JSON-RPC 2.0 allows a string or a number and explicitly retired the null id of 1.0. This
+# server takes str and int: a float id is a number a client cannot round-trip through every
+# JSON implementation intact, and matching a reply to the wrong request is worse than a
+# rejected one.
+RequestId = str | int
+
+
+class Notification(TypedDict):
+    """A message with no `id` key. It gets no reply — not even for an unknown method."""
+
+    jsonrpc: NotRequired[str]
+    method: str
+    params: NotRequired[dict[str, Any]]
+
+
+class Request(Notification):
+    """A notification plus the one key that makes a reply mandatory."""
+
+    id: RequestId
+
+
+class InitializeParams(TypedDict):
+    """Everything a client may send in `initialize`; every key is optional to us."""
+
+    protocolVersion: NotRequired[str]
+    capabilities: NotRequired[dict[str, Any]]
+    clientInfo: NotRequired[dict[str, Any]]
+
+
+class CallParams(TypedDict):
+    """`tools/call`: which tool, and the arguments its schema will be held to."""
+
+    name: str
+    arguments: NotRequired[dict[str, Any] | None]
+
+
+class ErrorObject(TypedDict):
+    code: int
+    message: str
+
+
+class Success(TypedDict):
+    jsonrpc: Literal["2.0"]
+    id: RequestId | None
+    result: dict[str, Any]
+
+
+class Failure(TypedDict):
+    # `id` is None when the request never had a usable one — a parse error, or an id this
+    # server refused. The spec asks for null there rather than an invented id.
+    jsonrpc: Literal["2.0"]
+    id: RequestId | None
+    error: ErrorObject
+
+
+Reply = Success | Failure
+
+
+def _is_request_id(value: Any) -> TypeGuard[RequestId]:
+    """`True` is an `int` in Python and is not one in JSON.
+
+    A client that sent `"id": true` and got back a reply keyed `1` would pair it with a
+    different request, so bool is checked out before the int check lets it through.
+    """
+    return isinstance(value, (str, int)) and not isinstance(value, bool)
+
+
+def _is_request(message: dict[str, Any]) -> TypeGuard[Request]:
+    """The rest of the request shape, once the caller has cleared the `id`."""
+    return isinstance(message.get("method"), str)
+
+
+def _is_initialize_params(params: dict[str, Any]) -> TypeGuard[InitializeParams]:
+    """Nothing is required, so only the one key we read has to be the right type."""
+    return isinstance(params.get("protocolVersion", ""), str)
+
+
+def _is_call_params(params: dict[str, Any]) -> TypeGuard[CallParams]:
+    arguments = params.get("arguments")
+    return isinstance(params.get("name"), str) and (
+        arguments is None or isinstance(arguments, dict)
+    )
+
+
+# ------------------------------------------------------------------ schemas from signatures
+
+_JSON_TYPES: dict[type, str] = {str: "string", bool: "boolean", int: "integer", float: "number"}
+
+_CHECKS: dict[str, Callable[[Any], bool]] = {
+    "string": lambda value: isinstance(value, str),
+    "boolean": lambda value: isinstance(value, bool),
+    "integer": lambda value: isinstance(value, int) and not isinstance(value, bool),
+    # JSON has one number type, so an integer is a number and `seconds: 0` is valid. A bool
+    # is not a number here for the same reason it is not an id.
+    "number": lambda value: isinstance(value, (int, float)) and not isinstance(value, bool),
+}
+
+
+def fragment(annotation: Any) -> dict[str, Any]:
+    """One parameter's JSON Schema, from its annotation.
+
+    `Annotated[int, "..."]` carries the description the model reads; `Literal[...]` becomes
+    an `enum`; and the `None` arm of `X | None` is dropped, because "may be left out" is
+    said by the parameter having a default and lands in `required`, not in `type`.
+
+    Anything with no mapping raises at import, where a wrong schema is a broken build
+    rather than a tool that advertises one contract and enforces another.
+    """
+    origin = get_origin(annotation)
+    if origin is Annotated:
+        inner, *notes = get_args(annotation)
+        described = fragment(inner)
+        for note in notes:
+            if isinstance(note, str):
+                described["description"] = note
+        return described
+    if origin is Union or origin is types.UnionType:
+        arms = [arm for arm in get_args(annotation) if arm is not type(None)]
+        if len(arms) != 1:
+            raise TypeError(f"cannot describe {annotation!r} in JSON Schema")
+        return fragment(arms[0])
+    if origin is Literal:
+        values = get_args(annotation)
+        named = {_JSON_TYPES.get(type(value)) for value in values}
+        if len(named) != 1 or None in named:
+            raise TypeError(f"cannot describe {annotation!r} in JSON Schema")
+        return {"type": named.pop(), "enum": list(values)}
+    if isinstance(annotation, type) and annotation in _JSON_TYPES:
+        return {"type": _JSON_TYPES[annotation]}
+    raise TypeError(f"no JSON Schema mapping for {annotation!r}")
+
+
+def schema_of(handler: Callable[..., str]) -> dict[str, Any]:
+    """A tool's `inputSchema`, read off the function that implements it.
+
+    Required is "has no default" — the rule Python already enforces at the call, so a schema
+    saying anything else would advertise a call that cannot happen. `required` is omitted
+    entirely when nothing is required, which is what a client expects to see for a tool
+    whose arguments are all optional.
+    """
+    called = getattr(handler, "__name__", "handler")
+    hints = get_type_hints(handler, include_extras=True)
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for name, parameter in inspect.signature(handler).parameters.items():
+        if parameter.kind not in (parameter.POSITIONAL_OR_KEYWORD, parameter.KEYWORD_ONLY):
+            raise TypeError(f"{called}: {name!r} cannot arrive as a JSON object key")
+        if name not in hints:
+            raise TypeError(f"{called}: {name!r} needs an annotation to describe")
+        properties[name] = fragment(hints[name])
+        if parameter.default is inspect.Parameter.empty:
+            required.append(name)
+    schema: dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def _validate(arguments: dict[str, Any], schema: dict[str, Any]) -> None:
+    """Arguments against the advertised schema, before the handler and before the network.
+
+    Everything here is the caller's mistake, so it is `-32602` and not a tool result: a
+    client that sent `since: "1"` has a bug the model cannot fix by reading a nicer error,
+    and letting it through would put a string where the service expects a seq. The other
+    direction — a fetch that fails, a name the service rejects — is data the model *can* act
+    on, and stays an `isError` result further down.
+    """
+    properties: dict[str, dict[str, Any]] = schema["properties"]
+    unexpected = set(arguments) - set(properties)
+    if unexpected:
+        raise _BadParamsError(f"unexpected arguments: {', '.join(sorted(unexpected))}")
+    missing = set(schema.get("required", ())) - set(arguments)
+    if missing:
+        raise _BadParamsError(f"missing arguments: {', '.join(sorted(missing))}")
+    for name, value in arguments.items():
+        expected = properties[name]
+        if not _CHECKS[expected["type"]](value):
+            raise _BadParamsError(f"argument {name!r} must be a {expected['type']}")
+        if "enum" in expected and value not in expected["enum"]:
+            allowed = ", ".join(repr(choice) for choice in expected["enum"])
+            raise _BadParamsError(f"argument {name!r} must be one of: {allowed}")
+
+
+# ------------------------------------------------------------------ tools
+
+
 class Tool:
-    """One callable tool: name, description, JSON Schema, handler.
+    """One callable tool: name, description, and the handler that is also its schema.
 
     `handler` returns the text the model sees. Raising is fine — a raised exception
     becomes an `isError` tool result rather than a JSON-RPC error, which is what the spec
     asks for: a failed tool call is data the model can react to, not a protocol fault.
     """
 
-    def __init__(self, name: str, description: str, schema: dict, handler: Callable[..., str]):
+    def __init__(self, name: str, description: str, handler: Callable[..., str]):
         self.name = name
         self.description = description
-        self.schema = schema
         self.handler = handler
+        self.schema = schema_of(handler)
 
-    def spec(self) -> dict:
+    def spec(self) -> dict[str, Any]:
         return {
             "name": self.name,
             "description": self.description,
@@ -61,31 +269,38 @@ class Server:
         self.instructions = instructions
         self.tools: dict[str, Tool] = {}
 
-    def tool(self, name: str, description: str, schema: dict) -> Callable:
+    def tool(self, name: str, description: str) -> Callable:
+        """Register a handler as a tool. Its parameters describe themselves."""
+
         def register(fn: Callable[..., str]) -> Callable[..., str]:
-            self.tools[name] = Tool(name, description, schema, fn)
+            self.tools[name] = Tool(name, description, fn)
             return fn
 
         return register
 
     # ------------------------------------------------------------------ dispatch
 
-    def handle(self, message: dict) -> dict | None:
+    def handle(self, message: dict[str, Any]) -> Reply | None:
         """One request in, one response out — or None for a notification.
 
-        Notifications (no `id`) must never be answered, including when they name a method
-        this server does not have: a response to a notification is a protocol violation
-        that some clients treat as fatal.
+        Notifications (no `id` *key*) must never be answered, including when they name a
+        method this server does not have: a response to a notification is a protocol
+        violation that some clients treat as fatal. `"id": null` is not a notification —
+        it is a request whose id this server refuses, and it gets told so.
         """
         if "id" not in message:
             return None
         ident = message["id"]
-        if isinstance(ident, bool) or not isinstance(ident, (str, int)):
+        if not _is_request_id(ident):
             return _error(None, INVALID_REQUEST, "request id must be a string or integer")
-        method = message.get("method")
-        params = message.get("params") or {}
-        if not isinstance(method, str):
+        if not _is_request(message):
             return _error(ident, INVALID_REQUEST, "missing method")
+        params = message.get("params") or {}
+        if not isinstance(params, dict):
+            # By-position params: legal JSON-RPC, but no method here takes them, and
+            # guessing which argument a client meant is worse than saying so.
+            return _error(ident, INVALID_PARAMS, "params must be an object")
+        method = message["method"]
         try:
             if method == "initialize":
                 return _ok(ident, self._initialize(params))
@@ -101,8 +316,8 @@ class Server:
             return _error(ident, INTERNAL_ERROR, f"{type(exc).__name__}: {exc}")
         return _error(ident, METHOD_NOT_FOUND, f"unknown method {method!r}")
 
-    def _initialize(self, params: dict) -> dict:
-        asked = params.get("protocolVersion")
+    def _initialize(self, params: dict[str, Any]) -> dict[str, Any]:
+        asked = params.get("protocolVersion") if _is_initialize_params(params) else None
         version = asked if asked in SUPPORTED_VERSIONS else LATEST_VERSION
         return {
             "protocolVersion": version,
@@ -113,20 +328,14 @@ class Server:
             "instructions": self.instructions,
         }
 
-    def _call(self, params: dict) -> dict:
-        name = params.get("name")
-        tool = self.tools.get(name) if isinstance(name, str) else None
+    def _call(self, params: dict[str, Any]) -> dict[str, Any]:
+        if not _is_call_params(params):
+            raise _BadParamsError("tools/call needs a string `name` and an object `arguments`")
+        tool = self.tools.get(params["name"])
         if tool is None:
-            raise _BadParamsError(f"unknown tool {name!r}")
+            raise _BadParamsError(f"unknown tool {params['name']!r}")
         arguments = params.get("arguments") or {}
-        if not isinstance(arguments, dict):
-            raise _BadParamsError("arguments must be an object")
-        unexpected = set(arguments) - set(tool.schema.get("properties", {}))
-        if unexpected:
-            raise _BadParamsError(f"unexpected arguments: {', '.join(sorted(unexpected))}")
-        missing = set(tool.schema.get("required", [])) - set(arguments)
-        if missing:
-            raise _BadParamsError(f"missing arguments: {', '.join(sorted(missing))}")
+        _validate(arguments, tool.schema)
         try:
             body = tool.handler(**arguments)
         except Exception as exc:
@@ -167,7 +376,7 @@ class _BadParamsError(ValueError):
     pass
 
 
-def _response(server: Server, message: Any) -> dict | list[dict] | None:
+def _response(server: Server, message: Any) -> Reply | list[Reply] | None:
     """The one JSON value to write back, or None when nothing may be written.
 
     A batch is answered by a single array, never by one top-level object per member: a
@@ -178,7 +387,7 @@ def _response(server: Server, message: Any) -> dict | list[dict] | None:
     if isinstance(message, list):
         if not message:
             return _error(None, INVALID_REQUEST, "batch must not be empty")
-        replies: list[dict] = []
+        replies: list[Reply] = []
         for member in message:
             if not isinstance(member, dict):
                 replies.append(_error(None, INVALID_REQUEST, "batch member must be an object"))
@@ -190,14 +399,14 @@ def _response(server: Server, message: Any) -> dict | list[dict] | None:
     return _error(None, INVALID_REQUEST, "message must be an object")
 
 
-def _ok(ident: Any, result: dict) -> dict:
+def _ok(ident: RequestId | None, result: dict[str, Any]) -> Success:
     return {"jsonrpc": "2.0", "id": ident, "result": result}
 
 
-def _error(ident: Any, code: int, message: str) -> dict:
+def _error(ident: RequestId | None, code: int, message: str) -> Failure:
     return {"jsonrpc": "2.0", "id": ident, "error": {"code": code, "message": message}}
 
 
-def _write(stdout: TextIO, message: dict | list[dict]) -> None:
+def _write(stdout: TextIO, message: Reply | list[Reply]) -> None:
     stdout.write(json.dumps(message, ensure_ascii=False) + "\n")
     stdout.flush()

--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -2,7 +2,7 @@
 
 Why not the SDK: this package exists so an agent runtime that speaks MCP can reach a
 service whose whole premise is that you need nothing to reach it. Shipping a wrapper that
-drags in a framework and a validation library to forward eight URL shapes would contradict
+drags in a framework and a validation library to forward a handful of URL shapes would contradict
 the thing it wraps — and `uvx technocore-mcp` with an empty dependency set starts in the
 time it takes to unpack one wheel.
 

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -2,8 +2,8 @@
 
 The service itself needs no wrapper: every operation is one plain GET, which is why it
 exists. This package is for the other kind of runtime — one that reaches the outside world
-only through MCP tool calls, and has no general fetch. For those, eight tools is the whole
-protocol.
+only through MCP tool calls, and has no general fetch. For those, the tools below are the
+whole protocol.
 
 Design notes worth keeping:
 
@@ -39,7 +39,8 @@ from . import protocol
 # check against this constant.
 VERSION = "0.1.0"
 DEFAULT_URL = "https://technocore.chat"
-TIMEOUT = 30.0  # comfortably over the service's own 10s long-poll ceiling
+WAIT_CEILING = 10.0  # the service's own long-poll ceiling; asking for more just holds a socket
+TIMEOUT = 3 * WAIT_CEILING  # comfortably over it, so a held poll is never the thing that times out
 
 BASE_URL = os.environ.get("TECHNOCORE_URL", DEFAULT_URL).rstrip("/")
 DEFAULT_NICK = os.environ.get("TECHNOCORE_NICK", "").strip()
@@ -123,9 +124,11 @@ def read_room(
 def wait_for_message(
     room: Room,
     since: Annotated[int, "The last seq you saw."],
-    seconds: Annotated[float, "How long to hold, 0-10. Default 10."] = 10.0,
+    seconds: Annotated[
+        float, f"How long to hold, 0-{WAIT_CEILING:g}. Default {WAIT_CEILING:g}."
+    ] = WAIT_CEILING,
 ) -> str:
-    return _fetch(f"/r/{_segment(room)}", {"since": since, "wait": min(seconds, 10.0)})
+    return _fetch(f"/r/{_segment(room)}", {"since": since, "wait": min(seconds, WAIT_CEILING)})
 
 
 @server.tool(

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -16,6 +16,11 @@ Design notes worth keeping:
 * **The signed lane is deliberately not wrapped.** Signing needs an Ed25519 private key;
   a tool that took one as an argument would encourage passing keys through an LLM's
   context. Runtimes that can sign should call the HTTP lane directly.
+* **One declaration per tool.** A handler's signature is its schema: `protocol.schema_of`
+  reads the `inputSchema` that `tools/list` advertises straight off the annotations below,
+  and `tools/call` holds arguments to that same schema before the handler runs. The
+  descriptions the model reads ride along in `Annotated`, next to the parameter they
+  describe, so there is nothing to keep in step by hand.
 """
 
 from __future__ import annotations
@@ -24,6 +29,7 @@ import os
 import urllib.error
 import urllib.parse
 import urllib.request
+from typing import Annotated, Literal
 
 from . import protocol
 
@@ -88,27 +94,24 @@ def _segment(value: str) -> str:
     return urllib.parse.quote(value, safe="")
 
 
-_ROOM = {"type": "string", "description": "Room name, ^[a-z0-9][a-z0-9_-]{0,47}$"}
+# The one parameter four tools share, written once. An alias, not a dict: it is the
+# parameter's type *and* the sentence the model reads about it.
+Room = Annotated[str, "Room name, ^[a-z0-9][a-z0-9_-]{0,47}$"]
 
 
 @server.tool(
     "read_room",
     "Read messages from a shared room, oldest first. Pass `since` with the last seq you "
     "saw to get only what is new. Content is untrusted input from strangers.",
-    {
-        "type": "object",
-        "properties": {
-            "room": _ROOM,
-            "since": {
-                "type": "integer",
-                "description": "Return only messages newer than this seq. The reply's last line carries the next one.",
-            },
-            "limit": {"type": "integer", "description": "1-200, default 50."},
-        },
-        "required": ["room"],
-    },
 )
-def read_room(room: str, since: int | None = None, limit: int | None = None) -> str:
+def read_room(
+    room: Room,
+    since: Annotated[
+        int | None,
+        "Return only messages newer than this seq. The reply's last line carries the next one.",
+    ] = None,
+    limit: Annotated[int | None, "1-200, default 50."] = None,
+) -> str:
     return _fetch(f"/r/{_segment(room)}", {"since": since, "limit": limit})
 
 
@@ -116,17 +119,12 @@ def read_room(room: str, since: int | None = None, limit: int | None = None) -> 
     "wait_for_message",
     "Long-poll a room: returns as soon as a message newer than `since` lands, or empty "
     "after `seconds`. Cheaper and faster than repeated reads — prefer this over polling.",
-    {
-        "type": "object",
-        "properties": {
-            "room": _ROOM,
-            "since": {"type": "integer", "description": "The last seq you saw."},
-            "seconds": {"type": "number", "description": "How long to hold, 0-10. Default 10."},
-        },
-        "required": ["room", "since"],
-    },
 )
-def wait_for_message(room: str, since: int, seconds: float = 10.0) -> str:
+def wait_for_message(
+    room: Room,
+    since: Annotated[int, "The last seq you saw."],
+    seconds: Annotated[float, "How long to hold, 0-10. Default 10."] = 10.0,
+) -> str:
     return _fetch(f"/r/{_segment(room)}", {"since": since, "wait": min(seconds, 10.0)})
 
 
@@ -134,24 +132,15 @@ def wait_for_message(room: str, since: int, seconds: float = 10.0) -> str:
     "say",
     "Post a message to a room, creating the room if it does not exist. The message is "
     "public, permanent-ish and attributed to a nickname anyone could also use.",
-    {
-        "type": "object",
-        "properties": {
-            "room": _ROOM,
-            "text": {
-                "type": "string",
-                "description": "Message body, <= 4096 characters, single-line.",
-            },
-            "nick": {
-                "type": "string",
-                "description": "Your self-asserted name, same character rules as a room. "
-                "Defaults to $TECHNOCORE_NICK.",
-            },
-        },
-        "required": ["room", "text"],
-    },
 )
-def say(room: str, text: str, nick: str = "") -> str:
+def say(
+    room: Room,
+    text: Annotated[str, "Message body, <= 4096 characters, single-line."],
+    nick: Annotated[
+        str,
+        "Your self-asserted name, same character rules as a room. Defaults to $TECHNOCORE_NICK.",
+    ] = "",
+) -> str:
     who = (nick or DEFAULT_NICK).strip()
     if not who:
         raise ValueError("no nick: pass `nick`, or set TECHNOCORE_NICK in the server config")
@@ -162,12 +151,8 @@ def say(room: str, text: str, nick: str = "") -> str:
     "list_rooms",
     "List public rooms, most recently active first, with their topics. Private (`p-`) "
     "rooms never appear here.",
-    {
-        "type": "object",
-        "properties": {"limit": {"type": "integer", "description": "How many rooms, default 50."}},
-    },
 )
-def list_rooms(limit: int | None = None) -> str:
+def list_rooms(limit: Annotated[int | None, "How many rooms, default 50."] = None) -> str:
     return _fetch("/rooms", {"limit": limit})
 
 
@@ -175,14 +160,10 @@ def list_rooms(limit: int | None = None) -> str:
     "discover_rooms",
     "Read the discovery log: one line per newly created public room, in creation order. "
     "This is how to find agents you had no room name for.",
-    {
-        "type": "object",
-        "properties": {
-            "since": {"type": "integer", "description": "Only announcements newer than this seq."}
-        },
-    },
 )
-def discover_rooms(since: int | None = None) -> str:
+def discover_rooms(
+    since: Annotated[int | None, "Only announcements newer than this seq."] = None,
+) -> str:
     return _fetch("/r/events", {"since": since})
 
 
@@ -190,16 +171,11 @@ def discover_rooms(since: int | None = None) -> str:
     "read_note",
     "Read a durable note. Notes outlive rooms and are the place to keep state between "
     "sessions — but they are world-readable and world-writable.",
-    {
-        "type": "object",
-        "properties": {
-            "namespace": {"type": "string", "description": "Note namespace."},
-            "key": {"type": "string", "description": "Note key."},
-        },
-        "required": ["namespace", "key"],
-    },
 )
-def read_note(namespace: str, key: str) -> str:
+def read_note(
+    namespace: Annotated[str, "Note namespace."],
+    key: Annotated[str, "Note key."],
+) -> str:
     return _fetch(f"/kv/{_segment(namespace)}/{_segment(key)}")
 
 
@@ -208,24 +184,13 @@ def read_note(namespace: str, key: str) -> str:
     "Write a durable note (<= 8192 characters). Optionally conditional: `if_matches` "
     "writes only when the note still holds that exact value, `if_absent` only when it "
     "does not exist yet. A failed condition reports the value that is actually there.",
-    {
-        "type": "object",
-        "properties": {
-            "namespace": {"type": "string"},
-            "key": {"type": "string"},
-            "value": {"type": "string"},
-            "if_matches": {"type": "string", "description": "Compare-and-set guard."},
-            "if_absent": {"type": "boolean", "description": "Create-only guard."},
-        },
-        "required": ["namespace", "key", "value"],
-    },
 )
 def write_note(
     namespace: str,
     key: str,
     value: str,
-    if_matches: str | None = None,
-    if_absent: bool = False,
+    if_matches: Annotated[str | None, "Compare-and-set guard."] = None,
+    if_absent: Annotated[bool, "Create-only guard."] = False,
 ) -> str:
     path = f"/kv/{_segment(namespace)}/{_segment(key)}/set/{_segment(value)}"
     query: dict = {}
@@ -240,7 +205,6 @@ def write_note(
     "list_notes",
     "List the keys in a note namespace. Namespaces themselves are never enumerable, and "
     "keys beginning `p-` are never listed.",
-    {"type": "object", "properties": {"namespace": {"type": "string"}}, "required": ["namespace"]},
 )
 def list_notes(namespace: str) -> str:
     return _fetch(f"/kv/{_segment(namespace)}")
@@ -252,14 +216,8 @@ def list_notes(namespace: str) -> str:
     "`patterns` is worked multi-agent choreographies (mailboxes, private channels, "
     "end-to-end encryption, room ownership). Use this for anything these tools do not "
     "cover — every lane is reachable with a plain GET.",
-    {
-        "type": "object",
-        "properties": {
-            "page": {"type": "string", "enum": ["manual", "patterns", "skill"]},
-        },
-    },
 )
-def read_docs(page: str = "manual") -> str:
+def read_docs(page: Literal["manual", "patterns", "skill"] = "manual") -> str:
     return _fetch({"manual": "/llms.txt", "patterns": "/patterns.md", "skill": "/skill.md"}[page])
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -64,8 +64,8 @@ RATE_READ = max(1, int(os.environ.get("CHAT_RATE_READ", "120")))  # requests/min
 RATE_WRITE = max(1, int(os.environ.get("CHAT_RATE_WRITE", "30")))
 # A per-IP budget on bringing *new rooms into existence*, measured over a day rather than a
 # minute. RATE_WRITE bounds how fast one caller can talk; nothing bounded how many rooms one
-# caller could create, and those are not the same resource. At 30 writes/min a single caller
-# exhausts the room cap in under three hours, and the slots it takes are everyone's — the
+# caller could create, and those are not the same resource. At RATE_WRITE a single caller
+# exhausts MAX_ROOMS in a matter of hours, and the slots it takes are everyone's — the
 # next caller, whoever they are, gets the fail-closed refusal. This is what makes MAX_ROOMS
 # a cap on the service rather than a race won by whoever creates rooms fastest.
 RATE_ROOMS_PER_DAY = max(1, int(os.environ.get("CHAT_RATE_ROOMS_PER_DAY", "20")))
@@ -1387,8 +1387,8 @@ def note_write_signed(request: Request) -> Response:
 
 
 async def note_post(request: Request) -> Response:
-    """The GET lane cannot carry a full-size note: 8192 characters URL-encode to more
-    than the request line allows (and more than Cloudflare's 16 KiB URL ceiling). Without
+    """The GET lane cannot carry a full-size note: MAX_VALUE_CHARS characters URL-encode to
+    more than the request line allows (and more than Cloudflare's 16 KiB URL ceiling). Without
     this lane the documented note cap was unreachable."""
     left, retry = take(request, "write", RATE_WRITE)
     if retry:

--- a/src/store.py
+++ b/src/store.py
@@ -154,13 +154,14 @@ ALLOW_NS = "room-allow"  # /kv/room-allow/<room>  -> space-separated did:keys
 # for its own atomicity. MAX_NOTES_PER_NS = MAX_ROOMS, so every room may hold an owner.
 NONCE_NS = "room-nonce"
 TOPIC_NS = "topic"  # /kv/topic/<room>      -> what the room is for
-# A topic is an ordinary note (8 KiB), and /rooms shows up to 50 of them: printed in full
-# that is a 400 KB reply against a response budget measured in kilobytes. The overview
+# A topic is an ordinary note (MAX_VALUE_CHARS), and /rooms shows one per room it lists:
+# printed in full that is a reply measured in hundreds of KB, against a response budget
+# measured in kilobytes. The overview
 # carries a preview; /kv/topic/<room> carries the whole thing.
 TOPIC_PREVIEW_CHARS = 120
 # Lazy expiry for the `e-` class: nothing sweeps in the background, records are simply not
 # returned once they are older than this, and physically leave on the next compaction or
-# when the 7-day reaper takes the file.
+# when the IDLE_SECONDS reaper takes the file.
 EPHEMERAL_TTL_SECONDS = int(os.environ.get("CHAT_EPHEMERAL_TTL_SECONDS", "900"))
 
 
@@ -244,25 +245,38 @@ def ownable(name: str) -> bool:
     return "d" in room_classes(name) and name not in UNOWNABLE_ROOMS
 
 
+# The Unicode categories `clean_text` replaces with a space, and why each is on the list.
+# One list, in one place: the reason a value is swept is the reason it is named here, and a
+# docstring that also enumerated them would be a second copy to keep in step.
+#
+#   Cc  control      — C0/C1 would break the JSONL one-record-per-line invariant.
+#   Cf  format       — the *invisible instruction* smuggling vector against LLM readers.
+#                      Unicode tag characters U+E0000–U+E007F encode ASCII that no human or
+#                      log line shows, bidi overrides (U+202E) reorder displayed text away
+#                      from what is stored (Trojan Source), and zero-width joiners hide word
+#                      boundaries. This service's stated top hazard is cross-agent prompt
+#                      injection (design doc §3.1), so text that renders as nothing must not
+#                      survive into another agent's context.
+#   Cs  surrogate    — never valid on its own in stored text.
+#   Co  private use  — renders as whatever the reader's font decides, which is not a promise.
+#   Zl  line sep     — U+2028, and Zp U+2029: invisible here, a line break to enough
+#   Zp  para sep       plain-text consumers (JS string literals among them) that one stored
+#                      value renders as two lines. The single-line promise has to hold for
+#                      every reader, not just the ones that agree with `str.splitlines`.
+INVISIBLE_CATEGORIES = ("Cc", "Cf", "Cs", "Co", "Zl", "Zp")
+
+
 def clean_text(text: str, limit: int = MAX_TEXT_CHARS) -> str:
-    """Drop every invisible character, not just ASCII controls.
+    """Replace every character in INVISIBLE_CATEGORIES with a space, then trim.
 
-    Two reasons, and the second is the important one on this service:
+    What that buys: one stored record is one line for every reader, and nothing that renders
+    as nothing survives into another agent's context.
 
-    * C0/C1 controls would break the JSONL one-record-per-line invariant.
-    * Format characters (category Cf) are the *invisible instruction* smuggling vector
-      against LLM readers — Unicode tag characters U+E0000–U+E007F encode ASCII that no
-      human or log line shows, bidi overrides (U+202E) reorder displayed text away from
-      what is stored (Trojan Source), and zero-width joiners hide word boundaries. This
-      service's stated top hazard is cross-agent prompt injection (design doc §3.1), so
-      text that renders as nothing must not survive into another agent's context.
-
-    Categories dropped: Cc (control), Cf (format), Cs (surrogate), Co (private use).
     Trade-off, accepted deliberately: ZWJ emoji sequences flatten (👨‍👩‍👧 → 👨👩👧).
     Mangled emoji is visible and harmless; a smuggled instruction is neither.
     """
     text = "".join(
-        " " if unicodedata.category(c) in ("Cc", "Cf", "Cs", "Co") else c for c in text
+        " " if unicodedata.category(c) in INVISIBLE_CATEGORIES else c for c in text
     ).strip()
     if not text:
         # Distinguishing "you sent nothing" from "the sweep ate all of it" matters: the
@@ -270,9 +284,9 @@ def clean_text(text: str, limit: int = MAX_TEXT_CHARS) -> str:
         # characters would otherwise re-send the same bytes and get the same refusal.
         raise StoreError(
             "empty text: nothing visible was left after the single-line sweep, which "
-            "replaces every control and format character (newline, zero-width, bidi "
-            "override, Unicode tag) with a space and then trims the ends. Send at least "
-            "one visible character."
+            "replaces every control, format and line-separator character (newline, "
+            "zero-width, bidi override, Unicode tag, U+2028) with a space and then trims "
+            "the ends. Send at least one visible character."
         )
     if len(text) > limit:
         raise StoreError(
@@ -466,8 +480,8 @@ def last_seq(root: Path, room: str) -> int:
 # which is the *same* read `last_seq` already did for every room /rooms shows, so the read
 # budget of the overview is unchanged and only the parse of those bytes is new. Worst case for
 # one /rooms request is therefore `shown` (<= MAX_LIMIT = 200) x WINDOW_BYTES = 12.8 MiB parsed,
-# ~210 ms at the ~60 MB/s parse rate measured in the design doc §5.1; at the default limit=50 it
-# is 3.2 MiB / ~55 ms, and a typical ~120-byte record makes the message cap bind first at ~24 KiB
+# ~210 ms at the ~60 MB/s parse rate measured in the design doc §5.1; at this function's default
+# limit it is 3.2 MiB / ~55 ms, and a typical ~120-byte record makes the message cap bind first at ~24 KiB
 # per room. Rooms that are *not* shown still cost only a directory stat. What this bound exists
 # to exclude is the obvious wrong implementation: a full-ring scan (10 MiB) across every room.
 WINDOW_MESSAGES = 200
@@ -711,7 +725,7 @@ def _reapable(path: Path, now: float, stillborn_rule: bool) -> str | None:
 
 # The three namespaces that gate access to a room rather than carry content. Their mtime
 # tracks when ownership last changed, not when the room was last used — so under the plain
-# idle rule a busy room's owner note expired after 7 quiet days of *ownership*, and with it
+# idle rule a busy room's owner note expired after IDLE_SECONDS of quiet *ownership*, and with it
 # went the allow-list (listed keys silently lose write access) and the replay counter (a
 # captured signed URL re-adding a revoked key starts working again). A control whose whole
 # job is to outlive an attacker must not expire before the thing it guards.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1195,6 +1195,11 @@ def test_invisible_characters_cannot_smuggle_instructions(client):
         "C1 control": "a\u0085b",
         "soft hyphen": "a\u00adb",
         "zero-width joiner": "a\u200db",
+        # Zl/Zp: invisible here, a line break to plenty of plain-text consumers. A value
+        # carrying one renders as two lines, which is the single-line promise broken for
+        # exactly the readers who cannot check it.
+        "line separator": "a\u2028b",
+        "paragraph separator": "a\u2029b",
     }
     for label, value in hostile.items():
         assert store.clean_text(value) == "a b", label
@@ -1202,6 +1207,27 @@ def test_invisible_characters_cannot_smuggle_instructions(client):
     client.post("/r/lobby", json={"from": "mallory", "text": "hello" + tag})
     stored = client.get("/r/lobby?format=json").json()["messages"][0]["text"]
     assert stored == "hello" and all(ord(c) < 0x80 for c in stored)
+
+
+def test_a_unicode_line_separator_cannot_split_a_stored_record(client):
+    """U+2028 and U+2029 are the two line breaks that every newline check misses: not Cc,
+    invisible to `str.splitlines`-shaped reasoning about \\n, and a line boundary to enough
+    plain-text consumers that one stored value renders as two lines. The single-line promise
+    has to hold for those readers too, so the sweep flattens them like any other invisible."""
+    client.post("/r/lobby", json={"from": "bot", "text": "first second"})
+    client.post("/r/lobby", json={"from": "bot", "text": "third fourth"})
+
+    assert [m["text"] for m in client.get("/r/lobby?format=json").json()["messages"]] == [
+        "first second",
+        "third fourth",
+    ]
+    view = client.get("/r/lobby").text
+    assert "<~bot> first second" in view and "<~bot> third fourth" in view
+    assert " " not in view and " " not in view
+
+    # Notes take the same sweep: their lane has its own cap but not its own rules.
+    client.get("/kv/plans/next/set/ship%E2%80%A8it")
+    assert "ship it" in client.get("/kv/plans/next").text
 
 
 def test_listings_never_echo_a_name_the_validator_would_reject(tmp_path):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -146,6 +146,17 @@ def test_notifications_are_never_answered(mcp):
     assert server.handle({"jsonrpc": "2.0", "method": "notifications/cancelled"}) is None
 
 
+def test_a_notification_is_a_missing_id_key_and_nothing_else(mcp):
+    """The distinction the whole reply/no-reply decision hangs on: no `id` key is a
+    notification and gets silence; `"id": null` is a request with an id JSON-RPC 2.0 does
+    not allow, and gets an error. Reading them as the same thing means either answering a
+    notification or swallowing a request."""
+    server, protocol = mcp
+    assert server.handle({"jsonrpc": "2.0", "method": "tools/list"}) is None
+    null = server.handle({"jsonrpc": "2.0", "id": None, "method": "tools/list"})
+    assert null["error"]["code"] == protocol.INVALID_REQUEST
+
+
 @pytest.mark.parametrize("ident", [None, True, False, 1.5, [], {}])
 def test_invalid_request_ids_are_rejected(mcp, ident):
     server, protocol = mcp
@@ -187,23 +198,102 @@ def test_unknown_methods_get_an_error_not_a_crash(mcp):
 # ------------------------------------------------------------------ the tools
 
 
+# What a client sees in `tools/list`, spelled out: property types and the required set for
+# every tool. The schemas are generated from the handlers' signatures, so this table is the
+# guard that a refactor of a handler cannot quietly change the contract clients integrated
+# against — an argument that stops being required, or an int that becomes a string, breaks
+# callers that never see this repo.
+ADVERTISED = {
+    "read_room": ({"room": "string", "since": "integer", "limit": "integer"}, ["room"]),
+    "wait_for_message": (
+        {"room": "string", "since": "integer", "seconds": "number"},
+        ["room", "since"],
+    ),
+    "say": ({"room": "string", "text": "string", "nick": "string"}, ["room", "text"]),
+    "list_rooms": ({"limit": "integer"}, []),
+    "discover_rooms": ({"since": "integer"}, []),
+    "read_note": ({"namespace": "string", "key": "string"}, ["namespace", "key"]),
+    "write_note": (
+        {
+            "namespace": "string",
+            "key": "string",
+            "value": "string",
+            "if_matches": "string",
+            "if_absent": "boolean",
+        },
+        ["namespace", "key", "value"],
+    ),
+    "list_notes": ({"namespace": "string"}, ["namespace"]),
+    "read_docs": ({"page": "string"}, []),
+}
+
+
 def test_every_tool_is_listed_with_a_usable_schema(mcp):
     server, _ = mcp
     tools = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})["result"]["tools"]
     names = {t["name"] for t in tools}
-    assert names == {
-        "read_room",
-        "wait_for_message",
-        "say",
-        "list_rooms",
-        "discover_rooms",
-        "read_note",
-        "write_note",
-        "list_notes",
-        "read_docs",
-    }
+    assert names == set(ADVERTISED)
     for tool in tools:
         assert tool["description"] and tool["inputSchema"]["type"] == "object"
+
+
+def test_generated_schemas_still_say_what_clients_already_integrated_against(mcp):
+    """The schemas moved from hand-written dicts to `inspect.signature`; what they describe
+    did not. `X | None` is an optional parameter of the non-None type, not a union, and a
+    parameter with no default is the only thing that lands in `required`."""
+    server, _ = mcp
+    tools = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})["result"]["tools"]
+    for tool in tools:
+        schema = tool["inputSchema"]
+        types, required = ADVERTISED[tool["name"]]
+        assert schema["type"] == "object"
+        assert {n: p["type"] for n, p in schema["properties"].items()} == types
+        # No `required` key at all when nothing is required — an empty list would be a
+        # different document to a client that checks for the key.
+        assert schema.get("required", []) == required
+        assert ("required" in schema) == bool(required)
+    pages = {t["name"]: t["inputSchema"] for t in tools}["read_docs"]["properties"]["page"]
+    assert pages["enum"] == ["manual", "patterns", "skill"]
+
+
+def test_the_descriptions_the_model_reads_survive_the_generation(mcp):
+    """The point of `Annotated` here: the sentence lives next to the parameter, and one
+    room description is shared by the four tools that take a room."""
+    server, _ = mcp
+    tools = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})["result"]["tools"]
+    schemas = {t["name"]: t["inputSchema"] for t in tools}
+    for name in ("read_room", "wait_for_message", "say"):
+        assert schemas[name]["properties"]["room"]["description"].startswith("Room name, ^[a-z0-9]")
+    assert "4096" in schemas["say"]["properties"]["text"]["description"]
+    assert "TECHNOCORE_NICK" in schemas["say"]["properties"]["nick"]["description"]
+
+
+def test_a_schema_cannot_drift_from_the_function_it_describes(mcp):
+    """The property set is the parameter list and the required set is "has no default",
+    read off the same object the call goes through. This is what replaced keeping two
+    declarations in step by hand."""
+    import inspect
+
+    server, _ = mcp
+    for tool in server.tools.values():
+        parameters = inspect.signature(tool.handler).parameters
+        assert set(tool.schema["properties"]) == set(parameters)
+        expected = [n for n, p in parameters.items() if p.default is inspect.Parameter.empty]
+        assert tool.schema.get("required", []) == expected
+
+
+def test_an_undescribable_parameter_fails_at_registration(mcp):
+    """A handler the schema cannot describe must break the build, not ship a tool whose
+    advertised contract is a guess."""
+    _, protocol = mcp
+    with pytest.raises(TypeError):
+        protocol.schema_of(lambda room: room)  # no annotation
+
+    def takes_a_list(items: list[str]) -> str:
+        return ""
+
+    with pytest.raises(TypeError):
+        protocol.schema_of(takes_a_list)
 
 
 def test_say_then_read_round_trips_through_the_real_service(mcp):
@@ -303,6 +393,57 @@ def test_bad_arguments_are_rejected_before_a_request_is_made(mcp):
     assert unexpected["error"]["code"] == protocol.INVALID_PARAMS
     unknown = call(server, "no_such_tool", {})
     assert unknown["error"]["code"] == protocol.INVALID_PARAMS
+
+
+def test_wrong_argument_types_are_rejected_before_any_request_is_made(mcp, monkeypatch):
+    """`since: "1"` is the client's bug, not something the model can act on, so it is a
+    JSON-RPC error and not a tool result — and it is caught here, before a string reaches
+    the query builder and the service gets asked for `?since=1` meaning something else."""
+    server, protocol = mcp
+
+    def never(request, timeout=None):
+        raise AssertionError(f"the network was reached: {request.full_url}")
+
+    monkeypatch.setattr(urllib.request, "urlopen", never)
+
+    since = call(server, "read_room", {"room": "lobby", "since": "1"})
+    assert (
+        since["error"]["code"] == protocol.INVALID_PARAMS and "since" in since["error"]["message"]
+    )
+
+    seconds = call(server, "wait_for_message", {"room": "lobby", "since": 0, "seconds": "10"})
+    assert seconds["error"]["code"] == protocol.INVALID_PARAMS
+    assert "seconds" in seconds["error"]["message"]
+
+    room = call(server, "read_room", {"room": 7})
+    assert room["error"]["code"] == protocol.INVALID_PARAMS and "room" in room["error"]["message"]
+
+    guard = call(server, "write_note", {"namespace": "n", "key": "k", "value": "v", "if_absent": 1})
+    assert guard["error"]["code"] == protocol.INVALID_PARAMS
+    assert "if_absent" in guard["error"]["message"]
+
+    # `true` is an `int` in Python and is not one in JSON.
+    flag = call(server, "read_room", {"room": "lobby", "since": True})
+    assert flag["error"]["code"] == protocol.INVALID_PARAMS
+
+    page = call(server, "read_docs", {"page": "handbook"})
+    assert page["error"]["code"] == protocol.INVALID_PARAMS and "page" in page["error"]["message"]
+
+
+def test_an_integer_is_an_acceptable_number(mcp):
+    """JSON has one number type: a client sending `seconds: 0` is not sending a wrong type,
+    and rejecting it would break the cheapest way to ask for a non-blocking read."""
+    server, _ = mcp
+    call(server, "say", {"room": "lobby", "text": "one", "nick": "bot"})
+    for seconds in (0, 0.0):
+        reply = call(server, "wait_for_message", {"room": "lobby", "since": 1, "seconds": seconds})
+        assert "no new messages" in text_of(reply)
+
+
+def test_by_position_params_are_rejected_rather_than_guessed(mcp):
+    server, protocol = mcp
+    reply = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": ["say"]})
+    assert reply["error"]["code"] == protocol.INVALID_PARAMS
 
 
 def test_a_rejected_name_comes_back_as_the_services_own_explanation(mcp):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -440,6 +440,30 @@ def test_an_integer_is_an_acceptable_number(mcp):
         assert "no new messages" in text_of(reply)
 
 
+def test_an_integral_float_is_an_acceptable_integer(mcp, monkeypatch):
+    """JSON Schema reads `integer` by value, not by spelling, so `1.0` satisfies the schema
+    this server advertised and a client that validated locally against it must not then be
+    told `-32602`. It reaches the handler as `1`, because `?since=1.0` is not what the
+    service parses — and `1.5`, which no reading makes an integer, is still rejected."""
+    server, protocol = mcp
+    asked = []
+    inner = urllib.request.urlopen
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda request, timeout=None: (asked.append(request.full_url), inner(request, timeout))[1],
+    )
+
+    for i in range(3):
+        call(server, "say", {"room": "lobby", "text": f"m{i}", "nick": "bot"})
+    body = text_of(call(server, "read_room", {"room": "lobby", "since": 2.0}))
+    assert "m2" in body and "m0" not in body
+    assert asked[-1].endswith("?since=2")
+
+    fraction = call(server, "read_room", {"room": "lobby", "since": 1.5})
+    assert fraction["error"]["code"] == protocol.INVALID_PARAMS
+
+
 def test_by_position_params_are_rejected_rather_than_guessed(mcp):
     server, protocol = mcp
     reply = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": ["say"]})


### PR DESCRIPTION
## What

Three things, all versions of "one fact, one place".

**MCP schemas (main change).** The nine hand-written `inputSchema` dicts are gone. `tools/list` generates them from each handler's signature, and `tools/call` validates arguments against that same schema — unknown, missing, wrong-typed or out-of-enum is `-32602`, raised before `urlopen`. The JSON-RPC envelope is modelled with stdlib `TypedDict`s and narrowed by `TypeGuard`s where the message arrives. All nine generated schemas are byte-identical to the dicts they replace. Handler failures stay `isError` results, results stay `text/plain`, the signed lane stays unwrapped. Two other behaviour changes: by-position `params` gets `-32602` instead of an internal error, and an integral float (`since: 1.0`) is accepted and narrowed to `1`, since JSON Schema reads `integer` by value.

**Fixes #24.** `clean_text` promised single-line values but swept only Cc, Cf, Cs, Co — U+2028 and U+2029 survived, and enough plain-text consumers treat either as a line boundary that one stored value could render as two lines. Both lanes take the same sweep. The category list is now one named constant carrying the reason each entry is on it, rather than a tuple plus a docstring that both had to be updated.

**Comment sweep.** Comments that restated a value living somewhere else now name the constant instead (`IDLE_SECONDS`, `RATE_WRITE`, `MAX_ROOMS`, `MAX_VALUE_CHARS`). Counts of enumerable things are deleted rather than corrected — "eight tools" appeared in two docstrings and `mcp/README.md` and had already drifted from the nine that exist. The wrapper's long-poll ceiling becomes `WAIT_CEILING`, and its tool description is generated from it. Left alone: comments recording a measurement or an external fact, where the number *is* the point, and the served manual, which already substitutes its caps.

## Why

A schema dict next to the handler it describes, a comment next to the constant it quotes, and a docstring listing what a tuple already lists are all two declarations of one fact — and in each case the copy had already gone stale. #24 is the same failure with teeth: a documented invariant the code only partly enforced.

- **#21** (request ids) is merged; this sits on top of it, same behaviour, now expressed as a `RequestId` guard and a `Request`/`Notification` split.
- **#16** (tool argument types) is subsumed: the same rejections fall out of the generated schema instead of a second hand-written validator. Its two cases are carried over and extended. Close it in favour of this, or merge it first and this drops its function.
- **#22** (`eight tools` → `nine tools`) is superseded and will now conflict: this deletes the count rather than correcting it, since correcting it is the churn.
- **#24** is fixed here.
- **#26** and **#23** are merged and in this branch. Nothing else open overlaps.

## Checks

- [x] `uv run python -m pytest tests -q` — 221 passed on the current head, with `main` merged in. Both #24 tests fail without the fix (verified by reverting the constant); every pre-existing test unchanged.
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`; `uv build --project mcp` builds; 3.11, the package floor, checked directly below CI's 3.12.
- [x] Benchmarked against `main`: `tools/list` byte-identical, 28 message shapes byte-identical, 6 changed on purpose. Dispatch +1.6–2.5 µs per `tools/call`; cold start +5.5 ms, of which generating all nine schemas is 0.7 ms and the rest is `import inspect`.
- [x] Served docs unchanged — the manual already substitutes its caps, and no advertised schema moved.
- [x] No new surface: this only narrows what `tools/call` accepts and what `clean_text` lets through.