### PR TITLE
ci: harden actions and cancel superseded builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      # Grouping keeps this to one reviewable PR while weekly checks shorten exposure to
+      # a compromised/deprecated action release.
+      interval: weekly
     # Majors are where the runtime bumps live (v7 of setup-uv is the node20 -> node24 move),
     # so they must not be filtered out — grouping keeps that one PR instead of six.
     groups:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # A newer commit makes an older build result obsolete on both PRs and main.
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -24,7 +25,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      # Full commit pins are the only immutable form for third-party actions. Dependabot
+      # updates these SHAs and the release comments together.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Runs PR-controlled code (the service and its tests), so no checkout
           # credentials are persisted where that code could read them.
@@ -32,9 +35,9 @@ jobs:
 
       # Installs the interpreter named in .python-version, so CI, local dev and the
       # image all run the same 3.12.
-      # Pinned to the full version: setup-uv stopped publishing floating major tags
-      # after v7, so `@v10` does not resolve. Dependabot bumps this pin.
-      - uses: astral-sh/setup-uv@v10.0.0
+      # Resolved from the full release version to an immutable commit: setup-uv stopped
+      # publishing floating major tags after v7, and Dependabot bumps this SHA.
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
       - run: uv sync --frozen

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -19,6 +19,13 @@ on:
   push:
     tags: ["mcp-v*"]
 
+# Publishing is not cancellable: PyPI versions are immutable, so cancelling after the
+# PyPI step and restarting would strand the registry half. Duplicate runs for the same
+# tag queue behind the active one instead.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: "PyPI + MCP registry"
@@ -30,11 +37,11 @@ jobs:
       # Both publishes are OIDC: PyPI trusted publishing, and the registry's namespace proof.
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       # Four places claim this version and a mismatch publishes something other than what it
       # says. server.json carries it twice — once for the server, once for the package —
@@ -85,8 +92,15 @@ jobs:
 
       - name: Install mcp-publisher
         run: |
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/').tar.gz" \
-            | tar xz mcp-publisher
+          # This job holds an OIDC publishing credential. Pin and verify the executable
+          # instead of running bytes from a mutable `latest` URL.
+          version="v1.8.1"
+          sha256="a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc"
+          archive="mcp-publisher_linux_amd64.tar.gz"
+          curl -fsSLO "https://github.com/modelcontextprotocol/registry/releases/download/${version}/${archive}"
+          echo "${sha256}  ${archive}" | sha256sum --check --strict
+          tar xzf "${archive}" mcp-publisher
+          rm "${archive}"
           ./mcp-publisher --version
 
       - name: Publish to the MCP registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ on:
   push:
     tags: ["v*"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Re-running the same image tag is safe; the newer run supersedes an older build.
+  cancel-in-progress: true
+
 jobs:
   publish:
     name: "build + push to GHCR"
@@ -23,7 +28,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -40,16 +45,16 @@ jobs:
         run: grep -q "^## \[${GITHUB_REF_NAME#v}\]" CHANGELOG.md ||
              { echo "::error::CHANGELOG.md has no section for ${GITHUB_REF_NAME}"; exit 1; }
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository }}
           # `latest` comes free with a semver tag — adding it explicitly emitted it twice.
@@ -58,7 +63,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/Dockerfile
@@ -74,7 +79,7 @@ jobs:
       # Attestation needs a public repo or a paid org plan; while the repo is private the
       # API returns "Feature not available for the flop-labs organization" and would fail an
       # otherwise-good release. It starts working the moment the repo goes public.
-      - uses: actions/attest-build-provenance@v4
+      - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         if: ${{ !github.event.repository.private }}
         with:
           subject-name: ghcr.io/${{ github.repository }}


### PR DESCRIPTION
## What

- cancel superseded PR, main-branch, and same-tag image builds
- serialize duplicate MCP publication runs instead of cancelling after an immutable PyPI upload
- update every GitHub Action to its current release and pin it to an immutable commit SHA
- update the MCP publishing workflow from `setup-uv` v5 to v10.0.1
- replace the mutable, unchecked `mcp-publisher` download with v1.8.1 plus its published SHA-256
- check grouped GitHub Action updates weekly instead of monthly

## Why

PR #15 identified two useful CI changes, but they are mixed with thousands of unrelated mechanical source/test changes and conflicts. This extracts the CI work into a reviewable four-file change.

Superseded builds waste runner time and can report stale results. Tag-based action references and a `latest` executable download are also mutable inputs; the MCP publisher runs in a job with OIDC publication authority, so that artifact should be both version-pinned and checksum-verified.

The MCP publish workflow deliberately uses `cancel-in-progress: false`: PyPI versions are immutable, so cancellation after the PyPI step could strand the registry half and make a restart fail. Duplicate publication runs queue instead.

## Validation

- `actionlint` 1.7.12
- YAML syntax/structure via `yamllint`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run python -m pytest tests -q` — 242 passed
- `uv build --project mcp`
- downloaded `mcp-publisher_linux_amd64.tar.gz` v1.8.1 and verified SHA-256 `a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc`

Release and publication jobs were not executed locally because they mutate external registries.