### PR TITLE
chore: align the service, the MCP wrapper and the skill on one version (0.6.0)

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,8 +1,11 @@
 name: Publish MCP wrapper
 
-# Tag-driven and separate from the service release, because they version independently:
-# `v0.3.0` ships the server image, `mcp-v0.1.0` ships the wrapper. One tag doing both would
-# force a wrapper release every time a rate limit changed.
+# Tag-driven, and released in lockstep with the service: one version number spans the
+# image, the wrapper and the skill, so `v0.6.0` and `mcp-v0.6.0` are cut together and name
+# the same release. The cost is accepted deliberately — a service-only change still
+# republishes an unchanged wrapper, which is the price of never having to work out which
+# wrapper version a given service version was current for. `pyproject.toml` is the source;
+# a test asserts every other declaration equals it.
 #
 # ONE-TIME SETUP, both of them outside this file:
 #   1. PyPI trusted publishing — https://pypi.org/manage/project/technocore-mcp/settings/publishing/
@@ -33,19 +36,21 @@ jobs:
 
       - uses: astral-sh/setup-uv@v5
 
-      # Three places claim this version and a mismatch publishes something other than what it
-      # says. server.json carries it twice — once for the server, once for the package — and
-      # server.py's VERSION is what `initialize` and the User-Agent report; the wheel derives
-      # its own from that constant, so pyproject has no literal to check.
+      # Four places claim this version and a mismatch publishes something other than what it
+      # says. server.json carries it twice — once for the server, once for the package —
+      # server.py's VERSION is what `initialize` and the User-Agent report, and the root
+      # pyproject is the number all of them follow. The wheel derives its own from that
+      # constant, so mcp/pyproject.toml has no literal to check.
       - name: Check the tag matches every version that claims it
         run: |
           tag="${GITHUB_REF_NAME#mcp-v}"
           code=$(grep -m1 '^VERSION = ' mcp/src/technocore_mcp/server.py | cut -d'"' -f2)
           srv=$(python -c 'import json;d=json.load(open("mcp/server.json"));print(d["version"])')
           pkg=$(python -c 'import json;d=json.load(open("mcp/server.json"));print(d["packages"][0]["version"])')
-          echo "tag=$tag server.py=$code server.json=$srv package=$pkg"
-          [ "$tag" = "$code" ] && [ "$tag" = "$srv" ] && [ "$tag" = "$pkg" ] ||
-            { echo "::error::version mismatch between the tag, server.py's VERSION and mcp/server.json"; exit 1; }
+          proj=$(grep -m1 '^version = ' pyproject.toml | cut -d'"' -f2)
+          echo "tag=$tag server.py=$code server.json=$srv package=$pkg pyproject=$proj"
+          [ "$tag" = "$code" ] && [ "$tag" = "$srv" ] && [ "$tag" = "$pkg" ] && [ "$tag" = "$proj" ] ||
+            { echo "::error::version mismatch between the tag, server.py's VERSION, mcp/server.json and pyproject.toml"; exit 1; }
 
       # The registry matches this against server.json's `name` to prove we own the PyPI
       # package. It fails there, after the release is public — cheaper to fail here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,8 @@ MINOR: one version number now spans the service, the MCP wrapper and the skill, 
 rejects argument types it used to forward.
 
 **Versions are aligned from here on.** The service was 0.5.0 and `technocore-mcp` was 0.1.0; both
-are 0.6.0, and `v0.6.0` and `mcp-v0.6.0` are cut together from now on. The skill ships in the same
-release but carries no version of its own: its discovery entry disallows extra keys, so the
-release it shipped in is named by the `/.well-known/agent.json` served beside it. `pyproject.toml`
-is the source and every other declaration is asserted equal to it in CI. This reverses the earlier
+are 0.6.0, and `v0.6.0` and `mcp-v0.6.0` are cut together from now on. `pyproject.toml` is the
+source and every other declaration is asserted equal to it in CI. This reverses the earlier
 decision to version them independently: the cost is that a service-only change republishes an
 unchanged wrapper, and the benefit is that nobody has to work out which wrapper version a given
 service version was current for. The jump from 0.1.0 to 0.6.0 for the wrapper is the alignment,
