### PR TITLE
perf(read_json): accumulate the body in a bytearray

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1112,13 +1112,13 @@ async def read_json(request: Request) -> dict | Response:
     declared = _cursor(request.headers.get("content-length"), 0)
     if declared and declared > MAX_BODY:
         return text(f"{too_large}\nyour Content-Length said {declared} bytes.", 413)
-    raw = b""
+    raw = bytearray()
     async for chunk in request.stream():
-        raw += chunk
+        raw.extend(chunk)
         if len(raw) > MAX_BODY:
             return text(f"{too_large}\nthe stream passed it before it ended.", 413)
     try:
-        payload = json.loads(raw or b"{}")
+        payload = json.loads(bytes(raw) if raw else b"{}")
     except ValueError as exc:
         return text(
             f"400 body must be JSON, and this did not parse: {exc}.\n"


### PR DESCRIPTION
## What

`read_json` in `src/app.py` accumulates the request body into a `bytearray` via
`.extend()` instead of a `bytes` object via `+=`. Callers see nothing different —
same status codes, same bodies, same cap behaviour.

## Why

`raw += chunk` allocates a new `bytes` object and copies everything received so far
on every iteration, so the buffering work is quadratic in the number of chunks rather
than linear in the body size. `bytearray.extend` appends in place.

The absolute numbers here are small — the cap is 32 KiB and bodies are abandoned at
it — so this is a correctness-of-idiom change rather than a capacity or safety one.
Not following on from an issue; it came out of reading the source.

One judgement call worth flagging: `json.loads` accepts a `bytearray` directly, so
`bytes(raw)` is not strictly required. I wrote `bytes(raw) if raw else b"{}"` because
the original `raw or b"{}"` leaned on falsiness, and being explicit about the empty
case seemed better than swapping one implicit truthiness check for another. Happy to
go back to `json.loads(raw or b"{}")` if you'd rather keep the line as it was.

Doesn't touch anything else open.

## Checks

- [x] `uv run python -m pytest tests -q`
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: the manual and `/skill.md` are built in
      `src/app.py`, plus `README.md`, `src/patterns.md`, `mcp/README.md`
- [x] New surface on a world-writable service: say what an abusive caller can do with it,
      or say "nothing new"

222 passed. Lint and `ty check` clean. `ci.yml` dispatched on the fork —
lint + tests + image build green on `ubuntu-latest`.

No documented limit, route or response changes, so nothing in the manual, `/skill.md`,
`README.md`, `src/patterns.md` or `mcp/README.md` is now wrong.

**Abuse surface: nothing new.** No new route, parameter or lane. The `MAX_BODY` check
stays inside the streaming loop, so an oversized body is still abandoned mid-stream
rather than buffered — the change only makes the buffering up to that point cheaper.