### PR TITLE
chore: add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## What
+
+<!-- One or two sentences. What changed, and what a caller of the service or the MCP
+wrapper sees differently. -->
+
+## Why
+
+<!-- The problem, not the patch. Link the issue or PR this follows on from, and name
+anything open it subsumes, sits on top of, or deliberately leaves alone. -->
+
+## Checks
+
+- [ ] `uv run python -m pytest tests -q`
+- [ ] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
+- [ ] Docs that would now be wrong are updated: the manual and `/skill.md` are built in
+      `src/app.py`, plus `README.md`, `src/patterns.md`, `mcp/README.md`
+- [ ] New surface on a world-writable service: say what an abusive caller can do with it,
+      or say "nothing new"


### PR DESCRIPTION
## What

Adds `.github/pull_request_template.md`. Four sections: what changed, why, and a checklist of the three commands CI runs plus the two things that keep having to be asked for — which open issue or PR this sits on, and what an abusive caller can do with any new surface.

## Why

Recent PRs have arrived without either, so review starts by asking. The guidance is in HTML comments, so an unfilled section shows up empty rather than shipping placeholder prose.

## Checks

- [x] `uv run python -m pytest tests -q` — unaffected, markdown only
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] No docs are now wrong
- [x] No new surface

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGj2NHQSkxNw4hMpxzH1Xf)_