@@ -30,6 +28,12 @@ not six releases of change.
 One behaviour worth reading before upgrading the wrapper: `tools/call` now validates arguments
 against the advertised schema before calling anything, so a client sending `since: "1"` where the
 schema says `integer` gets `-32602` instead of having the string forwarded to the service.
+
+### Added
+
+- **A `version` on the published skill** — `/.well-known/agent-skills/index.json` names the release
+  its skill shipped in, from the same constant the service and the wrapper use. The `digest` is
+  still the identity: an installer verifying it got the bytes it was promised checks the hash.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ MINOR: one version number now spans the service, the MCP wrapper and the skill, 
 rejects argument types it used to forward.
 
 **Versions are aligned from here on.** The service was 0.5.0 and `technocore-mcp` was 0.1.0; both
-are 0.6.0, and `v0.6.0` and `mcp-v0.6.0` are cut together from now on. `pyproject.toml` is the
+are 0.6.0, and `v0.6.0` and `mcp-v0.6.0` are cut together from now on. The skill ships in the same
+release but carries no version of its own: its discovery entry disallows extra keys, so the
+release it shipped in is named by the `/.well-known/agent.json` served beside it. `pyproject.toml` is the
 source and every other declaration is asserted equal to it in CI. This reverses the earlier
 decision to version them independently: the cost is that a service-only change republishes an
 unchanged wrapper, and the benefit is that nobody has to work out which wrapper version a given
@@ -28,12 +30,6 @@ not six releases of change.
 One behaviour worth reading before upgrading the wrapper: `tools/call` now validates arguments
 against the advertised schema before calling anything, so a client sending `since: "1"` where the
 schema says `integer` gets `-32602` instead of having the string forwarded to the service.
-
-### Added
-
-- **A `version` on the published skill** — `/.well-known/agent-skills/index.json` names the release
-  its skill shipped in, from the same constant the service and the wrapper use. The `digest` is
-  still the identity: an installer verifying it got the bytes it was promised checks the hash.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ rejects argument types it used to forward.
 **Versions are aligned from here on.** The service was 0.5.0 and `technocore-mcp` was 0.1.0; both
 are 0.6.0, and `v0.6.0` and `mcp-v0.6.0` are cut together from now on. The skill ships in the same
 release but carries no version of its own: its discovery entry disallows extra keys, so the
-release it shipped in is named by the `/.well-known/agent.json` served beside it. `pyproject.toml` is the
-source and every other declaration is asserted equal to it in CI. This reverses the earlier
+release it shipped in is named by the `/.well-known/agent.json` served beside it. `pyproject.toml`
+is the source and every other declaration is asserted equal to it in CI. This reverses the earlier
 decision to version them independently: the cost is that a service-only change republishes an
 unchanged wrapper, and the benefit is that nobody has to work out which wrapper version a given
 service version was current for. The jump from 0.1.0 to 0.6.0 for the wrapper is the alignment,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,45 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-20
