### PR TITLE
fix(stats): bound _identities so distinct_identities stays a live diagnostics

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -194,7 +194,11 @@ _started = time.time()
 # and an `identities` of 1 is not rate limiting anyone individually — it is rate limiting
 # the CDN, and the room budget is being shared by the entire internet.
 _proxy_evidence: dict[str, int] = {"proxied_requests": 0}
-_identities: set[str] = set()
+# Bounded LRU of distinct client IPs seen by the rate limiter.
+# Mirrors _buckets: OrderedDict with move_to_end / popitem(last=False)
+# evicts the idlest entry when full.  Re-inserting an existing identity
+# refreshes its recency so active callers survive a flood of new IPs.
+_identities: OrderedDict[str, None] = OrderedDict()
 MAX_IDENTITIES = 50_000  # bounded like _buckets; a counter that OOMs is not a diagnostic
 
 
@@ -242,8 +246,10 @@ def take(
     tokens, which never reaches the 1.0 a grant costs — the limit would refuse everything.
     """
     ip = client_ip(request)
-    if len(_identities) < MAX_IDENTITIES:
-        _identities.add(ip)
+    _identities[ip] = None  # refresh recency; new key if absent
+    _identities.move_to_end(ip)
+    while len(_identities) > MAX_IDENTITIES:
+        _identities.popitem(last=False)
     now = time.monotonic()
     cap = float(per_min if burst is None else burst)
     tokens, last = _buckets.get((ip, kind), (cap, now))
@@ -1547,7 +1553,9 @@ async def stats(request: Request) -> Response:
             "room_bytes_total": store.MAX_TOTAL_ROOM_BYTES,
         },
         # Whether "per IP" is true on this deployment. `client_ip_header` is what the
-        # limiter reads; `distinct_identities` is how many callers it has ever told apart;
+        # limiter reads; `distinct_identities` is how many callers the limiter has told
+        # apart among the most recent MAX_IDENTITIES seen (not all-time — old entries are
+        # evicted).
         # `proxied_requests_ignored` counts requests that arrived with a CDN's own client-IP
         # header while we were configured to ignore it. High proxied count with
         # distinct_identities near 1 means every caller is sharing one bucket — including

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2886,3 +2886,77 @@ def test_the_ai_catalog_lists_only_artifacts_that_resolve(client):
         assert entry["identifier"] and entry["type"] and entry["url"]
         path = entry["url"].split("testserver", 1)[-1] or "/"
         assert client.get(path).status_code == 200, f"{entry['identifier']} -> {path}"
+
+
+# ------------------------------------------------------------------ identities LRU
+#
+# _identities is a bounded OrderedDict LRU (mirrors _buckets).  Once full the
+# idlest entry is evicted; re-inserting an existing identity refreshes its
+# recency so active callers survive a flood of new IPs.
+
+
+def test_identities_evicts_oldest_when_full(client, monkeypatch):
+    """Fill past MAX_IDENTITIES and confirm the oldest entry is gone."""
+    import app as app_module
+
+    monkeypatch.setattr(app_module, "MAX_IDENTITIES", 5)
+    monkeypatch.setattr(app_module, "CLIENT_IP_HEADER", "cf-connecting-ip")
+    # Insert 5 distinct identities
+    for i in range(5):
+        client.get("/r/lobby", headers={"cf-connecting-ip": f"10.0.0.{i}"})
+    assert len(app_module._identities) == 5
+    assert "10.0.0.0" in app_module._identities
+    # Insert a 6th: oldest (10.0.0.0) is evicted
+    client.get("/r/lobby", headers={"cf-connecting-ip": "10.0.0.5"})
+    assert len(app_module._identities) == 5
+    assert "10.0.0.0" not in app_module._identities
+    assert "10.0.0.5" in app_module._identities
+
+
+def test_identities_reseen_identity_survives_eviction(client, monkeypatch):
+    """Re-seeing an existing identity refreshes its recency, so it survives
+    a flood that evicts its neighbours."""
+    import app as app_module
+
+    monkeypatch.setattr(app_module, "MAX_IDENTITIES", 4)
+    monkeypatch.setattr(app_module, "CLIENT_IP_HEADER", "cf-connecting-ip")
+    # Insert A, B, C, D
+    for nick in ("A", "B", "C", "D"):
+        client.get("/r/lobby", headers={"cf-connecting-ip": f"10.0.0.{nick}"})
+    assert len(app_module._identities) == 4
+    # Re-see B: B moves to the most-recent end
+    client.get("/r/lobby", headers={"cf-connecting-ip": "10.0.0.B"})
+    # Insert E, F: A and C should be evicted, B survives
+    for nick in ("E", "F"):
+        client.get("/r/lobby", headers={"cf-connecting-ip": f"10.0.0.{nick}"})
+    assert len(app_module._identities) == 4
+    assert "10.0.0.B" in app_module._identities, "re-seen identity was evicted"
+    assert "10.0.0.E" in app_module._identities
+    assert "10.0.0.F" in app_module._identities
+
+
+def test_identities_never_exceeds_max(client, monkeypatch):
+    """The LRU never grows past MAX_IDENTITIES, even under sustained flood."""
+    import app as app_module
+
+    monkeypatch.setattr(app_module, "MAX_IDENTITIES", 8)
+    monkeypatch.setattr(app_module, "CLIENT_IP_HEADER", "cf-connecting-ip")
+    for i in range(50):
+        client.get("/r/lobby", headers={"cf-connecting-ip": f"10.0.{i // 256}.{i % 256}"})
+    assert len(app_module._identities) <= 8
+
+
+def test_identities_stats_reflects_recent_window(client, monkeypatch):
+    """distinct_identities in /stats reports the bounded window count,
+    not an all-time total."""
+    import app as app_module
+
+    monkeypatch.setattr(app_module, "STATS_TOKEN", "t")
+    monkeypatch.setattr(app_module, "STATS_CACHE_SECONDS", 0)
+    monkeypatch.setattr(app_module, "MAX_IDENTITIES", 5)
+    monkeypatch.setattr(app_module, "CLIENT_IP_HEADER", "cf-connecting-ip")
+    # Insert 10 distinct IPs; the window holds at most 5
+    for i in range(10):
+        client.get("/r/lobby", headers={"cf-connecting-ip": f"10.0.{i // 256}.{i % 256}"})
+    ident = client.get("/stats", headers={"X-Stats-Token": "t"}).json()["client_identity"]
+    assert ident["distinct_identities"] == 5


### PR DESCRIPTION
## What

`_identities` becomes a bounded `OrderedDict` LRU instead of a `set` that stops
accepting entries at `MAX_IDENTITIES`. `/stats` callers see `distinct_identities`
track the most recent 50k callers rather than freezing at 50k forever.

## Why

The cap and the field's stated meaning currently pull against each other. The comment
on `MAX_IDENTITIES` says a counter that OOMs is not a diagnostic, right, but the
`set` only adds while under the cap, so once it fills nothing is ever evicted. Past
50k distinct callers the number is stuck at 50k and stops reflecting anything, which
is the same problem in the other direction: a counter that has stopped moving is also
not a diagnostic.

That matters most in the case `/stats` documents. The whole point of
`distinct_identities` is telling an operator whether per-IP limits are actually
per-IP, and the deployment where the count runs away is exactly the misconfigured one
— every caller minting a fresh identity per request. So the metric degrades soonest
where it is needed most.

`OrderedDict` with `move_to_end` / `popitem(last=False)` is the idiom `_buckets` and
`_rooms_cache` already use, so this is applying the existing pattern rather than
introducing one. Re-inserting refreshes recency, so an established caller survives a
flood of new IPs.

The `/stats` comment is updated because the meaning genuinely changes: the field is
now "callers told apart among the most recent `MAX_IDENTITIES` seen", not "ever". I
left the field name alone rather than widening the diff, but happy to rename it if
you'd rather the name carried that.

Doesn't touch anything else open. Sits on top of #28 only in the sense that both are
in `read_json`'s file; they don't conflict.

## Checks

- [x] `uv run python -m pytest tests -q`
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: the manual and `/skill.md` are built in
      `src/app.py`, plus `README.md`, `src/patterns.md`, `mcp/README.md`
- [x] New surface on a world-writable service: say what an abusive caller can do with it,
      or say "nothing new"

Four tests added covering eviction order, recency refresh on re-insert, the size
bound under sustained flood, and the `/stats` field reporting the windowed count.
`ci.yml` dispatched on the fork — lint + tests + image build green on `ubuntu-latest`.

`README.md` describes `distinct_identities` as the count being stuck near 1 alongside
a rising `proxied_requests_ignored`, which is still accurate under a window, so no
doc change was needed there. Nothing in `/skill.md`, `src/patterns.md` or
`mcp/README.md` mentions the field — `/stats` is internal and not in the generated
manifests.

**Abuse surface: nothing new.** No new route, parameter or lane. Memory is bounded by
the same `MAX_IDENTITIES` as before — strictly tighter, since the old set could sit at
the cap indefinitely while the LRU evicts. A flood of unique IPs can now push an
established caller's identity out of the *diagnostic*, but `_identities` is
observability only: it never gates a request, and rate-limit state lives in `_buckets`,
which is unchanged.