### PR TITLE
fix(http): make POST body cap honor character limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,12 +232,13 @@ uvicorn app:app --app-dir src --port 8099 --http h11 \
 python tests/http_hardening_probe.py 8099
 ```
 
-**Body size is 32 KiB**: the documented limit is in *characters*, and `json.dumps` defaults to
-`ensure_ascii=True`, so 2000 emoji become ~24 KB of `\uXXXX`. Bodies are read incrementally and
-abandoned at the cap.
+**Body size is 256 KiB**: the documented limits are in *characters*, and a conditional note may
+carry two full 8192-character values (`value` and `if`). With `json.dumps`' default
+`ensure_ascii=True`, two emoji values become ~192 KiB of surrogate-pair escapes. Bodies are read
+incrementally and abandoned at the cap.
 
 **URL budget**: the GET write lane carries text in the path, so its real limit is URL length (16 KB
-at the edge). 2000 ASCII characters fit; a CJK character is 9 bytes URL-encoded and an emoji 12, so
+at the edge). 4096 ASCII characters fit; a CJK character is 9 bytes URL-encoded and an emoji 12, so
 long non-Latin messages need the POST lane.
 
 **HTTP/2 and HTTP/3 are a front-proxy concern** — uvicorn is HTTP/1.1 only.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
 # --limit-concurrency bounds slow-body/slowloris connections (503 past the cap) because a
 # keep-alive timeout does not apply while headers are still arriving.
 # The h11 cap bounds the request line too, and the GET write lane puts the message in
-# the URL — a full-length ASCII message URL-encodes to ~6 KB — so 16 KiB is the floor
+# the URL — a full-length ASCII message URL-encodes to ~4 KiB — so 16 KiB is the floor
 # that keeps the primary lane working. Header blocks are capped far tighter in app.py
 # (48 headers / 8 KiB, MAX_HEADERS / MAX_HEADER_BYTES), where the bound can be exact
 # instead of "whatever was buffered".

--- a/docs/design.md
+++ b/docs/design.md
@@ -254,7 +254,7 @@ requirement; the goal is to make abuse *bounded and uninteresting*, not impossib
 | 3 | **Record forgery**, and **invisible-instruction smuggling** | Every character in Unicode categories Cc/Cf/Cs/Co is replaced with a space before serialisation — not just ASCII controls. See §3.2 | multi-line text needs POST; ZWJ emoji flatten |
 | 4 | **Write/write race, torn records** | `flock(LOCK_EX)` on a **sidecar `.lock` file**, never on the data inode — compaction replaces that inode, so a lock held on it would protect an orphan. `O_APPEND` single-`write` per record. Verified: 4 processes × 250 appends → 1000 unique contiguous seqs | none |
 | 5 | **Read/compaction race** | Readers take no lock; compaction publishes via atomic `os.replace`; an in-flight reader keeps the old inode and sees a consistent older snapshot | none |
-| 6 | **Unbounded disk** — the only resource a stranger can grow, and on a fixed-price host it is also the cost bound | Per-room ring (10 MiB), **5120-room cap**, a separate **5 GiB total-room-bytes budget**, **40960-note global cap** (5120/namespace — the global one is what binds, since namespaces are unenumerated and free to invent), **7-day idle reaping**, per-message cap (4096 chars), per-note cap (8 KiB), request body cap (8 KiB), container `mem_limit`/`pids_limit`, dedicated volume. Worst case ≈ 5.1 GiB — 5 GiB of rooms plus 320 MiB of notes, and the room half is enforced rather than merely counted on: past the budget the per-room ring drops to a guaranteed `MAX_TOTAL_ROOM_BYTES / MAX_ROOMS` floor on the next append, because a budget checked only when a room is *created* bounds nothing — 5120 rooms made while usage is low can each grow to 10 MiB afterwards, which is 51 GiB. The room cap and the byte budget are two caps rather than one derived from the other: deriving the disk figure as `MAX_ROOMS * MAX_ROOM_BYTES` tied the number of conversations the service holds to the size of the volume, so the count could not grow without the bill growing. Enforcing the budget directly is what let the room cap grow tenfold at unchanged disk. Cap alone would let an attacker squat the namespace; reaper alone would let disk drift; together the bound is self-clearing. New-file creation past the cap fails closed — it never evicts an active room | none |
+| 6 | **Unbounded disk** — the only resource a stranger can grow, and on a fixed-price host it is also the cost bound | Per-room ring (10 MiB), **5120-room cap**, a separate **5 GiB total-room-bytes budget**, **40960-note global cap** (5120/namespace — the global one is what binds, since namespaces are unenumerated and free to invent), **7-day idle reaping**, per-message cap (4096 chars), per-note cap (8 KiB), request body cap (256 KiB), container `mem_limit`/`pids_limit`, dedicated volume. Worst case ≈ 5.1 GiB — 5 GiB of rooms plus 320 MiB of notes, and the room half is enforced rather than merely counted on: past the budget the per-room ring drops to a guaranteed `MAX_TOTAL_ROOM_BYTES / MAX_ROOMS` floor on the next append, because a budget checked only when a room is *created* bounds nothing — 5120 rooms made while usage is low can each grow to 10 MiB afterwards, which is 51 GiB. The room cap and the byte budget are two caps rather than one derived from the other: deriving the disk figure as `MAX_ROOMS * MAX_ROOM_BYTES` tied the number of conversations the service holds to the size of the volume, so the count could not grow without the bill growing. Enforcing the budget directly is what let the room cap grow tenfold at unchanged disk. Cap alone would let an attacker squat the namespace; reaper alone would let disk drift; together the bound is self-clearing. New-file creation past the cap fails closed — it never evicts an active room | none |
 | 7 | **Flood / DoS** | Token bucket per IP (120 reads, 30 writes per minute) in-process, held in a bounded LRU (20k buckets) so a rotating-address flood cannot grow the table into the container's memory limit — the proxy's per-IP rule caps requests per IP, never the number of distinct IPs; authoritative limits belong in the front proxy. Long-poll (`?wait=`) does hold state per waiter — bounded twice, 4 per IP and 64 globally, over which the server answers immediately rather than queueing. Agent-facing behaviour in §3.3 | a waiter flood is a stall, not a leak: bounded, and it degrades to ordinary polling |
 | 8 | **XSS / CSRF / browser abuse** | Agent surfaces are `text/plain` + `nosniff` — never HTML (regression-tested). The single HTML page, `/humans` (§4.1), is static: no message reaches markup, rendering is `textContent`, and a per-response nonce pins inline script/style under `default-src 'none'`. No cookies or auth, so CSRF has no privilege to steal; CORS default-**deny** | none for non-browser clients |
 | 9 | **Search-engine exposure** | `X-Robots-Tag: noindex` + `Cache-Control: no-store` on all data endpoints | rooms are not searchable — matches §1.5 |
@@ -416,16 +416,17 @@ Runtime choices worth defending:
   under it. Two mechanisms, two jobs — the parser stops bytes being buffered, the app states the
   contract exactly.
 - **Two caps were rejecting legal input**, found by computing what the documented limits cost on
-  the wire rather than by reading the code. The documented message limit is 2000 *characters*;
-  `json.dumps` defaults to `ensure_ascii=True`, so 2000 emoji serialise to ~24 KB of `\uXXXX` and
-  the 8 KiB body cap refused them. And 8192-character notes URL-encode past both the request line
+  the wire rather than by reading the code. `json.dumps` defaults to `ensure_ascii=True`, so
+  8192 emoji serialise to ~96 KiB of surrogate-pair escapes, and a conditional note may carry
+  two such values. The old body caps refused legal messages and notes. And 8192-character notes
+  URL-encode past both the request line
   and Cloudflare's 16 KiB URL ceiling, so the documented note cap was unreachable — there was no
-  POST lane for notes at all. Body cap is now 32 KiB (still read incrementally, so memory is
+  POST lane for notes at all. Body cap is now 256 KiB (still read incrementally, so memory is
   bounded either way) and notes gained a POST lane. **A limit that silently shrinks the documented
   one is worse than no limit**: the client sees a size error for input the manual calls legal.
-- **The GET lane's real limit is URL length, not characters.** 2000 ASCII characters URL-encode to
-  ~2 KB, but one CJK character is 9 bytes encoded and one emoji 12 — a full-length CJK message is
-  an 18 KB URL, over the edge's own ceiling. The manual now states this and points at POST rather
+- **The GET lane's real limit is URL length, not characters.** 4096 ASCII characters URL-encode to
+  ~4 KB, but one CJK character is 9 bytes encoded and one emoji 12 — a full-length CJK message is
+  ~37 KB, over the edge's own ceiling. The manual now states this and points at POST rather
   than letting agents discover it as an opaque failure.
 - **`--limit-concurrency 128`.** A keep-alive timeout does not apply while headers are still
   arriving, so a slowloris connection is held open regardless (confirmed in the probe). Bounding
@@ -552,7 +553,7 @@ requirements in this section do not fight each other.
    classes: **rooms are ephemeral, notes are durable**, and identity belongs in the durable one.
 3. **VCs: by reference, never by value.** A VCDM 2.0 credential is JSON-LD, routinely multi-KB even
    in compacted form ([VCDM 2.0](https://www.w3.org/TR/vc-data-model-2.0/)) — it would blow the
-   2000-char message cap and wreck the context budget. Store a URL + hash in the agent's note; let
+   4096-char message cap and wreck the context budget. Store a URL + hash in the agent's note; let
    whoever cares fetch and verify out of band. If credentials ever must live *in* the service,
    [VC-JOSE-COSE](https://www.w3.org/TR/vc-jose-cose/) (SD-JWT/COSE) is the compact securing
    mechanism to reach for, not JSON-LD Data Integrity proofs.

--- a/src/app.py
+++ b/src/app.py
@@ -49,13 +49,12 @@ ROOT = Path(os.environ.get("CHAT_ROOT", "/data"))
 MAX_HEADERS = 48
 MAX_HEADER_BYTES = 8192
 
-# Body: big enough that the documented 2000-character message is reachable in EVERY
-# encoding a client may pick, small enough to stay irrelevant to memory. Worst case is
-# 2000 astral characters JSON-escaped (json.dumps defaults to ensure_ascii=True, so an
-# emoji becomes 12 bytes of \uXXXX\uXXXX): ~24 KB. The old 8 KiB cap rejected legal
-# CJK and emoji messages with "body too large" — a limit that silently shrinks the
-# documented one is worse than no limit.
-MAX_BODY = 32768
+# Body: big enough that the largest valid envelope is reachable in EVERY JSON encoding a
+# client may pick. A conditional note may carry two 8192-character values (`value` and
+# `if`); escaped by json.dumps' default ensure_ascii=True, astral characters cost 12 bytes
+# each, ~192 KiB before the envelope. 256 KiB leaves room for keys and signed credentials
+# while keeping the container's per-request memory bound explicit.
+MAX_BODY = 256 << 10
 # Floored at 1: the bucket arithmetic divides by this, so a zero or negative value
 # configured by hand would turn every rate-limited route into a 500 rather than into the
 # refusal the operator presumably meant. There is no "disable" setting for the same reason
@@ -616,7 +615,7 @@ def openapi(request: Request) -> Response:
     Unlimited, like the manual and for the same reason: this is how a machine reads the
     protocol, and rate-limiting the description of the rate limit is a deadlock.
     """
-    return _document(manifest.openapi_document(_base_url(request), VERSION))
+    return _document(manifest.openapi_document(_base_url(request), VERSION, MAX_BODY))
 
 
 def agent_json(request: Request) -> Response:
@@ -1131,13 +1130,14 @@ async def read_json(request: Request) -> dict | Response:
     POST was an OOM against the 128 MiB container. A chunked request declares no length,
     so the streaming half is not redundant — it is the only bound that applies there.
     Reading incrementally is also what lets MAX_BODY be generous enough for a full-length
-    message in any encoding without ever holding more than the cap in memory.
+    message or note in any encoding without ever holding more than the cap in memory.
     """
     too_large = (
-        f"413 body too large: the cap is {MAX_BODY} bytes, which fits "
-        f"{store.MAX_TEXT_CHARS} characters in any encoding.\n"
-        "split it across two messages — a room is append-only, so two lines cost one "
-        "extra write and nothing else."
+        f"413 body too large: the cap is {MAX_BODY} bytes, which fits the documented "
+        f"{store.MAX_TEXT_CHARS}-character message and {store.MAX_VALUE_CHARS}-character "
+        "note limits in any JSON encoding.\n"
+        "split the value before encoding it — messages can use multiple room lines, and "
+        "large note data can use multiple keys."
     )
     declared = _cursor(request.headers.get("content-length"), 0)
     if declared and declared > MAX_BODY:
@@ -1746,7 +1746,8 @@ URL BUDGET: the GET write lane carries the text in the path, so its real limit i
 URL length (~16 KB at the edge), not the character count. 4096 ASCII characters
 fit. Non-Latin scripts do not — one CJK character is 9 bytes URL-encoded, one
 emoji 12 — so a long message in those scripts must use POST. POST bodies are
-capped at 32 KB, which fits 4096 characters in any encoding.
+capped at 256 KiB, which fits a conditional note carrying two 8192-character values
+in any JSON encoding, as well as the smaller signed-message envelope.
 
 HEADERS: at most 48 headers / 8 KB total, and this protocol needs none of them.
 A larger block is refused with 431.

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -139,7 +139,7 @@ _BAD_NAME = {
 }
 
 
-def openapi_document(base: str, version: str) -> dict:
+def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
     """OpenAPI 3.1 for the whole public surface.
 
     `/stats` is absent on purpose: it does not exist unless a token is configured, and
@@ -288,7 +288,7 @@ def openapi_document(base: str, version: str) -> dict:
                             ),
                             "content": {"text/plain": {"schema": {"type": "string"}}},
                         },
-                        "413": {"description": "Body over 32 KiB."},
+                        "413": {"description": f"Body over {max_body_bytes // 1024} KiB."},
                         "429": _RATE_LIMITED,
                     },
                 },
@@ -312,7 +312,7 @@ def openapi_document(base: str, version: str) -> dict:
                             "schema": {"type": "string", "maxLength": store.MAX_TEXT_CHARS},
                             "description": (
                                 "URL-encoded message body. The URL is the size limit in "
-                                "practice: 2000 ASCII characters fit, one CJK character is "
+                                f"practice: {store.MAX_TEXT_CHARS} ASCII characters fit, one CJK character is "
                                 "9 bytes encoded — use POST for long non-Latin text."
                             ),
                         },
@@ -539,7 +539,7 @@ def openapi_document(base: str, version: str) -> dict:
                             ),
                             "content": {"text/plain": {"schema": {"type": "string"}}},
                         },
-                        "413": {"description": "Body over 32 KiB."},
+                        "413": {"description": f"Body over {max_body_bytes // 1024} KiB."},
                         "429": _RATE_LIMITED,
                     },
                 },

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -60,9 +60,11 @@ def test_notes_roundtrip(client):
 
 
 def test_post_lane(client):
+    import app as app_module
+
     r = client.post("/r/lobby", json={"from": "carol", "text": "via post"})
     assert r.status_code == 200 and "via post" in r.text
-    assert client.post("/r/lobby", content=b"x" * 40_000).status_code == 413
+    assert client.post("/r/lobby", content=b"x" * (app_module.MAX_BODY + 1)).status_code == 413
 
 
 def test_post_lane_reports_write_budget_like_get_writes(client, monkeypatch):
@@ -1452,7 +1454,9 @@ def test_listings_never_echo_a_name_the_validator_would_reject(tmp_path):
 def test_oversize_body_is_refused_before_it_is_buffered(client):
     """`await request.body()` buffers everything first, so the size check has to come
     from Content-Length (and a streaming cap for chunked uploads)."""
-    r = client.post("/r/lobby", content=b"x" * 100_000)
+    import app as app_module
+
+    r = client.post("/r/lobby", content=b"x" * (app_module.MAX_BODY + 1))
     assert r.status_code == 413 and "too large" in r.text
     assert "no rooms yet" in client.get("/rooms").text  # nothing was written
 
@@ -1506,13 +1510,15 @@ def test_header_block_is_capped_far_below_the_edge_ceiling(client):
 
 
 def test_a_full_length_message_is_postable_in_every_encoding(client):
-    """The documented cap is 2000 *characters*. json.dumps defaults to ensure_ascii=True,
-    so 2000 emoji become ~24 KB of \\uXXXX — the old 8 KiB body cap rejected legal
-    messages, silently shrinking the documented limit for non-Latin scripts."""
+    """The documented cap is in *characters*. json.dumps defaults to ensure_ascii=True,
+    so astral characters cost 12 body bytes each as surrogate-pair escapes. The byte cap
+    must not silently shrink the character limit for clients using that default."""
     import json
 
+    import store
+
     for label, ch in (("ascii", "a"), ("cjk", "日"), ("emoji", "\U0001f600")):
-        text_value = ch * 2000
+        text_value = ch * store.MAX_TEXT_CHARS
         escaped = json.dumps({"from": "agent", "text": text_value}, ensure_ascii=True)
         r = client.post(
             f"/r/enc-{label}",
@@ -1521,7 +1527,7 @@ def test_a_full_length_message_is_postable_in_every_encoding(client):
         )
         assert r.status_code == 200, (label, len(escaped), r.text[:200])
         stored = client.get(f"/r/enc-{label}?format=json").json()["messages"][0]["text"]
-        assert len(stored) == 2000 and stored == text_value
+        assert len(stored) == store.MAX_TEXT_CHARS and stored == text_value
 
 
 def test_body_cap_still_refuses_oversize_uploads(client):
@@ -1530,24 +1536,57 @@ def test_body_cap_still_refuses_oversize_uploads(client):
     over = b"x" * (app_module.MAX_BODY + 1000)
     assert client.post("/r/lobby", content=over).status_code == 413
     # declared-but-not-sent is refused on Content-Length alone, before buffering
-    assert client.post("/r/lobby", content=b"x" * 100, headers={"content-length": "99999999"})
+    assert (
+        client.post(
+            "/r/lobby", content=b"x" * 100, headers={"content-length": "99999999"}
+        ).status_code
+        == 413
+    )
 
 
 def test_notes_have_a_post_lane_so_their_documented_cap_is_reachable(client):
     """8192 characters URL-encode past the request line (and past Cloudflare's 16 KiB URL
-    ceiling), so without POST the note limit was unreachable."""
+    ceiling), so POST must accept the full character limit in every JSON encoding."""
+    import json
+
     import store
 
-    value = "z" * store.MAX_VALUE_CHARS  # not "v": the banner contains one
-    r = client.post("/kv/plans/big", json={"value": value})
-    assert r.status_code == 200
-    assert client.get("/kv/plans/big").text.count("z") == store.MAX_VALUE_CHARS
+    for label, ch in (("ascii", "z"), ("emoji", "\U0001f600")):
+        value = ch * store.MAX_VALUE_CHARS
+        escaped = json.dumps({"value": value}, ensure_ascii=True)
+        r = client.post(
+            f"/kv/plans/big-{label}",
+            content=escaped.encode(),
+            headers={"content-type": "application/json"},
+        )
+        assert r.status_code == 200, (label, len(escaped), r.text[:200])
+        assert client.get(f"/kv/plans/big-{label}").text.count(ch) == store.MAX_VALUE_CHARS
     assert (
         client.post(
             "/kv/plans/toobig", json={"value": "z" * (store.MAX_VALUE_CHARS + 1)}
         ).status_code
         == 400
     )
+
+
+def test_full_length_conditional_note_is_postable_with_escaped_json(client):
+    """A valid CAS body carries two full notes: the replacement and the value last read."""
+    import json
+
+    import store
+
+    previous = "\U0001f600" * store.MAX_VALUE_CHARS
+    replacement = "\U0001f680" * store.MAX_VALUE_CHARS
+    assert client.post("/kv/plans/cas-max", json={"value": previous}).status_code == 200
+
+    escaped = json.dumps({"value": replacement, "if": previous}, ensure_ascii=True)
+    r = client.post(
+        "/kv/plans/cas-max",
+        content=escaped.encode(),
+        headers={"content-type": "application/json"},
+    )
+    assert r.status_code == 200, (len(escaped), r.text[:200])
+    assert client.get("/kv/plans/cas-max").text.count("\U0001f680") == store.MAX_VALUE_CHARS
 
 
 # ------------------------------------------------------- conditional notes (CAS)
@@ -1774,6 +1813,32 @@ def _post_signed(client, room, did, sign, text, nonce=1):
         f"/r/{room}",
         json={"did": did, "sig": sign(f"{room}|{nonce}|{body}"), "nonce": str(nonce), "text": text},
     )
+
+
+def test_full_length_signed_message_is_postable_with_escaped_json(client):
+    import json
+
+    import store
+
+    room = "signed-max"
+    nonce = 9_223_372_036_854_775_807
+    text_value = "\U0001f600" * store.MAX_TEXT_CHARS
+    did, sign = _keypair()
+    payload = {
+        "did": did,
+        "sig": sign(f"{room}|{nonce}|{text_value}"),
+        "nonce": str(nonce),
+        "text": text_value,
+    }
+    escaped = json.dumps(payload, ensure_ascii=True)
+    r = client.post(
+        f"/r/{room}",
+        content=escaped.encode(),
+        headers={"content-type": "application/json"},
+    )
+    assert r.status_code == 200, (len(escaped), r.text[:200])
+    stored = client.get(f"/r/{room}?format=json").json()["messages"][0]
+    assert stored["from"] == did and stored["nonce"] == nonce and stored["text"] == text_value
 
 
 def test_a_signed_write_is_attributed_to_the_key_not_a_nickname(client):
@@ -2969,6 +3034,7 @@ def test_the_spec_and_the_running_app_describe_the_same_service(client):
 def test_openapi_limits_are_the_limits_the_server_enforces(client):
     """A published limit that disagrees with the enforced one is worse than none: a
     machine reader believes it. Generated from the constants, and this holds that line."""
+    import app as app_module
     import store
 
     doc = client.get("/openapi.json").json()
@@ -2979,6 +3045,9 @@ def test_openapi_limits_are_the_limits_the_server_enforces(client):
     assert next(p for p in value if p["name"] == "value")["schema"]["maxLength"] == (
         store.MAX_VALUE_CHARS
     )
+    body_limit = f"{app_module.MAX_BODY // 1024} KiB"
+    assert body_limit in doc["paths"]["/r/{room}"]["post"]["responses"]["413"]["description"]
+    assert body_limit in doc["paths"]["/kv/{ns}/{key}"]["post"]["responses"]["413"]["description"]
     room = next(p for p in say["parameters"] if p["name"] == "room")
     assert room["schema"]["pattern"] == store.NAME_RE.pattern
     # …and the version comes from the file that declares it, not a second copy.


### PR DESCRIPTION
## What

- raise the streamed JSON body cap from 32 KiB to 256 KiB so every valid envelope is reachable with `json.dumps`' default `ensure_ascii=True`, including a conditional note carrying full 8,192-character `value` and `if` fields
- generate both OpenAPI 413 descriptions from the enforced body cap instead of hardcoding `32 KiB`
- make the 413 response actionable for both room messages and notes
- align the active README, manual, and design limits with the enforced contract

## Why

The public limits are expressed in Unicode characters, but the request guard runs on wire bytes. Astral characters escaped by Python's default JSON encoder cost 12 bytes each.

On current `main` (`1197c9e`):

- a legal 4,096-emoji message serializes to 49,181 bytes and receives HTTP 413
- a legal 8,192-emoji note serializes to 98,317 bytes and receives HTTP 413
- a legal conditional write with full 8,192-emoji `value` and `if` fields serializes to 196,631 bytes
- the refusal incorrectly claims that 32,768 bytes fits 4,096 characters in every encoding

The existing regression test still exercised the former 2,000-character message limit, so it did not catch the drift after the public limit increased to 4,096.

256 KiB covers the largest valid request shape (two full note values in one CAS envelope), its JSON envelope, and signed credentials. The body is still read incrementally and rejected at a fixed bound; with the existing 128-connection ceiling, body buffering remains bounded.

## Validation

- RED: the strengthened message and note contract tests both failed with HTTP 413 on current behavior
- GREEN: 7 focused body-cap/OpenAPI tests passed, including maximum conditional-note and signed-message envelopes
- sabotage: restoring the stale `32 KiB` OpenAPI descriptions made the synchronization test fail; restoring generated descriptions made it pass
- `python -m pytest tests -q` — **242 passed**
- `ruff check .` — passed
- `ruff format --check .` — 21 files already formatted
- `ty check` — passed

## Scope

This PR does not change the storage character limits, GET write lane, rate limits, or persistence behavior. It changes only the bounded POST ingestion envelope, its regression tests, and the active documentation/machine-readable descriptions of that envelope.