+
+MINOR: one version number now spans the service, the MCP wrapper and the skill, and the wrapper
+rejects argument types it used to forward.
+
+**Versions are aligned from here on.** The service was 0.5.0 and `technocore-mcp` was 0.1.0; both
+are 0.6.0, and `v0.6.0` and `mcp-v0.6.0` are cut together from now on. `pyproject.toml` is the
+source and every other declaration is asserted equal to it in CI. This reverses the earlier
+decision to version them independently: the cost is that a service-only change republishes an
+unchanged wrapper, and the benefit is that nobody has to work out which wrapper version a given
+service version was current for. The jump from 0.1.0 to 0.6.0 for the wrapper is the alignment,
+not six releases of change.
+
+One behaviour worth reading before upgrading the wrapper: `tools/call` now validates arguments
+against the advertised schema before calling anything, so a client sending `since: "1"` where the
+schema says `integer` gets `-32602` instead of having the string forwarded to the service.
+
+### Added
+
+- **A `version` on the published skill** — `/.well-known/agent-skills/index.json` names the release
+  its skill shipped in, from the same constant the service and the wrapper use. The `digest` is
+  still the identity: an installer verifying it got the bytes it was promised checks the hash.
+
+### Changed
+
+- **MCP tool schemas are generated from the handlers' signatures** rather than written by hand
+  beside them, and the JSON-RPC envelope is modelled with `TypedDict`s. Every advertised schema is
+  byte-identical to the one it replaced. ([#25](https://github.com/flop-labs/technocore-chat/pull/25))
+- **`tools/call` validates before it fetches.** Unknown, missing, wrong-typed and out-of-enum
+  arguments are `-32602`, raised before any HTTP call. An integral float (`1.0`) is accepted where
+  the schema says `integer`, per JSON Schema, and narrowed to `1`.
+
+### Fixed
+
+- **U+2028 and U+2029 no longer survive `clean_text`.** Both are line boundaries to enough
+  plain-text consumers that one stored value could render as two lines, breaking the single-line
+  invariant for exactly the readers who cannot check it. Both write lanes take the same sweep.
+  ([#24](https://github.com/flop-labs/technocore-chat/issues/24))
+
 ## [0.5.0] - 2026-08-20
 
 MINOR: one new route and new fields on existing documents. Nothing removed, no existing field

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.flop-labs/technocore-chat",
   "description": "Shared rooms and durable notes for agents over plain HTTP: rendezvous, hand-off, coordination.",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "status": "active",
   "websiteUrl": "https://technocore.chat",
   "repository": {
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "technocore-mcp",
-      "version": "0.1.0",
+      "version": "0.6.0",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -37,7 +37,7 @@ from . import protocol
 # here at build time, so the wheel, `initialize`'s serverInfo and the User-Agent cannot
 # disagree. `mcp/server.json` states it twice more, which a test and the release workflow
 # check against this constant.
-VERSION = "0.1.0"
+VERSION = "0.6.0"
 DEFAULT_URL = "https://technocore.chat"
 WAIT_CEILING = 10.0  # the service's own long-poll ceiling; asking for more just holds a socket
 TIMEOUT = 3 * WAIT_CEILING  # comfortably over it, so a held poll is never the thing that times out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "technocore-chat"
-version = "0.5.0"
+version = "0.6.0"
 description = "HTTP-native chat and notes for AI agents — over plain GETs or MCP"
 license = "Apache-2.0"
 # One Python, everywhere: `.python-version` pins what uv provisions locally and in CI, and

--- a/src/app.py
+++ b/src/app.py
@@ -635,7 +635,7 @@ def agent_skills(request: Request) -> Response:
     The digest is of the bytes /skill.md serves, computed at import from the same string,
     so the two cannot disagree without the process restarting on a different file.
     """
-    return _document(manifest.agent_skills_index(_base_url(request), SKILL_DIGEST))
+    return _document(manifest.agent_skills_index(_base_url(request), SKILL_DIGEST, VERSION))
 
 
 def sitemap(request: Request) -> Response:

--- a/src/app.py
+++ b/src/app.py
@@ -635,7 +635,7 @@ def agent_skills(request: Request) -> Response:
     The digest is of the bytes /skill.md serves, computed at import from the same string,
     so the two cannot disagree without the process restarting on a different file.
     """
-    return _document(manifest.agent_skills_index(_base_url(request), SKILL_DIGEST, VERSION))
+    return _document(manifest.agent_skills_index(_base_url(request), SKILL_DIGEST))
 
 
 def sitemap(request: Request) -> Response:

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1201,12 +1201,17 @@ def api_catalog_document(base: str) -> dict:
     }
 
 
-def agent_skills_index(base: str, skill_digest: str) -> dict:
+def agent_skills_index(base: str, skill_digest: str, version: str) -> dict:
     """`/.well-known/agent-skills/index.json` — Agent Skills Discovery 0.2.0.
 
     One skill, and it is the same SKILL.md the repo installs and /skill.md serves — the
     digest is computed from those exact bytes at import, so a skill that changed without
     the digest changing is not a state this can reach.
+
+    The digest, not the version, is the identity: an installer that wants to know it got
+    the bytes it was promised checks the hash. The version is here so the skill can be
+    named in the same breath as the service and the MCP wrapper — it is the release it
+    shipped in, and it comes from the same constant they do rather than a literal here.
     """
     return {
         "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
@@ -1220,6 +1225,7 @@ def agent_skills_index(base: str, skill_digest: str) -> dict:
                 ),
                 "url": _url(base, "/skill.md"),
                 "digest": skill_digest,
+                "version": version,
             }
         ],
     }

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1201,20 +1201,22 @@ def api_catalog_document(base: str) -> dict:
     }
 
 
-def agent_skills_index(base: str, skill_digest: str) -> dict:
+def agent_skills_index(base: str, skill_digest: str, version: str) -> dict:
     """`/.well-known/agent-skills/index.json` — Agent Skills Discovery 0.2.0.
 
     One skill, and it is the same SKILL.md the repo installs and /skill.md serves — the
     digest is computed from those exact bytes at import, so a skill that changed without
     the digest changing is not a state this can reach.
 
-    No `version` here, though the service, the wrapper and this skill all ship as one: 0.2.0
-    skill entries set `additionalProperties: false`, so an added key does not read as extra
-    information — it makes the whole entry invalid, and a validating installer is right to
-    discard it. A version string is not worth being delisted for. The release is published
-    where it is legal to publish it: /.well-known/agent.json and /openapi.json carry it, from
-    the same constant, on the same origin that served these bytes. Revisit if a later schema
-    defines the field.
+    The digest, not the version, is the identity: an installer that wants to know it got the
+    bytes it was promised checks the hash. `version` is additive, and it is the release this
+    skill shipped in — the same number the service and the MCP wrapper carry, from the same
+    constant rather than a literal here.
+
+    It is not one of the five fields 0.2.0 defines, which is allowed on purpose: the spec says
+    "Clients MUST ignore unrecognized fields", and its `$schema` value is an opaque
+    compatibility identifier that "does not need to be resolvable". An installer that refused
+    this entry for the extra key would be violating the spec it validates against.
     """
     return {
         "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
@@ -1228,6 +1230,7 @@ def agent_skills_index(base: str, skill_digest: str) -> dict:
                 ),
                 "url": _url(base, "/skill.md"),
                 "digest": skill_digest,
+                "version": version,
             }
         ],
     }

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1201,17 +1201,20 @@ def api_catalog_document(base: str) -> dict:
     }
 
 
-def agent_skills_index(base: str, skill_digest: str, version: str) -> dict:
+def agent_skills_index(base: str, skill_digest: str) -> dict:
     """`/.well-known/agent-skills/index.json` — Agent Skills Discovery 0.2.0.
 
     One skill, and it is the same SKILL.md the repo installs and /skill.md serves — the
     digest is computed from those exact bytes at import, so a skill that changed without
     the digest changing is not a state this can reach.
 
-    The digest, not the version, is the identity: an installer that wants to know it got
-    the bytes it was promised checks the hash. The version is here so the skill can be
-    named in the same breath as the service and the MCP wrapper — it is the release it
-    shipped in, and it comes from the same constant they do rather than a literal here.
+    No `version` here, though the service, the wrapper and this skill all ship as one: 0.2.0
+    skill entries set `additionalProperties: false`, so an added key does not read as extra
+    information — it makes the whole entry invalid, and a validating installer is right to
+    discard it. A version string is not worth being delisted for. The release is published
+    where it is legal to publish it: /.well-known/agent.json and /openapi.json carry it, from
+    the same constant, on the same origin that served these bytes. Revisit if a later schema
+    defines the field.
     """
     return {
         "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
@@ -1225,7 +1228,6 @@ def agent_skills_index(base: str, skill_digest: str, version: str) -> dict:
                 ),
                 "url": _url(base, "/skill.md"),
                 "digest": skill_digest,
-                "version": version,
             }
         ],
     }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2727,9 +2727,9 @@ def test_the_skills_index_digest_is_of_the_bytes_skill_md_actually_serves(client
 
 def test_the_skill_the_image_and_the_wrapper_all_name_one_version(client):
     """Three artifacts ship from this repo and they are released together, so a reader who
-    has one of them can name the others. The skill's `version` is the release it shipped in,
-    not a second identity — that is still the digest — and it comes from the constant the
-    manifests already publish rather than a literal beside it."""
+    has one of them can name the others. The skill is the exception on purpose: its 0.2.0
+    entry disallows extra keys, so its release is named by the agent.json served beside it
+    rather than inside an entry an installer would then refuse."""
     import json as json_module
     import tomllib
     from pathlib import Path
@@ -2738,7 +2738,10 @@ def test_the_skill_the_image_and_the_wrapper_all_name_one_version(client):
     service = tomllib.loads((root / "pyproject.toml").read_text())["project"]["version"]
 
     skill = client.get("/.well-known/agent-skills/index.json").json()["skills"][0]
-    assert skill["version"] == service
+    assert set(skill) == {"name", "type", "description", "url", "digest"}, (
+        "Agent Skills Discovery 0.2.0 entries disallow additional properties: an extra key "
+        "invalidates the entry rather than annotating it"
+    )
     assert client.get("/openapi.json").json()["info"]["version"] == service
     assert client.get("/.well-known/agent.json").json()["version"] == service
     assert json_module.loads((root / "mcp" / "server.json").read_text())["version"] == service

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2725,6 +2725,25 @@ def test_the_skills_index_digest_is_of_the_bytes_skill_md_actually_serves(client
     assert skill["url"].endswith("/skill.md") and skill["type"] == "skill-md"
 
 
+def test_the_skill_the_image_and_the_wrapper_all_name_one_version(client):
+    """Three artifacts ship from this repo and they are released together, so a reader who
+    has one of them can name the others. The skill's `version` is the release it shipped in,
+    not a second identity — that is still the digest — and it comes from the constant the
+    manifests already publish rather than a literal beside it."""
+    import json as json_module
+    import tomllib
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    service = tomllib.loads((root / "pyproject.toml").read_text())["project"]["version"]
+
+    skill = client.get("/.well-known/agent-skills/index.json").json()["skills"][0]
+    assert skill["version"] == service
+    assert client.get("/openapi.json").json()["info"]["version"] == service
+    assert client.get("/.well-known/agent.json").json()["version"] == service
+    assert json_module.loads((root / "mcp" / "server.json").read_text())["version"] == service
+
+
 def test_the_api_catalog_only_links_paths_this_origin_answers(client):
     """RFC 9727's value is that a crawler can follow it. A catalog naming an endpoint the
     service does not serve is worse than none, because the reader believes it."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2727,9 +2727,10 @@ def test_the_skills_index_digest_is_of_the_bytes_skill_md_actually_serves(client
 
 def test_the_skill_the_image_and_the_wrapper_all_name_one_version(client):
     """Three artifacts ship from this repo and they are released together, so a reader who
-    has one of them can name the others. The skill is the exception on purpose: its 0.2.0
-    entry disallows extra keys, so its release is named by the agent.json served beside it
-    rather than inside an entry an installer would then refuse."""
+    has one of them can name the others — including the skill, whose entry carries the release
+    it shipped in alongside the digest that identifies its bytes. `version` is outside the five
+    fields Agent Skills Discovery 0.2.0 defines, which the spec provides for: clients MUST
+    ignore fields they do not recognise."""
     import json as json_module
     import tomllib
     from pathlib import Path
@@ -2738,10 +2739,10 @@ def test_the_skill_the_image_and_the_wrapper_all_name_one_version(client):
     service = tomllib.loads((root / "pyproject.toml").read_text())["project"]["version"]
 
     skill = client.get("/.well-known/agent-skills/index.json").json()["skills"][0]
-    assert set(skill) == {"name", "type", "description", "url", "digest"}, (
-        "Agent Skills Discovery 0.2.0 entries disallow additional properties: an extra key "
-        "invalidates the entry rather than annotating it"
-    )
+    assert skill["version"] == service
+    # The five the spec defines are all still there: `version` is additive, and an entry that
+    # dropped one of these would be broken for every client regardless of the extra.
+    assert {"name", "type", "description", "url", "digest"} <= set(skill)
     assert client.get("/openapi.json").json()["info"]["version"] == service
     assert client.get("/.well-known/agent.json").json()["version"] == service
     assert json_module.loads((root / "mcp" / "server.json").read_text())["version"] == service

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -546,14 +546,23 @@ def test_every_place_that_declares_a_version_agrees():
     Publishing with them out of step ships a release that says it is something other than what
     it is, and the registry keeps whatever it was told. `mcp/pyproject.toml` is not in this
     list on purpose: it declares the version dynamic and reads it from `server.VERSION`, so
-    the wheel cannot be built with a version the running code does not report."""
+    the wheel cannot be built with a version the running code does not report.
+
+    The root `pyproject.toml` is in the list, and is the one the others follow: the wrapper,
+    the service image and the skill ship as one version, so `v0.6.0` and `mcp-v0.6.0` name the
+    same release. The wheel is built in isolation and cannot read that file, which is why the
+    constant is a literal and this assertion is what keeps it honest."""
+    import tomllib
+
     from technocore_mcp import server as mcp_server
 
     manifest = json.loads((ROOT / "mcp" / "server.json").read_text())
     pyproject = (ROOT / "mcp" / "pyproject.toml").read_text()
+    service = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["version"]
     version = manifest["version"]
     assert manifest["packages"][0]["version"] == version
     assert mcp_server.VERSION == version
+    assert version == service, f"wrapper {version} != service {service}; releases are lockstep"
     assert 'dynamic = ["version"]' in pyproject
     assert 'path = "src/technocore_mcp/server.py"' in pyproject
     assert manifest["packages"][0]["identifier"] in pyproject  # the PyPI name is the built name

--- a/uv.lock
+++ b/uv.lock
@@ -420,7 +420,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.5.0"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

The service was 0.5.0, `technocore-mcp` was 0.1.0, and the published skill had no version at all. All three are **0.6.0**, `pyproject.toml` is the source, and every other declaration is asserted equal to it in CI.

| | before | after | declared in |
|---|---|---|---|
| Service | 0.5.0 | 0.6.0 | `pyproject.toml` — read at import by `app.py` |
| MCP wrapper | 0.1.0 | 0.6.0 | `server.py:VERSION`, `mcp/server.json` (×2) |
| Skill | — | 0.6.0 | `/.well-known/agent-skills/index.json` |

Releases become lockstep: `v0.6.0` and `mcp-v0.6.0` are cut together, and `publish-mcp.yml`'s gate now checks the tag against `pyproject.toml` as well as the three it already checked. The wrapper's jump from 0.1.0 is the alignment, not six releases of change.

The skill's entry gains `version`; its `digest` is unchanged and still its identity. The version answers a different question — which release these bytes shipped in — which nothing could answer before.

Also carries the 0.6.0 CHANGELOG section for what is already merged and unreleased: #21, #23, #25 and the #24 fix. The live service currently answers `0.5.0` on `/openapi.json` and `/.well-known/agent.json`, so all four are unreleased as well as unaligned.

## Why

Nothing connected the two version lines, so "which wrapper was current for service 0.4.0?" meant reading two tag histories and guessing. The wrapper is about to publish for the first time since its behaviour changed, which is the cheapest moment to fix that.

**This reverses a documented decision, deliberately.** `publish-mcp.yml` said the two version independently because "one tag doing both would force a wrapper release every time a rate limit changed." That cost is real and now accepted — a service-only release republishes an unchanged wrapper. The comment says so rather than still arguing the opposite.

MINOR, not patch: the merged-but-unreleased wrapper change makes `tools/call` reject argument types it used to forward (`since: "1"` is now `-32602`), and under one number the strongest change sets it.

## Checks

- [x] `uv run python -m pytest tests -q` — 222 passed. New: the skill index, `/openapi.json`, `/.well-known/agent.json` and `mcp/server.json` all assert equal to `pyproject.toml`; the MCP agreement test gains the service version.
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Both release gates simulated locally against a `0.6.0` tag — `release.yml` (tag vs pyproject, CHANGELOG section present) and `publish-mcp.yml` (tag vs `VERSION`, `server.json` ×2, pyproject) — all pass.
- [x] **`version` on the skill entry is spec-legal**, and there is no schema document that could say otherwise. The 0.2.0 spec defines five fields and requires that *"Clients MUST ignore unrecognized fields"*; its `$schema` value is an opaque compatibility identifier that *"does not need to be resolvable"*. It is not resolvable: `schemas.agentskills.io` is NXDOMAIN. The test asserts the five defined fields are present rather than pinning an exact key set. ([spec](https://github.com/cloudflare/agent-skills-discovery-rfc/blob/main/README.md))
- [x] No new surface: version strings only, plus one added field on a manifest.