### PR TITLE
fix(http): send Allow on 405, correct nine OpenAPI mismatches, and pin the lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,9 @@ jobs:
           curl -fsS localhost:8080/.well-known/agent.json | grep -q '"content_is_untrusted"'
           docker rm -f technocore-chat-ci
 
-  # A separate job because it needs the service running and nothing else here does, and
-  # because a red contract check should point at the contract rather than at "the tests".
-  # It runs against the instance's own /openapi.json, so what is checked is always the
-  # document this build would serve, not a copy of it committed beside the code.
+  # Separate because it needs the service running, and because a red contract check should
+  # point at the contract rather than at "the tests". It fetches the instance's own
+  # /openapi.json, so there is no committed copy to drift.
   contract:
     name: "openapi contract"
     runs-on: ubuntu-latest
@@ -101,14 +100,11 @@ jobs:
           enable-cache: true
       - run: uv sync --frozen --group contract
 
-      # Tuned so the fuzzer spends its budget on handlers rather than on the parts of the
-      # service that exist to stop it:
-      #   CHAT_MAX_WAIT       the long-poll ceiling, published as the `wait` maximum — at
-      #                       the default 10 a few generated long polls cost more wall
-      #                       clock than the whole run.
-      #   CHAT_RATE_*         the limiter would otherwise answer most of the run with 429,
-      #                       which conforms to the schema and checks nothing.
-      # Everything else is the shipped configuration.
+      # Tuned so the fuzzer spends its budget on handlers rather than on the parts that
+      # exist to stop it. CHAT_MAX_WAIT is published as the `wait` maximum, and at the
+      # default 10 a few generated long polls cost more than the whole run; without the
+      # rate bumps the limiter answers most of it with a 429 that conforms and checks
+      # nothing. Everything else is the shipped configuration.
       - name: Start the service
         run: |
           CHAT_ROOT="$(mktemp -d)" \
@@ -120,30 +116,25 @@ jobs:
             sleep 1
           done
 
-      # Deterministic by construction: --generation-deterministic fixes the generator
-      # (it supersedes --seed, which the CLI then ignores) and the pinned schemathesis in
-      # the `contract` group fixes the generator itself, so a failure here is a change in
-      # this service. Under ten seconds and ~800 requests at these settings.
+      # Deterministic: --generation-deterministic fixes the generation (superseding
+      # --seed, which the CLI then ignores) and the pinned schemathesis fixes the generator,
+      # so a failure is a change in this service. ~800 requests in under ten seconds.
       #
-      # The checks are named rather than `all`, because two of the rest encode assumptions
-      # this service deliberately breaks:
-      #   negative_data_rejection expects schema-invalid input to be refused, and `?wait=x`
-      #     or `?limit=x` is *ignored* here (`_cursor` falls back to the default) — being
-      #     lenient about a query parameter an agent guessed wrong is the point.
-      #   positive_data_acceptance expects schema-valid input to succeed, and a valid write
-      #     to a mailbox, an owned room or a reserved namespace is refused by design.
-      # What is left is the part that must hold: no 500s, and every response conforming to
-      # the status, content type, headers and schema the document promised — plus the two
-      # 405 checks, since Allow is the one machine-readable part of a refused method.
+      # Checks are named rather than `all`, because two of the rest assume things this
+      # service breaks on purpose: negative_data_rejection expects schema-invalid input to
+      # be refused, but a mistyped `?wait=` or `?limit=` is ignored (`_cursor` falls back);
+      # positive_data_acceptance expects valid input to succeed, but a valid write to a
+      # mailbox or a reserved namespace is refused. What remains is what must hold — no
+      # 500s, every response matching the status, content type, headers and schema
+      # promised, and the two 405 checks, since Allow is the machine-readable half of a
+      # refused method.
       #
-      # --warnings lists what to *enable*, and three are left out on purpose. `missing_auth`
-      # fires on an operation that only ever answers 403 and suggests credentials, which
-      # this service has none of — POST /r/events is refused by design, not unauthenticated.
-      # `validation_mismatch` fires on the signed lanes, where a generated 86-character
-      # string is never a valid Ed25519 signature and never will be. `missing_test_data`
-      # fires because a generated note name has never been written and 404 is the correct
-      # answer — a note is created by writing it, so there is no fixture to seed. None of
-      # the three is actionable, and a warning that is always present is one nobody reads.
+      # --warnings lists what to *enable*. Three are left out because they can never clear:
+      # missing_auth (POST /r/events only ever 403s, and there are no credentials to
+      # suggest), validation_mismatch (a generated 86-character string is never a valid
+      # Ed25519 signature), missing_test_data (a generated note name has never been
+      # written, and 404 is the right answer). A warning that is always there is one
+      # nobody reads.
       - name: Check the running service against its own /openapi.json
         run: |
           uv run schemathesis run http://localhost:8099/openapi.json \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,79 @@ jobs:
           curl -fsS localhost:8080/openapi.json | grep -q '"openapi"'
           curl -fsS localhost:8080/.well-known/agent.json | grep -q '"content_is_untrusted"'
           docker rm -f technocore-chat-ci
+
+  # A separate job because it needs the service running and nothing else here does, and
+  # because a red contract check should point at the contract rather than at "the tests".
+  # It runs against the instance's own /openapi.json, so what is checked is always the
+  # document this build would serve, not a copy of it committed beside the code.
+  contract:
+    name: "openapi contract"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+      - run: uv sync --frozen --group contract
+
+      # Tuned so the fuzzer spends its budget on handlers rather than on the parts of the
+      # service that exist to stop it:
+      #   CHAT_MAX_WAIT       the long-poll ceiling, published as the `wait` maximum — at
+      #                       the default 10 a few generated long polls cost more wall
+      #                       clock than the whole run.
+      #   CHAT_RATE_*         the limiter would otherwise answer most of the run with 429,
+      #                       which conforms to the schema and checks nothing.
+      # Everything else is the shipped configuration.
+      - name: Start the service
+        run: |
+          CHAT_ROOT="$(mktemp -d)" \
+          CHAT_MAX_WAIT=1 \
+          CHAT_RATE_READ=1000000 CHAT_RATE_WRITE=1000000 CHAT_RATE_ROOMS_PER_DAY=1000000 \
+            uv run uvicorn --app-dir src app:app --port 8099 --log-level warning &
+          for _ in $(seq 30); do
+            curl -fsS localhost:8099/healthz && break
+            sleep 1
+          done
+
+      # Deterministic by construction: --generation-deterministic fixes the generator
+      # (it supersedes --seed, which the CLI then ignores) and the pinned schemathesis in
+      # the `contract` group fixes the generator itself, so a failure here is a change in
+      # this service. Under ten seconds and ~800 requests at these settings.
+      #
+      # The checks are named rather than `all`, because two of the rest encode assumptions
+      # this service deliberately breaks:
+      #   negative_data_rejection expects schema-invalid input to be refused, and `?wait=x`
+      #     or `?limit=x` is *ignored* here (`_cursor` falls back to the default) — being
+      #     lenient about a query parameter an agent guessed wrong is the point.
+      #   positive_data_acceptance expects schema-valid input to succeed, and a valid write
+      #     to a mailbox, an owned room or a reserved namespace is refused by design.
+      # What is left is the part that must hold: no 500s, and every response conforming to
+      # the status, content type, headers and schema the document promised — plus the two
+      # 405 checks, since Allow is the one machine-readable part of a refused method.
+      #
+      # --warnings lists what to *enable*, and three are left out on purpose. `missing_auth`
+      # fires on an operation that only ever answers 403 and suggests credentials, which
+      # this service has none of — POST /r/events is refused by design, not unauthenticated.
+      # `validation_mismatch` fires on the signed lanes, where a generated 86-character
+      # string is never a valid Ed25519 signature and never will be. `missing_test_data`
+      # fires because a generated note name has never been written and 404 is the correct
+      # answer — a note is created by writing it, so there is no fixture to seed. None of
+      # the three is actionable, and a warning that is always present is one nobody reads.
+      - name: Check the running service against its own /openapi.json
+        run: |
+          uv run schemathesis run http://localhost:8099/openapi.json \
+            --url http://localhost:8099 \
+            --checks not_a_server_error,status_code_conformance,content_type_conformance,response_headers_conformance,response_schema_conformance,unsupported_method,allow_header_conformance \
+            --phases examples,coverage,fuzzing \
+            --max-examples 25 \
+            --generation-deterministic \
+            --max-response-time 10 \
+            --warnings missing_deserializer,unused_openapi_auth,unsupported_regex,method_not_allowed,constants_extraction,unmatched_filter \
+            --no-color

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,11 +1,9 @@
 name: Mutation
 
-# Weekly, and on demand — never on a pull request. A scoped pass is tens of minutes, and
-# what it produces is a reading rather than a verdict: a surviving mutant is a question
-# for a human ("would anyone notice if this were wrong, and should they?"), not a defect
-# to block a merge on. Blocking on it would only teach people to widen the scope file.
-#
-# Sunday 04:20 UTC: off the weekday peak, and a fixed minute so the run is easy to find.
+# Weekly and on demand, never on a pull request. A scoped pass is tens of minutes and
+# produces a reading, not a verdict: a surviving mutant is a question ("would anyone
+# notice if this were wrong, and should they?"). Blocking merges on it would only teach
+# people to narrow the scope file.
 on:
   workflow_dispatch:
   schedule:
@@ -13,16 +11,15 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  # No cancel-in-progress: a run that is 40 minutes in has results worth finishing, and
-  # nothing downstream is waiting on it.
+  # A run 40 minutes in has results worth finishing, and nothing waits on it.
   cancel-in-progress: false
 
 jobs:
   mutate:
     name: "scoped mutants"
     runs-on: ubuntu-latest
-    # Measured at ~1s per mutant against the scoped test selection, and the scope is under
-    # a thousand. Generous, because the alternative to a slow run is no run.
+    # ~970 mutants at roughly a second each, measured. Generous: the alternative to a slow
+    # run is no run.
     timeout-minutes: 90
     permissions:
       contents: read
@@ -36,22 +33,20 @@ jobs:
           enable-cache: true
       - run: uv sync --frozen --group mutation
 
-      # mutmut copies the project into mutants/ and runs the suite there once per mutant,
-      # so the suite has to pass in that copy before any of this means anything. Failing
-      # here is a missing entry in `also_copy`, not a mutation finding.
+      # mutmut runs the suite in a copy of the project, so it has to pass there first.
+      # Failing here is a missing entry in `also_copy`, not a mutation finding.
       - name: Baseline
         run: uv run python -m pytest tests -q
 
-      # `xargs` rather than a literal argument list: the scope lives in one Python file
-      # with the reasoning for each entry beside it, and a copy of it here would drift.
+      # `xargs` rather than a literal list: the scope lives in one file with the reasoning
+      # beside each entry, and a copy here would drift.
       - name: Run the scoped mutants
         run: |
           uv run python tests/mutation_scope.py --patterns \
             | xargs uv run mutmut run --max-children 4
 
-      # Always: a run that died halfway still knows what it killed, and the report is the
-      # only artifact anyone reads. It exits non-zero when the *harness* broke — mutants
-      # generated and never judged — which is the one thing here worth a red run.
+      # Always: a run that died halfway still knows what it killed. Exits non-zero only
+      # when the harness broke — mutants generated and never judged.
       - name: Report
         if: always()
         run: |

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,59 @@
+name: Mutation
+
+# Weekly, and on demand — never on a pull request. A scoped pass is tens of minutes, and
+# what it produces is a reading rather than a verdict: a surviving mutant is a question
+# for a human ("would anyone notice if this were wrong, and should they?"), not a defect
+# to block a merge on. Blocking on it would only teach people to widen the scope file.
+#
+# Sunday 04:20 UTC: off the weekday peak, and a fixed minute so the run is easy to find.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "20 4 * * 0"
+
+concurrency:
+  group: ${{ github.workflow }}
+  # No cancel-in-progress: a run that is 40 minutes in has results worth finishing, and
+  # nothing downstream is waiting on it.
+  cancel-in-progress: false
+
+jobs:
+  mutate:
+    name: "scoped mutants"
+    runs-on: ubuntu-latest
+    # Measured at ~1s per mutant against the scoped test selection, and the scope is under
+    # a thousand. Generous, because the alternative to a slow run is no run.
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+      - run: uv sync --frozen --group mutation
+
+      # mutmut copies the project into mutants/ and runs the suite there once per mutant,
+      # so the suite has to pass in that copy before any of this means anything. Failing
+      # here is a missing entry in `also_copy`, not a mutation finding.
+      - name: Baseline
+        run: uv run python -m pytest tests -q
+
+      # `xargs` rather than a literal argument list: the scope lives in one Python file
+      # with the reasoning for each entry beside it, and a copy of it here would drift.
+      - name: Run the scoped mutants
+        run: |
+          uv run python tests/mutation_scope.py --patterns \
+            | xargs uv run mutmut run --max-children 4
+
+      # Always: a run that died halfway still knows what it killed, and the report is the
+      # only artifact anyone reads. It exits non-zero when the *harness* broke — mutants
+      # generated and never judged — which is the one thing here worth a red run.
+      - name: Report
+        if: always()
+        run: |
+          uv run mutmut export-cicd-stats
+          uv run python tests/mutation_scope.py --report | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 data/
 dist/
 node_modules/
+mutants/
+.schemathesis/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ of the contract, not an implementation detail: agents parse it.
   authorization gates, the caps and the refusal bodies. Between them they took the suite from 242
   tests to 264 and found no defect in the service — what they found is the contract work below.
 
+  Two of the contract checks are rules rather than lists, which is the difference that mattered.
+  The status check began as a hand-written table, and `POST /r/events` was added to the document
+  after the table was written, so it went unprovoked until a reviewer found the statuses it really
+  returns. It now holds in both directions: every refusal a test provokes is documented, and every
+  documented refusal has a test that provokes it. Beside it, every input limit the document
+  publishes is exercised at its extreme against the running server — the same omission on the
+  *read* side is what let `?wait=` advertise fractional values it silently discarded, a failure
+  with no contract signature for a fuzzer or a coverage gate to catch.
+
 ### Fixed
 
 - **A 405 carries `Allow`, naming every verb the *path* takes.** RFC 9110 §15.5.6 makes the header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,17 @@ of the contract, not an implementation detail: agents parse it.
     malformed request, and a client told only about 400 retried the identical bytes.
   - The four URL write lanes document their 404. The path convertor does not match a raw newline,
     so `%0A` in `<text>` reaches no handler — deliberate, and written down nowhere.
-  - `POST /r/events` is documented as an operation that always answers 403. Documenting only `GET`
-    said the path took no POST at all, so the refusal arrived as a surprise.
+  - `POST /r/events` is documented, with its request body and all four statuses. Documenting only
+    `GET` said the path took no POST at all; documenting only the 403 was the same mistake one
+    level down, since the body is parsed before the refusal and a malformed or oversized one is
+    answered on its own terms.
   - Error responses declare their `text/plain` body, so a reader knows there is one.
+
+- **`?wait=` accepts the fractional values it has always advertised.** The parameter is published
+  as `type: number` and the poll interval is half a second, so `wait=0.5` is the shortest wait
+  that can return anything — but it was parsed with `int()`, so every fractional value became no
+  wait at all and the caller got an immediate empty reply indistinguishable from an idle room. On
+  an instance with a sub-second ceiling that defeated every conforming value there is.
 
 - **The `?wait=` ceiling is published from the value the server enforces**, and is now tunable as
   `CHAT_MAX_WAIT` (default 10, unchanged). It was a hardcoded 10 in five places — the `wait`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,10 +53,12 @@ of the contract, not an implementation detail: agents parse it.
   - Error responses declare their `text/plain` body, so a reader knows there is one.
 
 - **The `?wait=` ceiling is published from the value the server enforces**, and is now tunable as
-  `CHAT_MAX_WAIT` (default 10, unchanged). It was a literal in three places — the `wait` maximum in
-  `/openapi.json`, and the polling advice in both `/.well-known/agent.json` and the 429 body — so a
-  tuned instance advertised a number nobody honoured. `agent.json` also gains
-  `limits.long_poll_seconds`.
+  `CHAT_MAX_WAIT` (default 10, unchanged). It was a hardcoded 10 in five places — the `wait`
+  maximum in `/openapi.json`, the polling advice in `/.well-known/agent.json`, the 429 body, the
+  `WAITING` section of the manual, and the route map a 404 prints — so a tuned instance advertised
+  a number nobody honoured. `agent.json` also gains `limits.long_poll_seconds`. The examples in
+  `SKILL.md` and `patterns.md` still say 10: both are served byte-for-byte and cannot carry a
+  per-deployment number, and the server clamps rather than refusing, so the example still works.
 
 ## [0.7.0] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,42 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A 405 carries `Allow`, and it names every verb the *path* takes.** RFC 9110 §15.5.6 makes the
+  header mandatory on a 405 and it was absent, so the one machine-readable part of that answer was
+  missing. The union matters as much as the header: two routes share `/r/<room>` and two share
+  `/kv/<ns>/<key>`, and Starlette builds `Allow` from whichever route partially matched first — it
+  would have said `GET, HEAD` on the two paths that plainly also take POST, ruling out the one verb
+  that would have worked. The corrective body is unchanged and now repeats the list, for the same
+  reason the rate-limit body repeats `Retry-After`: agent harnesses surface the body and drop the
+  headers. `OPTIONS` is not in the list because it is not implemented.
+
+- **`/openapi.json` describes the service the server actually is.** Six mismatches, each one a
+  thing a generated client or a contract test would have got wrong:
+  - The signed lane published three different `did`/`sig`/`nonce` shapes — an unbounded `+` on
+    `say-signed` that accepted `did:key:z6Mk` as a whole DID, a bare `string` on `set-signed`, and
+    prose in the room POST body that no generator can read. All three now come from one set of
+    regexes in `didkey.py`, beside the code that enforces them, so a client built against any copy
+    is built against the real rule. The POST body also states that `did` travels with `sig` and
+    `nonce` (`dependentRequired`) — a body carrying only `did` is refused, never quietly
+    downgraded to an unsigned write.
+  - `text` and `value` carry `minLength: 1`. `required: ["text"]` is satisfied by `""`, which is a
+    400: the single-line sweep leaves nothing visible and the write is refused. A generator reading
+    only `required` emitted a client whose empty-message call could never succeed.
+  - `GET /kv/<ns>/<key>` documents its 400. A name outside the allowlist is not the 404 the
+    contract implied, and the two are not interchangeable: 404 means "write it", 400 means "that
+    name can never exist here".
+  - `POST /kv/<ns>/<key>` documents its 400 and its 403. The contract described a POST that could
+    reach `room-nonce`, `room-owners` and `room-allow` — namespaces the server has never let an
+    unsigned caller write.
+  - `GET /r/<room>/say-signed/...` documents its 403, and `GET /kv/<ns>/<key>/set-signed/...`
+    documents its 409 and its two conditional query parameters. A signature that does not verify is
+    a refusal, not a malformed request, and a client that had only been told about 400 treated the
+    403 as a transport fault and retried the identical bytes.
+  - The remaining bare-`description` error responses declare their `text/plain` body, so a reader
+    knows there is one.
+
 ## [0.7.0] - 2026-08-21
 
 MINOR: `/rooms` marks the two fields on it that a caller chose, `/humans` registers WebMCP tools,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,20 @@ of the contract, not an implementation detail: agents parse it.
     `GET` said the path took no POST at all; documenting only the 403 was the same mistake one
     level down, since the body is parsed before the refusal and a malformed or oversized one is
     answered on its own terms.
-  - Error responses declare their `text/plain` body, so a reader knows there is one.
+  - **Every** documented response declares the body it returns, not just the error ones. A
+    response with no `content` tells a generated client there is nothing to show, which on a
+    service whose refusals *are* the documentation hides the correction at the moment a caller
+    needs it. The 413s, the "Written." 200s and every document route were still bare; the three
+    that negotiate markdown now advertise both types they serve.
+
+- **A non-finite `CHAT_MAX_WAIT` is refused at startup instead of published.** `float()` accepts
+  `inf` and `nan` where the `int()` beside it raises, and this is the one setting whose value is
+  published — so a misconfigured instance served `"maximum": Infinity` in `/openapi.json` and
+  `"long_poll_seconds": Infinity` in `/.well-known/agent.json`. Python emits and reads that back;
+  RFC 8259 does not permit it, so every strict parser rejects the whole document. A discovery
+  service answering with undiscoverable documents is worse off than one that refuses to boot,
+  which is what the settings beside it already do. An integral ceiling also publishes as an
+  integer again (`10`, not `10.0`); a fractional one stays a float.
 
 - **`?wait=` accepts the fractional values it has always advertised.** The parameter is published
   as `type: number` and the poll interval is half a second, so `wait=0.5` is the shortest wait

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,38 @@ of the contract, not an implementation detail: agents parse it.
   authorization gates, the caps, the refusal bodies — and scheduled rather than gating, because a
   surviving mutant is a question for a human. It reports; it does not vote.
 
+  All 226 survivors of its first full run were then reviewed. **No defect was found in the
+  service** — every survivor was either an equivalent mutant, a wording change that left the
+  correction intact, or a real behaviour nothing pinned. Twelve tests and four sharpened
+  assertions came out of it, taking the scoped score from 77% to 81%:
+  - **`did:key` has exactly one spelling.** Ownership compares DID *strings*, so a key with
+    more than one accepted form is a key whose owner the service cannot recognise. Three
+    separate guards enforce that — prefix, exact length, multicodec — and each is a two-part
+    condition whose halves were never tested apart. `or`→`and` short-circuits away the
+    second half of each one, and all three survived.
+  - **The streaming half of the body cap had never run.** `read_json` bounds the upload
+    twice, and the second bound exists for chunked requests that declare no length — but
+    every oversize test sent a body the test client sized for it, so only the
+    Content-Length branch was ever reached.
+  - **The reaper's note side, and its resilience.** Note locks and empty namespaces are
+    swept by a second, hand-written walk that nothing exercised; one file raising mid-pass
+    must skip that file, not abandon the rest; and the counters must add up across a wave
+    rather than report the last room taken.
+  - **A busy ephemeral room keeps its unexpired history.** Compaction retains the newest
+    record unconditionally and stops at the first expired one; drop that guard and every
+    rotation of a busy `e-` room truncates to a single line. Only a room whose records are
+    all still fresh at rotation time distinguishes the two.
+  - **Two signed writers cannot both spend one nonce**, at either end of the counter's
+    life. The docstring promised it; nothing raced it.
+  - **The caps bind *at* the cap**, not one byte past it, and their refusals carry the
+    numbers a caller acts on — the cap that was hit, and how full the disk is against how
+    big it was sized.
+
+  Accepted and not acted on: the exact-threshold `>`/`>=` mutants on the idle and expiry
+  comparisons. The state machine excludes ages within five seconds of a threshold on
+  purpose, because the model counts whole simulated seconds against a real clock, and a
+  test that flakes on its own timing is worth less than the boundary it pins.
+
   Its first run produced three tests, all cases the suite would not have noticed:
   - A torn line no longer reads as an empty room: `_stillborn` skips what it cannot parse, so a
     room with one damaged byte and two answered messages is not a monologue. Turning that
@@ -48,6 +80,11 @@ of the contract, not an implementation detail: agents parse it.
     room holding old records would have quietly stopped expiring them.
 
 ### Fixed
+
+- **The 429 body's poll advice honours the configured `?wait=` ceiling.** It said `&wait=10`
+  from a literal, which became wrong the moment that ceiling was made tunable — the same
+  drift the manifest change below closes, in the one place that is a response rather than a
+  document.
 
 - **A 405 carries `Allow`, naming every verb the *path* takes.** RFC 9110 §15.5.6 makes the header
   mandatory and it was absent, so the one machine-readable part of that answer was missing. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,47 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Added
+
+- **`tests/test_store_stateful.py` — a Hypothesis state machine over the store's lifecycle.**
+  Every rule in `store.py` is easy to satisfy on its own; what is hard is satisfying all of them
+  at once, in an order nobody wrote a test for. Compaction rewrites a room, expiry hides records
+  the file still holds, the reaper deletes the file outright, and a conditional note write has to
+  see what the last write left — so the bugs that survive example tests are the ones that need a
+  particular *sequence*. The machine generates the sequences and holds each step to the contract:
+  `seq` contiguous and never reused, a read a contiguous run ending at the newest readable record,
+  compaction dropping records but never renumbering or reordering them, a CAS winning exactly when
+  the value it was handed is still there and losing with the actual value attached, and the reaper
+  taking what is idle and nothing else. Time is modelled by moving the whole store into the past —
+  file mtimes *and* record timestamps, because the reaper stats the file and the `e-` class parses
+  the record, and ageing one without the other produces a store that has never existed.
+  Derandomised, so a failure is reproducible and CI does not find a different bug every run.
+
+- **A contract job on every pull request.** It fuzzes the running service against the
+  `/openapi.json` that same instance serves — no committed copy to drift — and fails on a response
+  whose status, content type, headers or body the document did not promise. Under ten seconds and
+  ~800 requests. It found three of the gaps fixed below, including the `403` on `POST /r/events`
+  that a client reading the old document would have met as a 405.
+
+- **A weekly scoped mutation run** (`.github/workflows/mutation.yml`, scope in
+  `tests/mutation_scope.py`). Coverage says a line ran; this asks whether a test would have
+  *noticed* it being wrong. Scoped to the four places where being subtly wrong is silent and
+  expensive — the TTL thresholds, the authorization gates, the caps, and the refusal bodies — and
+  scheduled rather than gating, because a surviving mutant is a question for a human and blocking
+  merges on it only teaches people to narrow the scope. It reports; it does not vote.
+
+  Three tests come from its first run, all in the TTL group and all cases where the suite would
+  not have noticed the code being wrong:
+  - A torn line no longer reads as an empty room. `_stillborn` skips what it cannot parse rather
+    than stopping at it, so a room with one damaged byte and two answered messages is not a
+    monologue — turning that `continue` into a `break` passed the entire suite.
+  - A room whose records cannot be counted at all is never stillborn. Everything else in this
+    service fails closed; this one place has to fail open, or the first IO error the reaper meets
+    costs live data.
+  - A second-precision `ts` still expires. Records written before `ts` gained microseconds carry
+    the older form, expiry is the only thing that parses `ts`, and nothing exercised that branch —
+    an `e-` room holding old records would have quietly stopped expiring them.
+
 ### Fixed
 
 - **A 405 carries `Allow`, and it names every verb the *path* takes.** RFC 9110 §15.5.6 makes the
@@ -47,6 +88,19 @@ of the contract, not an implementation detail: agents parse it.
     403 as a transport fault and retried the identical bytes.
   - The remaining bare-`description` error responses declare their `text/plain` body, so a reader
     knows there is one.
+
+  Three more the contract job found once the six above were in:
+  - The four URL write lanes document their `404`. Starlette's path convertor does not match a
+    raw newline, so `/r/<room>/say/<nick>/a%0Ab` matches no route and never reaches the handler —
+    deliberately (it is what makes forging a second JSONL record out of one message impossible),
+    and previously written down nowhere.
+  - `POST /r/events` is documented, as an operation that always answers `403`. The route accepts
+    the method because `/r/{room}` does; documenting only `GET` told a client the path took no
+    POST at all, so the refusal arrived as something it had never been told could happen.
+  - `?wait=`'s published maximum comes from the enforced ceiling, now `CHAT_MAX_WAIT`, instead of
+    a hardcoded `10` beside a hardcoded `10.0` — the drift `src/manifest.py` exists to prevent.
+    `/.well-known/agent.json` carries the same number in `limits.long_poll_seconds` and stops
+    saying `&wait=10` on an instance tuned to something else.
 
 ## [0.7.0] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,92 +15,82 @@ of the contract, not an implementation detail: agents parse it.
 ### Added
 
 - **`tests/test_store_stateful.py` — a Hypothesis state machine over the store's lifecycle.**
-  Every rule in `store.py` is easy to satisfy on its own; what is hard is satisfying all of them
-  at once, in an order nobody wrote a test for. Compaction rewrites a room, expiry hides records
-  the file still holds, the reaper deletes the file outright, and a conditional note write has to
-  see what the last write left — so the bugs that survive example tests are the ones that need a
-  particular *sequence*. The machine generates the sequences and holds each step to the contract:
-  `seq` contiguous and never reused, a read a contiguous run ending at the newest readable record,
-  compaction dropping records but never renumbering or reordering them, a CAS winning exactly when
-  the value it was handed is still there and losing with the actual value attached, and the reaper
-  taking what is idle and nothing else. Time is modelled by moving the whole store into the past —
-  file mtimes *and* record timestamps, because the reaper stats the file and the `e-` class parses
-  the record, and ageing one without the other produces a store that has never existed.
-  Derandomised, so a failure is reproducible and CI does not find a different bug every run.
+  Every rule in `store.py` is easy to satisfy alone; what is hard is satisfying all of them at
+  once, in an order nobody wrote a test for — so the bugs that survive example tests are the ones
+  needing a particular *sequence*. The machine generates the sequences and holds each step to the
+  contract: `seq` contiguous and never reused, a read a contiguous run ending at the newest
+  readable record, compaction dropping records but never renumbering or reordering them, a CAS
+  winning exactly when the value it was handed is still there and losing with the actual value
+  attached, and the reaper taking what is idle and nothing else. Simulated time moves file mtimes
+  *and* record timestamps, because the reaper stats one and `e-` expiry parses the other.
+  Derandomised, so CI does not find a different bug every run.
 
-- **A contract job on every pull request.** It fuzzes the running service against the
-  `/openapi.json` that same instance serves — no committed copy to drift — and fails on a response
-  whose status, content type, headers or body the document did not promise. Under ten seconds and
-  ~800 requests. It found three of the gaps fixed below, including the `403` on `POST /r/events`
-  that a client reading the old document would have met as a 405.
+- **A contract job on every pull request.** Schemathesis against the `/openapi.json` the instance
+  itself serves — no committed copy to drift — failing on any response whose status, content type,
+  headers or body the document did not promise. ~800 requests in under ten seconds. It found three
+  of the gaps fixed below, including the `403` on `POST /r/events` that a client reading the old
+  document would have met as a 405.
 
 - **A weekly scoped mutation run** (`.github/workflows/mutation.yml`, scope in
   `tests/mutation_scope.py`). Coverage says a line ran; this asks whether a test would have
-  *noticed* it being wrong. Scoped to the four places where being subtly wrong is silent and
-  expensive — the TTL thresholds, the authorization gates, the caps, and the refusal bodies — and
-  scheduled rather than gating, because a surviving mutant is a question for a human and blocking
-  merges on it only teaches people to narrow the scope. It reports; it does not vote.
+  *noticed* it being wrong. Scoped to where being wrong is silent — TTL thresholds, the
+  authorization gates, the caps, the refusal bodies — and scheduled rather than gating, because a
+  surviving mutant is a question for a human. It reports; it does not vote.
 
-  Three tests come from its first run, all in the TTL group and all cases where the suite would
-  not have noticed the code being wrong:
-  - A torn line no longer reads as an empty room. `_stillborn` skips what it cannot parse rather
-    than stopping at it, so a room with one damaged byte and two answered messages is not a
-    monologue — turning that `continue` into a `break` passed the entire suite.
-  - A room whose records cannot be counted at all is never stillborn. Everything else in this
-    service fails closed; this one place has to fail open, or the first IO error the reaper meets
-    costs live data.
-  - A second-precision `ts` still expires. Records written before `ts` gained microseconds carry
-    the older form, expiry is the only thing that parses `ts`, and nothing exercised that branch —
-    an `e-` room holding old records would have quietly stopped expiring them.
+  Its first run produced three tests, all cases the suite would not have noticed:
+  - A torn line no longer reads as an empty room: `_stillborn` skips what it cannot parse, so a
+    room with one damaged byte and two answered messages is not a monologue. Turning that
+    `continue` into a `break` passed the entire suite.
+  - A room whose records cannot be counted is never stillborn. Everything else here fails closed;
+    this one place must fail open, or the reaper's first IO error costs live data.
+  - A second-precision `ts` still expires. Records predating microsecond `ts` carry the older
+    form, expiry is the only thing that parses `ts`, and nothing exercised that branch — an `e-`
+    room holding old records would have quietly stopped expiring them.
 
 ### Fixed
 
-- **A 405 carries `Allow`, and it names every verb the *path* takes.** RFC 9110 §15.5.6 makes the
-  header mandatory on a 405 and it was absent, so the one machine-readable part of that answer was
-  missing. The union matters as much as the header: two routes share `/r/<room>` and two share
-  `/kv/<ns>/<key>`, and Starlette builds `Allow` from whichever route partially matched first — it
-  would have said `GET, HEAD` on the two paths that plainly also take POST, ruling out the one verb
-  that would have worked. The corrective body is unchanged and now repeats the list, for the same
-  reason the rate-limit body repeats `Retry-After`: agent harnesses surface the body and drop the
-  headers. `OPTIONS` is not in the list because it is not implemented.
+- **A 405 carries `Allow`, naming every verb the *path* takes.** RFC 9110 §15.5.6 makes the header
+  mandatory and it was absent, so the one machine-readable part of that answer was missing. The
+  union matters as much as the header: two routes share `/r/<room>` and two share `/kv/<ns>/<key>`,
+  and Starlette builds `Allow` from whichever partially matched first — `GET, HEAD` on paths that
+  plainly also take POST, ruling out the verb that would have worked. The corrective body is
+  unchanged and now repeats the list, for the reason the rate-limit body repeats `Retry-After`:
+  agent harnesses show the body and drop the headers. `OPTIONS` is absent because it is not
+  implemented.
 
 - **`/openapi.json` describes the service the server actually is.** Six mismatches, each one a
   thing a generated client or a contract test would have got wrong:
-  - The signed lane published three different `did`/`sig`/`nonce` shapes — an unbounded `+` on
+  - The signed lane published three different `did`/`sig`/`nonce` shapes: an unbounded `+` on
     `say-signed` that accepted `did:key:z6Mk` as a whole DID, a bare `string` on `set-signed`, and
     prose in the room POST body that no generator can read. All three now come from one set of
-    regexes in `didkey.py`, beside the code that enforces them, so a client built against any copy
-    is built against the real rule. The POST body also states that `did` travels with `sig` and
-    `nonce` (`dependentRequired`) — a body carrying only `did` is refused, never quietly
+    regexes in `didkey.py`, beside the code enforcing them. The POST body also states that `did`
+    travels with `sig` and `nonce` (`dependentRequired`) — `did` alone is refused, never quietly
     downgraded to an unsigned write.
   - `text` and `value` carry `minLength: 1`. `required: ["text"]` is satisfied by `""`, which is a
-    400: the single-line sweep leaves nothing visible and the write is refused. A generator reading
-    only `required` emitted a client whose empty-message call could never succeed.
+    400 — the sweep leaves nothing visible — so a generator reading only `required` emitted a
+    client whose empty-message call could never succeed.
   - `GET /kv/<ns>/<key>` documents its 400. A name outside the allowlist is not the 404 the
     contract implied, and the two are not interchangeable: 404 means "write it", 400 means "that
     name can never exist here".
-  - `POST /kv/<ns>/<key>` documents its 400 and its 403. The contract described a POST that could
-    reach `room-nonce`, `room-owners` and `room-allow` — namespaces the server has never let an
-    unsigned caller write.
-  - `GET /r/<room>/say-signed/...` documents its 403, and `GET /kv/<ns>/<key>/set-signed/...`
-    documents its 409 and its two conditional query parameters. A signature that does not verify is
-    a refusal, not a malformed request, and a client that had only been told about 400 treated the
-    403 as a transport fault and retried the identical bytes.
-  - The remaining bare-`description` error responses declare their `text/plain` body, so a reader
-    knows there is one.
+  - `POST /kv/<ns>/<key>` documents its 400 and 403. The contract described a POST reaching
+    `room-nonce`, `room-owners` and `room-allow` — namespaces no unsigned caller has ever written.
+  - `GET /r/<room>/say-signed/...` documents its 403, and `GET /kv/<ns>/<key>/set-signed/...` its
+    409 and two conditional query parameters. A signature that does not verify is a refusal, not a
+    malformed request; a client told only about 400 read the 403 as a transport fault and retried
+    the identical bytes.
+  - The remaining bare-`description` error responses declare their `text/plain` body.
 
-  Three more the contract job found once the six above were in:
-  - The four URL write lanes document their `404`. Starlette's path convertor does not match a
-    raw newline, so `/r/<room>/say/<nick>/a%0Ab` matches no route and never reaches the handler —
-    deliberately (it is what makes forging a second JSONL record out of one message impossible),
-    and previously written down nowhere.
-  - `POST /r/events` is documented, as an operation that always answers `403`. The route accepts
-    the method because `/r/{room}` does; documenting only `GET` told a client the path took no
-    POST at all, so the refusal arrived as something it had never been told could happen.
-  - `?wait=`'s published maximum comes from the enforced ceiling, now `CHAT_MAX_WAIT`, instead of
-    a hardcoded `10` beside a hardcoded `10.0` — the drift `src/manifest.py` exists to prevent.
-    `/.well-known/agent.json` carries the same number in `limits.long_poll_seconds` and stops
-    saying `&wait=10` on an instance tuned to something else.
+  Three more the contract job found once those six were in:
+  - The four URL write lanes document their `404`. Starlette's path convertor does not match a raw
+    newline, so `/r/<room>/say/<nick>/a%0Ab` matches no route and never reaches the handler —
+    deliberate (it is what makes forging a second JSONL record impossible), and written down
+    nowhere.
+  - `POST /r/events` is documented as an operation that always answers `403`. The route accepts the
+    method because `/r/{room}` does; documenting only `GET` said the path took no POST at all, so
+    the refusal arrived as something the client had never been told could happen.
+  - `?wait=`'s published maximum comes from the enforced ceiling, now `CHAT_MAX_WAIT`, instead of a
+    hardcoded `10` beside a hardcoded `10.0`. `/.well-known/agent.json` carries the same number in
+    `limits.long_poll_seconds` and stops saying `&wait=10` on an instance tuned otherwise.
 
 ## [0.7.0] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,120 +14,49 @@ of the contract, not an implementation detail: agents parse it.
 
 ### Added
 
-- **`tests/test_store_stateful.py` — a Hypothesis state machine over the store's lifecycle.**
-  Every rule in `store.py` is easy to satisfy alone; what is hard is satisfying all of them at
-  once, in an order nobody wrote a test for — so the bugs that survive example tests are the ones
-  needing a particular *sequence*. The machine generates the sequences and holds each step to the
-  contract: `seq` contiguous and never reused, a read a contiguous run ending at the newest
-  readable record, compaction dropping records but never renumbering or reordering them, a CAS
-  winning exactly when the value it was handed is still there and losing with the actual value
-  attached, and the reaper taking what is idle and nothing else. Simulated time moves file mtimes
-  *and* record timestamps, because the reaper stats one and `e-` expiry parses the other.
-  Derandomised, so CI does not find a different bug every run.
-
-- **A contract job on every pull request.** Schemathesis against the `/openapi.json` the instance
-  itself serves — no committed copy to drift — failing on any response whose status, content type,
-  headers or body the document did not promise. ~800 requests in under ten seconds. It found three
-  of the gaps fixed below, including the `403` on `POST /r/events` that a client reading the old
-  document would have met as a 405.
-
-- **A weekly scoped mutation run** (`.github/workflows/mutation.yml`, scope in
-  `tests/mutation_scope.py`). Coverage says a line ran; this asks whether a test would have
-  *noticed* it being wrong. Scoped to where being wrong is silent — TTL thresholds, the
-  authorization gates, the caps, the refusal bodies — and scheduled rather than gating, because a
-  surviving mutant is a question for a human. It reports; it does not vote.
-
-  All 226 survivors of its first full run were then reviewed. **No defect was found in the
-  service** — every survivor was either an equivalent mutant, a wording change that left the
-  correction intact, or a real behaviour nothing pinned. Twelve tests and four sharpened
-  assertions came out of it, taking the scoped score from 77% to 81%:
-  - **`did:key` has exactly one spelling.** Ownership compares DID *strings*, so a key with
-    more than one accepted form is a key whose owner the service cannot recognise. Three
-    separate guards enforce that — prefix, exact length, multicodec — and each is a two-part
-    condition whose halves were never tested apart. `or`→`and` short-circuits away the
-    second half of each one, and all three survived.
-  - **The streaming half of the body cap had never run.** `read_json` bounds the upload
-    twice, and the second bound exists for chunked requests that declare no length — but
-    every oversize test sent a body the test client sized for it, so only the
-    Content-Length branch was ever reached.
-  - **The reaper's note side, and its resilience.** Note locks and empty namespaces are
-    swept by a second, hand-written walk that nothing exercised; one file raising mid-pass
-    must skip that file, not abandon the rest; and the counters must add up across a wave
-    rather than report the last room taken.
-  - **A busy ephemeral room keeps its unexpired history.** Compaction retains the newest
-    record unconditionally and stops at the first expired one; drop that guard and every
-    rotation of a busy `e-` room truncates to a single line. Only a room whose records are
-    all still fresh at rotation time distinguishes the two.
-  - **Two signed writers cannot both spend one nonce**, at either end of the counter's
-    life. The docstring promised it; nothing raced it.
-  - **The caps bind *at* the cap**, not one byte past it, and their refusals carry the
-    numbers a caller acts on — the cap that was hit, and how full the disk is against how
-    big it was sized.
-
-  Accepted and not acted on: the exact-threshold `>`/`>=` mutants on the idle and expiry
-  comparisons. The state machine excludes ages within five seconds of a threshold on
-  purpose, because the model counts whole simulated seconds against a real clock, and a
-  test that flakes on its own timing is worth less than the boundary it pins.
-
-  Its first run produced three tests, all cases the suite would not have noticed:
-  - A torn line no longer reads as an empty room: `_stillborn` skips what it cannot parse, so a
-    room with one damaged byte and two answered messages is not a monologue. Turning that
-    `continue` into a `break` passed the entire suite.
-  - A room whose records cannot be counted is never stillborn. Everything else here fails closed;
-    this one place must fail open, or the reaper's first IO error costs live data.
-  - A second-precision `ts` still expires. Records predating microsecond `ts` carry the older
-    form, expiry is the only thing that parses `ts`, and nothing exercised that branch — an `e-`
-    room holding old records would have quietly stopped expiring them.
+- **Three checks that are not example tests**, because the failures worth catching here are not
+  example-shaped. `tests/test_store_stateful.py` drives append, read, expiry, compaction, the
+  reaper and conditional writes in generated orders, holding each step to the store's contract. A
+  contract job fuzzes every pull request against the `/openapi.json` that instance serves, so an
+  undocumented status code is a red build. A weekly scoped mutation run (`tests/mutation_scope.py`)
+  asks whether a test would have *noticed* the code being wrong, over the TTL thresholds, the
+  authorization gates, the caps and the refusal bodies. Between them they took the suite from 242
+  tests to 264 and found no defect in the service — what they found is the contract work below.
 
 ### Fixed
 
-- **The 429 body's poll advice honours the configured `?wait=` ceiling.** It said `&wait=10`
-  from a literal, which became wrong the moment that ceiling was made tunable — the same
-  drift the manifest change below closes, in the one place that is a response rather than a
-  document.
-
 - **A 405 carries `Allow`, naming every verb the *path* takes.** RFC 9110 §15.5.6 makes the header
   mandatory and it was absent, so the one machine-readable part of that answer was missing. The
-  union matters as much as the header: two routes share `/r/<room>` and two share `/kv/<ns>/<key>`,
-  and Starlette builds `Allow` from whichever partially matched first — `GET, HEAD` on paths that
-  plainly also take POST, ruling out the verb that would have worked. The corrective body is
-  unchanged and now repeats the list, for the reason the rate-limit body repeats `Retry-After`:
-  agent harnesses show the body and drop the headers. `OPTIONS` is absent because it is not
-  implemented.
+  union matters as much: two routes share `/r/<room>` and two share `/kv/<ns>/<key>`, and Starlette
+  builds `Allow` from whichever partially matched first — `GET, HEAD` on paths that plainly also
+  take POST, ruling out the verb that would have worked. The corrective body is unchanged and now
+  repeats the list, for the reason the rate-limit body repeats `Retry-After`: agent harnesses show
+  the body and drop the headers.
 
-- **`/openapi.json` describes the service the server actually is.** Six mismatches, each one a
-  thing a generated client or a contract test would have got wrong:
-  - The signed lane published three different `did`/`sig`/`nonce` shapes: an unbounded `+` on
-    `say-signed` that accepted `did:key:z6Mk` as a whole DID, a bare `string` on `set-signed`, and
-    prose in the room POST body that no generator can read. All three now come from one set of
-    regexes in `didkey.py`, beside the code enforcing them. The POST body also states that `did`
-    travels with `sig` and `nonce` (`dependentRequired`) — `did` alone is refused, never quietly
-    downgraded to an unsigned write.
+- **`/openapi.json` describes the service the server actually is.** Nine mismatches, each one a
+  thing a generated client would have got wrong:
+  - The signed lane published three different `did`/`sig`/`nonce` shapes — an unbounded `+` that
+    accepted `did:key:z6Mk` as a whole DID, a bare `string`, and prose no generator can read. All
+    three now come from one set of regexes in `didkey.py`, beside the code enforcing them, and the
+    POST body states that `did` travels with `sig` and `nonce`.
   - `text` and `value` carry `minLength: 1`. `required: ["text"]` is satisfied by `""`, which is a
-    400 — the sweep leaves nothing visible — so a generator reading only `required` emitted a
-    client whose empty-message call could never succeed.
-  - `GET /kv/<ns>/<key>` documents its 400. A name outside the allowlist is not the 404 the
-    contract implied, and the two are not interchangeable: 404 means "write it", 400 means "that
-    name can never exist here".
-  - `POST /kv/<ns>/<key>` documents its 400 and 403. The contract described a POST reaching
-    `room-nonce`, `room-owners` and `room-allow` — namespaces no unsigned caller has ever written.
-  - `GET /r/<room>/say-signed/...` documents its 403, and `GET /kv/<ns>/<key>/set-signed/...` its
-    409 and two conditional query parameters. A signature that does not verify is a refusal, not a
-    malformed request; a client told only about 400 read the 403 as a transport fault and retried
-    the identical bytes.
-  - The remaining bare-`description` error responses declare their `text/plain` body.
+    400 — the single-line sweep leaves nothing visible.
+  - `GET` and `POST /kv/<ns>/<key>` document their 400, and the POST its 403: the contract
+    described a POST reaching three namespaces no unsigned caller has ever written.
+  - `say-signed` documents its 403 and `set-signed` its 409, plus the two conditional query
+    parameters it has always accepted. A signature that does not verify is a refusal, not a
+    malformed request, and a client told only about 400 retried the identical bytes.
+  - The four URL write lanes document their 404. The path convertor does not match a raw newline,
+    so `%0A` in `<text>` reaches no handler — deliberate, and written down nowhere.
+  - `POST /r/events` is documented as an operation that always answers 403. Documenting only `GET`
+    said the path took no POST at all, so the refusal arrived as a surprise.
+  - Error responses declare their `text/plain` body, so a reader knows there is one.
 
-  Three more the contract job found once those six were in:
-  - The four URL write lanes document their `404`. Starlette's path convertor does not match a raw
-    newline, so `/r/<room>/say/<nick>/a%0Ab` matches no route and never reaches the handler —
-    deliberate (it is what makes forging a second JSONL record impossible), and written down
-    nowhere.
-  - `POST /r/events` is documented as an operation that always answers `403`. The route accepts the
-    method because `/r/{room}` does; documenting only `GET` said the path took no POST at all, so
-    the refusal arrived as something the client had never been told could happen.
-  - `?wait=`'s published maximum comes from the enforced ceiling, now `CHAT_MAX_WAIT`, instead of a
-    hardcoded `10` beside a hardcoded `10.0`. `/.well-known/agent.json` carries the same number in
-    `limits.long_poll_seconds` and stops saying `&wait=10` on an instance tuned otherwise.
+- **The `?wait=` ceiling is published from the value the server enforces**, and is now tunable as
+  `CHAT_MAX_WAIT` (default 10, unchanged). It was a literal in three places — the `wait` maximum in
+  `/openapi.json`, and the polling advice in both `/.well-known/agent.json` and the 429 body — so a
+  tuned instance advertised a number nobody honoured. `agent.json` also gains
+  `limits.long_poll_seconds`.
 
 ## [0.7.0] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,81 +14,57 @@ of the contract, not an implementation detail: agents parse it.
 
 ### Added
 
-- **Three checks that are not example tests**, because the failures worth catching here are not
-  example-shaped. `tests/test_store_stateful.py` drives append, read, expiry, compaction, the
-  reaper and conditional writes in generated orders, holding each step to the store's contract. A
-  contract job fuzzes every pull request against the `/openapi.json` that instance serves, so an
-  undocumented status code is a red build. A weekly scoped mutation run (`tests/mutation_scope.py`)
-  asks whether a test would have *noticed* the code being wrong, over the TTL thresholds, the
-  authorization gates, the caps and the refusal bodies. Between them they took the suite from 242
-  tests to 264 and found no defect in the service — what they found is the contract work below.
-
-  Two of the contract checks are rules rather than lists, which is the difference that mattered.
-  The status check began as a hand-written table, and `POST /r/events` was added to the document
-  after the table was written, so it went unprovoked until a reviewer found the statuses it really
-  returns. It now holds in both directions: every refusal a test provokes is documented, and every
-  documented refusal has a test that provokes it. Beside it, every input limit the document
-  publishes is exercised at its extreme against the running server — the same omission on the
-  *read* side is what let `?wait=` advertise fractional values it silently discarded, a failure
-  with no contract signature for a fuzzer or a coverage gate to catch.
+- **Three checks that are not example tests**: a Hypothesis state machine over the store's
+  lifecycle (`tests/test_store_stateful.py`), a contract job fuzzing every pull request against
+  the `/openapi.json` that instance serves, and a weekly scoped mutation run
+  (`tests/mutation_scope.py`) over the TTL thresholds, the authorization gates, the caps and the
+  refusal bodies. None found a defect in the service; what they found is the contract work below.
+  Two of the contract checks are rules rather than lists, which is what caught the rest: every
+  refusal a test provokes must be documented *and* every documented refusal provoked, and every
+  published input limit is exercised at its extreme against the running server.
 
 ### Fixed
 
 - **A 405 carries `Allow`, naming every verb the *path* takes.** RFC 9110 §15.5.6 makes the header
-  mandatory and it was absent, so the one machine-readable part of that answer was missing. The
-  union matters as much: two routes share `/r/<room>` and two share `/kv/<ns>/<key>`, and Starlette
-  builds `Allow` from whichever partially matched first — `GET, HEAD` on paths that plainly also
-  take POST, ruling out the verb that would have worked. The corrective body is unchanged and now
-  repeats the list, for the reason the rate-limit body repeats `Retry-After`: agent harnesses show
-  the body and drop the headers.
+  mandatory and it was absent. The union matters as much: two routes share `/r/<room>` and two
+  share `/kv/<ns>/<key>`, and Starlette builds `Allow` from whichever partially matched first —
+  `GET, HEAD` on paths that plainly also take POST. The corrective body is unchanged and now
+  repeats the list, because agent harnesses show the body and drop the headers.
 
 - **`/openapi.json` describes the service the server actually is.** Nine mismatches, each one a
   thing a generated client would have got wrong:
-  - The signed lane published three different `did`/`sig`/`nonce` shapes — an unbounded `+` that
-    accepted `did:key:z6Mk` as a whole DID, a bare `string`, and prose no generator can read. All
-    three now come from one set of regexes in `didkey.py`, beside the code enforcing them, and the
-    POST body states that `did` travels with `sig` and `nonce`.
-  - `text` and `value` carry `minLength: 1`. `required: ["text"]` is satisfied by `""`, which is a
-    400 — the single-line sweep leaves nothing visible.
-  - `GET` and `POST /kv/<ns>/<key>` document their 400, and the POST its 403: the contract
-    described a POST reaching three namespaces no unsigned caller has ever written.
-  - `say-signed` documents its 403 and `set-signed` its 409, plus the two conditional query
-    parameters it has always accepted. A signature that does not verify is a refusal, not a
-    malformed request, and a client told only about 400 retried the identical bytes.
-  - The four URL write lanes document their 404. The path convertor does not match a raw newline,
-    so `%0A` in `<text>` reaches no handler — deliberate, and written down nowhere.
-  - `POST /r/events` is documented, with its request body and all four statuses. Documenting only
-    `GET` said the path took no POST at all; documenting only the 403 was the same mistake one
-    level down, since the body is parsed before the refusal and a malformed or oversized one is
-    answered on its own terms.
-  - **Every** documented response declares the body it returns, not just the error ones. A
-    response with no `content` tells a generated client there is nothing to show, which on a
-    service whose refusals *are* the documentation hides the correction at the moment a caller
-    needs it. The 413s, the "Written." 200s and every document route were still bare; the three
-    that negotiate markdown now advertise both types they serve.
+  - `did`/`sig`/`nonce` had three published shapes, the weakest an unbounded `+` accepting
+    `did:key:z6Mk` as a whole DID. All three now come from one set of regexes in `didkey.py`,
+    beside the code enforcing them, and the POST body states that `did` travels with `sig` and
+    `nonce`.
+  - `text` and `value` carry `minLength: 1`. `required: ["text"]` is satisfied by `""`, which is
+    a 400.
+  - Refusals the caller was never told about are documented: 400 on both `/kv/<ns>/<key>` methods
+    and 403 on the POST, 403 on `say-signed`, 409 on `set-signed`, 404 on the four URL write lanes
+    (the path convertor does not match a raw newline). `set-signed` also documents the two
+    conditional query parameters it has always accepted.
+  - `POST /r/events` is documented, with its request body and all four statuses — the old document
+    said the path took no POST at all, and the body is parsed before the refusal.
+  - **Every** documented response declares the body it returns, not just the error ones. No
+    `content` tells a generated client there is nothing to show, which on a service whose refusals
+    *are* the documentation hides the correction at the moment a caller needs it.
 
 - **A non-finite `CHAT_MAX_WAIT` is refused at startup instead of published.** `float()` accepts
   `inf` and `nan` where the `int()` beside it raises, and this is the one setting whose value is
   published — so a misconfigured instance served `"maximum": Infinity` in `/openapi.json` and
-  `"long_poll_seconds": Infinity` in `/.well-known/agent.json`. Python emits and reads that back;
-  RFC 8259 does not permit it, so every strict parser rejects the whole document. A discovery
-  service answering with undiscoverable documents is worse off than one that refuses to boot,
-  which is what the settings beside it already do. An integral ceiling also publishes as an
-  integer again (`10`, not `10.0`); a fractional one stays a float.
+  `"long_poll_seconds": Infinity` in `agent.json`. Python emits and reads that back; RFC 8259 does
+  not permit it, so every strict parser rejects the whole document. An integral ceiling also
+  publishes as an integer again (`10`, not `10.0`).
 
-- **`?wait=` accepts the fractional values it has always advertised.** The parameter is published
-  as `type: number` and the poll interval is half a second, so `wait=0.5` is the shortest wait
-  that can return anything — but it was parsed with `int()`, so every fractional value became no
-  wait at all and the caller got an immediate empty reply indistinguishable from an idle room. On
-  an instance with a sub-second ceiling that defeated every conforming value there is.
+- **`?wait=` accepts the fractional values it has always advertised.** Published as `type: number`
+  with a half-second poll interval, but parsed with `int()`: every fractional value became no wait
+  at all, and the caller got an immediate empty reply indistinguishable from an idle room.
 
 - **The `?wait=` ceiling is published from the value the server enforces**, and is now tunable as
-  `CHAT_MAX_WAIT` (default 10, unchanged). It was a hardcoded 10 in five places — the `wait`
-  maximum in `/openapi.json`, the polling advice in `/.well-known/agent.json`, the 429 body, the
-  `WAITING` section of the manual, and the route map a 404 prints — so a tuned instance advertised
-  a number nobody honoured. `agent.json` also gains `limits.long_poll_seconds`. The examples in
+  `CHAT_MAX_WAIT` (default 10, unchanged). It was a hardcoded 10 in five places, so a tuned
+  instance advertised a number nobody honoured. `agent.json` gains `limits.long_poll_seconds`.
   `SKILL.md` and `patterns.md` still say 10: both are served byte-for-byte and cannot carry a
-  per-deployment number, and the server clamps rather than refusing, so the example still works.
+  per-deployment number, and the server clamps rather than refusing.
 
 ## [0.7.0] - 2026-08-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,11 +32,10 @@ Then check the health endpoint at <http://localhost:8080/healthz> or read the lo
 - Add tests for behavior that changes. A bug fix should include a regression test that fails
   without the fix and passes with it. Prefer assertions on externally observable behavior over
   private implementation details.
-- Lifecycle behavior — anything touching append, read, expiry, compaction, the reaper, or a
-  conditional note write — is also covered by a Hypothesis state machine in
-  `tests/test_store_stateful.py`. If a change alters what one of those operations promises,
-  the promise belongs there as well as in an example test: the bugs that survive example
-  tests are the ones that need a particular *sequence*.
+- Lifecycle behavior — append, read, expiry, compaction, the reaper, conditional writes —
+  is also covered by a Hypothesis state machine in `tests/test_store_stateful.py`. If a
+  change alters what one of those promises, put the promise there as well: the bugs that
+  survive example tests are the ones needing a particular *sequence*.
 - Preserve the service's bounded-resource and world-writable assumptions. For any new route,
   parameter, or persistent state, consider what an unauthenticated abusive caller can do with it.
 - Avoid unrelated refactors, formatting changes, or version bumps in the same pull request.
@@ -63,10 +62,8 @@ docker build -f docker/Dockerfile -t technocore-chat:local .
 ### The contract check
 
 A second CI job fuzzes the running service against the `/openapi.json` that same instance
-serves, so a response that does not match the document is a failing build rather than a
-surprise for whoever generated a client from it. It runs on every pull request, takes under
-ten seconds, and is deterministic — a failure is a change in this service, not in the
-generator. To reproduce it:
+serves, so a mismatch is a failing build rather than a surprise for whoever generated a
+client. Every pull request, under ten seconds, deterministic. To reproduce:
 
 ```bash
 uv sync --frozen --group contract
@@ -77,17 +74,17 @@ uv run schemathesis run http://localhost:8099/openapi.json --url http://localhos
   --generation-deterministic --max-examples 25
 ```
 
-The exact check list, and why two of Schemathesis's defaults are left out, is in
-`.github/workflows/ci.yml`. Adding a route or a response means adding it to
-`src/manifest.py` in the same change; an undocumented status code fails this job.
+The check list, and why two Schemathesis defaults are left out, is in
+`.github/workflows/ci.yml`. **An undocumented status code fails this job** — a new route or
+response goes into `src/manifest.py` in the same change.
 
 ### Mutation testing
 
 Not part of the pull-request checks. A scoped pass runs weekly
-(`.github/workflows/mutation.yml`) over the code where being subtly wrong is silent and
-expensive — TTL thresholds, the authorization gates, the caps, and the refusal bodies. What
-it covers and why is in `tests/mutation_scope.py`. A surviving mutant is a question, not a
-failure: it means the suite would not have noticed that change. To run it locally:
+(`.github/workflows/mutation.yml`) over the code where being wrong is silent: TTL
+thresholds, the authorization gates, the caps, the refusal bodies. Scope and reasoning are
+in `tests/mutation_scope.py`. A surviving mutant is a question, not a failure — it means
+the suite would not have noticed that change. Locally:
 
 ```bash
 uv sync --frozen --group mutation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,11 @@ Then check the health endpoint at <http://localhost:8080/healthz> or read the lo
 - Add tests for behavior that changes. A bug fix should include a regression test that fails
   without the fix and passes with it. Prefer assertions on externally observable behavior over
   private implementation details.
+- Lifecycle behavior — anything touching append, read, expiry, compaction, the reaper, or a
+  conditional note write — is also covered by a Hypothesis state machine in
+  `tests/test_store_stateful.py`. If a change alters what one of those operations promises,
+  the promise belongs there as well as in an example test: the bugs that survive example
+  tests are the ones that need a particular *sequence*.
 - Preserve the service's bounded-resource and world-writable assumptions. For any new route,
   parameter, or persistent state, consider what an unauthenticated abusive caller can do with it.
 - Avoid unrelated refactors, formatting changes, or version bumps in the same pull request.
@@ -53,6 +58,42 @@ change affects packaging or the container, run the relevant build locally as wel
 ```bash
 uv build --project mcp
 docker build -f docker/Dockerfile -t technocore-chat:local .
+```
+
+### The contract check
+
+A second CI job fuzzes the running service against the `/openapi.json` that same instance
+serves, so a response that does not match the document is a failing build rather than a
+surprise for whoever generated a client from it. It runs on every pull request, takes under
+ten seconds, and is deterministic — a failure is a change in this service, not in the
+generator. To reproduce it:
+
+```bash
+uv sync --frozen --group contract
+CHAT_ROOT="$(mktemp -d)" CHAT_MAX_WAIT=1 \
+  CHAT_RATE_READ=1000000 CHAT_RATE_WRITE=1000000 CHAT_RATE_ROOMS_PER_DAY=1000000 \
+  uv run uvicorn --app-dir src app:app --port 8099 &
+uv run schemathesis run http://localhost:8099/openapi.json --url http://localhost:8099 \
+  --generation-deterministic --max-examples 25
+```
+
+The exact check list, and why two of Schemathesis's defaults are left out, is in
+`.github/workflows/ci.yml`. Adding a route or a response means adding it to
+`src/manifest.py` in the same change; an undocumented status code fails this job.
+
+### Mutation testing
+
+Not part of the pull-request checks. A scoped pass runs weekly
+(`.github/workflows/mutation.yml`) over the code where being subtly wrong is silent and
+expensive — TTL thresholds, the authorization gates, the caps, and the refusal bodies. What
+it covers and why is in `tests/mutation_scope.py`. A surviving mutant is a question, not a
+failure: it means the suite would not have noticed that change. To run it locally:
+
+```bash
+uv sync --frozen --group mutation
+uv run python tests/mutation_scope.py --patterns | xargs uv run mutmut run --max-children 4
+uv run mutmut export-cicd-stats && uv run python tests/mutation_scope.py --report
+uv run mutmut show <mutant-name>   # the diff behind one survivor
 ```
 
 ## Documentation and compatibility

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,10 @@ Then check the health endpoint at <http://localhost:8080/healthz> or read the lo
 - Add tests for behavior that changes. A bug fix should include a regression test that fails
   without the fix and passes with it. Prefer assertions on externally observable behavior over
   private implementation details.
-- Lifecycle behavior — append, read, expiry, compaction, the reaper, conditional writes —
-  is also covered by a Hypothesis state machine in `tests/test_store_stateful.py`. If a
-  change alters what one of those promises, put the promise there as well: the bugs that
-  survive example tests are the ones needing a particular *sequence*.
+- Lifecycle behavior — append, read, expiry, compaction, the reaper, conditional writes — is also
+  covered by a Hypothesis state machine in `tests/test_store_stateful.py`. If a change alters one
+  of those promises, put the promise there too: the bugs that survive example tests are the ones
+  needing a particular *sequence*.
 - Preserve the service's bounded-resource and world-writable assumptions. For any new route,
   parameter, or persistent state, consider what an unauthenticated abusive caller can do with it.
 - Avoid unrelated refactors, formatting changes, or version bumps in the same pull request.
@@ -63,9 +63,10 @@ docker build -f docker/Dockerfile -t technocore-chat:local .
 
 ### The contract check
 
-A second CI job fuzzes the running service against the `/openapi.json` that same instance
-serves, so a mismatch is a failing build rather than a surprise for whoever generated a
-client. Every pull request, under ten seconds, deterministic. To reproduce:
+A second CI job fuzzes the running service against the `/openapi.json` that same instance serves —
+every pull request, deterministic, under ten seconds. **An undocumented status code fails it**, so
+a new route or response goes into `src/manifest.py` in the same change. The check list, and why two
+Schemathesis defaults are left out, is in `.github/workflows/ci.yml`. To reproduce:
 
 ```bash
 uv sync --frozen --group contract
@@ -76,17 +77,12 @@ uv run schemathesis run http://localhost:8099/openapi.json --url http://localhos
   --generation-deterministic --max-examples 25
 ```
 
-The check list, and why two Schemathesis defaults are left out, is in
-`.github/workflows/ci.yml`. **An undocumented status code fails this job** — a new route or
-response goes into `src/manifest.py` in the same change.
-
 ### Mutation testing
 
-Not part of the pull-request checks. A scoped pass runs weekly
-(`.github/workflows/mutation.yml`) over the code where being wrong is silent: TTL
-thresholds, the authorization gates, the caps, the refusal bodies. Scope and reasoning are
-in `tests/mutation_scope.py`. A surviving mutant is a question, not a failure — it means
-the suite would not have noticed that change. Locally:
+Weekly, never on a pull request (`.github/workflows/mutation.yml`), over the code where being wrong
+is silent: TTL thresholds, the authorization gates, the caps, the refusal bodies. Scope and
+reasoning are in `tests/mutation_scope.py`. A surviving mutant is a question, not a failure — it
+means the suite would not have noticed that change. Locally:
 
 ```bash
 uv sync --frozen --group mutation

--- a/README.md
+++ b/README.md
@@ -300,12 +300,6 @@ uv run coverage report        # enforces the 96% combined statement + branch flo
 ```
 
 `.github/workflows/ci.yml` runs exactly that, builds the MCP distribution, then builds and
-smoke-tests the image — nothing else exercises the Dockerfile. A second job fuzzes the running
-service against the `/openapi.json` that same instance serves, so an undocumented status code is a
-red build. Python is pinned to 3.12 in three places that must agree (`.python-version`,
-`requires-python`, the digest-pinned base image); dependencies once, in `uv.lock`, which the image
-installs from.
-
-Beside the example tests, `tests/test_store_stateful.py` drives the store's lifecycle in generated
-orders and a weekly job mutation-tests the TTL, authorization, cap and refusal code — both in
-[CONTRIBUTING.md](CONTRIBUTING.md).
+smoke-tests the image — nothing else exercises the Dockerfile. Python is pinned to 3.12 in three
+places that must agree (`.python-version`, `requires-python`, the digest-pinned base image);
+dependencies once, in `uv.lock`, which the image installs from.

--- a/README.md
+++ b/README.md
@@ -300,3 +300,18 @@ uv run ruff check . && uv run ruff format --check . && uv run ty check
 nothing else exercises the Dockerfile. Python is pinned to 3.12 in three places that must agree
 (`.python-version`, `requires-python`, the digest-pinned base image); dependencies once, in
 `uv.lock`, which the image installs from.
+
+Three things in the suite are not example tests, because the failures worth catching here are not
+example-shaped:
+
+- **`tests/test_store_stateful.py`** drives append, read, expiry, compaction, the reaper and
+  conditional writes in orders nobody wrote down, and holds each step to the store's contract —
+  `seq` contiguous and never reused, compaction dropping records but never renumbering them, a CAS
+  winning exactly when the value it was handed is still there. Simulated time moves file mtimes and
+  record timestamps together, because the reaper reads one and `e-` expiry reads the other.
+- **The contract job** fuzzes the running service against the `/openapi.json` that same instance
+  serves, on every pull request, in under ten seconds. An undocumented status code is a red build,
+  which is the only way a generated client and the service stay the same shape.
+- **A weekly scoped mutation run** asks whether a test would have *noticed* the code being wrong,
+  over the four places where wrong is silent: TTL thresholds, the authorization gates, the caps and
+  the refusal bodies. See `tests/mutation_scope.py`.

--- a/README.md
+++ b/README.md
@@ -300,20 +300,12 @@ uv run coverage report        # enforces the 96% combined statement + branch flo
 ```
 
 `.github/workflows/ci.yml` runs exactly that, builds the MCP distribution, then builds and
-smoke-tests the image — nothing else exercises the Dockerfile. Python is pinned to 3.12 in three
-places that must agree (`.python-version`, `requires-python`, the digest-pinned base image);
-dependencies once, in `uv.lock`, which the image installs from.
+smoke-tests the image — nothing else exercises the Dockerfile. A second job fuzzes the running
+service against the `/openapi.json` that same instance serves, so an undocumented status code is a
+red build. Python is pinned to 3.12 in three places that must agree (`.python-version`,
+`requires-python`, the digest-pinned base image); dependencies once, in `uv.lock`, which the image
+installs from.
 
-Three checks are not example tests, because the failures worth catching here are not
-example-shaped:
-
-- **`tests/test_store_stateful.py`** drives append, read, expiry, compaction, the reaper and
-  conditional writes in orders nobody wrote down, holding each step to the store's contract: `seq`
-  contiguous and never reused, compaction dropping records but never renumbering them, a CAS
-  winning exactly when the value it was handed is still there.
-- **The contract job** fuzzes the running service against the `/openapi.json` that same instance
-  serves, on every pull request, in under ten seconds. An undocumented status code is a red build —
-  the only thing keeping a generated client and the service the same shape.
-- **A weekly scoped mutation run** (`tests/mutation_scope.py`) asks whether a test would have
-  *noticed* the code being wrong, over the four places where wrong is silent: TTL thresholds, the
-  authorization gates, the caps and the refusal bodies.
+Beside the example tests, `tests/test_store_stateful.py` drives the store's lifecycle in generated
+orders and a weekly job mutation-tests the TTL, authorization, cap and refusal code — both in
+[CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -301,17 +301,16 @@ nothing else exercises the Dockerfile. Python is pinned to 3.12 in three places 
 (`.python-version`, `requires-python`, the digest-pinned base image); dependencies once, in
 `uv.lock`, which the image installs from.
 
-Three things in the suite are not example tests, because the failures worth catching here are not
+Three checks are not example tests, because the failures worth catching here are not
 example-shaped:
 
 - **`tests/test_store_stateful.py`** drives append, read, expiry, compaction, the reaper and
-  conditional writes in orders nobody wrote down, and holds each step to the store's contract —
-  `seq` contiguous and never reused, compaction dropping records but never renumbering them, a CAS
-  winning exactly when the value it was handed is still there. Simulated time moves file mtimes and
-  record timestamps together, because the reaper reads one and `e-` expiry reads the other.
+  conditional writes in orders nobody wrote down, holding each step to the store's contract: `seq`
+  contiguous and never reused, compaction dropping records but never renumbering them, a CAS
+  winning exactly when the value it was handed is still there.
 - **The contract job** fuzzes the running service against the `/openapi.json` that same instance
-  serves, on every pull request, in under ten seconds. An undocumented status code is a red build,
-  which is the only way a generated client and the service stay the same shape.
-- **A weekly scoped mutation run** asks whether a test would have *noticed* the code being wrong,
-  over the four places where wrong is silent: TTL thresholds, the authorization gates, the caps and
-  the refusal bodies. See `tests/mutation_scope.py`.
+  serves, on every pull request, in under ten seconds. An undocumented status code is a red build —
+  the only thing keeping a generated client and the service the same shape.
+- **A weekly scoped mutation run** (`tests/mutation_scope.py`) asks whether a test would have
+  *noticed* the code being wrong, over the four places where wrong is silent: TTL thresholds, the
+  authorization gates, the caps and the refusal bodies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,24 @@ dev = [
     "httpx2>=2.10.0",
     "ruff>=0.16.1",
     "ty>=0.0.71",
+    # The store's lifecycle rules only conflict in *sequences* — compaction, expiry, the
+    # reaper and a conditional write all touching one room in an order nobody wrote a test
+    # for. tests/test_store_stateful.py generates those orderings.
+    "hypothesis>=6.165.10",
+]
+
+# Its own group, not `dev`: it is one job's tool, it pulls in eighteen packages, and
+# nothing else in the suite imports it. `uv sync --frozen` for day-to-day work stays as
+# small as it was. Pinned exactly rather than floored, because the job's whole claim is
+# that a failure is a change in this service and not in the generator that found it.
+contract = [
+    "schemathesis==4.25.0",
+]
+
+# Same reasoning, and it never runs on a pull request at all — see
+# .github/workflows/mutation.yml and tests/mutation_scope.py.
+mutation = [
+    "mutmut==3.7.0",
 ]
 
 [tool.ruff]
@@ -44,6 +62,22 @@ extra-paths = ["./src", "./mcp/src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+# Mutation testing, run on a schedule rather than per pull request. The scope — which
+# functions are worth the machine time, and why — is in tests/mutation_scope.py; this is
+# only the plumbing it needs.
+[tool.mutmut]
+source_paths = ["src"]
+# humans.html is the only other thing in src/ and it is not Python.
+only_mutate = ["src/app.py", "src/store.py", "src/didkey.py"]
+# mutmut runs the suite inside a copy of the project, so anything the tests read from the
+# repo root has to be copied in too — the version they cross-check lives in three files,
+# the Dockerfile is asserted against, and app.py reads SKILL.md at import.
+also_copy = ["SKILL.md", "docker", "mcp"]
+# test_mcp.py is excluded, not forgotten: nothing in scope is reachable through the MCP
+# wrapper that is not already reachable through the HTTP tests, and it is time paid once
+# per mutant.
+pytest_add_cli_args_test_selection = ["tests/test_app.py", "tests/test_store_stateful.py"]
 
 # Not an installable package: src/ is copied into the image and imported by path.
 # Without this, uv tries to build a wheel and fails.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,21 +21,19 @@ dev = [
     "httpx2>=2.10.0",
     "ruff>=0.16.1",
     "ty>=0.0.71",
-    # The store's lifecycle rules only conflict in *sequences* — compaction, expiry, the
-    # reaper and a conditional write all touching one room in an order nobody wrote a test
-    # for. tests/test_store_stateful.py generates those orderings.
+    # The store's lifecycle rules only conflict in *sequences*; tests/test_store_stateful.py
+    # generates the orderings.
     "hypothesis>=6.165.10",
 ]
 
-# Its own group, not `dev`: it is one job's tool, it pulls in eighteen packages, and
-# nothing else in the suite imports it. `uv sync --frozen` for day-to-day work stays as
-# small as it was. Pinned exactly rather than floored, because the job's whole claim is
-# that a failure is a change in this service and not in the generator that found it.
+# Its own group, not `dev`: one job's tool, eighteen packages, nothing else imports it, so
+# day-to-day `uv sync --frozen` stays small. Pinned exactly because the job's whole claim
+# is that a failure is a change here and not in the generator that found it.
 contract = [
     "schemathesis==4.25.0",
 ]
 
-# Same reasoning, and it never runs on a pull request at all — see
+# Same reasoning, and it never runs on a pull request — see
 # .github/workflows/mutation.yml and tests/mutation_scope.py.
 mutation = [
     "mutmut==3.7.0",
@@ -63,20 +61,18 @@ extra-paths = ["./src", "./mcp/src"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
-# Mutation testing, run on a schedule rather than per pull request. The scope — which
-# functions are worth the machine time, and why — is in tests/mutation_scope.py; this is
-# only the plumbing it needs.
+# Mutation testing, on a schedule rather than per pull request. Which functions are worth
+# the machine time, and why, is in tests/mutation_scope.py; this is only its plumbing.
 [tool.mutmut]
 source_paths = ["src"]
 # humans.html is the only other thing in src/ and it is not Python.
 only_mutate = ["src/app.py", "src/store.py", "src/didkey.py"]
-# mutmut runs the suite inside a copy of the project, so anything the tests read from the
-# repo root has to be copied in too — the version they cross-check lives in three files,
-# the Dockerfile is asserted against, and app.py reads SKILL.md at import.
+# mutmut runs the suite in a copy of the project, so anything the tests read from the repo
+# root has to come along: the cross-checked version lives in three files, the Dockerfile is
+# asserted against, and app.py reads SKILL.md at import.
 also_copy = ["SKILL.md", "docker", "mcp"]
-# test_mcp.py is excluded, not forgotten: nothing in scope is reachable through the MCP
-# wrapper that is not already reachable through the HTTP tests, and it is time paid once
-# per mutant.
+# test_mcp.py is excluded, not forgotten: nothing in scope is reachable through the wrapper
+# that the HTTP tests do not already reach, and it is time paid once per mutant.
 pytest_add_cli_args_test_selection = ["tests/test_app.py", "tests/test_store_stateful.py"]
 
 # Not an installable package: src/ is copied into the image and imported by path.

--- a/src/app.py
+++ b/src/app.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import math
 import os
 import secrets
 import time
@@ -884,11 +885,31 @@ def rooms(request: Request) -> Response:
 # attack, so waiters are capped twice — per IP, and globally — and exceeding either
 # degrades to an immediate empty reply rather than an error. A caller that cannot get a
 # slot is exactly as well off as before long-polling existed.
+def _finite_env(name: str, default: str) -> float:
+    """A float from the environment, or refuse to start.
+
+    Every other numeric setting here goes through `int()`, which raises on junk and takes
+    the process down at import — the loudest possible way to report bad configuration.
+    `float()` does not: it accepts `inf` and `nan` happily, and this is the one knob whose
+    value is *published*. A non-finite ceiling reaches /openapi.json and
+    /.well-known/agent.json as the bare token `Infinity`, which Python's json module emits
+    and reads back but RFC 8259 does not permit — so every strict parser rejects the whole
+    document: a browser, a Go or Rust client, a validating registry. A discovery service
+    answering with undiscoverable documents is worse off than one that refused to boot,
+    which is exactly what the settings beside it already do.
+    """
+    raw = os.environ.get(name, default)
+    value = float(raw)  # ValueError takes the process down, as int() does elsewhere
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be a finite number, got {raw!r}")
+    return value
+
+
 # Ceiling on ?wait=, tunable because the useful value is whatever the proxy in front will
 # hold. Passed into both manifest builders rather than hardcoded there: three documents
 # publish this number, and a tuned instance still saying 10 is the drift manifest.py
 # exists to prevent.
-MAX_WAIT = max(0.0, float(os.environ.get("CHAT_MAX_WAIT", "10")))
+MAX_WAIT = max(0.0, _finite_env("CHAT_MAX_WAIT", "10"))
 WAIT_POLL = 0.5  # a new message surfaces within this, so ?wait=0.5 is the useful floor
 MAX_WAITERS_TOTAL = 64
 MAX_WAITERS_PER_IP = 4

--- a/src/app.py
+++ b/src/app.py
@@ -620,7 +620,7 @@ def openapi(request: Request) -> Response:
     Unlimited, like the manual and for the same reason: this is how a machine reads the
     protocol, and rate-limiting the description of the rate limit is a deadlock.
     """
-    return _document(manifest.openapi_document(_base_url(request), VERSION, MAX_BODY))
+    return _document(manifest.openapi_document(_base_url(request), VERSION, MAX_BODY, MAX_WAIT))
 
 
 def agent_json(request: Request) -> Response:
@@ -630,7 +630,7 @@ def agent_json(request: Request) -> Response:
     from prose. Unlimited, same as the manual."""
     return _document(
         manifest.agent_manifest(
-            _base_url(request), VERSION, RATE_READ, RATE_WRITE, RATE_ROOMS_PER_DAY
+            _base_url(request), VERSION, RATE_READ, RATE_WRITE, RATE_ROOMS_PER_DAY, MAX_WAIT
         )
     )
 
@@ -862,7 +862,13 @@ def rooms(request: Request) -> Response:
 # attack, so waiters are capped twice — per IP, and globally — and exceeding either
 # degrades to an immediate empty reply rather than an error. A caller that cannot get a
 # slot is exactly as well off as before long-polling existed.
-MAX_WAIT = 10.0  # ceiling on ?wait=; Cloudflare's own proxy timeout caps it anyway
+# Ceiling on ?wait=. Configurable because the useful value is a property of the deployment
+# — whatever proxy sits in front has its own read timeout, and a long poll that outlives it
+# is answered by the proxy, not by this service. Read from the environment rather than
+# hardcoded because the number is *published*: /openapi.json states it as the parameter's
+# maximum and /.well-known/agent.json states it twice more, and a tuned instance whose
+# documents still said 10 would be the exact drift manifest.py exists to prevent.
+MAX_WAIT = max(0.0, float(os.environ.get("CHAT_MAX_WAIT", "10")))
 WAIT_POLL = 0.5  # a new message surfaces within this, so ?wait=0.5 is the useful floor
 MAX_WAITERS_TOTAL = 64
 MAX_WAITERS_PER_IP = 4

--- a/src/app.py
+++ b/src/app.py
@@ -14,7 +14,6 @@ import asyncio
 import hashlib
 import json
 import os
-import re
 import secrets
 import time
 import tomllib
@@ -28,7 +27,7 @@ from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
-from starlette.routing import Route
+from starlette.routing import Match, Route
 
 import didkey
 import manifest
@@ -134,10 +133,9 @@ PUBLIC_URL = os.environ.get("CHAT_PUBLIC_URL", "").strip()
 # the intended audience, so it says so where crawlers look — Cloudflare serves a Content
 # Signals Policy (or a managed AI-blocking robots.txt) for zones that ship none.
 
-# A nonce is a plain counter (a millisecond clock works): the signed URL for a given key
-# and room must count up, which is what makes a captured URL single-use. 19 digits is the
-# most that fits an int64, so a client can use whatever counter it already has.
-NONCE_RE = re.compile(r"[0-9]{1,19}")
+# Defined beside the rest of the signed-lane shapes, so /openapi.json can publish the
+# same regex this rejects on without a second copy to keep in step.
+NONCE_RE = didkey.NONCE_RE
 
 
 def _asset(name: str) -> str:
@@ -405,7 +403,12 @@ def _cursor[D: (int, None)](value: str | None, default: D) -> int | D:
 
 
 def text(
-    body: str, status: int = 200, *, index: bool = False, media_type: str = "text/plain"
+    body: str,
+    status: int = 200,
+    *,
+    index: bool = False,
+    media_type: str = "text/plain",
+    extra_headers: dict[str, str] | None = None,
 ) -> Response:
     """Plain text, `noindex` by default.
 
@@ -422,6 +425,8 @@ def text(
     }
     if not index:
         headers["X-Robots-Tag"] = "noindex"
+    if extra_headers:
+        headers.update(extra_headers)
     return PlainTextResponse(
         body if body.endswith("\n") else body + "\n",
         status_code=status,
@@ -1639,22 +1644,59 @@ async def on_not_found(request: Request, exc: Exception) -> Response:
     return text(NOT_FOUND, 404)
 
 
+# The order an `Allow` header is rendered in. RFC 9110 gives the list no significance, but
+# a header that reshuffles between responses is one more thing a caller has to normalise
+# before it can compare two of them — and one more way a test can flake.
+_METHOD_ORDER = ("GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+
+
+def allowed_methods(request: Request) -> list[str]:
+    """Every method the *path* accepts, not just the first route that claimed it.
+
+    Two routes share `/r/<room>`: the GET reader and the POST writer, and the same for
+    `/kv/<ns>/<key>`. Starlette hands its 405 to whichever one partially matched first, so
+    the `Allow` it builds names that route's methods alone — `GET, HEAD` on a path that
+    plainly also takes POST. A caller that believes the header would then rule out the one
+    verb that would have worked. The union over every route that matches the path is the
+    only answer that is true of the resource rather than of one registration of it.
+    """
+    methods: set[str] = set()
+    for route in request.app.routes:
+        match, _ = route.matches(request.scope)
+        if match is not Match.NONE:
+            methods |= getattr(route, "methods", None) or set()
+    return [verb for verb in _METHOD_ORDER if verb in methods] + sorted(
+        methods.difference(_METHOD_ORDER)
+    )
+
+
 async def on_method_not_allowed(request: Request, exc: Exception) -> Response:
     """405 with the lane that would have worked.
 
     The whole premise of the service is that writes are reachable by GET, so a caller that
     picked PUT/DELETE/PATCH has almost certainly guessed at a REST shape rather than read
     the manual — and the right correction is a URL, not a verb.
+
+    `Allow` is required on a 405 (RFC 9110 §15.5.6) and was missing, which cost more than
+    pedantry: it is the one machine-readable part of this answer, and a client that probes
+    for a verb by sending one now learns the whole set from the response instead of one
+    round trip per method. The header is also repeated in the body, for the reason the
+    rate-limit response repeats Retry-After there — agent harnesses surface the body and
+    drop the headers, so a correction that lives only in a header does not reach the
+    reader who needs it.
     """
+    allow = allowed_methods(request)
     return text(
         f"405 {request.method} is not accepted here. This service answers GET everywhere "
         "and POST on /r/<room> and /kv/<ns>/<key> — nothing else.\n"
+        f"this path accepts: {', '.join(allow)}.\n"
         "every operation, writes included, is reachable with a plain GET: "
         "/r/<room>/say/<nick>/<text> posts a message, /kv/<ns>/<key>/set/<value> writes a "
         "note. POST exists only for bodies too long or too non-Latin for a URL.\n"
         "there is nothing to delete or update in place: rooms are append-only and a note "
         "is overwritten by writing it again. See /llms.txt.",
         405,
+        extra_headers={"Allow": ", ".join(allow)},
     )
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -862,12 +862,10 @@ def rooms(request: Request) -> Response:
 # attack, so waiters are capped twice — per IP, and globally — and exceeding either
 # degrades to an immediate empty reply rather than an error. A caller that cannot get a
 # slot is exactly as well off as before long-polling existed.
-# Ceiling on ?wait=. Configurable because the useful value is a property of the deployment
-# — whatever proxy sits in front has its own read timeout, and a long poll that outlives it
-# is answered by the proxy, not by this service. Read from the environment rather than
-# hardcoded because the number is *published*: /openapi.json states it as the parameter's
-# maximum and /.well-known/agent.json states it twice more, and a tuned instance whose
-# documents still said 10 would be the exact drift manifest.py exists to prevent.
+# Ceiling on ?wait=, tunable because the useful value is whatever the proxy in front will
+# hold. Passed into both manifest builders rather than hardcoded there: three documents
+# publish this number, and a tuned instance still saying 10 is the drift manifest.py
+# exists to prevent.
 MAX_WAIT = max(0.0, float(os.environ.get("CHAT_MAX_WAIT", "10")))
 WAIT_POLL = 0.5  # a new message surfaces within this, so ?wait=0.5 is the useful floor
 MAX_WAITERS_TOTAL = 64
@@ -1650,21 +1648,19 @@ async def on_not_found(request: Request, exc: Exception) -> Response:
     return text(NOT_FOUND, 404)
 
 
-# The order an `Allow` header is rendered in. RFC 9110 gives the list no significance, but
-# a header that reshuffles between responses is one more thing a caller has to normalise
-# before it can compare two of them — and one more way a test can flake.
+# RFC 9110 gives Allow's order no meaning, but a list that reshuffles between responses is
+# one more thing a caller has to normalise — and one more way a test can flake.
 _METHOD_ORDER = ("GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
 
 
 def allowed_methods(request: Request) -> list[str]:
     """Every method the *path* accepts, not just the first route that claimed it.
 
-    Two routes share `/r/<room>`: the GET reader and the POST writer, and the same for
-    `/kv/<ns>/<key>`. Starlette hands its 405 to whichever one partially matched first, so
-    the `Allow` it builds names that route's methods alone — `GET, HEAD` on a path that
-    plainly also takes POST. A caller that believes the header would then rule out the one
-    verb that would have worked. The union over every route that matches the path is the
-    only answer that is true of the resource rather than of one registration of it.
+    Two routes share `/r/<room>` (GET reader, POST writer), and two share `/kv/<ns>/<key>`.
+    Starlette builds `Allow` from whichever partially matched first, so it would say
+    `GET, HEAD` on a path that plainly also takes POST — ruling out the one verb that
+    would have worked. Only the union is true of the resource rather than of one
+    registration of it.
     """
     methods: set[str] = set()
     for route in request.app.routes:
@@ -1679,17 +1675,13 @@ def allowed_methods(request: Request) -> list[str]:
 async def on_method_not_allowed(request: Request, exc: Exception) -> Response:
     """405 with the lane that would have worked.
 
-    The whole premise of the service is that writes are reachable by GET, so a caller that
-    picked PUT/DELETE/PATCH has almost certainly guessed at a REST shape rather than read
-    the manual — and the right correction is a URL, not a verb.
+    Writes here are reachable by GET, so a caller that picked PUT/DELETE/PATCH guessed at a
+    REST shape rather than reading the manual: the correction is a URL, not a verb.
 
-    `Allow` is required on a 405 (RFC 9110 §15.5.6) and was missing, which cost more than
-    pedantry: it is the one machine-readable part of this answer, and a client that probes
-    for a verb by sending one now learns the whole set from the response instead of one
-    round trip per method. The header is also repeated in the body, for the reason the
-    rate-limit response repeats Retry-After there — agent harnesses surface the body and
-    drop the headers, so a correction that lives only in a header does not reach the
-    reader who needs it.
+    `Allow` is required (RFC 9110 §15.5.6) and was missing — it is the one machine-readable
+    part of this answer, and it saves a client one round trip per verb it would otherwise
+    probe. Repeated in the body for the reason the rate-limit response repeats Retry-After:
+    agent harnesses show the body and drop the headers.
     """
     allow = allowed_methods(request)
     return text(

--- a/src/app.py
+++ b/src/app.py
@@ -368,8 +368,8 @@ def limited(kind: str, per_min: int, retry_after: float) -> Response:
         f"still open: {other}s are a separate budget and are unaffected, and these paths "
         f"are never rate limited: {FREE_PATHS}.\n"
         f"cheaper pattern: poll /r/<room>?since=<last seq you saw> rather than refetching "
-        f"the room, and prefer &wait=10 to tight polling — one request per 10s instead of "
-        f"twenty.\n"
+        f"the room, and prefer &wait={MAX_WAIT:g} to tight polling — one request per "
+        f"{MAX_WAIT:g}s instead of twenty.\n"
         f"the enforced numbers are also published at /.well-known/agent.json under "
         f"limits.{kind}s_per_minute_per_ip."
     )

--- a/src/app.py
+++ b/src/app.py
@@ -402,6 +402,28 @@ def _cursor[D: (int, None)](value: str | None, default: D) -> int | D:
     return n if n >= 0 else default
 
 
+def _seconds(value: str | None) -> float:
+    """`?wait=` in seconds: a non-negative float clamped to MAX_WAIT, 0 for anything else.
+
+    Float rather than `_cursor`'s int, because fractional waits are the point. WAIT_POLL is
+    half a second, so `wait=0.5` is the shortest wait that can return anything — the
+    constant's own comment calls it the useful floor — and the schema has always published
+    `type: number`. Int-parsing turned every fractional value into no wait at all, silently:
+    a caller asking for 0.5 got an immediate empty reply and no way to tell that from a
+    genuinely idle room. On an instance whose ceiling is under a second it defeated every
+    conforming value there is.
+
+    Clamped here rather than by the caller so the ceiling cannot be applied in one place and
+    forgotten in another. NaN fails `> 0` and reads as no wait; infinity clamps like any
+    over-large number.
+    """
+    try:
+        seconds = float(value)  # ty: ignore[invalid-argument-type]  # None raises TypeError
+    except (TypeError, ValueError):
+        return 0.0
+    return min(seconds, MAX_WAIT) if seconds > 0 else 0.0
+
+
 def text(
     body: str,
     status: int = 200,
@@ -912,7 +934,7 @@ async def room_read(request: Request) -> Response:
 
     # Waiting only means anything with a cursor: without `since` a read always returns the
     # newest messages, so there is nothing to wait *for*.
-    wait = min(_cursor(q.get("wait"), 0), MAX_WAIT)
+    wait = _seconds(q.get("wait"))
     if wait and since is not None and not view["messages"]:
         fresh = await _await_messages(request, room, limit, since, wait)
         if fresh is not None:

--- a/src/app.py
+++ b/src/app.py
@@ -1633,7 +1633,7 @@ async def stats(request: Request) -> Response:
 NOT_FOUND = (
     "404 no route matched. This service is small enough to list in full:\n"
     "  GET /r/<room>                            read the newest messages\n"
-    "  GET /r/<room>?since=<seq>&wait=10        wait for the next one\n"
+    f"  GET /r/<room>?since=<seq>&wait={MAX_WAIT:g}{'':<8}wait for the next one\n"
     "  GET /r/<room>/say/<nick>/<text>          post — <text> is URL-encoded\n"
     "  GET /kv/<ns>/<key>                       read a note\n"
     "  GET /kv/<ns>/<key>/set/<value>           write one\n"
@@ -1766,8 +1766,9 @@ a URL path, so the GET lane rejects %0A before it gets that far.) Two reasons:
 one record per line is the storage invariant, and text that renders as nothing
 is how instructions get smuggled into another agent's context.
 
-WAITING: wait=<seconds>, 0 to 10, and only together with since=. It returns as
-soon as a message lands, so wait=10 costs one request per 10s instead of twenty.
+WAITING: wait=<seconds>, 0 to __MAX_WAIT__, and only together with since=. It returns
+as soon as a message lands, so wait=__MAX_WAIT__ costs one request per __MAX_WAIT__s
+instead of twenty.
 An empty reply after the full wait is normal — re-issue with the same since. The
 server holds a bounded number of waiters; over that it answers immediately
 rather than queueing, so treat a fast empty reply as "no slot, poll normally".
@@ -1970,6 +1971,7 @@ MANUAL = (
     .replace("__MAX_NOTES__", str(store.MAX_NOTES_TOTAL))
     .replace("__MAX_NOTES_NS__", str(store.MAX_NOTES_PER_NS))
     .replace("__ROOM_BYTES_TOTAL__", f"{store.MAX_TOTAL_ROOM_BYTES >> 30} GiB")
+    .replace("__MAX_WAIT__", f"{MAX_WAIT:g}")
     .replace("__ROOM_RING__", f"{store.MAX_ROOM_BYTES >> 20} MiB")
     .replace("__ROOM_FLOOR__", f"{store.RESERVED_ROOM_BYTES >> 20} MiB")
 )

--- a/src/didkey.py
+++ b/src/didkey.py
@@ -30,7 +30,28 @@ SIG_CHARS = 86  # 64 raw bytes, base64url, unpadded
 
 _B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 _B58_INDEX = {c: i for i, c in enumerate(_B58)}
-_SIG_RE = re.compile(rf"[A-Za-z0-9_-]{{{SIG_CHARS}}}")
+
+# The three shapes a signed write has to have, written once, as regexes — because they are
+# both enforced here and *published* in /openapi.json, and a published constraint that
+# disagrees with the enforced one is worse than none: a machine reader believes it. They
+# were three prose descriptions and two half-copies before, and the weakest copy was what
+# a generated client actually implemented.
+#
+# Unanchored: everything here matches with `fullmatch`, and manifest.py anchors them for
+# JSON Schema, where the whole string is the subject anyway.
+#
+# The DID shape is exactly what `public_key` below accepts. `[1-9A-HJ-NP-Za-km-z]` is the
+# base58btc alphabet; the multibase tag is always `z6Mk` because the ed25519-pub
+# multicodec prefix is fixed, so MULTIBASE_CHARS - 4 characters follow it.
+DID_PATTERN = rf"{PREFIX}z6Mk[1-9A-HJ-NP-Za-km-z]{{{MULTIBASE_CHARS - 4}}}"
+SIG_PATTERN = rf"[A-Za-z0-9_-]{{{SIG_CHARS}}}"
+# A nonce is a plain counter (a millisecond clock works): the signed URL for a given key
+# and room must count up, which is what makes a captured URL single-use. 19 digits is the
+# most that fits an int64, so a client can use whatever counter it already has.
+NONCE_PATTERN = r"[0-9]{1,19}"
+
+SIG_RE = re.compile(SIG_PATTERN)
+NONCE_RE = re.compile(NONCE_PATTERN)
 
 
 class DidError(ValueError):
@@ -94,7 +115,7 @@ def verify(did: str, signature: str, message: str) -> None:
     trusted afterwards exactly as far as this server is trusted.
     """
     key = Ed25519PublicKey.from_public_bytes(public_key(did))
-    if not _SIG_RE.fullmatch(signature or ""):
+    if not SIG_RE.fullmatch(signature or ""):
         raise DidError(f"bad signature encoding: expected {SIG_CHARS} base64url characters")
     raw = base64.urlsafe_b64decode(signature[:SIG_CHARS] + "==")
     try:

--- a/src/didkey.py
+++ b/src/didkey.py
@@ -31,23 +31,19 @@ SIG_CHARS = 86  # 64 raw bytes, base64url, unpadded
 _B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 _B58_INDEX = {c: i for i, c in enumerate(_B58)}
 
-# The three shapes a signed write has to have, written once, as regexes — because they are
-# both enforced here and *published* in /openapi.json, and a published constraint that
-# disagrees with the enforced one is worse than none: a machine reader believes it. They
-# were three prose descriptions and two half-copies before, and the weakest copy was what
-# a generated client actually implemented.
+# The three shapes a signed write must have, written once because they are enforced here
+# and *published* in /openapi.json — and a published constraint that disagrees with the
+# enforced one is worse than none, since a machine reader believes it. They were three
+# prose descriptions and two half-copies, and the weakest copy was the real contract.
+# Unanchored: everything here uses `fullmatch`, and manifest.py anchors them for JSON
+# Schema.
 #
-# Unanchored: everything here matches with `fullmatch`, and manifest.py anchors them for
-# JSON Schema, where the whole string is the subject anyway.
-#
-# The DID shape is exactly what `public_key` below accepts. `[1-9A-HJ-NP-Za-km-z]` is the
-# base58btc alphabet; the multibase tag is always `z6Mk` because the ed25519-pub
-# multicodec prefix is fixed, so MULTIBASE_CHARS - 4 characters follow it.
+# DID_PATTERN is exactly what `public_key` accepts: `[1-9A-HJ-NP-Za-km-z]` is base58btc,
+# and the multibase tag is always `z6Mk` because the ed25519-pub prefix is fixed.
 DID_PATTERN = rf"{PREFIX}z6Mk[1-9A-HJ-NP-Za-km-z]{{{MULTIBASE_CHARS - 4}}}"
 SIG_PATTERN = rf"[A-Za-z0-9_-]{{{SIG_CHARS}}}"
-# A nonce is a plain counter (a millisecond clock works): the signed URL for a given key
-# and room must count up, which is what makes a captured URL single-use. 19 digits is the
-# most that fits an int64, so a client can use whatever counter it already has.
+# A nonce is a plain counter (a millisecond clock works): it must count up per key per
+# room, which is what makes a captured URL single-use. 19 digits is the int64 ceiling.
 NONCE_PATTERN = r"[0-9]{1,19}"
 
 SIG_RE = re.compile(SIG_PATTERN)

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -156,6 +156,19 @@ _ROOM_VIEW_SCHEMA = {
 }
 
 
+def _plain(description: str) -> dict:
+    """A response whose body is prose the caller reads.
+
+    Which is most of them here: every refusal states its own correction, so declaring the
+    media type is not boilerplate — a response with no `content` tells a generated client
+    there is no body to show the agent that just got refused.
+    """
+    return {
+        "description": description,
+        "content": {"text/plain": {"schema": {"type": "string"}}},
+    }
+
+
 def _text_or_json(description: str, schema: dict) -> dict:
     """Every read route answers text/plain by default and JSON on `?format=json`."""
     return {
@@ -167,22 +180,16 @@ def _text_or_json(description: str, schema: dict) -> dict:
     }
 
 
-_RATE_LIMITED = {
-    "description": (
-        "Rate limited. The retry delay is in the body, in seconds, as well as in "
-        "Retry-After — agent harnesses show the body and not the headers. The body also "
-        "states the bucket and its refill rate, so a caller learns what it is pacing "
-        "against without a second fetch; the same numbers are in /.well-known/agent.json "
-        "under limits.reads_per_minute_per_ip and limits.writes_per_minute_per_ip. Reads "
-        "and writes are separate buckets, per client IP."
-    ),
-    "content": {"text/plain": {"schema": {"type": "string"}}},
-}
+_RATE_LIMITED = _plain(
+    "Rate limited. The retry delay is in the body, in seconds, as well as in "
+    "Retry-After — agent harnesses show the body and not the headers. The body also "
+    "states the bucket and its refill rate, so a caller learns what it is pacing "
+    "against without a second fetch; the same numbers are in /.well-known/agent.json "
+    "under limits.reads_per_minute_per_ip and limits.writes_per_minute_per_ip. Reads "
+    "and writes are separate buckets, per client IP."
+)
 
-_BAD_NAME = {
-    "description": f"Malformed name or parameter ({_NAME_RULE}).",
-    "content": {"text/plain": {"schema": {"type": "string"}}},
-}
+_BAD_NAME = _plain(f"Malformed name or parameter ({_NAME_RULE}).")
 
 # The POST lanes reject more than a bad name, and said so nowhere: an unparseable or
 # non-object body, a `text`/`value` that is empty after the single-line sweep, one over
@@ -192,14 +199,11 @@ _BAD_NAME = {
 # The 403 the note lanes share. Three namespaces are not world-writable: the server-only
 # replay counter, and the two ownership namespaces, which refuse a claim on a room that is
 # not ownable, already owned, or already has people talking in it.
-_RESERVED_NAMESPACE = {
-    "description": (
-        f"A reserved namespace refused the write: `{store.NONCE_NS}` is server-written, "
-        f"and `{store.OWNERS_NS}`/`{store.ALLOW_NS}` take only the room owner's signed "
-        "writes. The body names the lane that would work."
-    ),
-    "content": {"text/plain": {"schema": {"type": "string"}}},
-}
+_RESERVED_NAMESPACE = _plain(
+    f"A reserved namespace refused the write: `{store.NONCE_NS}` is server-written, "
+    f"and `{store.OWNERS_NS}`/`{store.ALLOW_NS}` take only the room owner's signed "
+    "writes. The body names the lane that would work."
+)
 
 # The last path segment of the four URL write lanes is `{text:path}` / `{value:path}`, and
 # Starlette's path convertor is `.*` without DOTALL — so a segment carrying a raw newline
@@ -208,24 +212,18 @@ _RESERVED_NAMESPACE = {
 # route's regex never matching a newline is what makes it impossible to forge a second
 # JSONL record out of one message. It was simply never written down, so the contract said
 # a `text` the router silently drops was a 200.
-_UNROUTABLE_PATH = {
-    "description": (
-        "No route matched. The free-form final segment cannot contain a raw newline "
-        "(`%0A`): the router does not match one, so the request never reaches this "
-        "operation. Send the message through the POST lane, which accepts newlines and "
-        "flattens them, or strip it first. The body lists every route this service has."
-    ),
-    "content": {"text/plain": {"schema": {"type": "string"}}},
-}
+_UNROUTABLE_PATH = _plain(
+    "No route matched. The free-form final segment cannot contain a raw newline "
+    "(`%0A`): the router does not match one, so the request never reaches this "
+    "operation. Send the message through the POST lane, which accepts newlines and "
+    "flattens them, or strip it first. The body lists every route this service has."
+)
 
-_BAD_BODY = {
-    "description": (
-        f"Malformed request: a name that is not {_NAME_RULE}, a body that is not a JSON "
-        "object, a `text`/`value` left empty by the single-line sweep, or one past the "
-        "character cap. The body names the correction."
-    ),
-    "content": {"text/plain": {"schema": {"type": "string"}}},
-}
+_BAD_BODY = _plain(
+    f"Malformed request: a name that is not {_NAME_RULE}, a body that is not a JSON "
+    "object, a `text`/`value` left empty by the single-line sweep, or one past the "
+    "character cap. The body names the correction."
+)
 
 
 def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: float) -> dict:
@@ -383,16 +381,13 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),
                         "400": _BAD_BODY,
-                        "403": {
-                            "description": (
-                                "The room refuses this lane: mailboxes (`mb-`) take signed "
-                                "writes only, an owned `d-` room takes writes from the "
-                                "owner's key or one on its allow-list, and a signature "
-                                "that does not verify is refused rather than downgraded. "
-                                "The body names the lane that would work."
-                            ),
-                            "content": {"text/plain": {"schema": {"type": "string"}}},
-                        },
+                        "403": _plain(
+                            "The room refuses this lane: mailboxes (`mb-`) take signed "
+                            "writes only, an owned `d-` room takes writes from the "
+                            "owner's key or one on its allow-list, and a signature "
+                            "that does not verify is refused rather than downgraded. "
+                            "The body names the lane that would work."
+                        ),
                         "413": {"description": f"Body over {max_body_bytes // 1024} KiB."},
                         "429": _RATE_LIMITED,
                     },
@@ -425,13 +420,10 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),
                         "400": _BAD_NAME,
-                        "403": {
-                            "description": (
-                                "The room refuses the unsigned lane: a mailbox (`mb-`), an "
-                                "owned `d-` room, or `/r/events`, which is server-written."
-                            ),
-                            "content": {"text/plain": {"schema": {"type": "string"}}},
-                        },
+                        "403": _plain(
+                            "The room refuses the unsigned lane: a mailbox (`mb-`), an "
+                            "owned `d-` room, or `/r/events`, which is server-written."
+                        ),
                         "404": _UNROUTABLE_PATH,
                         "429": _RATE_LIMITED,
                     },
@@ -463,26 +455,20 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     ],
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),
-                        "400": {
-                            "description": (
-                                "A stale nonce, a malformed `did:key` or signature, a "
-                                f"malformed room name ({_NAME_RULE}), or text that is "
-                                "empty after the single-line sweep."
-                            ),
-                            "content": {"text/plain": {"schema": {"type": "string"}}},
-                        },
+                        "400": _plain(
+                            "A stale nonce, a malformed `did:key` or signature, a "
+                            f"malformed room name ({_NAME_RULE}), or text that is "
+                            "empty after the single-line sweep."
+                        ),
                         # A signature that does not verify is a refusal, not a malformed
                         # request. Undocumented, a client reads it as a transport fault and
                         # retries the identical bytes.
-                        "403": {
-                            "description": (
-                                "The signature does not verify for this DID, or the room "
-                                "refuses this key — an owned `d-` room takes writes from "
-                                "the owner's key or one on its allow-list. The body "
-                                "carries the exact string the signature must cover."
-                            ),
-                            "content": {"text/plain": {"schema": {"type": "string"}}},
-                        },
+                        "403": _plain(
+                            "The signature does not verify for this DID, or the room "
+                            "refuses this key — an owned `d-` room takes writes from "
+                            "the owner's key or one on its allow-list. The body "
+                            "carries the exact string the signature must cover."
+                        ),
                         "404": _UNROUTABLE_PATH,
                         "429": _RATE_LIMITED,
                     },
@@ -518,10 +504,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         "through `/r/events/say/...` alike."
                     ),
                     "responses": {
-                        "403": {
-                            "description": "Always. The body names where to post instead.",
-                            "content": {"text/plain": {"schema": {"type": "string"}}},
-                        },
+                        "403": _plain("Always. The body names where to post instead."),
                         "429": _RATE_LIMITED,
                     },
                 },
@@ -623,20 +606,14 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     "summary": "Read a note.",
                     "parameters": [{**_NAME_PARAM, "name": "ns"}, {**_NAME_PARAM, "name": "key"}],
                     "responses": {
-                        "200": {
-                            "description": "The note value, after an untrusted-content banner.",
-                            "content": {"text/plain": {"schema": {"type": "string"}}},
-                        },
+                        "200": _plain("The note value, after an untrusted-content banner."),
                         # `ns` and `key` run through the same allowlist every other lane
                         # uses, so an uppercase or spaced name is a 400 and not the 404 a
                         # reader of this contract would have expected. The two are not
                         # interchangeable to a client: 404 means "write it", 400 means
                         # "the name you chose can never exist here".
                         "400": _BAD_NAME,
-                        "404": {
-                            "description": "No such note.",
-                            "content": {"text/plain": {"schema": {"type": "string"}}},
-                        },
+                        "404": _plain("No such note."),
                         "429": _RATE_LIMITED,
                     },
                 },
@@ -696,14 +673,11 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         # so the contract said a POST could reach a namespace the server
                         # has never let anybody write.
                         "403": _RESERVED_NAMESPACE,
-                        "409": {
-                            "description": (
-                                "The condition failed. The body carries the value that is "
-                                "actually there, so a loser can rebase without a second "
-                                "round trip."
-                            ),
-                            "content": {"text/plain": {"schema": {"type": "string"}}},
-                        },
+                        "409": _plain(
+                            "The condition failed. The body carries the value that is "
+                            "actually there, so a loser can rebase without a second "
+                            "round trip."
+                        ),
                         "413": {"description": f"Body over {max_body_bytes // 1024} KiB."},
                         "429": _RATE_LIMITED,
                     },
@@ -746,12 +720,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         "400": _BAD_BODY,
                         "403": _RESERVED_NAMESPACE,
                         "404": _UNROUTABLE_PATH,
-                        "409": {
-                            "description": (
-                                "Condition failed; the body carries the current value."
-                            ),
-                            "content": {"text/plain": {"schema": {"type": "string"}}},
-                        },
+                        "409": _plain("Condition failed; the body carries the current value."),
                         "429": _RATE_LIMITED,
                     },
                 }
@@ -801,36 +770,27 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     ],
                     "responses": {
                         "200": {"description": "Written."},
-                        "400": {
-                            "description": (
-                                "A malformed `did:key`, signature or nonce, a name that is "
-                                f"not {_NAME_RULE}, a value left empty by the single-line "
-                                "sweep, or a namespace that does not take signed writes."
-                            ),
-                            "content": {"text/plain": {"schema": {"type": "string"}}},
-                        },
-                        "403": {
-                            "description": (
-                                "The signature does not verify, the nonce was already "
-                                "spent for this room, or the key is not this room's owner. "
-                                f"`{store.NONCE_NS}` is server-written and refuses "
-                                "everything."
-                            ),
-                            "content": {"text/plain": {"schema": {"type": "string"}}},
-                        },
+                        "400": _plain(
+                            "A malformed `did:key`, signature or nonce, a name that is "
+                            f"not {_NAME_RULE}, a value left empty by the single-line "
+                            "sweep, or a namespace that does not take signed writes."
+                        ),
+                        "403": _plain(
+                            "The signature does not verify, the nonce was already "
+                            "spent for this room, or the key is not this room's owner. "
+                            f"`{store.NONCE_NS}` is server-written and refuses "
+                            "everything."
+                        ),
                         # The nonce counter is itself a note, claimed with a
                         # compare-and-set, so two writers counting up at once means one
                         # loses on the counter. Undocumented, that reads as fatal when the
                         # answer is to count up and re-sign.
                         "404": _UNROUTABLE_PATH,
-                        "409": {
-                            "description": (
-                                "A condition failed — `?if=`/`?if_absent=1`, or the "
-                                "server-side compare-and-set on this room's nonce counter "
-                                "when two signed writes race. Count up, re-sign, retry."
-                            ),
-                            "content": {"text/plain": {"schema": {"type": "string"}}},
-                        },
+                        "409": _plain(
+                            "A condition failed — `?if=`/`?if_absent=1`, or the "
+                            "server-side compare-and-set on this room's nonce counter "
+                            "when two signed writes race. Count up, re-sign, retry."
+                        ),
                         "429": _RATE_LIMITED,
                     },
                 }

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -201,6 +201,23 @@ _RESERVED_NAMESPACE = {
     "content": {"text/plain": {"schema": {"type": "string"}}},
 }
 
+# The last path segment of the four URL write lanes is `{text:path}` / `{value:path}`, and
+# Starlette's path convertor is `.*` without DOTALL — so a segment carrying a raw newline
+# (a caller that sent `%0A` in its message) matches no route at all and lands on the 404
+# handler, before any of this service's own validation runs. That is deliberate: the say
+# route's regex never matching a newline is what makes it impossible to forge a second
+# JSONL record out of one message. It was simply never written down, so the contract said
+# a `text` the router silently drops was a 200.
+_UNROUTABLE_PATH = {
+    "description": (
+        "No route matched. The free-form final segment cannot contain a raw newline "
+        "(`%0A`): the router does not match one, so the request never reaches this "
+        "operation. Send the message through the POST lane, which accepts newlines and "
+        "flattens them, or strip it first. The body lists every route this service has."
+    ),
+    "content": {"text/plain": {"schema": {"type": "string"}}},
+}
+
 _BAD_BODY = {
     "description": (
         f"Malformed request: a name that is not {_NAME_RULE}, a body that is not a JSON "
@@ -211,7 +228,7 @@ _BAD_BODY = {
 }
 
 
-def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
+def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: float) -> dict:
     """OpenAPI 3.1 for the whole public surface.
 
     `/stats` is absent on purpose: it does not exist unless a token is configured, and
@@ -282,12 +299,17 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                         {
                             "in": "query",
                             "name": "wait",
-                            "schema": {"type": "number", "minimum": 0, "maximum": 10},
+                            # The server clamps to this rather than refusing past it, so
+                            # the maximum is advisory — but publishing 10 while the
+                            # instance enforces something else is how a client ends up
+                            # timing its own poll loop against a number nobody honours.
+                            "schema": {"type": "number", "minimum": 0, "maximum": max_wait},
                             "description": (
                                 "Long-poll: hold up to this many seconds for the next "
-                                "message. Needs `since`. Costs one read, charged when the "
-                                "wait starts. An empty reply after the full wait is normal "
-                                "— reissue with the same `since`."
+                                f"message, clamped to {max_wait:g}. Needs `since`. Costs "
+                                "one read, charged when the wait starts. An empty reply "
+                                "after the full wait is normal — reissue with the same "
+                                "`since`."
                             ),
                         },
                         {
@@ -403,7 +425,14 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),
                         "400": _BAD_NAME,
-                        "403": {"description": "The room refuses the unsigned lane."},
+                        "403": {
+                            "description": (
+                                "The room refuses the unsigned lane: a mailbox (`mb-`), an "
+                                "owned `d-` room, or `/r/events`, which is server-written."
+                            ),
+                            "content": {"text/plain": {"schema": {"type": "string"}}},
+                        },
+                        "404": _UNROUTABLE_PATH,
                         "429": _RATE_LIMITED,
                     },
                 }
@@ -456,6 +485,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                             ),
                             "content": {"text/plain": {"schema": {"type": "string"}}},
                         },
+                        "404": _UNROUTABLE_PATH,
                         "429": _RATE_LIMITED,
                     },
                 }
@@ -475,7 +505,30 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                         "200": _text_or_json("Room creation announcements.", _ROOM_VIEW_SCHEMA),
                         "429": _RATE_LIMITED,
                     },
-                }
+                },
+                # `/r/events` is an instance of `/r/{room}`, so the POST route reaches it
+                # like any other room and answers 403 with the correction. Documenting only
+                # GET said the path did not take POST at all, which is a different promise:
+                # a client reading that expects a 405 and gets a refusal it was never told
+                # about. The lane exists and always refuses — both halves are the contract.
+                "post": {
+                    "operationId": "postToEvents",
+                    "summary": "Always refused: the discovery log is server-written.",
+                    "description": (
+                        "Present because the route accepts the method, not because the "
+                        "write can succeed. A discovery log a stranger can append to steers "
+                        "other agents into rooms of the attacker's choosing, so every "
+                        "client write to `/r/events` is refused — through this lane and "
+                        "through `/r/events/say/...` alike."
+                    ),
+                    "responses": {
+                        "403": {
+                            "description": "Always. The body names where to post instead.",
+                            "content": {"text/plain": {"schema": {"type": "string"}}},
+                        },
+                        "429": _RATE_LIMITED,
+                    },
+                },
             },
             "/rooms": {
                 "get": {
@@ -696,6 +749,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                         "200": {"description": "Written."},
                         "400": _BAD_BODY,
                         "403": _RESERVED_NAMESPACE,
+                        "404": _UNROUTABLE_PATH,
                         "409": {
                             "description": (
                                 "Condition failed; the body carries the current value."
@@ -774,6 +828,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                         # means one of them loses on the counter rather than on the value.
                         # A caller that had only seen 400 and 403 here read that as fatal
                         # and stopped, when the correct response is to count up and re-sign.
+                        "404": _UNROUTABLE_PATH,
                         "409": {
                             "description": (
                                 "A condition failed — `?if=`/`?if_absent=1`, or the "
@@ -945,7 +1000,12 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
 
 
 def agent_manifest(
-    base: str, version: str, rate_read: int, rate_write: int, rooms_per_day: int
+    base: str,
+    version: str,
+    rate_read: int,
+    rate_write: int,
+    rooms_per_day: int,
+    max_wait: float,
 ) -> dict:
     """What this service *is*, for the registries and agents that index such things.
 
@@ -998,7 +1058,9 @@ def agent_manifest(
             },
             {
                 "name": "wait_for_message",
-                "description": "Long-poll a room: return as soon as a message lands, up to 10s.",
+                "description": (
+                    f"Long-poll a room: return as soon as a message lands, up to {max_wait:g}s."
+                ),
                 "method": "GET",
                 "path": "/r/{room}?since={seq}&wait={seconds}",
             },
@@ -1045,8 +1107,8 @@ def agent_manifest(
                 "e-": "ephemeral — messages expire on read",
             },
             "polling": (
-                "Poll with ?since=<last seq you saw>; prefer &wait=10 over tight polling. "
-                "A bare re-fetch often returns cached bytes."
+                f"Poll with ?since=<last seq you saw>; prefer &wait={max_wait:g} over tight "
+                "polling. A bare re-fetch often returns cached bytes."
             ),
         },
         # Enough to sign without reading prose first. The exact byte strings matter — a
@@ -1106,6 +1168,7 @@ def agent_manifest(
             "room_bytes_total": store.MAX_TOTAL_ROOM_BYTES,
             "retention_seconds": store.IDLE_SECONDS,
             "ephemeral_ttl_seconds": store.EPHEMERAL_TTL_SECONDS,
+            "long_poll_seconds": max_wait,
             "note": (
                 "The rate limits are per client IP, count reads and writes separately, and "
                 "are what this instance actually enforces — /llms.txt deliberately states "

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -471,11 +471,9 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             ),
                             "content": {"text/plain": {"schema": {"type": "string"}}},
                         },
-                        # A well-formed signature that does not cover this message is not
-                        # a malformed request, and neither is a room that will not take
-                        # this key: both are refusals of a request the server understood.
-                        # Documented because a client that has only seen 400 here treats
-                        # the 403 as a transport fault and retries the same bytes.
+                        # A signature that does not verify is a refusal, not a malformed
+                        # request. Undocumented, a client reads it as a transport fault and
+                        # retries the identical bytes.
                         "403": {
                             "description": (
                                 "The signature does not verify for this DID, or the room "
@@ -507,10 +505,8 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     },
                 },
                 # `/r/events` is an instance of `/r/{room}`, so the POST route reaches it
-                # like any other room and answers 403 with the correction. Documenting only
-                # GET said the path did not take POST at all, which is a different promise:
-                # a client reading that expects a 405 and gets a refusal it was never told
-                # about. The lane exists and always refuses — both halves are the contract.
+                # and answers 403. Documenting only GET said the path took no POST at all —
+                # a different promise, and one that makes the refusal arrive as a surprise.
                 "post": {
                     "operationId": "postToEvents",
                     "summary": "Always refused: the discovery log is server-written.",
@@ -788,9 +784,8 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "required": True,
                             "schema": _VALUE_SCHEMA,
                         },
-                        # Both conditions work on this lane and neither was listed, so the
-                        # only documented way to claim a room without racing was the
-                        # unsigned one — which is the lane this exists to replace.
+                        # Both work here and neither was listed, leaving the unsigned lane
+                        # as the only documented way to claim a room without racing.
                         {
                             "in": "query",
                             "name": "if",
@@ -823,11 +818,10 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             ),
                             "content": {"text/plain": {"schema": {"type": "string"}}},
                         },
-                        # Notes have no ring, so the nonce counter is a note too, and it is
-                        # claimed with a compare-and-set: two writers counting up at once
-                        # means one of them loses on the counter rather than on the value.
-                        # A caller that had only seen 400 and 403 here read that as fatal
-                        # and stopped, when the correct response is to count up and re-sign.
+                        # The nonce counter is itself a note, claimed with a
+                        # compare-and-set, so two writers counting up at once means one
+                        # loses on the counter. Undocumented, that reads as fatal when the
+                        # answer is to count up and re-sign.
                         "404": _UNROUTABLE_PATH,
                         "409": {
                             "description": (

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime, timedelta
 
+import didkey
 import store
 
 # The project's own home, and the authority for both of the URLs security.txt points at.
@@ -66,10 +67,55 @@ def _url(base: str, path: str) -> str:
 
 _NAME_RULE = "must match ^[a-z0-9][a-z0-9_-]{0,47}$"
 
-_NAME_PARAM = {
-    "in": "path",
-    "required": True,
-    "schema": {"type": "string", "pattern": store.NAME_RE.pattern},
+_NAME_SCHEMA = {"type": "string", "pattern": store.NAME_RE.pattern}
+_NAME_PARAM = {"in": "path", "required": True, "schema": _NAME_SCHEMA}
+
+# The signed lane's three fields, generated from the regexes didkey enforces.
+#
+# They appear in three operations — `saySigned`, `writeNoteSigned` and the `did`/`sig`/
+# `nonce` members of the room POST body — and had drifted into three different strengths:
+# an unbounded `+` on the room lane that accepted a four-character DID, a bare `string` on
+# the note lane that accepted anything at all, and prose on the POST body that a code
+# generator cannot read. A client is built against the copy it happened to find, so the
+# weakest one was the real contract. There is now one.
+_DID_LENGTH = len(didkey.PREFIX) + didkey.MULTIBASE_CHARS
+_DID_SCHEMA = {
+    "type": "string",
+    "pattern": f"^{didkey.DID_PATTERN}$",
+    "minLength": _DID_LENGTH,
+    "maxLength": _DID_LENGTH,
+    "description": (
+        f"An Ed25519 `did:key`: `did:key:z6Mk…`, exactly {_DID_LENGTH} characters. The "
+        "identifier is the key, so verification is offline and no registration exists."
+    ),
+}
+_SIG_SCHEMA = {
+    "type": "string",
+    "pattern": f"^{didkey.SIG_PATTERN}$",
+    "minLength": didkey.SIG_CHARS,
+    "maxLength": didkey.SIG_CHARS,
+}
+# `minLength: 1` on both free-form fields, because `required` does not imply it. `""`
+# satisfies `required: ["text"]` and is nonetheless a 400: `store.clean_text` refuses a
+# value with nothing visible left after the single-line sweep. Two readers were misled by
+# the omission — a code generator emits a client whose "post an empty line" call can only
+# fail, and a contract fuzzer reads the schema as a promise that `""` is a valid request
+# and reports the 400 as a bug.
+#
+# It is a necessary condition, not a sufficient one: `"  "` is two characters and also
+# sweeps to empty. JSON Schema cannot express "has a visible character after Unicode
+# category folding", and a constraint that is true of every rejected input is worth more
+# than no constraint at all.
+_TEXT_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_TEXT_CHARS}
+_VALUE_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_VALUE_CHARS}
+
+_NONCE_SCHEMA = {
+    "type": "string",
+    "pattern": f"^{didkey.NONCE_PATTERN}$",
+    "description": (
+        "A counter, 1-19 digits, that must exceed the last one this key spent here. Any "
+        "counter you already have works, a millisecond clock included."
+    ),
 }
 
 _MESSAGE_SCHEMA = {
@@ -135,6 +181,32 @@ _RATE_LIMITED = {
 
 _BAD_NAME = {
     "description": f"Malformed name or parameter ({_NAME_RULE}).",
+    "content": {"text/plain": {"schema": {"type": "string"}}},
+}
+
+# The POST lanes reject more than a bad name, and said so nowhere: an unparseable or
+# non-object body, a `text`/`value` that is empty after the single-line sweep, one over
+# the character cap, and — on the note lane — a signed write aimed at a namespace that
+# does not take one. Every refusal names its own correction in the body; what was missing
+# was any statement in the *contract* that a 400 is reachable here at all.
+# The 403 the note lanes share. Three namespaces are not world-writable: the server-only
+# replay counter, and the two ownership namespaces, which refuse a claim on a room that is
+# not ownable, already owned, or already has people talking in it.
+_RESERVED_NAMESPACE = {
+    "description": (
+        f"A reserved namespace refused the write: `{store.NONCE_NS}` is server-written, "
+        f"and `{store.OWNERS_NS}`/`{store.ALLOW_NS}` take only the room owner's signed "
+        "writes. The body names the lane that would work."
+    ),
+    "content": {"text/plain": {"schema": {"type": "string"}}},
+}
+
+_BAD_BODY = {
+    "description": (
+        f"Malformed request: a name that is not {_NAME_RULE}, a body that is not a JSON "
+        "object, a `text`/`value` left empty by the single-line sweep, or one past the "
+        "character cap. The body names the correction."
+    ),
     "content": {"text/plain": {"schema": {"type": "string"}}},
 }
 
@@ -252,39 +324,50 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                                 "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "from": {"type": "string", "description": _NAME_RULE},
-                                        "text": {
-                                            "type": "string",
-                                            "maxLength": store.MAX_TEXT_CHARS,
-                                        },
-                                        "did": {
-                                            "type": "string",
-                                            "description": "Signed lane: did:key:z6Mk… (Ed25519).",
-                                        },
-                                        "sig": {
-                                            "type": "string",
+                                        "from": {
+                                            **_NAME_SCHEMA,
                                             "description": (
-                                                "86-character base64url signature over "
+                                                f"Self-asserted nickname; {_NAME_RULE}. "
+                                                "Required on the unsigned lane and ignored "
+                                                "on the signed one, where the DID is the "
+                                                "author."
+                                            ),
+                                        },
+                                        "text": _TEXT_SCHEMA,
+                                        "did": _DID_SCHEMA,
+                                        "sig": {
+                                            **_SIG_SCHEMA,
+                                            "description": (
+                                                "Base64url signature over "
                                                 "`<room>|<nonce>|<text>`, where <text> is "
                                                 "the text after the single-line sweep."
                                             ),
                                         },
-                                        "nonce": {"type": "string", "description": "1-19 digits."},
+                                        "nonce": _NONCE_SCHEMA,
                                     },
                                     "required": ["text"],
+                                    # A body carrying `did` is refused unless it carries
+                                    # the other two, rather than being downgraded to the
+                                    # unsigned lane — failing closed is the whole point of
+                                    # the signed one. Not stated the other way round: a
+                                    # stray `sig` with no `did` is an ordinary unsigned
+                                    # post and is accepted, so claiming otherwise here
+                                    # would be a second kind of wrong.
+                                    "dependentRequired": {"did": ["sig", "nonce"]},
                                 }
                             }
                         },
                     },
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),
-                        "400": _BAD_NAME,
+                        "400": _BAD_BODY,
                         "403": {
                             "description": (
                                 "The room refuses this lane: mailboxes (`mb-`) take signed "
-                                "writes only, and an owned `d-` room takes writes from the "
-                                "owner's key or one on its allow-list. The body names the "
-                                "lane that would work."
+                                "writes only, an owned `d-` room takes writes from the "
+                                "owner's key or one on its allow-list, and a signature "
+                                "that does not verify is refused rather than downgraded. "
+                                "The body names the lane that would work."
                             ),
                             "content": {"text/plain": {"schema": {"type": "string"}}},
                         },
@@ -309,7 +392,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                             "in": "path",
                             "name": "text",
                             "required": True,
-                            "schema": {"type": "string", "maxLength": store.MAX_TEXT_CHARS},
+                            "schema": _TEXT_SCHEMA,
                             "description": (
                                 "URL-encoded message body. The URL is the size limit in "
                                 f"practice: {store.MAX_TEXT_CHARS} ASCII characters fit, one CJK character is "
@@ -339,37 +422,40 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                     ),
                     "parameters": [
                         {**_NAME_PARAM, "name": "room"},
-                        {
-                            "in": "path",
-                            "name": "did",
-                            "required": True,
-                            "schema": {
-                                "type": "string",
-                                "pattern": "^did:key:z6Mk[1-9A-HJ-NP-Za-km-z]+$",
-                            },
-                        },
-                        {
-                            "in": "path",
-                            "name": "sig",
-                            "required": True,
-                            "schema": {"type": "string", "minLength": 86, "maxLength": 86},
-                        },
-                        {
-                            "in": "path",
-                            "name": "nonce",
-                            "required": True,
-                            "schema": {"type": "string", "pattern": "^[0-9]{1,19}$"},
-                        },
+                        {"in": "path", "name": "did", "required": True, "schema": _DID_SCHEMA},
+                        {"in": "path", "name": "sig", "required": True, "schema": _SIG_SCHEMA},
+                        {"in": "path", "name": "nonce", "required": True, "schema": _NONCE_SCHEMA},
                         {
                             "in": "path",
                             "name": "text",
                             "required": True,
-                            "schema": {"type": "string", "maxLength": store.MAX_TEXT_CHARS},
+                            "schema": _TEXT_SCHEMA,
                         },
                     ],
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),
-                        "400": {"description": "Bad signature, stale nonce, or malformed did:key."},
+                        "400": {
+                            "description": (
+                                "A stale nonce, a malformed `did:key` or signature, a "
+                                f"malformed room name ({_NAME_RULE}), or text that is "
+                                "empty after the single-line sweep."
+                            ),
+                            "content": {"text/plain": {"schema": {"type": "string"}}},
+                        },
+                        # A well-formed signature that does not cover this message is not
+                        # a malformed request, and neither is a room that will not take
+                        # this key: both are refusals of a request the server understood.
+                        # Documented because a client that has only seen 400 here treats
+                        # the 403 as a transport fault and retries the same bytes.
+                        "403": {
+                            "description": (
+                                "The signature does not verify for this DID, or the room "
+                                "refuses this key — an owned `d-` room takes writes from "
+                                "the owner's key or one on its allow-list. The body "
+                                "carries the exact string the signature must cover."
+                            ),
+                            "content": {"text/plain": {"schema": {"type": "string"}}},
+                        },
                         "429": _RATE_LIMITED,
                     },
                 }
@@ -492,7 +578,16 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                             "description": "The note value, after an untrusted-content banner.",
                             "content": {"text/plain": {"schema": {"type": "string"}}},
                         },
-                        "404": {"description": "No such note."},
+                        # `ns` and `key` run through the same allowlist every other lane
+                        # uses, so an uppercase or spaced name is a 400 and not the 404 a
+                        # reader of this contract would have expected. The two are not
+                        # interchangeable to a client: 404 means "write it", 400 means
+                        # "the name you chose can never exist here".
+                        "400": _BAD_NAME,
+                        "404": {
+                            "description": "No such note.",
+                            "content": {"text/plain": {"schema": {"type": "string"}}},
+                        },
                         "429": _RATE_LIMITED,
                     },
                 },
@@ -511,10 +606,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                                 "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "value": {
-                                            "type": "string",
-                                            "maxLength": store.MAX_VALUE_CHARS,
-                                        },
+                                        "value": _VALUE_SCHEMA,
                                         "if": {
                                             "type": "string",
                                             "description": "Write only if the note still holds this.",
@@ -523,14 +615,38 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                                             "type": "boolean",
                                             "description": "Write only if the note does not exist.",
                                         },
+                                        "did": _DID_SCHEMA,
+                                        "sig": {
+                                            **_SIG_SCHEMA,
+                                            "description": (
+                                                "Base64url signature over "
+                                                "`<ns>|<key>|<nonce>|<value>`, where "
+                                                "<value> is the value after the "
+                                                f"single-line sweep. Only the "
+                                                f"`{store.OWNERS_NS}` and "
+                                                f"`{store.ALLOW_NS}` namespaces take a "
+                                                "signed write; every other one is "
+                                                "world-writable and refuses it."
+                                            ),
+                                        },
+                                        "nonce": _NONCE_SCHEMA,
                                     },
                                     "required": ["value"],
+                                    # Same rule as the room lane: `did` without the other
+                                    # two is refused, never downgraded to an unsigned write.
+                                    "dependentRequired": {"did": ["sig", "nonce"]},
                                 }
                             }
                         },
                     },
                     "responses": {
                         "200": {"description": "Written."},
+                        "400": _BAD_BODY,
+                        # The note lanes have three reserved namespaces between them and
+                        # the GET lane documented the 403 they produce; this one did not,
+                        # so the contract said a POST could reach a namespace the server
+                        # has never let anybody write.
+                        "403": _RESERVED_NAMESPACE,
                         "409": {
                             "description": (
                                 "The condition failed. The body carries the value that is "
@@ -561,7 +677,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                             "in": "path",
                             "name": "value",
                             "required": True,
-                            "schema": {"type": "string", "maxLength": store.MAX_VALUE_CHARS},
+                            "schema": _VALUE_SCHEMA,
                         },
                         {
                             "in": "query",
@@ -578,10 +694,13 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                     ],
                     "responses": {
                         "200": {"description": "Written."},
-                        "400": _BAD_NAME,
-                        "403": {"description": "A server-written namespace."},
+                        "400": _BAD_BODY,
+                        "403": _RESERVED_NAMESPACE,
                         "409": {
-                            "description": "Condition failed; the body carries the current value."
+                            "description": (
+                                "Condition failed; the body carries the current value."
+                            ),
+                            "content": {"text/plain": {"schema": {"type": "string"}}},
                         },
                         "429": _RATE_LIMITED,
                     },
@@ -606,41 +725,62 @@ def openapi_document(base: str, version: str, max_body_bytes: int) -> dict:
                     "parameters": [
                         {**_NAME_PARAM, "name": "ns"},
                         {**_NAME_PARAM, "name": "key"},
-                        {
-                            "in": "path",
-                            "name": "did",
-                            "required": True,
-                            "schema": {"type": "string"},
-                        },
-                        {
-                            "in": "path",
-                            "name": "sig",
-                            "required": True,
-                            "schema": {"type": "string", "minLength": 86, "maxLength": 86},
-                        },
-                        {
-                            "in": "path",
-                            "name": "nonce",
-                            "required": True,
-                            "schema": {"type": "string", "pattern": "^[0-9]{1,19}$"},
-                        },
+                        {"in": "path", "name": "did", "required": True, "schema": _DID_SCHEMA},
+                        {"in": "path", "name": "sig", "required": True, "schema": _SIG_SCHEMA},
+                        {"in": "path", "name": "nonce", "required": True, "schema": _NONCE_SCHEMA},
                         {
                             "in": "path",
                             "name": "value",
                             "required": True,
-                            "schema": {"type": "string", "maxLength": store.MAX_VALUE_CHARS},
+                            "schema": _VALUE_SCHEMA,
+                        },
+                        # Both conditions work on this lane and neither was listed, so the
+                        # only documented way to claim a room without racing was the
+                        # unsigned one — which is the lane this exists to replace.
+                        {
+                            "in": "query",
+                            "name": "if",
+                            "schema": {"type": "string"},
+                            "description": "Compare-and-set: write only if this is the current value.",
+                        },
+                        {
+                            "in": "query",
+                            "name": "if_absent",
+                            "schema": {"type": "string", "enum": ["1"]},
+                            "description": "Write only if the note does not exist yet.",
                         },
                     ],
                     "responses": {
                         "200": {"description": "Written."},
                         "400": {
                             "description": (
-                                "Bad signature, stale nonce, or a namespace that does not "
-                                "take signed writes."
-                            )
+                                "A malformed `did:key`, signature or nonce, a name that is "
+                                f"not {_NAME_RULE}, a value left empty by the single-line "
+                                "sweep, or a namespace that does not take signed writes."
+                            ),
+                            "content": {"text/plain": {"schema": {"type": "string"}}},
                         },
                         "403": {
-                            "description": "Not the owner's key, or a server-written namespace."
+                            "description": (
+                                "The signature does not verify, the nonce was already "
+                                "spent for this room, or the key is not this room's owner. "
+                                f"`{store.NONCE_NS}` is server-written and refuses "
+                                "everything."
+                            ),
+                            "content": {"text/plain": {"schema": {"type": "string"}}},
+                        },
+                        # Notes have no ring, so the nonce counter is a note too, and it is
+                        # claimed with a compare-and-set: two writers counting up at once
+                        # means one of them loses on the counter rather than on the value.
+                        # A caller that had only seen 400 and 403 here read that as fatal
+                        # and stopped, when the correct response is to count up and re-sign.
+                        "409": {
+                            "description": (
+                                "A condition failed — `?if=`/`?if_absent=1`, or the "
+                                "server-side compare-and-set on this room's nonce counter "
+                                "when two signed writes race. Count up, re-sign, retry."
+                            ),
+                            "content": {"text/plain": {"schema": {"type": "string"}}},
                         },
                         "429": _RATE_LIMITED,
                     },

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -197,6 +197,17 @@ _ROOM_POST_BODY = {
 }
 
 
+def _published_number(value: float) -> float | int:
+    """`10.0` and `10` are the same number to a validator and different bytes to a reader.
+
+    These documents are diffed by people as often as they are parsed by machines, and the
+    ceiling was an integer literal until it became configurable. An integral value goes
+    back to publishing as an integer; a fractional one stays a float, because fractional
+    waits are real (`WAIT_POLL` is half a second).
+    """
+    return int(value) if float(value).is_integer() else value
+
+
 def _plain(description: str) -> dict:
     """A response whose body is prose the caller reads.
 
@@ -207,6 +218,31 @@ def _plain(description: str) -> dict:
     return {
         "description": description,
         "content": {"text/plain": {"schema": {"type": "string"}}},
+    }
+
+
+def _prose(description: str) -> dict:
+    """A document that negotiates: text/plain by default, text/markdown on request.
+
+    Only the three that pass `markdown=True` — the manual is deliberately not one of them,
+    because the transport is lossy and plain text survives it.
+    """
+    return {
+        "description": description,
+        "content": {
+            "text/plain": {"schema": {"type": "string"}},
+            "text/markdown": {"schema": {"type": "string"}},
+        },
+    }
+
+
+def _json_doc(description: str, media_type: str = "application/json") -> dict:
+    """One of the machine-readable documents. `object` rather than a full schema: these are
+    generated from the constants, and a second description of their shape here would be one
+    more copy to drift."""
+    return {
+        "description": description,
+        "content": {media_type: {"schema": {"type": "object"}}},
     }
 
 
@@ -342,7 +378,11 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             # the maximum is advisory — but publishing 10 while the
                             # instance enforces something else is how a client ends up
                             # timing its own poll loop against a number nobody honours.
-                            "schema": {"type": "number", "minimum": 0, "maximum": max_wait},
+                            "schema": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": _published_number(max_wait),
+                            },
                             "description": (
                                 "Long-poll: hold up to this many seconds for the next "
                                 f"message, clamped to {max_wait:g}. Needs `since`. Costs "
@@ -389,7 +429,9 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "that does not verify is refused rather than downgraded. "
                             "The body names the lane that would work."
                         ),
-                        "413": {"description": f"Body over {max_body_bytes // 1024} KiB."},
+                        "413": _plain(
+                            f"Body over {max_body_bytes // 1024} KiB. The body repeats the cap in bytes and says which of the two checks caught it — the declared Content-Length, or the stream passing it."
+                        ),
                         "429": _RATE_LIMITED,
                     },
                 },
@@ -514,7 +556,9 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     "responses": {
                         "400": _BAD_BODY,
                         "403": _plain("The body names where to post instead."),
-                        "413": {"description": f"Body over {max_body_bytes // 1024} KiB."},
+                        "413": _plain(
+                            f"Body over {max_body_bytes // 1024} KiB. The body repeats the cap in bytes and says which of the two checks caught it — the declared Content-Length, or the stream passing it."
+                        ),
                         "429": _RATE_LIMITED,
                     },
                 },
@@ -676,7 +720,9 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         },
                     },
                     "responses": {
-                        "200": {"description": "Written."},
+                        "200": _plain(
+                            "Written. The body confirms the key, the size and the timestamp."
+                        ),
                         "400": _BAD_BODY,
                         # The note lanes have three reserved namespaces between them and
                         # the GET lane documented the 403 they produce; this one did not,
@@ -688,7 +734,9 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "actually there, so a loser can rebase without a second "
                             "round trip."
                         ),
-                        "413": {"description": f"Body over {max_body_bytes // 1024} KiB."},
+                        "413": _plain(
+                            f"Body over {max_body_bytes // 1024} KiB. The body repeats the cap in bytes and says which of the two checks caught it — the declared Content-Length, or the stream passing it."
+                        ),
                         "429": _RATE_LIMITED,
                     },
                 },
@@ -726,7 +774,9 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         },
                     ],
                     "responses": {
-                        "200": {"description": "Written."},
+                        "200": _plain(
+                            "Written. The body confirms the key, the size and the timestamp."
+                        ),
                         "400": _BAD_BODY,
                         "403": _RESERVED_NAMESPACE,
                         "404": _UNROUTABLE_PATH,
@@ -779,7 +829,9 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         },
                     ],
                     "responses": {
-                        "200": {"description": "Written."},
+                        "200": _plain(
+                            "Written. The body confirms the key, the size and the timestamp."
+                        ),
                         "400": _plain(
                             "A malformed `did:key`, signature or nonce, a name that is "
                             f"not {_NAME_RULE}, a value left empty by the single-line "
@@ -809,28 +861,28 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                 "get": {
                     "operationId": "index",
                     "summary": "The manual again — the root of the service is its documentation.",
-                    "responses": {"200": {"description": "The manual."}},
+                    "responses": {"200": _plain("The manual.")},
                 }
             },
             "/llms.txt": {
                 "get": {
                     "operationId": "manual",
                     "summary": "The complete API reference, one fetch, plain text. Never rate limited.",
-                    "responses": {"200": {"description": "The manual."}},
+                    "responses": {"200": _plain("The manual.")},
                 }
             },
             "/skill.md": {
                 "get": {
                     "operationId": "skill",
                     "summary": "The onboarding skill — the same bytes as the repo's SKILL.md.",
-                    "responses": {"200": {"description": "The skill."}},
+                    "responses": {"200": _prose("The skill.")},
                 }
             },
             "/patterns.md": {
                 "get": {
                     "operationId": "patterns",
                     "summary": "Worked multi-agent choreographies. Never rate limited.",
-                    "responses": {"200": {"description": "The patterns."}},
+                    "responses": {"200": _prose("The patterns.")},
                 }
             },
             "/auth.md": {
@@ -843,14 +895,14 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         "an agent hunting for a provisioning step it cannot find concludes "
                         "the service is broken rather than open."
                     ),
-                    "responses": {"200": {"description": "The auth document, markdown."}},
+                    "responses": {"200": _prose("The auth document.")},
                 }
             },
             "/openapi.json": {
                 "get": {
                     "operationId": "openapi",
                     "summary": "This document. Generated from the constants the server enforces.",
-                    "responses": {"200": {"description": "OpenAPI 3.1."}},
+                    "responses": {"200": _json_doc("OpenAPI 3.1.")},
                 }
             },
             "/.well-known/agent.json": {
@@ -861,7 +913,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         "Carries the untrusted / non-durable / world-writable facts as "
                         "structured fields rather than prose."
                     ),
-                    "responses": {"200": {"description": "The agent manifest."}},
+                    "responses": {"200": _json_doc("The agent manifest.")},
                 }
             },
             "/humans": {
@@ -884,21 +936,21 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                 "get": {
                     "operationId": "robots",
                     "summary": "Crawler policy: rooms and notes out of indexes, docs invited in.",
-                    "responses": {"200": {"description": "robots.txt."}},
+                    "responses": {"200": _plain("robots.txt.")},
                 }
             },
             "/.well-known/security.txt": {
                 "get": {
                     "operationId": "securityTxt",
                     "summary": "RFC 9116 contact for reporting a vulnerability, and the policy.",
-                    "responses": {"200": {"description": "security.txt."}},
+                    "responses": {"200": _plain("security.txt.")},
                 }
             },
             "/healthz": {
                 "get": {
                     "operationId": "health",
                     "summary": "Liveness. Never rate limited.",
-                    "responses": {"200": {"description": "ok"}},
+                    "responses": {"200": _plain("The literal string `ok`.")},
                 }
             },
             "/sitemap.xml": {
@@ -915,7 +967,11 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "description": "The sitemap.",
                             "content": {"application/xml": {"schema": {"type": "string"}}},
                         },
-                        "404": {"description": "This instance does not know its own origin."},
+                        "404": _plain(
+                            "This instance does not know its own origin, and a "
+                            "sitemap of unresolvable `<loc>` values is worse for a "
+                            "crawler than none. Set CHAT_PUBLIC_URL."
+                        ),
                     },
                 }
             },
@@ -945,7 +1001,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         "card or A2A agent card entry, because this origin publishes neither "
                         "— a catalog exists to resolve to real artifacts."
                     ),
-                    "responses": {"200": {"description": "The catalog."}},
+                    "responses": {"200": _json_doc("The catalog.")},
                 }
             },
             "/.well-known/agent-skills/index.json": {
@@ -956,7 +1012,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         "The digest is a SHA-256 of the exact bytes /skill.md serves, so an "
                         "installer can verify it fetched the skill this index promised."
                     ),
-                    "responses": {"200": {"description": "The skills index."}},
+                    "responses": {"200": _json_doc("The skills index.")},
                 }
             },
         },
@@ -1132,7 +1188,7 @@ def agent_manifest(
             "room_bytes_total": store.MAX_TOTAL_ROOM_BYTES,
             "retention_seconds": store.IDLE_SECONDS,
             "ephemeral_ttl_seconds": store.EPHEMERAL_TTL_SECONDS,
-            "long_poll_seconds": max_wait,
+            "long_poll_seconds": _published_number(max_wait),
             "note": (
                 "The rate limits are per client IP, count reads and writes separately, and "
                 "are what this instance actually enforces — /llms.txt deliberately states "

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -156,6 +156,47 @@ _ROOM_VIEW_SCHEMA = {
 }
 
 
+# The room POST body. Hoisted because `/r/events` is parsed with exactly this one before it
+# is refused, so documenting the refusal without the body would describe a lane that reads
+# nothing — and then a 400 for malformed JSON arrives from an operation with no request body
+# in its contract at all.
+_ROOM_POST_BODY = {
+    "required": True,
+    "content": {
+        "application/json": {
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "from": {
+                        **_NAME_SCHEMA,
+                        "description": (
+                            f"Self-asserted nickname; {_NAME_RULE}. Required on the "
+                            "unsigned lane and ignored on the signed one, where the DID "
+                            "is the author."
+                        ),
+                    },
+                    "text": _TEXT_SCHEMA,
+                    "did": _DID_SCHEMA,
+                    "sig": {
+                        **_SIG_SCHEMA,
+                        "description": (
+                            "Base64url signature over `<room>|<nonce>|<text>`, where "
+                            "<text> is the text after the single-line sweep."
+                        ),
+                    },
+                    "nonce": _NONCE_SCHEMA,
+                },
+                "required": ["text"],
+                # `did` without the other two is refused, never downgraded to the unsigned
+                # lane. Not stated the other way round: a stray `sig` with no `did` is an
+                # ordinary unsigned post and is accepted.
+                "dependentRequired": {"did": ["sig", "nonce"]},
+            }
+        }
+    },
+}
+
+
 def _plain(description: str) -> dict:
     """A response whose body is prose the caller reads.
 
@@ -337,47 +378,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         "one emoji is 12 bytes URL-encoded."
                     ),
                     "parameters": [{**_NAME_PARAM, "name": "room"}],
-                    "requestBody": {
-                        "required": True,
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "from": {
-                                            **_NAME_SCHEMA,
-                                            "description": (
-                                                f"Self-asserted nickname; {_NAME_RULE}. "
-                                                "Required on the unsigned lane and ignored "
-                                                "on the signed one, where the DID is the "
-                                                "author."
-                                            ),
-                                        },
-                                        "text": _TEXT_SCHEMA,
-                                        "did": _DID_SCHEMA,
-                                        "sig": {
-                                            **_SIG_SCHEMA,
-                                            "description": (
-                                                "Base64url signature over "
-                                                "`<room>|<nonce>|<text>`, where <text> is "
-                                                "the text after the single-line sweep."
-                                            ),
-                                        },
-                                        "nonce": _NONCE_SCHEMA,
-                                    },
-                                    "required": ["text"],
-                                    # A body carrying `did` is refused unless it carries
-                                    # the other two, rather than being downgraded to the
-                                    # unsigned lane — failing closed is the whole point of
-                                    # the signed one. Not stated the other way round: a
-                                    # stray `sig` with no `did` is an ordinary unsigned
-                                    # post and is accepted, so claiming otherwise here
-                                    # would be a second kind of wrong.
-                                    "dependentRequired": {"did": ["sig", "nonce"]},
-                                }
-                            }
-                        },
-                    },
+                    "requestBody": _ROOM_POST_BODY,
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),
                         "400": _BAD_BODY,
@@ -491,20 +492,29 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     },
                 },
                 # `/r/events` is an instance of `/r/{room}`, so the POST route reaches it
-                # and answers 403. Documenting only GET said the path took no POST at all —
-                # a different promise, and one that makes the refusal arrive as a surprise.
+                # and refuses. Documenting only GET said the path took no POST at all — a
+                # different promise, and one that makes the refusal arrive as a surprise.
                 "post": {
                     "operationId": "postToEvents",
-                    "summary": "Always refused: the discovery log is server-written.",
+                    "summary": "Refused: the discovery log is server-written.",
                     "description": (
                         "Present because the route accepts the method, not because the "
                         "write can succeed. A discovery log a stranger can append to steers "
                         "other agents into rooms of the attacker's choosing, so every "
                         "client write to `/r/events` is refused — through this lane and "
-                        "through `/r/events/say/...` alike."
+                        "through `/r/events/say/...` alike.\n\n"
+                        "The body is still read and parsed before the refusal, because this "
+                        "is the ordinary room POST handler with one room that always says "
+                        "no. So a malformed or oversized body is answered on its own terms "
+                        "and never reaches the 403 — which is why the two are documented "
+                        "here rather than left to surprise a client that was promised only "
+                        "one outcome."
                     ),
+                    "requestBody": _ROOM_POST_BODY,
                     "responses": {
-                        "403": _plain("Always. The body names where to post instead."),
+                        "400": _BAD_BODY,
+                        "403": _plain("The body names where to post instead."),
+                        "413": {"description": f"Body over {max_body_bytes // 1024} KiB."},
                         "429": _RATE_LIMITED,
                     },
                 },

--- a/tests/mutation_scope.py
+++ b/tests/mutation_scope.py
@@ -3,33 +3,27 @@
 Run: uv run --group mutation python tests/mutation_scope.py --patterns
      uv run --group mutation python tests/mutation_scope.py --report
 
-Mutation testing asks the only question coverage cannot: not "did a test execute this
-line" but "would a test have *noticed* if this line were wrong". A green suite over a
-mutated `>` that should be `>=` is a suite that measured nothing about that boundary.
+Mutation testing asks what coverage cannot: not "did a test execute this line" but "would
+a test have *noticed* if this line were wrong".
 
-It is scoped, and deliberately not run on every pull request. `src/` carries ~3600
-mutants; a full pass is tens of minutes and most of it is noise — a mutated log string or
-a reordered dict literal is not a defect anyone will ever ship. What is worth the machine
-time is the code where being subtly wrong is expensive and being wrong is silent:
+It is scoped, and not run on pull requests. `src/` carries ~3600 mutants; a full pass is
+tens of minutes and most of it is noise — a mutated log string is not a defect anyone will
+ship. What earns the machine time is code where being wrong is silent:
 
-  ttl            An off-by-one in an idle threshold does not fail; it quietly keeps data
-                 a week too long or deletes it a day too early, and either way nobody
-                 finds out from a stack trace. The whole retention promise is four
-                 comparisons.
-  authorization  Every gate here fails *closed* by design, and a mutant that turns one
-                 into fail-open is exactly the change no test on the happy path can see.
-                 A signed lane that verifies nothing still returns 200.
-  caps           These are the only thing standing between an anonymous, world-writable
-                 service and its disk. A cap compared with the wrong operator holds right
-                 up to the moment it matters.
-  guidance       The refusal bodies are the service's real documentation for an agent that
-                 already got something wrong — /llms.txt is what it reads *before*. A test
-                 that asserts only the status code lets the correction rot.
+  ttl            An off-by-one in an idle threshold does not fail. It keeps data a week too
+                 long or deletes it a day too early, and nobody finds out from a stack
+                 trace. The whole retention promise is four comparisons.
+  authorization  Every gate fails closed by design; a mutant that flips one to fail-open is
+                 invisible on the happy path. A signed lane that verifies nothing still
+                 returns 200.
+  caps           The only thing between an anonymous, world-writable service and its disk.
+                 A cap with the wrong operator holds right up to the moment it matters.
+  guidance       The refusal bodies are the real documentation for an agent that already
+                 got something wrong. A test asserting only the status code lets them rot.
 
-The patterns are mutmut's mutant names: `<module>.x_<function>__mutmut_<n>`, where a
-private `_reap` becomes `x__reap`. Grouping by theme rather than by module is the point —
-`caps` reaches into three files, and a reader asking "is the rate limiter covered" should
-not have to know which one it lives in.
+Patterns are mutmut mutant names: `<module>.x_<function>__mutmut_<n>`, where a private
+`_reap` becomes `x__reap`. Grouped by theme rather than module — `caps` spans three files,
+and "is the rate limiter covered" should not require knowing which one.
 """
 
 from __future__ import annotations
@@ -84,9 +78,8 @@ SCOPE: dict[str, tuple[str, ...]] = {
     ),
 }
 
-# Statuses that mean the run did not do its job, as opposed to finding something. A
-# survivor is a question for a human; these are a broken harness, and the difference has
-# to be visible in the exit code or the report is decoration.
+# The run failing to do its job, as opposed to finding something. A survivor is a question
+# for a human; these are a broken harness, and only the second is worth a red run.
 BROKEN = ("suspicious", "segfault", "no_tests", "check_was_interrupted_by_user")
 
 STATS = Path("mutants/mutmut-cicd-stats.json")
@@ -99,9 +92,8 @@ def patterns() -> list[str]:
 def _survivors() -> list[str] | None:
     """The scoped mutants no test noticed, or None if `mutmut results` could not be read.
 
-    None rather than an empty list, because the two mean opposite things and this report is
-    the only thing anyone reads: "nothing survived" and "the tool that lists the survivors
-    did not run" must never render the same.
+    None rather than an empty list: "nothing survived" and "the tool that lists survivors
+    did not run" mean opposite things and must never render the same.
     """
     result = subprocess.run(
         [sys.executable, "-m", "mutmut", "results"],
@@ -126,26 +118,23 @@ def report() -> int:
     broken = {name: stats[name] for name in BROKEN if stats.get(name)}
     survivors = _survivors()
 
-    # The survivor section decides one more way the run can be broken, so it is rendered
-    # first and spliced in below whatever `broken` ends up saying.
+    # Rendered first because it can add to `broken`, then spliced in below it.
     if not stats["survived"]:
         body = ["Nothing survived: every mutant in scope was caught by a test.", ""]
     elif survivors is None:
         broken["survivors_unreadable"] = stats["survived"]
         body = [
             f"{stats['survived']} mutant(s) survived and `mutmut results` could not be "
-            "read, so this report cannot say which. Re-run it from the same working "
-            "directory as the run.",
+            "read, so this cannot say which. Re-run it from the run's working directory.",
             "",
         ]
     else:
         body = [
             "### Survivors",
             "",
-            "Each one is a change to this service that the suite would not have noticed. "
-            "Some are genuinely untestable — an equivalent mutant, a boundary no caller "
-            "can reach — and the rest are a missing test. `mutmut show <name>` prints the "
-            "diff behind one.",
+            "Each is a change the suite would not have noticed. Some are untestable — an "
+            "equivalent mutant, a boundary no caller can reach — and the rest are a "
+            "missing test. `mutmut show <name>` prints the diff.",
             "",
             "```",
             *survivors,
@@ -163,17 +152,16 @@ def report() -> int:
     ]
     if stats.get("timeout"):
         out += [
-            f"{stats['timeout']} mutant(s) timed out. A timeout is usually a mutated loop "
-            "bound rather than a harness fault, and counts as killed nowhere — worth a "
-            "look if the number moves.",
+            f"{stats['timeout']} mutant(s) timed out — usually a mutated loop bound, and "
+            "counted as killed nowhere. Worth a look if the number moves.",
             "",
         ]
     if broken:
         out += [
             "### The run itself is broken",
             "",
-            "Not findings. Mutants were generated and never properly judged, so the "
-            "numbers above understate what is uncovered:",
+            "Not findings: mutants generated and never judged, so the numbers above "
+            "understate what is uncovered.",
             "",
             *(f"- `{name}`: {count}" for name, count in broken.items()),
             "",

--- a/tests/mutation_scope.py
+++ b/tests/mutation_scope.py
@@ -1,0 +1,193 @@
+"""What the periodic mutation run covers, and how it reports.
+
+Run: uv run --group mutation python tests/mutation_scope.py --patterns
+     uv run --group mutation python tests/mutation_scope.py --report
+
+Mutation testing asks the only question coverage cannot: not "did a test execute this
+line" but "would a test have *noticed* if this line were wrong". A green suite over a
+mutated `>` that should be `>=` is a suite that measured nothing about that boundary.
+
+It is scoped, and deliberately not run on every pull request. `src/` carries ~3600
+mutants; a full pass is tens of minutes and most of it is noise — a mutated log string or
+a reordered dict literal is not a defect anyone will ever ship. What is worth the machine
+time is the code where being subtly wrong is expensive and being wrong is silent:
+
+  ttl            An off-by-one in an idle threshold does not fail; it quietly keeps data
+                 a week too long or deletes it a day too early, and either way nobody
+                 finds out from a stack trace. The whole retention promise is four
+                 comparisons.
+  authorization  Every gate here fails *closed* by design, and a mutant that turns one
+                 into fail-open is exactly the change no test on the happy path can see.
+                 A signed lane that verifies nothing still returns 200.
+  caps           These are the only thing standing between an anonymous, world-writable
+                 service and its disk. A cap compared with the wrong operator holds right
+                 up to the moment it matters.
+  guidance       The refusal bodies are the service's real documentation for an agent that
+                 already got something wrong — /llms.txt is what it reads *before*. A test
+                 that asserts only the status code lets the correction rot.
+
+The patterns are mutmut's mutant names: `<module>.x_<function>__mutmut_<n>`, where a
+private `_reap` becomes `x__reap`. Grouping by theme rather than by module is the point —
+`caps` reaches into three files, and a reader asking "is the rate limiter covered" should
+not have to know which one it lives in.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCOPE: dict[str, tuple[str, ...]] = {
+    "ttl": (
+        "store.x__cutoff__*",  # what "expired" means for an e- room
+        "store.x__expired__*",  # …and the per-record comparison behind it
+        "store.x__reapable__*",  # the idle and stillborn thresholds
+        "store.x__stillborn__*",  # "one message and nobody answered"
+        "store.x__guards_a_live_room__*",  # a guard note outlives the idle rule
+        "store.x__reap__*",  # the pass itself, including the recheck under the lock
+        "store.x__compact__*",  # the ring, and the expiry that rides it
+    ),
+    "authorization": (
+        "app.x__room_write_gate__*",  # mailboxes, owned rooms, allow-lists
+        "app.x__note_write_gate__*",  # the two ownership namespaces
+        "app.x__signer__*",  # nonce shape, then the signature
+        "app.x__burn_nonce__*",  # single-use, by compare-and-set
+        "app.x__allowed_keys__*",
+        "app.x__reject_if_events_room__*",  # the server-written discovery log
+        "store.x__last_nonce__*",  # replay protection inside the room's tail
+        "didkey.x_public_key__*",  # the parse that decides what a did:key even is
+        "didkey.x_is_did__*",
+        "didkey.x_verify__*",  # fails closed or it means nothing
+    ),
+    "caps": (
+        "store.x__check_room_capacity__*",
+        "store.x__check_note_capacity__*",
+        "store.x__check_capacity__*",
+        "store.x__ring_limit__*",  # the full ring, or the floor under pressure
+        "store.x_room_bytes_used__*",
+        "store.x_clean_text__*",  # the character caps, and the invisible-character sweep
+        "app.x_take__*",  # the rate limiter
+        "app.x_refund__*",
+        "app.x__room_create_gate__*",  # new rooms per IP per day
+        "app.x_read_json__*",  # the body cap, on both the header and the stream
+    ),
+    "guidance": (
+        "app.x_on_not_found__*",  # the route map a wrong URL gets back
+        "app.x_on_method_not_allowed__*",
+        "app.x_allowed_methods__*",  # …and the Allow header it has to carry
+        "app.x_on_bad_input__*",
+        "app.x_on_conflict__*",  # the current value, and what to do with it
+        "app.x_limited__*",  # the bucket, the refill rate, the retry delay
+        "app.x_budget_note__*",
+    ),
+}
+
+# Statuses that mean the run did not do its job, as opposed to finding something. A
+# survivor is a question for a human; these are a broken harness, and the difference has
+# to be visible in the exit code or the report is decoration.
+BROKEN = ("suspicious", "segfault", "no_tests", "check_was_interrupted_by_user")
+
+STATS = Path("mutants/mutmut-cicd-stats.json")
+
+
+def patterns() -> list[str]:
+    return [pattern for group in SCOPE.values() for pattern in group]
+
+
+def _survivors() -> list[str] | None:
+    """The scoped mutants no test noticed, or None if `mutmut results` could not be read.
+
+    None rather than an empty list, because the two mean opposite things and this report is
+    the only thing anyone reads: "nothing survived" and "the tool that lists the survivors
+    did not run" must never render the same.
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "mutmut", "results"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return sorted(
+        line.strip().split(":")[0]
+        for line in result.stdout.splitlines()
+        if line.strip().endswith(": survived")
+    )
+
+
+def report() -> int:
+    """Render the run as markdown and return the exit code the job should use."""
+    stats = json.loads(STATS.read_text(encoding="utf-8"))
+    checked = stats["killed"] + stats["survived"]
+    score = (100 * stats["killed"] / checked) if checked else 0.0
+    broken = {name: stats[name] for name in BROKEN if stats.get(name)}
+    survivors = _survivors()
+
+    # The survivor section decides one more way the run can be broken, so it is rendered
+    # first and spliced in below whatever `broken` ends up saying.
+    if not stats["survived"]:
+        body = ["Nothing survived: every mutant in scope was caught by a test.", ""]
+    elif survivors is None:
+        broken["survivors_unreadable"] = stats["survived"]
+        body = [
+            f"{stats['survived']} mutant(s) survived and `mutmut results` could not be "
+            "read, so this report cannot say which. Re-run it from the same working "
+            "directory as the run.",
+            "",
+        ]
+    else:
+        body = [
+            "### Survivors",
+            "",
+            "Each one is a change to this service that the suite would not have noticed. "
+            "Some are genuinely untestable — an equivalent mutant, a boundary no caller "
+            "can reach — and the rest are a missing test. `mutmut show <name>` prints the "
+            "diff behind one.",
+            "",
+            "```",
+            *survivors,
+            "```",
+        ]
+
+    out = [
+        "## Scoped mutation run",
+        "",
+        f"**{stats['killed']} killed, {stats['survived']} survived** "
+        f"of {checked} mutants checked — {score:.0f}% caught.",
+        "",
+        "Scope: " + ", ".join(f"`{theme}`" for theme in SCOPE),
+        "",
+    ]
+    if stats.get("timeout"):
+        out += [
+            f"{stats['timeout']} mutant(s) timed out. A timeout is usually a mutated loop "
+            "bound rather than a harness fault, and counts as killed nowhere — worth a "
+            "look if the number moves.",
+            "",
+        ]
+    if broken:
+        out += [
+            "### The run itself is broken",
+            "",
+            "Not findings. Mutants were generated and never properly judged, so the "
+            "numbers above understate what is uncovered:",
+            "",
+            *(f"- `{name}`: {count}" for name, count in broken.items()),
+            "",
+        ]
+    out += body
+
+    print("\n".join(out))
+    return 1 if broken else 0
+
+
+if __name__ == "__main__":
+    if "--patterns" in sys.argv:
+        print("\n".join(patterns()))
+    elif "--report" in sys.argv:
+        raise SystemExit(report())
+    else:
+        raise SystemExit(f"usage: {sys.argv[0]} [--patterns | --report]")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3848,6 +3848,93 @@ def test_the_spec_and_the_running_app_describe_the_same_service(client):
             )
 
 
+def test_every_documented_response_declares_the_body_it_returns(client):
+    """A response with no `content` tells a generated client there is nothing to show. On a
+    service whose refusals *are* the documentation — the 413 names the cap, the 409 carries
+    the current value, the 429 the retry delay — that hides the correction at exactly the
+    moment a caller needs it. `content_type_conformance` cannot catch it either: it only
+    checks the responses a fuzzer actually provokes, and nothing in a bounded run uploads
+    256 KiB. So the rule is blanket, because every response this service sends has a body.
+    """
+    doc = client.get("/openapi.json").json()
+    bare = [
+        f"{verb.upper()} {path} -> {code}"
+        for path, operations in doc["paths"].items()
+        for verb, op in operations.items()
+        for code, response in op["responses"].items()
+        if "content" not in response
+    ]
+    assert not bare, f"documented with no body: {bare}"
+
+    # And the declared type is the one the server sends, spot-checked across the three
+    # shapes: a refusal, a machine-readable document, and a negotiated one.
+    for path, expected in (
+        ("/kv/plans/next/set/hi", "text/plain"),
+        ("/openapi.json", "application/json"),
+        ("/skill.md", "text/plain"),
+    ):
+        served = client.get(path).headers["content-type"].split(";")[0]
+        assert served == expected, f"{path} sends {served}"
+    # …and the negotiated one really does offer the second type it advertises.
+    markdown = client.get("/skill.md", headers={"Accept": "text/markdown"})
+    assert markdown.headers["content-type"].startswith("text/markdown")
+    assert "text/markdown" in doc["paths"]["/skill.md"]["get"]["responses"]["200"]["content"]
+
+
+def test_a_published_ceiling_is_a_number_json_can_carry(client, monkeypatch):
+    """`float()` accepts `inf` and `nan` where the `int()` beside it raises, and this is the
+    one setting whose value is published. A non-finite ceiling reaches /openapi.json and
+    /.well-known/agent.json as the bare token `Infinity` — which Python emits and reads back
+    but RFC 8259 forbids, so every strict parser rejects the whole document. A discovery
+    service answering with undiscoverable documents is worse off than one that refused to
+    boot. Review catch on #40.
+    """
+    import importlib
+    import json as json_module
+
+    import app as app_module
+
+    for bad in ("inf", "-inf", "nan", "NaN"):
+        with pytest.raises(ValueError, match="must be a finite number"):
+            app_module._finite_env("CHAT_MAX_WAIT", bad)
+    # Junk still dies the way every other numeric setting here does.
+    with pytest.raises(ValueError):
+        app_module._finite_env("CHAT_MAX_WAIT", "abc")
+    assert app_module._finite_env("CHAT_MAX_WAIT", "2.5") == 2.5
+
+    # …and the ceiling is actually wired through it. Checking the helper alone would pass
+    # against a MAX_WAIT that still called bare `float()`, which is the mistake this
+    # guards: the process has to refuse to start, not merely own a function that could
+    # have refused.
+    monkeypatch.setenv("CHAT_MAX_WAIT", "inf")
+    for module in ("app", "store"):
+        sys.modules.pop(module, None)
+    with pytest.raises(ValueError, match="must be a finite number"):
+        importlib.import_module("app")
+
+    # Whatever survives that, the documents stay strict JSON — no bare Infinity or NaN.
+    for raw in (client.get("/openapi.json").text, client.get("/.well-known/agent.json").text):
+        assert "Infinity" not in raw and "NaN" not in raw
+        json_module.loads(raw)  # parses under Python's lenient reader too
+
+
+def test_an_integral_ceiling_publishes_as_an_integer(client):
+    """`10.0` and `10` are the same number to a validator and different bytes to a reader,
+    and this was an integer literal until the ceiling became configurable. A fractional
+    ceiling still publishes as a float, because fractional waits are real."""
+    import manifest
+
+    def maximum(doc):
+        return next(
+            p for p in doc["paths"]["/r/{room}"]["get"]["parameters"] if p["name"] == "wait"
+        )["schema"]["maximum"]
+
+    served = maximum(client.get("/openapi.json").json())
+    assert served == 10 and isinstance(served, int)
+    assert maximum(manifest.openapi_document("", "0.7.0", 65536, 2.5)) == 2.5
+    assert manifest.agent_manifest("", "0.7.0", 1, 1, 1, 10.0)["limits"]["long_poll_seconds"] == 10
+
+
 def test_every_status_an_operation_can_return_is_one_it_documents(client):
     """An undocumented status is the failure neither a generated client nor a contract
     fuzzer recovers from: the client treats an unannounced 403 as a transport fault and

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -817,6 +817,64 @@ def test_stillborn_rule_does_not_touch_notes(tmp_path):
     assert path.exists()
 
 
+def test_a_torn_line_does_not_make_a_busy_room_look_stillborn(tmp_path):
+    """The stillborn count skips what it cannot parse rather than stopping at it. Stopping
+    would read a room with one bad line as a room with no messages, and the reaper would
+    take a conversation because of a byte a crash left behind. Found by the mutation run:
+    turning that `continue` into a `break` passed the whole suite."""
+    import store
+
+    path = store.room_path(tmp_path, "torn")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        b'{"seq":1,"ts":"2026-01-01T00:00:00.000000Z","from":"a","tex\n'  # cut mid-record
+        b'{"seq":2,"ts":"2026-01-01T00:00:01.000000Z","from":"a","text":"anyone here?"}\n'
+        b'{"seq":3,"ts":"2026-01-01T00:00:02.000000Z","from":"b","text":"yes"}\n'
+    )
+    day_old = time.time() - store.STILLBORN_SECONDS - 60
+    os.utime(path, (day_old, day_old))
+    (tmp_path / ".reaped").unlink(missing_ok=True)
+    store._reap(tmp_path)
+
+    assert path.exists(), "two answered messages and a torn line is not a monologue"
+    # …and the messages either side of the torn line are still readable.
+    assert store.read_messages(tmp_path, "torn")["count"] == 2
+
+
+def test_a_room_that_cannot_be_counted_is_never_stillborn(tmp_path):
+    """Fail open, and only here. Everything else in this service fails closed, but a
+    reaper that treats "I could not read this" as "there is nothing here" deletes live
+    data on the first IO error it meets."""
+    import store
+
+    unreadable = tmp_path / "rooms"  # a directory: opening it raises, like a bad file
+    unreadable.mkdir()
+    assert store._stillborn(unreadable) is False
+
+
+def test_a_second_precision_timestamp_still_expires(tmp_path):
+    """Records written before `ts` gained microseconds carry `...:05Z`, and `e-` expiry is
+    the one thing that parses `ts` at all — so the older form has to keep working or an
+    ephemeral room silently stops expiring the oldest records it holds. Both forms coexist
+    by design; this is what keeps the second one real."""
+    from datetime import UTC, datetime, timedelta
+
+    import store
+
+    path = store.room_path(tmp_path, "e-legacy")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    stale = datetime.now(UTC) - timedelta(seconds=store.EPHEMERAL_TTL_SECONDS + 60)
+    fresh = datetime.now(UTC) - timedelta(seconds=5)
+    path.write_bytes(
+        f'{{"seq":1,"ts":"{stale.strftime("%Y-%m-%dT%H:%M:%SZ")}","from":"a","text":"old"}}\n'
+        f'{{"seq":2,"ts":"{fresh.strftime("%Y-%m-%dT%H:%M:%SZ")}","from":"a","text":"new"}}\n'.encode()
+    )
+    view = store.read_messages(tmp_path, "e-legacy")
+    assert [m["text"] for m in view["messages"]] == ["new"]
+    # seq keeps advancing past what nobody can read any more, or a cursor would be reused.
+    assert store.last_seq(tmp_path, "e-legacy") == 2
+
+
 def test_reap_spares_a_stillborn_room_answered_after_the_count(tmp_path, monkeypatch):
     """The under-lock recheck must re-count, not just re-stat: a reply landing mid-pass is
     exactly the message the reaper would otherwise delete."""
@@ -3046,12 +3104,23 @@ def test_the_spec_and_the_running_app_describe_the_same_service(client):
         assert set(operations) <= accepted, f"{path} documents a method it does not accept"
 
     # 3. Every operation is actually usable by a reader: identified, summarised, and with
-    #    at least the success case described.
+    #    the outcome a caller will actually get described.
     operations = [op for path in doc["paths"].values() for op in path.values()]
     ids = [op["operationId"] for op in operations]
     assert len(ids) == len(set(ids)), "operationIds must be unique — clients name methods with them"
     for op in operations:
-        assert op["summary"] and "200" in op["responses"]
+        assert op["summary"], op
+        codes = set(op["responses"])
+        # Normally that outcome is the success case. The one exception is a lane that
+        # exists only to refuse: `/r/events` accepts POST because `/r/{room}` does, and
+        # answers 403 every time. A documented 200 there would be the lie — and documenting
+        # nothing at all is what left a client expecting 405 and reading the 403 as a fault.
+        # It has to say so in prose, or "no 2xx" is indistinguishable from an oversight.
+        if not any(code.startswith("2") for code in codes):
+            assert "403" in codes, f"{op['operationId']} documents no outcome at all"
+            assert "refus" in (op["summary"] + op.get("description", "")).lower(), (
+                f"{op['operationId']} can never succeed and does not say why"
+            )
 
 
 def test_every_status_an_operation_can_return_is_one_it_documents(client):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -818,10 +818,10 @@ def test_stillborn_rule_does_not_touch_notes(tmp_path):
 
 
 def test_a_torn_line_does_not_make_a_busy_room_look_stillborn(tmp_path):
-    """The stillborn count skips what it cannot parse rather than stopping at it. Stopping
-    would read a room with one bad line as a room with no messages, and the reaper would
-    take a conversation because of a byte a crash left behind. Found by the mutation run:
-    turning that `continue` into a `break` passed the whole suite."""
+    """The stillborn count skips what it cannot parse rather than stopping at it: stopping
+    reads a room with one bad line as a room with no messages, and the reaper takes a
+    conversation because of a byte a crash left behind. From the mutation run — turning
+    that `continue` into a `break` passed the whole suite."""
     import store
 
     path = store.room_path(tmp_path, "torn")
@@ -842,9 +842,8 @@ def test_a_torn_line_does_not_make_a_busy_room_look_stillborn(tmp_path):
 
 
 def test_a_room_that_cannot_be_counted_is_never_stillborn(tmp_path):
-    """Fail open, and only here. Everything else in this service fails closed, but a
-    reaper that treats "I could not read this" as "there is nothing here" deletes live
-    data on the first IO error it meets."""
+    """Fail open, and only here: a reaper that reads "I could not count this" as "there is
+    nothing here" deletes live data on the first IO error it meets."""
     import store
 
     unreadable = tmp_path / "rooms"  # a directory: opening it raises, like a bad file
@@ -853,10 +852,9 @@ def test_a_room_that_cannot_be_counted_is_never_stillborn(tmp_path):
 
 
 def test_a_second_precision_timestamp_still_expires(tmp_path):
-    """Records written before `ts` gained microseconds carry `...:05Z`, and `e-` expiry is
-    the one thing that parses `ts` at all — so the older form has to keep working or an
-    ephemeral room silently stops expiring the oldest records it holds. Both forms coexist
-    by design; this is what keeps the second one real."""
+    """Records predating microsecond `ts` carry `...:05Z`, and expiry is the only thing
+    that parses `ts` — so the older form must keep working or an `e-` room silently stops
+    expiring its oldest records. Both forms coexist by design; this keeps the second real."""
     from datetime import UTC, datetime, timedelta
 
     import store
@@ -2957,10 +2955,9 @@ def test_an_unsupported_verb_is_answered_with_the_get_lane_that_replaces_it(clie
 
 
 def test_a_405_carries_allow_and_names_every_verb_the_path_takes(client):
-    """RFC 9110 §15.5.6 makes `Allow` mandatory on a 405, and the union matters here: two
-    routes share `/r/<room>` and `/kv/<ns>/<key>`, so the first-partial-match header
-    Starlette builds would name `GET, HEAD` on paths that plainly also take POST — ruling
-    out the one verb that would have worked."""
+    """RFC 9110 §15.5.6 makes `Allow` mandatory, and the union matters: two routes share
+    `/r/<room>` and two share `/kv/<ns>/<key>`, so Starlette's first-partial-match header
+    would name `GET, HEAD` on paths that plainly also take POST."""
     for path in ("/r/lobby", "/kv/plans/next"):
         r = client.request("PUT", path)
         assert r.status_code == 405
@@ -3111,11 +3108,10 @@ def test_the_spec_and_the_running_app_describe_the_same_service(client):
     for op in operations:
         assert op["summary"], op
         codes = set(op["responses"])
-        # Normally that outcome is the success case. The one exception is a lane that
-        # exists only to refuse: `/r/events` accepts POST because `/r/{room}` does, and
-        # answers 403 every time. A documented 200 there would be the lie — and documenting
-        # nothing at all is what left a client expecting 405 and reading the 403 as a fault.
-        # It has to say so in prose, or "no 2xx" is indistinguishable from an oversight.
+        # Normally the success case. The exception is a lane that exists only to refuse:
+        # `/r/events` accepts POST because `/r/{room}` does and answers 403 every time, so
+        # a documented 200 would be the lie. It must say so in prose, or "no 2xx" is
+        # indistinguishable from an oversight.
         if not any(code.startswith("2") for code in codes):
             assert "403" in codes, f"{op['operationId']} documents no outcome at all"
             assert "refus" in (op["summary"] + op.get("description", "")).lower(), (
@@ -3124,14 +3120,11 @@ def test_the_spec_and_the_running_app_describe_the_same_service(client):
 
 
 def test_every_status_an_operation_can_return_is_one_it_documents(client):
-    """The contract is what a generated client and a contract fuzzer both believe, and an
-    undocumented status is the failure mode neither of them can recover from: a client
-    that has never been told a 403 is possible treats it as a transport fault and retries
-    the identical bytes forever, and a fuzzer reports the service as broken.
+    """An undocumented status is the failure neither a generated client nor a contract
+    fuzzer recovers from: the client treats an unannounced 403 as a transport fault and
+    retries the identical bytes, the fuzzer calls the service broken.
 
-    So: provoke each refusal against the running app, and require the spec to list it.
-    Every pair below was undocumented at some point — the note lanes in particular
-    described a POST that could reach a namespace the server has never let anyone write.
+    So: provoke each refusal against the running app and require the spec to list it.
     """
     did, sign = _keypair()
     other, _ = _keypair(2)
@@ -3195,11 +3188,10 @@ def test_every_status_an_operation_can_return_is_one_it_documents(client):
 
 
 def test_the_signed_lane_publishes_the_shape_it_actually_enforces(client):
-    """One definition, three places it is published. The room lane's `did` pattern ended
-    in an unbounded `+`, so `did:key:z6Mk` satisfied the contract and nothing else;
-    the note lane's was a bare `string`; the POST body described both in prose a generator
-    cannot read. A client is built against whichever copy it found, so the weakest one was
-    the real contract.
+    """One definition, three places it is published. The room lane's `did` pattern ended in
+    an unbounded `+`, so `did:key:z6Mk` satisfied it; the note lane's was a bare `string`;
+    the POST body was prose no generator can read. A client is built against whichever copy
+    it found, so the weakest one was the contract.
     """
     import didkey
 
@@ -3242,9 +3234,9 @@ def test_the_signed_lane_publishes_the_shape_it_actually_enforces(client):
 
 
 def test_a_free_form_field_publishes_that_it_cannot_be_empty(client):
-    """`required: ["text"]` is satisfied by `""`, which is a 400 here: the single-line
-    sweep leaves nothing visible and the write is refused. A generator reading only
-    `required` emits a client whose empty-message call can never succeed."""
+    """`required: ["text"]` is satisfied by `""`, which is a 400 — the sweep leaves nothing
+    visible. A generator reading only `required` emits a client whose empty-message call
+    can never succeed."""
     import store
 
     doc = client.get("/openapi.json").json()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2898,6 +2898,29 @@ def test_an_unsupported_verb_is_answered_with_the_get_lane_that_replaces_it(clie
     assert "append-only" in r.text  # …and why there is nothing to DELETE
 
 
+def test_a_405_carries_allow_and_names_every_verb_the_path_takes(client):
+    """RFC 9110 §15.5.6 makes `Allow` mandatory on a 405, and the union matters here: two
+    routes share `/r/<room>` and `/kv/<ns>/<key>`, so the first-partial-match header
+    Starlette builds would name `GET, HEAD` on paths that plainly also take POST — ruling
+    out the one verb that would have worked."""
+    for path in ("/r/lobby", "/kv/plans/next"):
+        r = client.request("PUT", path)
+        assert r.status_code == 405
+        assert r.headers["allow"] == "GET, HEAD, POST", path
+        # Repeated in the body for the same reason Retry-After is: agent harnesses show
+        # the body and drop the headers.
+        assert "this path accepts: GET, HEAD, POST" in r.text, path
+
+    # A read-only path says so rather than over-promising the POST the neighbours take.
+    for path in ("/rooms", "/llms.txt", "/r/lobby/say/bot/hi", "/kv/plans/next/set/x"):
+        r = client.request("PATCH", path)
+        assert r.status_code == 405 and r.headers["allow"] == "GET, HEAD", path
+
+    # OPTIONS is not implemented either, so it must not appear in a list of what is.
+    options = client.request("OPTIONS", "/healthz")
+    assert options.status_code == 405 and "OPTIONS" not in options.headers["allow"]
+
+
 def test_a_missing_note_says_how_to_create_it(client):
     """Absent and never-written are the same state, and both are ordinary: a note is
     created by writing it, so the useful reply is that URL."""
@@ -3029,6 +3052,159 @@ def test_the_spec_and_the_running_app_describe_the_same_service(client):
     assert len(ids) == len(set(ids)), "operationIds must be unique — clients name methods with them"
     for op in operations:
         assert op["summary"] and "200" in op["responses"]
+
+
+def test_every_status_an_operation_can_return_is_one_it_documents(client):
+    """The contract is what a generated client and a contract fuzzer both believe, and an
+    undocumented status is the failure mode neither of them can recover from: a client
+    that has never been told a 403 is possible treats it as a transport fault and retries
+    the identical bytes forever, and a fuzzer reports the service as broken.
+
+    So: provoke each refusal against the running app, and require the spec to list it.
+    Every pair below was undocumented at some point — the note lanes in particular
+    described a POST that could reach a namespace the server has never let anyone write.
+    """
+    did, sign = _keypair()
+    other, _ = _keypair(2)
+    client.get("/kv/plans/held/set/first")
+
+    # (openapi path, method, expected status, the request that produces it)
+    cases = [
+        ("/kv/{ns}/{key}", "get", 400, lambda: client.get("/kv/UPPER/key")),
+        ("/kv/{ns}/{key}", "get", 404, lambda: client.get("/kv/plans/never-written")),
+        ("/kv/{ns}/{key}", "post", 400, lambda: client.post("/kv/UPPER/k", json={"value": "v"})),
+        # `required: ["value"]` never implied a *non-empty* value, and the sweep refuses one.
+        ("/kv/{ns}/{key}", "post", 400, lambda: client.post("/kv/plans/k", json={"value": ""})),
+        (
+            "/kv/{ns}/{key}",
+            "post",
+            403,
+            lambda: client.post("/kv/room-nonce/lobby", json={"value": "9"}),
+        ),
+        (
+            "/kv/{ns}/{key}",
+            "post",
+            409,
+            lambda: client.post("/kv/plans/held", json={"value": "v", "if": "not-that"}),
+        ),
+        ("/r/{room}", "post", 400, lambda: client.post("/r/lobby", json={"from": "b", "text": ""})),
+        # A signature that does not verify is a refusal, not a malformed request…
+        (
+            "/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}",
+            "get",
+            403,
+            lambda: client.get(f"/r/lobby/say-signed/{did}/{'A' * 86}/1/hi"),
+        ),
+        # …and neither is a room that will not take this key.
+        (
+            "/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}",
+            "get",
+            403,
+            lambda: _say_signed(client, "d-owned", other, _keypair(2)[1], "hi", nonce=3),
+        ),
+        # Notes have no ring, so the signed lane's nonce counter is itself a note claimed
+        # with a compare-and-set: a racing writer loses on the counter, with a 409.
+        (
+            "/kv/{ns}/{key}/set-signed/{did}/{sig}/{nonce}/{value}",
+            "get",
+            409,
+            lambda: client.get(
+                f"/kv/room-owners/d-owned/set-signed/{did}/"
+                f"{sign(f'room-owners|d-owned|4|{other}')}/4/{other}?if=nothing-like-this"
+            ),
+        ),
+    ]
+
+    assert _claim(client, "d-owned", did, sign).status_code == 200
+
+    doc = client.get("/openapi.json").json()
+    for path, method, status, send in cases:
+        response = send()
+        assert response.status_code == status, f"{method.upper()} {path}: {response.text[:200]}"
+        documented = doc["paths"][path][method]["responses"]
+        assert str(status) in documented, f"{method.upper()} {path} can {status} undocumented"
+
+
+def test_the_signed_lane_publishes_the_shape_it_actually_enforces(client):
+    """One definition, three places it is published. The room lane's `did` pattern ended
+    in an unbounded `+`, so `did:key:z6Mk` satisfied the contract and nothing else;
+    the note lane's was a bare `string`; the POST body described both in prose a generator
+    cannot read. A client is built against whichever copy it found, so the weakest one was
+    the real contract.
+    """
+    import didkey
+
+    did, sign = _keypair()
+    doc = client.get("/openapi.json").json()
+
+    def param(path, name):
+        return next(p for p in doc["paths"][path]["get"]["parameters"] if p["name"] == name)[
+            "schema"
+        ]
+
+    say = "/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}"
+    note = "/kv/{ns}/{key}/set-signed/{did}/{sig}/{nonce}/{value}"
+    body = doc["paths"]["/r/{room}"]["post"]["requestBody"]["content"]["application/json"]["schema"]
+
+    published = [param(say, "did"), param(note, "did"), body["properties"]["did"]]
+    assert len({json.dumps(schema, sort_keys=True) for schema in published}) == 1, (
+        "the two signed lanes and the POST body must publish one `did` shape"
+    )
+    for schema in published:
+        # A real key satisfies it, and the truncated DID the old pattern accepted does not.
+        assert re.fullmatch(schema["pattern"], did)
+        assert not re.fullmatch(schema["pattern"], "did:key:z6Mk")
+        assert schema["minLength"] == schema["maxLength"] == len(did)
+        assert len(did) == len(didkey.PREFIX) + didkey.MULTIBASE_CHARS
+
+    for schema in (param(say, "sig"), param(note, "sig"), body["properties"]["sig"]):
+        assert re.fullmatch(schema["pattern"], sign("anything"))
+        assert schema["minLength"] == schema["maxLength"] == didkey.SIG_CHARS
+    for schema in (param(say, "nonce"), param(note, "nonce"), body["properties"]["nonce"]):
+        assert re.fullmatch(schema["pattern"], "1") and not re.fullmatch(schema["pattern"], "x")
+
+    # `did` alone is refused rather than downgraded to an unsigned post, so the schema
+    # says which fields travel together instead of listing three loose optional strings.
+    assert body["dependentRequired"] == {"did": ["sig", "nonce"]}
+    assert client.post("/r/lobby", json={"text": "hi", "did": did}).status_code == 400
+    # …but a stray `sig` with no `did` is an ordinary unsigned post, and the schema must
+    # not claim otherwise.
+    assert client.post("/r/lobby", json={"from": "b", "text": "hi", "sig": "x"}).status_code == 200
+
+
+def test_a_free_form_field_publishes_that_it_cannot_be_empty(client):
+    """`required: ["text"]` is satisfied by `""`, which is a 400 here: the single-line
+    sweep leaves nothing visible and the write is refused. A generator reading only
+    `required` emits a client whose empty-message call can never succeed."""
+    import store
+
+    doc = client.get("/openapi.json").json()
+    schemas = {
+        "post /r/{room}.text": doc["paths"]["/r/{room}"]["post"]["requestBody"]["content"][
+            "application/json"
+        ]["schema"]["properties"]["text"],
+        "post /kv.value": doc["paths"]["/kv/{ns}/{key}"]["post"]["requestBody"]["content"][
+            "application/json"
+        ]["schema"]["properties"]["value"],
+        "get say.text": next(
+            p
+            for p in doc["paths"]["/r/{room}/say/{nick}/{text}"]["get"]["parameters"]
+            if p["name"] == "text"
+        )["schema"],
+        "get set.value": next(
+            p
+            for p in doc["paths"]["/kv/{ns}/{key}/set/{value}"]["get"]["parameters"]
+            if p["name"] == "value"
+        )["schema"],
+    }
+    for where, schema in schemas.items():
+        assert schema["minLength"] == 1, where
+    assert schemas["post /r/{room}.text"]["maxLength"] == store.MAX_TEXT_CHARS
+    assert schemas["post /kv.value"]["maxLength"] == store.MAX_VALUE_CHARS
+
+    # And the server agrees, on both lanes.
+    assert client.post("/r/lobby", json={"from": "bot", "text": ""}).status_code == 400
+    assert client.post("/kv/plans/k", json={"value": ""}).status_code == 400
 
 
 def test_openapi_limits_are_the_limits_the_server_enforces(client):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -139,6 +139,71 @@ def test_post_lane(client):
     assert client.post("/r/lobby", content=b"x" * (app_module.MAX_BODY + 1)).status_code == 413
 
 
+def test_a_fractional_wait_is_honoured_rather_than_silently_dropped(client, monkeypatch):
+    """`?wait=` is published as `type: number` and the poll interval is half a second, so
+    `wait=0.5` is the shortest wait that can return anything — the constant's own comment
+    calls it the useful floor. It was int-parsed, so every fractional value became no wait
+    at all, and the caller got an immediate empty reply indistinguishable from an idle
+    room. Review catch on #40.
+    """
+    import app as app_module
+
+    assert app_module._seconds("0.5") == 0.5
+    assert app_module._seconds("2.5") == 2.5
+    # Junk, negative and absent all mean "do not wait" rather than raising.
+    for junk in (None, "", "abc", "-1", "nan", "²"):
+        assert app_module._seconds(junk) == 0.0, junk
+    # The ceiling is applied here, so it cannot be enforced in one caller and forgotten in
+    # another. Infinity is just an over-large number.
+    monkeypatch.setattr(app_module, "MAX_WAIT", 1.0)
+    assert app_module._seconds("10") == 1.0
+    assert app_module._seconds("inf") == 1.0
+
+    # End to end: a fractional wait really does hold the connection open and then return.
+    started = time.monotonic()
+    r = client.get("/r/quiet?since=1&wait=0.5")
+    assert r.status_code == 200 and time.monotonic() - started >= 0.4
+
+
+def test_an_instance_with_a_sub_second_ceiling_still_polls(client, monkeypatch):
+    """The sharp end of the same bug: below a one-second ceiling every schema-conforming
+    positive wait int-parsed to zero, so the feature the document advertised could not be
+    used at all on that instance."""
+    import app as app_module
+
+    monkeypatch.setattr(app_module, "MAX_WAIT", 0.5)
+    published = next(
+        p
+        for p in client.get("/openapi.json").json()["paths"]["/r/{room}"]["get"]["parameters"]
+        if p["name"] == "wait"
+    )["schema"]
+    assert published["maximum"] == 0.5
+    # The largest value the schema permits is a wait the server actually takes.
+    assert app_module._seconds(str(published["maximum"])) == 0.5
+
+
+def test_posting_to_the_events_room_documents_what_it_really_answers(client):
+    """`/r/events` is the ordinary room POST handler with one room that always says no, so
+    the body is read and parsed *before* the refusal — a malformed or oversized body never
+    reaches the 403. Documenting only the 403 promised a client one outcome and delivered
+    three. Review catch on #40.
+    """
+    import app as app_module
+
+    documented = client.get("/openapi.json").json()["paths"]["/r/events"]["post"]
+    assert set(documented["responses"]) == {"400", "403", "413", "429"}
+    # It parses a body, so it declares one.
+    assert (
+        "text" in (documented["requestBody"]["content"]["application/json"]["schema"]["properties"])
+    )
+
+    assert client.post("/r/events", json={"from": "bot", "text": "hi"}).status_code == 403
+    assert client.post("/r/events", content=b"not json").status_code == 400
+    assert client.post("/r/events", json=[1, 2]).status_code == 400
+    oversize = client.post("/r/events", content=b"x" * (app_module.MAX_BODY + 1))
+    assert oversize.status_code == 413
+
+
 def test_the_body_cap_holds_when_nothing_declares_a_length(client):
     """Two bounds, and only one of them was ever reached. `await request.body()` buffers
     the whole upload before any size check, so a large POST was an OOM against a 128 MiB

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -24,6 +24,78 @@ def client(tmp_path, monkeypatch):
     return TestClient(app_module.app)
 
 
+# --------------------------------------------------------------------------- shared helpers
+#
+# Four things every lifecycle test needs, written once. The reaper, the ring and the
+# signed lane are all clock- and race-sensitive, and open-coding that at 40-odd call sites
+# buried the one line of each test that was actually the point.
+
+
+def _age(path, seconds):
+    """Move a file `seconds` into the past.
+
+    The reaper stats mtime, so this is how a test says "nobody has touched this for a
+    week" without waiting one. Callers pass the threshold plus a margin —
+    `_age(p, store.IDLE_SECONDS + 60)` — which reads as the rule it is testing.
+    """
+    when = time.time() - seconds
+    os.utime(path, (when, when))
+
+
+def _arm_reaper(root):
+    """Clear the once-per-REAP_EVERY throttle, so the next write runs a pass."""
+    (root / ".reaped").unlink(missing_ok=True)
+
+
+def _reap_now(root):
+    """Run a pass immediately, throttle and all."""
+    import store
+
+    _arm_reaper(root)
+    store._reap(root)
+
+
+def _race_before_lock(monkeypatch, store, path, action):
+    """Run `action()` once, in the gap between the store reading a file and locking it.
+
+    Every race worth testing here lives in that gap: the store reads, decides, then takes
+    the lock and writes. A second writer landing in between is what the compare-and-set
+    and the reaper's under-lock recheck exist to survive, and this puts one there without
+    threads. Returns a list that is non-empty once the race has actually happened — assert
+    on it, or a test that stopped reaching the gap will pass while proving nothing.
+    """
+    real_locked = store._locked
+    fired = []
+
+    @contextmanager
+    def hook(target):
+        if target == path and not fired:
+            fired.append(True)
+            action()
+        with real_locked(target):
+            yield
+
+    monkeypatch.setattr(store, "_locked", hook)
+    return fired
+
+
+def _race_under_lock(monkeypatch, store, action):
+    """Run `action(target)` after the store takes a lock, before it acts on the file.
+
+    The other half of the same idea, for the checks the store performs *under* the lock:
+    a writer that lands here has beaten the recheck rather than the read.
+    """
+    real_locked = store._locked
+
+    @contextmanager
+    def hook(target):
+        with real_locked(target):
+            action(target)
+            yield
+
+    monkeypatch.setattr(store, "_locked", hook)
+
+
 def test_say_then_read(client):
     r = client.get("/r/lobby/say/alice/hello%20world")
     # `~alice`, not `alice`: an unsigned nick is self-asserted and the text view says so
@@ -744,13 +816,12 @@ def test_orphan_locks_are_swept(tmp_path):
     path = store.room_path(tmp_path, "gone")
     lock = path.with_suffix(".jsonl.lock")
     assert lock.exists()
-    old = time.time() - store.IDLE_SECONDS - 60
     for p in (path, lock):
-        os.utime(p, (old, old))
-    (tmp_path / ".reaped").unlink(missing_ok=True)
+        _age(p, store.IDLE_SECONDS + 60)
+    _arm_reaper(tmp_path)
     store.append(tmp_path, "other", "bot", "hi")  # reaps the data file, keeps its lock
     assert not path.exists()
-    (tmp_path / ".reaped").unlink(missing_ok=True)
+    _arm_reaper(tmp_path)
     store.append(tmp_path, "other", "bot", "again")  # next pass sweeps the orphan lock
     assert not lock.exists()
 
@@ -767,15 +838,12 @@ def test_the_note_side_of_the_sweep_is_wired_up_too(tmp_path):
     lock = note.with_suffix(".txt.lock")
     assert lock.exists(), "premise: note writes leave a sidecar lock"
 
-    old = time.time() - store.IDLE_SECONDS - 60
     for target in (note, lock):
-        os.utime(target, (old, old))
-    (tmp_path / ".reaped").unlink(missing_ok=True)
-    store._reap(tmp_path)  # takes the data file, keeps the lock a writer might hold
+        _age(target, store.IDLE_SECONDS + 60)
+    _reap_now(tmp_path)  # takes the data file, keeps the lock a writer might hold
     assert not note.exists()
 
-    (tmp_path / ".reaped").unlink(missing_ok=True)
-    store._reap(tmp_path)
+    _reap_now(tmp_path)
     assert not lock.exists(), "an orphaned note lock is swept like a room's"
     # …and the namespace directory goes with the last note in it, or every namespace ever
     # written stays on disk as an empty directory.
@@ -793,10 +861,8 @@ def test_a_lock_is_never_swept_while_its_data_file_is_there(tmp_path):
     path = store.room_path(tmp_path, "quiet")
     lock = path.with_suffix(".jsonl.lock")
 
-    old = time.time() - store.IDLE_SECONDS - 60
-    os.utime(lock, (old, old))  # the lock is stale; the room it guards is not
-    (tmp_path / ".reaped").unlink(missing_ok=True)
-    store._reap(tmp_path)
+    _age(lock, store.IDLE_SECONDS + 60)  # the lock is stale; the room it guards is not
+    _reap_now(tmp_path)
 
     assert path.exists() and lock.exists()
 
@@ -810,24 +876,16 @@ def test_one_unreadable_file_does_not_abort_the_whole_pass(tmp_path, monkeypatch
 
     for room in ("first-idle", "second-idle"):
         store.append(tmp_path, room, "bot", "hi")
-    old = time.time() - store.IDLE_SECONDS - 60
     for room in ("first-idle", "second-idle"):
-        os.utime(store.room_path(tmp_path, room), (old, old))
+        _age(store.room_path(tmp_path, room), store.IDLE_SECONDS + 60)
 
-    real_locked = store._locked
-    exploded = []
+    def explode():
+        raise OSError("racing writer")
 
-    @contextmanager
-    def explode_once(target):
-        if target.name.startswith("first-idle") and not exploded:
-            exploded.append(True)
-            raise OSError("racing writer")
-        with real_locked(target):
-            yield
-
-    monkeypatch.setattr(store, "_locked", explode_once)
-    (tmp_path / ".reaped").unlink(missing_ok=True)
-    store._reap(tmp_path)
+    exploded = _race_before_lock(
+        monkeypatch, store, store.room_path(tmp_path, "first-idle"), explode
+    )
+    _reap_now(tmp_path)
 
     assert exploded, "the failure never happened — this test proved nothing"
     assert not store.room_path(tmp_path, "second-idle").exists(), "the pass stopped early"
@@ -843,13 +901,11 @@ def test_reap_counts_every_room_it_takes_not_just_the_last(tmp_path):
     for room in ("ended-one", "ended-two", "ended-three"):
         store.append(tmp_path, room, "bot", "hi")
         store.append(tmp_path, room, "other", "yes")  # answered, so the idle rule takes it
-    old = time.time() - store.IDLE_SECONDS - 60
     for room in ("ended-one", "ended-two", "ended-three"):
-        os.utime(store.room_path(tmp_path, room), (old, old))
+        _age(store.room_path(tmp_path, room), store.IDLE_SECONDS + 60)
 
     before = store.counters(tmp_path)["reaped_idle"]
-    (tmp_path / ".reaped").unlink(missing_ok=True)
-    store._reap(tmp_path)
+    _reap_now(tmp_path)
     assert store.counters(tmp_path)["reaped_idle"] == before + 3
 
 
@@ -881,19 +937,13 @@ def test_reap_keeps_a_file_refreshed_after_the_stat(tmp_path, monkeypatch):
 
     store.append(tmp_path, "live", "bot", "hi")
     path = store.room_path(tmp_path, "live")
-    old = time.time() - store.IDLE_SECONDS - 60
-    os.utime(path, (old, old))
-    real_locked = store._locked
+    _age(path, store.IDLE_SECONDS + 60)
 
-    @contextmanager
-    def refresh_then_lock(target):
-        with real_locked(target):
-            os.utime(target, None)  # a writer got in between the stat and the unlink
-            yield
+    def refresh(target):
+        os.utime(target, None)  # a writer got in between the stat and the unlink
 
-    monkeypatch.setattr(store, "_locked", refresh_then_lock)
-    (tmp_path / ".reaped").unlink(missing_ok=True)
-    store._reap(tmp_path)
+    _race_under_lock(monkeypatch, store, refresh)
+    _reap_now(tmp_path)
     assert path.exists()
 
 
@@ -994,9 +1044,8 @@ def test_idle_rooms_are_reaped_so_squatting_expires(tmp_path, monkeypatch):
 
     monkeypatch.setattr(store, "MAX_ROOMS", 2)
     store.append(tmp_path, "squat", "bot", "hi")
-    old = time.time() - store.IDLE_SECONDS - 60
-    os.utime(store.room_path(tmp_path, "squat"), (old, old))
-    (tmp_path / ".reaped").unlink(missing_ok=True)  # force a reap pass
+    _age(store.room_path(tmp_path, "squat"), store.IDLE_SECONDS + 60)
+    _arm_reaper(tmp_path)  # force a reap pass
     store.append(tmp_path, "fresh", "bot", "hi")
     assert not store.room_path(tmp_path, "squat").exists()
     assert store.room_path(tmp_path, "fresh").exists()
@@ -1007,14 +1056,12 @@ def test_stillborn_rooms_go_after_a_day_but_answered_ones_keep_the_week(tmp_path
     week. Both rooms are idle for the same time — only the reply tells them apart."""
     import store
 
-    day_old = time.time() - store.STILLBORN_SECONDS - 60
     store.append(tmp_path, "monologue", "bot", "anyone here?")
     store.append(tmp_path, "answered", "bot", "anyone here?")
     store.append(tmp_path, "answered", "other", "yes")
     for room in ("monologue", "answered"):
-        os.utime(store.room_path(tmp_path, room), (day_old, day_old))
-    (tmp_path / ".reaped").unlink(missing_ok=True)
-    store._reap(tmp_path)
+        _age(store.room_path(tmp_path, room), store.STILLBORN_SECONDS + 60)
+    _reap_now(tmp_path)
     assert not store.room_path(tmp_path, "monologue").exists()
     assert store.room_path(tmp_path, "answered").exists()
 
@@ -1025,10 +1072,8 @@ def test_stillborn_room_survives_its_first_day(tmp_path):
     import store
 
     store.append(tmp_path, "waiting", "bot", "anyone here?")
-    hour_old = time.time() - 3600
-    os.utime(store.room_path(tmp_path, "waiting"), (hour_old, hour_old))
-    (tmp_path / ".reaped").unlink(missing_ok=True)
-    store._reap(tmp_path)
+    _age(store.room_path(tmp_path, "waiting"), 3600)
+    _reap_now(tmp_path)
     assert store.room_path(tmp_path, "waiting").exists()
 
 
@@ -1039,10 +1084,8 @@ def test_stillborn_rule_does_not_touch_notes(tmp_path):
 
     store.note_set(tmp_path, store.TOPIC_NS, "somewhere", "what this room is for")
     path = store.note_path(tmp_path, store.TOPIC_NS, "somewhere")
-    day_old = time.time() - store.STILLBORN_SECONDS - 60
-    os.utime(path, (day_old, day_old))
-    (tmp_path / ".reaped").unlink(missing_ok=True)
-    store._reap(tmp_path)
+    _age(path, store.STILLBORN_SECONDS + 60)
+    _reap_now(tmp_path)
     assert path.exists()
 
 
@@ -1060,10 +1103,8 @@ def test_a_torn_line_does_not_make_a_busy_room_look_stillborn(tmp_path):
         b'{"seq":2,"ts":"2026-01-01T00:00:01.000000Z","from":"a","text":"anyone here?"}\n'
         b'{"seq":3,"ts":"2026-01-01T00:00:02.000000Z","from":"b","text":"yes"}\n'
     )
-    day_old = time.time() - store.STILLBORN_SECONDS - 60
-    os.utime(path, (day_old, day_old))
-    (tmp_path / ".reaped").unlink(missing_ok=True)
-    store._reap(tmp_path)
+    _age(path, store.STILLBORN_SECONDS + 60)
+    _reap_now(tmp_path)
 
     assert path.exists(), "two answered messages and a torn line is not a monologue"
     # …and the messages either side of the torn line are still readable.
@@ -1109,21 +1150,15 @@ def test_reap_spares_a_stillborn_room_answered_after_the_count(tmp_path, monkeyp
 
     store.append(tmp_path, "racing", "bot", "anyone here?")
     path = store.room_path(tmp_path, "racing")
-    day_old = time.time() - store.STILLBORN_SECONDS - 60
-    os.utime(path, (day_old, day_old))
-    real_locked = store._locked
+    _age(path, store.STILLBORN_SECONDS + 60)
 
-    @contextmanager
-    def answer_then_lock(target):
-        with real_locked(target):
-            with target.open("ab") as f:  # a reply got in between the count and the unlink
-                f.write(b'{"seq":2,"ts":"2026-01-01T00:00:00Z","from":"other","text":"yes"}\n')
-            os.utime(target, (day_old, day_old))  # still idle: only the count saves it
-            yield
+    def answer(target):
+        with target.open("ab") as f:  # a reply got in between the count and the unlink
+            f.write(b'{"seq":2,"ts":"2026-01-01T00:00:00Z","from":"other","text":"yes"}\n')
+        _age(target, store.STILLBORN_SECONDS + 60)  # still idle: only the count saves it
 
-    monkeypatch.setattr(store, "_locked", answer_then_lock)
-    (tmp_path / ".reaped").unlink(missing_ok=True)
-    store._reap(tmp_path)
+    _race_under_lock(monkeypatch, store, answer)
+    _reap_now(tmp_path)
     assert path.exists()
 
 
@@ -1374,8 +1409,7 @@ def test_reaper_spares_active_files_and_throttles_itself(tmp_path, monkeypatch):
     # a reap ran on the first write, so the marker exists and the next pass is throttled
     marker = tmp_path / ".reaped"
     assert marker.exists()
-    stale = time.time() - store.IDLE_SECONDS - 60
-    os.utime(store.room_path(tmp_path, "other"), (stale, stale))
+    _age(store.room_path(tmp_path, "other"), store.IDLE_SECONDS + 60)
     store.append(tmp_path, "active", "bot", "again")
     assert store.room_path(tmp_path, "other").exists()  # throttled: not reaped yet
     marker.unlink()
@@ -1389,8 +1423,7 @@ def test_rooms_overview_carries_stats_newest_first(client, tmp_path):
     client.get("/r/old/say/bot/first")
     client.get("/r/busy/say/bot/a")
     client.get("/r/busy/say/bot/b")
-    stale = time.time() - 3600
-    os.utime(store.room_path(tmp_path, "old"), (stale, stale))
+    _age(store.room_path(tmp_path, "old"), 3600)
 
     view = client.get("/rooms?format=json").json()
     names = [r["room"] for r in view["rooms"]]
@@ -2057,6 +2090,21 @@ def test_a_failed_announcement_never_fails_the_write(tmp_path, monkeypatch):
 # ------------------------------------------------------------ signed writes (did:key)
 
 
+def _multibase(raw: bytes) -> str:
+    """base58btc, the encoding a `did:key` multibase segment is written in.
+
+    Spelt out rather than imported: `didkey` only ever decodes, and a test that built its
+    keys with the decoder's own inverse could not catch the decoder being wrong.
+    """
+    alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    n = int.from_bytes(raw, "big")
+    out = ""
+    while n:
+        n, rem = divmod(n, 58)
+        out = alphabet[rem] + out
+    return out
+
+
 def _keypair(seed: int = 1):
     """A deterministic Ed25519 key and its did:key, so a failure is reproducible."""
     import base64
@@ -2068,27 +2116,10 @@ def _keypair(seed: int = 1):
     key = Ed25519PrivateKey.from_private_bytes(bytes([seed]) * 32)
     raw = key.public_key().public_bytes_raw()
 
-    alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-    n = int.from_bytes(didkey.MULTICODEC_ED25519 + raw, "big")
-    out = ""
-    while n:
-        n, rem = divmod(n, 58)
-        out = alphabet[rem] + out
-
     def sign(message: str) -> str:
         return base64.urlsafe_b64encode(key.sign(message.encode())).decode().rstrip("=")
 
-    return f"{didkey.PREFIX}z{out}", sign
-
-
-def _multibase(raw: bytes) -> str:
-    alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-    n = int.from_bytes(raw, "big")
-    out = ""
-    while n:
-        n, rem = divmod(n, 58)
-        out = alphabet[rem] + out
-    return out
+    return f"{didkey.PREFIX}z{_multibase(didkey.MULTICODEC_ED25519 + raw)}", sign
 
 
 def test_a_did_key_has_exactly_one_spelling(client):
@@ -2466,21 +2497,19 @@ def test_ownership_guards_do_not_expire_out_from_under_a_live_room(tmp_path):
     store.append(tmp_path, "d-live", "bot", "hi")
     for ns, value in ((store.OWNERS_NS, did), (store.ALLOW_NS, did), (store.NONCE_NS, "7")):
         store.note_set(tmp_path, ns, "d-live", value)
-        old = time.time() - store.IDLE_SECONDS - 60
-        os.utime(store.note_path(tmp_path, ns, "d-live"), (old, old))
+        _age(store.note_path(tmp_path, ns, "d-live"), store.IDLE_SECONDS + 60)
 
-    (tmp_path / ".reaped").unlink(missing_ok=True)
+    _arm_reaper(tmp_path)
     store.append(tmp_path, "d-live", "bot", "still talking")  # forces a reap pass
     for ns in (store.OWNERS_NS, store.ALLOW_NS, store.NONCE_NS):
         assert store.note_get(tmp_path, ns, "d-live") is not None, ns
 
     # once the room itself goes, the guards go with it — bounded exactly as before
-    old = time.time() - store.IDLE_SECONDS - 60
-    os.utime(store.room_path(tmp_path, "d-live"), (old, old))
-    (tmp_path / ".reaped").unlink(missing_ok=True)
+    _age(store.room_path(tmp_path, "d-live"), store.IDLE_SECONDS + 60)
+    _arm_reaper(tmp_path)
     store.append(tmp_path, "elsewhere", "bot", "hi")
     assert not store.room_path(tmp_path, "d-live").exists()
-    (tmp_path / ".reaped").unlink(missing_ok=True)
+    _arm_reaper(tmp_path)
     store.append(tmp_path, "elsewhere", "bot", "again")
     for ns in (store.OWNERS_NS, store.ALLOW_NS, store.NONCE_NS):
         assert store.note_get(tmp_path, ns, "d-live") is None, ns
@@ -2663,19 +2692,12 @@ def test_two_signed_writers_cannot_both_spend_one_nonce(client, tmp_path, monkey
     assert _claim(client, "d-race", owner, owner_sign).status_code == 200  # burns nonce 1
 
     counter = store.note_path(tmp_path, store.NONCE_NS, "d-race")
-    real_locked = store._locked
-    raced = []
-
-    @contextmanager
-    def spend_then_lock(target):
-        # The other writer gets there between our read of the counter and our claim on it.
-        if target == counter and not raced:
-            raced.append(True)
-            counter.write_text("9", encoding="utf-8")
-        with real_locked(target):
-            yield
-
-    monkeypatch.setattr(store, "_locked", spend_then_lock)
+    raced = _race_before_lock(
+        monkeypatch,
+        store,
+        counter,
+        lambda: counter.write_text("9", encoding="utf-8"),  # the other writer got there
+    )
     lost = _set_signed(client, store.ALLOW_NS, "d-race", owner, owner_sign, owner, nonce=5)
 
     assert raced, "the race never happened — this test proved nothing"
@@ -2698,19 +2720,12 @@ def test_two_first_claims_cannot_both_create_one_nonce_counter(client, tmp_path,
 
     owner, owner_sign = _keypair()
     counter = store.note_path(tmp_path, store.NONCE_NS, "d-first")
-    real_locked = store._locked
-    raced = []
 
-    @contextmanager
-    def create_then_lock(target):
-        if target == counter and not raced:
-            raced.append(True)
-            counter.parent.mkdir(parents=True, exist_ok=True)
-            counter.write_text("1", encoding="utf-8")  # the other claim got there first
-        with real_locked(target):
-            yield
+    def create():
+        counter.parent.mkdir(parents=True, exist_ok=True)
+        counter.write_text("1", encoding="utf-8")  # the other claim got there first
 
-    monkeypatch.setattr(store, "_locked", create_then_lock)
+    raced = _race_before_lock(monkeypatch, store, counter, create)
     lost = _claim(client, "d-first", owner, owner_sign)
 
     assert raced, "the race never happened — this test proved nothing"
@@ -3153,11 +3168,9 @@ def test_message_counter_survives_the_reaper(tmp_path):
         store.append(tmp_path, "doomed", "bot", f"m{i}")
     assert store.counters(tmp_path)["messages"] == 3
 
-    old = time.time() - store.IDLE_SECONDS - 60
     for room in ("doomed", "events"):
-        os.utime(store.room_path(tmp_path, room), (old, old))
-    (tmp_path / ".reaped").unlink(missing_ok=True)
-    store._reap(tmp_path)
+        _age(store.room_path(tmp_path, room), store.IDLE_SECONDS + 60)
+    _reap_now(tmp_path)
 
     assert not store.room_path(tmp_path, "doomed").exists()
     assert store.counters(tmp_path)["messages"] == 3  # monotonic across the deletion
@@ -3172,12 +3185,9 @@ def test_reap_counters_tell_the_two_rules_apart(tmp_path):
     store.append(tmp_path, "monologue", "bot", "anyone here?")
     store.append(tmp_path, "ended", "bot", "hi")
     store.append(tmp_path, "ended", "other", "bye")
-    stale = time.time() - store.IDLE_SECONDS - 60
-    day_old = time.time() - store.STILLBORN_SECONDS - 60
-    os.utime(store.room_path(tmp_path, "monologue"), (day_old, day_old))
-    os.utime(store.room_path(tmp_path, "ended"), (stale, stale))
-    (tmp_path / ".reaped").unlink(missing_ok=True)
-    store._reap(tmp_path)
+    _age(store.room_path(tmp_path, "monologue"), store.STILLBORN_SECONDS + 60)
+    _age(store.room_path(tmp_path, "ended"), store.IDLE_SECONDS + 60)
+    _reap_now(tmp_path)
 
     counts = store.counters(tmp_path)
     assert (counts["reaped_stillborn"], counts["reaped_idle"]) == (1, 1)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -67,6 +67,33 @@ def test_post_lane(client):
     assert client.post("/r/lobby", content=b"x" * (app_module.MAX_BODY + 1)).status_code == 413
 
 
+def test_the_body_cap_holds_when_nothing_declares_a_length(client):
+    """Two bounds, and only one of them was ever reached. `await request.body()` buffers
+    the whole upload before any size check, so a large POST was an OOM against a 128 MiB
+    container; the Content-Length refusal fixes the honest case and the streaming cap
+    fixes the rest. A chunked request declares no length, so the second bound is the only
+    one that applies there — and every oversize test until now sent a declared length,
+    because the test client computes one for you.
+    """
+    import app as app_module
+
+    def chunked():
+        for _ in range(4):
+            yield b"x" * (app_module.MAX_BODY // 2)
+
+    streamed = client.post("/r/lobby", content=chunked())
+    assert streamed.status_code == 413
+    assert "the stream passed it before it ended" in streamed.text
+
+    declared = client.post("/r/lobby", content=b"x" * (app_module.MAX_BODY + 1))
+    assert declared.status_code == 413
+    assert f"your Content-Length said {app_module.MAX_BODY + 1} bytes" in declared.text
+
+    # Both bodies name the cap, because a caller that just lost an upload needs the number.
+    for response in (streamed, declared):
+        assert f"the cap is {app_module.MAX_BODY} bytes" in response.text
+
+
 def test_post_lane_reports_write_budget_like_get_writes(client, monkeypatch):
     """POST pays the same write bucket as GET /say, so it must carry the same in-body
     budget hint for clients whose harness does not expose response headers.
@@ -122,6 +149,11 @@ def test_rate_limit_is_actionable_without_headers(client, monkeypatch):
     assert r.headers["retry-after"].isdigit()
     # the wait is in the body too: harness webfetch shows page text, not headers
     assert "retry after:" in r.text and "429 rate limited" in r.text
+    # …and it is the right order of magnitude. A bucket refilling at 4/min hands back a
+    # token in ~15s; the arithmetic that produces that is one character from reporting
+    # four minutes, and an agent that believes it sleeps through its own work.
+    assert 1 <= int(r.headers["retry-after"]) <= 60 // 4 + 1
+    assert f"retry after: {r.headers['retry-after']}s" in r.text  # header and body agree
     # the manual stays reachable while throttled, so a limited agent can learn to back off
     assert client.get("/llms.txt").status_code == 200
     assert client.get("/r/lobby").status_code == 200  # reads have their own budget
@@ -142,6 +174,20 @@ def test_the_429_names_the_budget_the_manual_deliberately_does_not(client, monke
     # what still works while throttled, and where to read the limits up front
     assert "reads are a separate budget" in r.text
     assert "limits.writes_per_minute_per_ip" in r.text
+    # The poll advice names the ceiling this instance enforces, not a hardcoded 10 — the
+    # same reason the manual states no rate limit it cannot guarantee.
+    assert f"&wait={app_module.MAX_WAIT:g}" in r.text
+
+    # The read bucket is the other half, and it is the one an agent hits first. `other` is
+    # computed from `kind`, so a 429 that names the wrong budget as "still open" sends the
+    # caller straight back into the bucket it just emptied.
+    monkeypatch.setattr(app_module, "RATE_READ", 1)
+    for _ in range(2):
+        read = client.get("/r/lobby")
+    assert read.status_code == 429
+    assert "the read budget for your IP (1/min) is spent" in read.text
+    assert "writes are a separate budget" in read.text
+    assert "limits.reads_per_minute_per_ip" in read.text
 
 
 def test_the_refill_rate_stays_a_number_an_agent_can_pace_against(client):
@@ -272,6 +318,69 @@ def test_the_byte_budget_bounds_growth_and_not_only_creation(tmp_path, monkeypat
     # And the floor still holds a conversation rather than truncating to nothing.
     view = store.read_messages(tmp_path, "first", limit=5)
     assert view["messages"], "compaction must never empty a room"
+
+
+def test_the_byte_budget_binds_at_the_cap_and_not_one_byte_past_it(tmp_path, monkeypatch):
+    """Both budget comparisons are `at or over`, and both were only ever driven strictly
+    over. `>=` vs `>` and `<` vs `<=` are invisible until usage lands exactly on the
+    number, which is precisely where an operator who sized the disk expects it to bite."""
+    import store
+
+    monkeypatch.setattr(store, "MAX_ROOMS", 10_000)  # far from binding: bytes must do it
+    store.append(tmp_path, "room0", "bot", "hi")
+    used = store._scan(tmp_path / "rooms", ".jsonl", sized=True)[1]
+    monkeypatch.setattr(store, "MAX_TOTAL_ROOM_BYTES", used)  # exactly at the budget
+
+    with pytest.raises(store.StoreError, match="room storage is full"):
+        store.append(tmp_path, "overflow", "bot", "hi")
+
+    # The same equality on the growth half: at the budget a room gets its floor, not the
+    # full ring, or "the budget bounds growth" is off by one byte.
+    (tmp_path / store.USAGE_FILE).write_text(str(used))
+    assert store._ring_limit(tmp_path) == store.RESERVED_ROOM_BYTES
+
+
+def test_a_capacity_refusal_carries_the_numbers_a_caller_acts_on(tmp_path, monkeypatch):
+    """These bodies are the service's answer to "now what", and the actionable part is the
+    figures: the cap that was hit, and how full the disk is against how big it was sized.
+    Matching only the opening words leaves every number in them free to be wrong."""
+    import store
+
+    monkeypatch.setattr(store, "MAX_ROOMS", 1)
+    store.append(tmp_path, "only", "bot", "hi")
+    with pytest.raises(store.StoreError, match=r"room limit reached \(1 is the cap"):
+        store.append(tmp_path, "second", "bot", "hi")
+
+    # Two note caps, two messages, and the number is the actionable part of both.
+    monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 1)
+    store.note_set(tmp_path, "plans", "only", "hi")
+    with pytest.raises(store.StoreError, match=r"note limit reached \(1 is the cap"):
+        store.note_set(tmp_path, "plans", "second", "hi")
+
+    monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 10_000)
+    monkeypatch.setattr(store, "MAX_NOTES_TOTAL", 1)
+    with pytest.raises(store.StoreError, match=r"note limit reached \(1 across all namespaces"):
+        store.note_set(tmp_path, "elsewhere", "second", "hi")
+
+    # "how full, of how much" is the figure an operator sizes a disk against, and the two
+    # shifts that produce it are one character from reporting megabytes as terabytes.
+    monkeypatch.setattr(store, "MAX_ROOMS", 10_000)
+    monkeypatch.setattr(store, "MAX_TOTAL_ROOM_BYTES", 3 << 20)
+    monkeypatch.setattr(store, "_scan", lambda *a, **k: (1, 5 << 20))  # 5 MiB on disk
+    with pytest.raises(store.StoreError, match="5 MiB of a 3 MiB budget"):
+        store.append(tmp_path, "overflow", "bot", "hi")
+
+
+def test_an_empty_usage_file_reads_as_no_pressure(tmp_path):
+    """A write cut short leaves the file there and empty. Reading that as *some* pressure
+    would throttle every room to its floor on the strength of a truncated write; the
+    documented default is 0, and it is the same fail-open as a missing file."""
+    import store
+
+    (tmp_path / store.USAGE_FILE).write_text("")
+    assert store.room_bytes_used(tmp_path) == 0
+    (tmp_path / store.USAGE_FILE).write_text("   \n")
+    assert store.room_bytes_used(tmp_path) == 0
 
 
 def test_the_reaper_records_room_usage_for_the_ring_to_read(tmp_path, monkeypatch):
@@ -644,6 +753,126 @@ def test_orphan_locks_are_swept(tmp_path):
     (tmp_path / ".reaped").unlink(missing_ok=True)
     store.append(tmp_path, "other", "bot", "again")  # next pass sweeps the orphan lock
     assert not lock.exists()
+
+
+def test_the_note_side_of_the_sweep_is_wired_up_too(tmp_path):
+    """Notes are nested one directory deeper than rooms and carry a different suffix, so
+    the sweep walks them with a second, hand-written tuple that nothing exercised — every
+    way of getting that tuple wrong leaves note locks and empty namespaces accumulating
+    forever, silently and unboundedly, on the half of the store nobody was watching."""
+    import store
+
+    store.note_set(tmp_path, "scratch", "gone", "value")
+    note = store.note_path(tmp_path, "scratch", "gone")
+    lock = note.with_suffix(".txt.lock")
+    assert lock.exists(), "premise: note writes leave a sidecar lock"
+
+    old = time.time() - store.IDLE_SECONDS - 60
+    for target in (note, lock):
+        os.utime(target, (old, old))
+    (tmp_path / ".reaped").unlink(missing_ok=True)
+    store._reap(tmp_path)  # takes the data file, keeps the lock a writer might hold
+    assert not note.exists()
+
+    (tmp_path / ".reaped").unlink(missing_ok=True)
+    store._reap(tmp_path)
+    assert not lock.exists(), "an orphaned note lock is swept like a room's"
+    # …and the namespace directory goes with the last note in it, or every namespace ever
+    # written stays on disk as an empty directory.
+    assert not note.parent.exists()
+
+
+def test_a_lock_is_never_swept_while_its_data_file_is_there(tmp_path):
+    """The sweep spares a lock whose data file still exists, whatever the lock's own age —
+    a lock is touched only when someone writes, so a busy room with a quiet week looks
+    exactly like an orphan. Unlinking it splits the lock domain: the next writer locks a
+    fresh inode and two writers append at once."""
+    import store
+
+    store.append(tmp_path, "quiet", "bot", "hi")
+    path = store.room_path(tmp_path, "quiet")
+    lock = path.with_suffix(".jsonl.lock")
+
+    old = time.time() - store.IDLE_SECONDS - 60
+    os.utime(lock, (old, old))  # the lock is stale; the room it guards is not
+    (tmp_path / ".reaped").unlink(missing_ok=True)
+    store._reap(tmp_path)
+
+    assert path.exists() and lock.exists()
+
+
+def test_one_unreadable_file_does_not_abort_the_whole_pass(tmp_path, monkeypatch):
+    """The reaper walks every room and note in one pass, and a racing writer or a
+    permission blip on any one of them is ordinary. Skipping that entry costs nothing;
+    stopping the pass leaves everything after it unreaped until the next interval, which
+    on a store under pressure is how a disk fills while the reaper reports success."""
+    import store
+
+    for room in ("first-idle", "second-idle"):
+        store.append(tmp_path, room, "bot", "hi")
+    old = time.time() - store.IDLE_SECONDS - 60
+    for room in ("first-idle", "second-idle"):
+        os.utime(store.room_path(tmp_path, room), (old, old))
+
+    real_locked = store._locked
+    exploded = []
+
+    @contextmanager
+    def explode_once(target):
+        if target.name.startswith("first-idle") and not exploded:
+            exploded.append(True)
+            raise OSError("racing writer")
+        with real_locked(target):
+            yield
+
+    monkeypatch.setattr(store, "_locked", explode_once)
+    (tmp_path / ".reaped").unlink(missing_ok=True)
+    store._reap(tmp_path)
+
+    assert exploded, "the failure never happened — this test proved nothing"
+    assert not store.room_path(tmp_path, "second-idle").exists(), "the pass stopped early"
+
+
+def test_reap_counts_every_room_it_takes_not_just_the_last(tmp_path):
+    """The counters are the only monotonic numbers in the store, and a digest reports
+    deltas from them. One reap pass usually takes many rooms; a counter that assigns
+    instead of accumulating reports 1 whatever the wave size, which is exactly the signal
+    a wave is supposed to produce."""
+    import store
+
+    for room in ("ended-one", "ended-two", "ended-three"):
+        store.append(tmp_path, room, "bot", "hi")
+        store.append(tmp_path, room, "other", "yes")  # answered, so the idle rule takes it
+    old = time.time() - store.IDLE_SECONDS - 60
+    for room in ("ended-one", "ended-two", "ended-three"):
+        os.utime(store.room_path(tmp_path, room), (old, old))
+
+    before = store.counters(tmp_path)["reaped_idle"]
+    (tmp_path / ".reaped").unlink(missing_ok=True)
+    store._reap(tmp_path)
+    assert store.counters(tmp_path)["reaped_idle"] == before + 3
+
+
+def test_an_ephemeral_room_keeps_the_history_that_has_not_expired(tmp_path, monkeypatch):
+    """Compaction retains the newest record of an `e-` room unconditionally, then stops at
+    the first expired one. The guard that makes it unconditional is `and kept`, and
+    dropping it turns every rotation of a *busy* ephemeral room into a truncation to one
+    line — losing history that is still well inside its TTL. Only a room whose records are
+    all fresh at rotation time can tell the two apart."""
+    import store
+
+    monkeypatch.setattr(store, "MAX_ROOM_BYTES", 2048)
+    monkeypatch.setattr(store, "COMPACT_KEEP_BYTES", 1024)
+
+    for i in range(40):  # well past the ring, and all of it written just now
+        store.append(tmp_path, "e-busy", "bot", f"message {i} " + "x" * 60)
+
+    view = store.read_messages(tmp_path, "e-busy", limit=50)
+    assert view["count"] > 1, "a rotating ephemeral room must keep unexpired history"
+    assert view["messages"][-1]["seq"] == store.last_seq(tmp_path, "e-busy")
+    # contiguous: compaction drops from the front, it never leaves a hole
+    seqs = [m["seq"] for m in view["messages"]]
+    assert seqs == list(range(seqs[0], seqs[-1] + 1))
 
 
 def test_reap_keeps_a_file_refreshed_after_the_stat(tmp_path, monkeypatch):
@@ -1852,6 +2081,51 @@ def _keypair(seed: int = 1):
     return f"{didkey.PREFIX}z{out}", sign
 
 
+def _multibase(raw: bytes) -> str:
+    alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    n = int.from_bytes(raw, "big")
+    out = ""
+    while n:
+        n, rem = divmod(n, 58)
+        out = alphabet[rem] + out
+    return out
+
+
+def test_a_did_key_has_exactly_one_spelling(client):
+    """Ownership compares DID *strings*: `_note_write_gate` asks `signer != current`, and
+    `_allowed_keys` matches by string. So a key with more than one accepted spelling is a
+    key whose owner the service cannot recognise — the caller signs with the same private
+    key, presents an alias, and fails its own allow-list.
+
+    Each of the three shapes below decodes to a real key's bytes and is refused only by
+    the *other* half of a two-part check. `or` → `and` short-circuits on the common
+    operand and silently deletes that half, which is why all three need pinning
+    separately rather than as one "malformed DID" case.
+    """
+    import didkey
+
+    did, _ = _keypair()
+    mb = did[len(didkey.PREFIX) :]
+    real = didkey.public_key(did)
+
+    # Right suffix, wrong prefix — same length, so only the `startswith` check refuses it.
+    alias = "XXXXXXXX" + mb
+    # Right prefix and leading `z`, one base58 zero-digit too long. Base58 ignores the
+    # padding, so it decodes to the same 34 bytes; only the exact-length check refuses it.
+    padded = didkey.PREFIX + "z1" + mb[1:]
+    # Right prefix and right length, but the multicodec says something other than
+    # ed25519-pub. Only the codec check refuses it.
+    wrong_codec = didkey.PREFIX + "z" + _multibase(b"\xe7\x01" + real)
+    assert len(wrong_codec) == len(did), "premise: this must pass the length check to matter"
+
+    for spelling in (alias, padded, wrong_codec):
+        with pytest.raises(didkey.DidError):
+            didkey.public_key(spelling)
+        assert not didkey.is_did(spelling)
+
+    assert didkey.public_key(did) == real  # …and the canonical one still works
+
+
 def _say_signed(client, room, did, sign, text, nonce=1):
     """The canonical string is `room|nonce|text` over the *swept* text — what is stored."""
     import store
@@ -2374,6 +2648,77 @@ def test_a_replayed_ownership_url_cannot_roll_an_allow_list_back(client):
     # the counter is server-written and world-readable, never client-writable
     assert client.get("/kv/room-nonce/d-bounty").text.strip().endswith("3")
     assert client.get("/kv/room-nonce/d-bounty/set/0").status_code == 403
+
+
+def test_two_signed_writers_cannot_both_spend_one_nonce(client, tmp_path, monkeypatch):
+    """The counter is read before it is claimed, so two writers racing one room both pass
+    the "greater than the last one" check against the same stale value. Only the
+    compare-and-set inside `note_set` separates them — without it both writes land, the
+    counter ends up at whichever finished last, and a nonce that was already spent becomes
+    spendable again. That is the single-use guarantee, and nothing exercised it.
+    """
+    import store
+
+    owner, owner_sign = _keypair()
+    assert _claim(client, "d-race", owner, owner_sign).status_code == 200  # burns nonce 1
+
+    counter = store.note_path(tmp_path, store.NONCE_NS, "d-race")
+    real_locked = store._locked
+    raced = []
+
+    @contextmanager
+    def spend_then_lock(target):
+        # The other writer gets there between our read of the counter and our claim on it.
+        if target == counter and not raced:
+            raced.append(True)
+            counter.write_text("9", encoding="utf-8")
+        with real_locked(target):
+            yield
+
+    monkeypatch.setattr(store, "_locked", spend_then_lock)
+    lost = _set_signed(client, store.ALLOW_NS, "d-race", owner, owner_sign, owner, nonce=5)
+
+    assert raced, "the race never happened — this test proved nothing"
+    assert lost.status_code == 409
+    # The loser must not drag the counter back to its own value: a nonce between 5 and 9
+    # would otherwise be spendable a second time.
+    assert store.note_get(tmp_path, store.NONCE_NS, "d-race") == "9"
+    # …and the write the burnt nonce was carrying does not land either.
+    assert store.note_get(tmp_path, store.ALLOW_NS, "d-race") is None
+
+
+def test_two_first_claims_cannot_both_create_one_nonce_counter(client, tmp_path, monkeypatch):
+    """The other end of the same guarantee. On a room's first signed write there is no
+    counter to compare against, so the CAS runs as create-if-absent instead — and if that
+    half is missing, two callers racing the first claim both create it and both spend
+    nonce 1. The replace path above cannot catch this one: it only engages once a counter
+    exists.
+    """
+    import store
+
+    owner, owner_sign = _keypair()
+    counter = store.note_path(tmp_path, store.NONCE_NS, "d-first")
+    real_locked = store._locked
+    raced = []
+
+    @contextmanager
+    def create_then_lock(target):
+        if target == counter and not raced:
+            raced.append(True)
+            counter.parent.mkdir(parents=True, exist_ok=True)
+            counter.write_text("1", encoding="utf-8")  # the other claim got there first
+        with real_locked(target):
+            yield
+
+    monkeypatch.setattr(store, "_locked", create_then_lock)
+    lost = _claim(client, "d-first", owner, owner_sign)
+
+    assert raced, "the race never happened — this test proved nothing"
+    assert lost.status_code == 409
+    assert store.note_get(tmp_path, store.NONCE_NS, "d-first") == "1"
+    # The loser's claim does not land: the room stays unowned rather than owned by whoever
+    # lost the race for its counter.
+    assert store.note_get(tmp_path, store.OWNERS_NS, "d-first") is None
 
 
 # ------------------------------------------------------------------ ephemeral rooms
@@ -2952,6 +3297,9 @@ def test_an_unsupported_verb_is_answered_with_the_get_lane_that_replaces_it(clie
     assert r.status_code == 405
     assert "/kv/<ns>/<key>/set/<value>" in r.text
     assert "append-only" in r.text  # …and why there is nothing to DELETE
+    # The pointer has to be fetchable as printed: routes are case-sensitive, so a body
+    # that shouted /LLMS.TXT would send an agent that copied it to a 404.
+    assert "/llms.txt" in r.text and client.get("/llms.txt").status_code == 200
 
 
 def test_a_405_carries_allow_and_names_every_verb_the_path_takes(client):
@@ -2999,6 +3347,10 @@ def test_a_lost_conditional_write_says_how_to_rebase(client):
     absent = client.get("/kv/plans/absent/set/x?if=something")
     assert absent.status_code == 409
     assert "no note there at all" in absent.text and "if_absent=1" in absent.text
+    # Both branches keep the store's own diagnostic ahead of the generic advice: the
+    # template says what to do, the exception says which condition actually fired.
+    assert absent.text.startswith("409 note plans/absent")
+    assert lost.text.startswith("409 note plans/next changed since you read it")
 
 
 def test_a_rejected_name_names_the_usual_causes(client):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -55,6 +55,18 @@ def _reap_now(root):
     store._reap(root)
 
 
+def _ok(client, target, post=None):
+    """Send `target` (a path, or an already-made response) and require it to succeed.
+
+    A published limit is honoured only if the server *accepts* the extreme value; a 4xx
+    here means the document is advertising something no caller can use.
+    """
+    if isinstance(target, str):
+        target = client.post(target, json=post) if post is not None else client.get(target)
+    assert target.status_code == 200, f"published limit refused: {target.text[:160]}"
+    return target
+
+
 def _race_before_lock(monkeypatch, store, path, action):
     """Run `action()` once, in the gap between the store reading a file and locking it.
 
@@ -3935,21 +3947,76 @@ def test_an_integral_ceiling_publishes_as_an_integer(client):
     assert manifest.agent_manifest("", "0.7.0", 1, 1, 1, 10.0)["limits"]["long_poll_seconds"] == 10
 
 
-def test_every_status_an_operation_can_return_is_one_it_documents(client):
-    """An undocumented status is the failure neither a generated client nor a contract
-    fuzzer recovers from: the client treats an unannounced 403 as a transport fault and
-    retries the identical bytes, the fuzzer calls the service broken.
+# Statuses whose provoking case is a fixture rather than a request shape: 429 needs the
+# rate limiter wound down and 413 a quarter-megabyte upload, and both already have tests
+# built around exactly that. Everything else a caller can hit by choosing its own bytes.
+_REFUSALS = frozenset({"400", "403", "404", "409"})
 
-    So: provoke each refusal against the running app and require the spec to list it.
+
+def test_every_refusal_is_provoked_and_every_provoked_refusal_is_documented(client):
+    """Both directions, because each catches what the other cannot.
+
+    An undocumented status is the failure neither a generated client nor a contract fuzzer
+    recovers from: the client treats an unannounced 403 as a transport fault and retries
+    the identical bytes, the fuzzer calls the service broken. So every case below is
+    provoked against the running app and the spec must list what came back.
+
+    The second assertion is the one that would have saved a round of review. This started
+    as a hand-written table, and `POST /r/events` was added to the document *after* the
+    table was written — so it documented a 403 no test had ever asked for, and a reviewer
+    found the 400 and 413 it also returns. A table only covers what someone remembered to
+    add; requiring every documented refusal to have a case makes forgetting fail the build.
     """
     did, sign = _keypair()
-    other, _ = _keypair(2)
+    other, other_sign = _keypair(2)
     client.get("/kv/plans/held/set/first")
+    assert _claim(client, "d-owned", did, sign).status_code == 200
+    signed_note = f"{sign('room-owners|d-owned|4|' + other)}/4/{other}"
 
     # (openapi path, method, expected status, the request that produces it)
     cases = [
+        # Reads.
+        ("/r/{room}", "get", 400, lambda: client.get("/r/UPPER")),
+        ("/kv/{ns}", "get", 400, lambda: client.get("/kv/UPPER")),
         ("/kv/{ns}/{key}", "get", 400, lambda: client.get("/kv/UPPER/key")),
         ("/kv/{ns}/{key}", "get", 404, lambda: client.get("/kv/plans/never-written")),
+        # A sitemap needs an origin, and a Host that is not one leaves it with nothing to
+        # point at. Spaces cannot appear in a hostname, so this is never a real origin.
+        (
+            "/sitemap.xml",
+            "get",
+            404,
+            lambda: client.get("/sitemap.xml", headers={"host": "not a host"}),
+        ),
+        # The URL write lanes. `%0A` matches no route at all — deliberate, and the reason a
+        # message cannot forge a second JSONL record.
+        ("/r/{room}/say/{nick}/{text}", "get", 400, lambda: client.get("/r/UPPER/say/bot/hi")),
+        ("/r/{room}/say/{nick}/{text}", "get", 403, lambda: client.get("/r/mb-box/say/bot/hi")),
+        ("/r/{room}/say/{nick}/{text}", "get", 404, lambda: client.get("/r/lobby/say/bot/a%0Ab")),
+        ("/kv/{ns}/{key}/set/{value}", "get", 400, lambda: client.get("/kv/UPPER/k/set/v")),
+        ("/kv/{ns}/{key}/set/{value}", "get", 403, lambda: client.get("/kv/room-nonce/x/set/1")),
+        ("/kv/{ns}/{key}/set/{value}", "get", 404, lambda: client.get("/kv/plans/k/set/a%0Ab")),
+        (
+            "/kv/{ns}/{key}/set/{value}",
+            "get",
+            409,
+            lambda: client.get("/kv/plans/held/set/second?if=not-that"),
+        ),
+        # The POST lanes.
+        ("/r/{room}", "post", 400, lambda: client.post("/r/lobby", json={"from": "b", "text": ""})),
+        (
+            "/r/{room}",
+            "post",
+            403,
+            lambda: client.post("/r/mb-box", json={"from": "b", "text": "hi"}),
+        ),
+        ("/r/events", "post", 400, lambda: client.post("/r/events", content=b"not json")),
+        (
+            "/r/events",
+            "post",
+            403,
+            lambda: client.post("/r/events", json={"from": "b", "text": "hi"}),
+        ),
         ("/kv/{ns}/{key}", "post", 400, lambda: client.post("/kv/UPPER/k", json={"value": "v"})),
         # `required: ["value"]` never implied a *non-empty* value, and the sweep refuses one.
         ("/kv/{ns}/{key}", "post", 400, lambda: client.post("/kv/plans/k", json={"value": ""})),
@@ -3965,20 +4032,50 @@ def test_every_status_an_operation_can_return_is_one_it_documents(client):
             409,
             lambda: client.post("/kv/plans/held", json={"value": "v", "if": "not-that"}),
         ),
-        ("/r/{room}", "post", 400, lambda: client.post("/r/lobby", json={"from": "b", "text": ""})),
-        # A signature that does not verify is a refusal, not a malformed request…
+        # The signed lanes. A signature that does not verify is a refusal, not a malformed
+        # request; a stale nonce is the other way round.
+        (
+            "/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}",
+            "get",
+            400,
+            lambda: client.get(f"/r/lobby/say-signed/{did}/{'A' * 86}/not-a-nonce/hi"),
+        ),
         (
             "/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}",
             "get",
             403,
             lambda: client.get(f"/r/lobby/say-signed/{did}/{'A' * 86}/1/hi"),
         ),
-        # …and neither is a room that will not take this key.
+        (
+            "/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}",
+            "get",
+            404,
+            lambda: client.get(f"/r/lobby/say-signed/{did}/{'A' * 86}/1/a%0Ab"),
+        ),
+        # …and a room that will not take this key is a refusal too.
         (
             "/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}",
             "get",
             403,
-            lambda: _say_signed(client, "d-owned", other, _keypair(2)[1], "hi", nonce=3),
+            lambda: _say_signed(client, "d-owned", other, other_sign, "hi", nonce=3),
+        ),
+        (
+            "/kv/{ns}/{key}/set-signed/{did}/{sig}/{nonce}/{value}",
+            "get",
+            400,
+            lambda: _set_signed(client, "plans", "k", did, sign, "v", nonce=9),
+        ),
+        (
+            "/kv/{ns}/{key}/set-signed/{did}/{sig}/{nonce}/{value}",
+            "get",
+            403,
+            lambda: client.get(f"/kv/room-owners/d-owned/set-signed/{did}/{'A' * 86}/9/{other}"),
+        ),
+        (
+            "/kv/{ns}/{key}/set-signed/{did}/{sig}/{nonce}/{value}",
+            "get",
+            404,
+            lambda: client.get(f"/kv/room-owners/d-owned/set-signed/{did}/{'A' * 86}/9/a%0Ab"),
         ),
         # Notes have no ring, so the signed lane's nonce counter is itself a note claimed
         # with a compare-and-set: a racing writer loses on the counter, with a 409.
@@ -3987,13 +4084,10 @@ def test_every_status_an_operation_can_return_is_one_it_documents(client):
             "get",
             409,
             lambda: client.get(
-                f"/kv/room-owners/d-owned/set-signed/{did}/"
-                f"{sign(f'room-owners|d-owned|4|{other}')}/4/{other}?if=nothing-like-this"
+                f"/kv/room-owners/d-owned/set-signed/{did}/{signed_note}?if=nothing-like-this"
             ),
         ),
     ]
-
-    assert _claim(client, "d-owned", did, sign).status_code == 200
 
     doc = client.get("/openapi.json").json()
     for path, method, status, send in cases:
@@ -4001,6 +4095,117 @@ def test_every_status_an_operation_can_return_is_one_it_documents(client):
         assert response.status_code == status, f"{method.upper()} {path}: {response.text[:200]}"
         documented = doc["paths"][path][method]["responses"]
         assert str(status) in documented, f"{method.upper()} {path} can {status} undocumented"
+
+    # …and nothing documented is left unprovoked.
+    provoked = {(path, method, str(status)) for path, method, status, _ in cases}
+    unprovoked = sorted(
+        f"{method.upper()} {path} -> {code}"
+        for path, operations in doc["paths"].items()
+        for method, op in operations.items()
+        for code in op["responses"]
+        if code in _REFUSALS and (path, method, code) not in provoked
+    )
+    assert not unprovoked, f"documented but never provoked by a test: {unprovoked}"
+
+
+def _published_bounds(doc):
+    """Every input constraint the document publishes, keyed by the constraint itself.
+
+    Keyed by the bound rather than by the site because the same promise is repeated: the
+    name pattern appears on eleven parameters and means one thing each time. Twelve
+    distinct promises across forty-odd declarations.
+    """
+    keys = ("maximum", "minimum", "maxLength", "minLength", "enum", "pattern")
+    found = set()
+    for operations in doc["paths"].values():
+        for op in operations.values():
+            schemas = [p["schema"] for p in op.get("parameters", [])]
+            body = op.get("requestBody")
+            if body:
+                schemas += list(
+                    body["content"]["application/json"]["schema"]["properties"].values()
+                )
+            for schema in schemas:
+                bound = {k: schema[k] for k in keys if k in schema}
+                if bound:
+                    found.add(json.dumps(bound, sort_keys=True))
+    return found
+
+
+def test_every_published_limit_is_one_the_server_actually_honours(client, monkeypatch):
+    """The read side of the contract, which is where this branch kept going wrong.
+
+    Every fix here traced where a number is *written down* — three publishing sites for the
+    wait ceiling, then two more — and none of them asked who parses it back. That is
+    precisely where the bug was: `?wait=` was published as `type: number` and int-parsed,
+    so every fractional value a conforming client could send was silently discarded. The
+    failure had no contract signature at all — a documented 200 with a schema-valid body,
+    identical to an idle room — so no fuzzer, coverage gate or mutation run could see it.
+
+    So: take each bound at its extreme, send it, and require the server to honour it. And
+    require the table to cover every bound the document publishes, or the next parameter
+    added with a limit nobody honours passes unnoticed the same way.
+    """
+    import app as app_module
+
+    monkeypatch.setattr(app_module, "MAX_WAIT", 0.5)  # keep the long-poll case quick
+    doc = client.get("/openapi.json").json()
+    did, sign = _keypair()
+    longest_name = "a" * 48
+
+    def wait_is_honoured():
+        published = next(
+            p for p in doc["paths"]["/r/{room}"]["get"]["parameters"] if p["name"] == "wait"
+        )["schema"]["maximum"]
+        started = time.monotonic()
+        client.get(f"/r/idle?since=1&wait={published}")
+        # It has to actually hold the connection, not return an immediate empty reply that
+        # a caller cannot tell from a quiet room.
+        assert time.monotonic() - started >= published * 0.8
+
+    # (the bound as published, a request using it at its extreme)
+    checks = [
+        ('{"pattern": "^[a-z0-9][a-z0-9_-]{0,47}$"}', lambda: _ok(client, f"/r/{longest_name}")),
+        (
+            '{"maxLength": 4096, "minLength": 1}',
+            lambda: _ok(client, "/r/lobby", post={"from": "b", "text": "x" * 4096}),
+        ),
+        (
+            '{"maxLength": 8192, "minLength": 1}',
+            lambda: _ok(client, "/kv/plans/big", post={"value": "x" * 8192}),
+        ),
+        ('{"maximum": 200, "minimum": 1}', lambda: _ok(client, "/r/lobby?limit=200")),
+        ('{"minimum": 0}', lambda: _ok(client, "/r/lobby?since=0")),
+        ('{"minimum": 1}', lambda: _ok(client, "/rooms?limit=1")),
+        ('{"enum": ["json"]}', lambda: client.get("/r/lobby?format=json").json()),
+        ('{"enum": ["1"]}', lambda: _ok(client, "/kv/plans/fresh/set/v?if_absent=1")),
+        ('{"maximum": 0.5, "minimum": 0}', wait_is_honoured),
+        # The signed lane's three, at the exact shapes it publishes. A room each, because a
+        # nonce is single-use per key per room and the 19-digit one spends the ceiling —
+        # 10**19 - 1 being the largest the published pattern allows, and an int64 fits it.
+        (
+            '{"pattern": "^[0-9]{1,19}$"}',
+            lambda: _ok(
+                client, _say_signed(client, "big-nonce", did, sign, "hi", nonce=10**19 - 1)
+            ),
+        ),
+        (
+            '{"maxLength": 56, "minLength": 56, '
+            '"pattern": "^did:key:z6Mk[1-9A-HJ-NP-Za-km-z]{44}$"}',
+            lambda: _ok(client, _say_signed(client, "signed-did", did, sign, "signed")),
+        ),
+        (
+            '{"maxLength": 86, "minLength": 86, "pattern": "^[A-Za-z0-9_-]{86}$"}',
+            lambda: _ok(client, _say_signed(client, "signed-sig", did, sign, "again")),
+        ),
+    ]
+
+    for _bound, exercise in checks:
+        exercise()
+
+    covered = {bound for bound, _ in checks}
+    published = _published_bounds(doc)
+    assert not published - covered, f"published but never exercised: {sorted(published - covered)}"
 
 
 def test_the_signed_lane_publishes_the_shape_it_actually_enforces(client):

--- a/tests/test_store_stateful.py
+++ b/tests/test_store_stateful.py
@@ -1,26 +1,21 @@
-"""Hypothesis state machines over the store's lifecycle.
+"""A Hypothesis state machine over the store's lifecycle.
 
 Run: uv run --group dev python -m pytest tests/test_store_stateful.py
 
-Why a state machine and not more example tests. Every rule in `store.py` is easy to state
-and easy to satisfy on its own; what is hard is satisfying all of them at once, in an order
-nobody wrote a test for. Compaction rewrites a room, expiry hides records the file still
-holds, the reaper deletes the file outright, and a conditional note write has to see the
-value the last write left — so the interesting bugs live in the *sequences*: a seq reused
-after a compaction that kept nothing, a cursor that skips a record because expiry and
-`since` disagree about which end of the file to stop at, a guard note reclaimed while the
-room it guards is still busy. Hypothesis generates those orderings; these machines say what
-must be true after every one of them.
+Every rule in `store.py` is easy to satisfy alone; what is hard is satisfying all of them
+at once, in an order nobody wrote a test for. So the interesting bugs live in the
+*sequences*: a seq reused after a compaction that kept nothing, a cursor that skips a
+record because expiry and `since` disagree about which end of the file to stop at, a guard
+note reclaimed while the room it guards is still busy.
 
-The model deliberately does not predict compaction byte-for-byte. Compaction's contract is
-"keep the newest records that fit, drop the rest, never reorder and never renumber" — so
-the machine reads back what survived and holds *that* to the contract, rather than
-re-implementing `_compact` and testing the copy.
+Two things about the model:
 
-Time is modelled by moving the whole store into the past — every file's mtime *and* every
-record's `ts`. Both, because the two lifetimes read different clocks: the reaper stats the
-file, the `e-` class parses the record. Ageing one without the other produces a store that
-has never existed.
+- It does not predict compaction byte-for-byte. The contract is "keep the newest that fit,
+  drop the rest, never reorder and never renumber", so the machine reads back what survived
+  and holds *that* to it, rather than re-implementing `_compact` and testing the copy.
+- Time moves the whole store into the past: file mtimes *and* record timestamps. The reaper
+  stats the file and `e-` expiry parses the record, so ageing one without the other
+  produces a store that has never existed.
 """
 
 from __future__ import annotations
@@ -41,35 +36,28 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 import store  # noqa: E402
 
-# Every threshold is compared against a real clock — `time.time()` at the moment the
-# reaper or the read runs — while the model counts whole seconds of simulated ageing. The
-# two differ by however long the step took, so an age that lands *on* a threshold is
-# genuinely ambiguous. Assertions are one-sided outside this band and skipped inside it:
-# a test that flakes on its own timing teaches nothing about the code.
+# Thresholds are compared against a real clock while the model counts whole seconds of
+# simulated ageing, so an age landing *on* a threshold is genuinely ambiguous. Assertions
+# are one-sided outside this band and skipped inside it.
 GUARD_SECONDS = 5
 
-# Small enough that a handful of appends rotates a room, so compaction is reached inside a
-# default-length run instead of being a case only a 10 MiB test could see. A record is
-# ~90-140 bytes, so a room rotates every three or four messages.
+# A record is ~90-140 bytes, so a room rotates every three or four messages and compaction
+# is reached inside a default-length run.
 RING_BYTES = 512
 
-# Three rooms, not one per class. Every extra name divides the same step budget, and a run
-# that touches five rooms twice each never reaches compaction; `store.py` distinguishes
-# exactly two things about a name here — whether it is ephemeral and whether it is the
-# events room — so one of each plus a plain room covers the behaviour and leaves the steps
-# to go deep. Which names are unlisted or mailboxes is app.py's business, not the store's.
+# Three rooms, not one per class: every extra name divides the same step budget, and a run
+# that touches five rooms twice each never reaches compaction. `store.py` cares about
+# exactly one thing here — whether a name is ephemeral. Mailboxes and unlisted rooms are
+# app.py's business.
 ROOMS = ("lobby", "e-fast", "d-owned")
 NICKS = ("alice", "bob")
-# `room-owners` is a *guard* namespace: its notes are exempt from the idle rule for as long
-# as the room they name is still live, which is a rule with no meaning unless a note and a
-# room of the same name are both in play. Hence the `d-owned` key.
+# `room-owners/d-owned` on purpose: guard notes are exempt from the idle rule while the
+# room they name is live, which means nothing unless both are in play.
 NOTES = (("plans", "next"), ("topic", "lobby"), ("room-owners", "d-owned"))
 
-# No character here is in INVISIBLE_CATEGORIES, so the value the model records is the value
-# the store stores — `test_the_model_and_the_sweep_agree_on_these_values` holds that line
-# rather than leaving it to a comment. Built to be non-empty and unpadded by construction
-# rather than by `.filter()`: `clean_text` trims the ends and refuses what is left empty,
-# and a filter that rejects most of what it is offered spends the budget on retries.
+# Nothing here is in INVISIBLE_CATEGORIES, so the value the model records is the value the
+# store stores (held by the two tests at the bottom). Non-empty and unpadded by
+# construction rather than by `.filter()`, which would spend the budget on retries.
 _VISIBLE = "abcdefghijklmnopqrstuvwxyz0123456789-_.,:!?éü日🙂"
 SAFE_TEXT = st.builds(
     lambda first, rest: first + rest,
@@ -95,11 +83,10 @@ def _age_world(root: Path, seconds: int) -> None:
     for path in sorted(root.rglob("*")):
         if path.is_dir():
             continue
-        # Stat first. Rewriting a room to shift its records also stamps it with the
-        # current mtime, so reading the mtime afterwards would age the file from *now*
-        # instead of from where it already was — and every advance after the first would
-        # silently reset the file's age to one step. The reaper reads mtime, so the whole
-        # idle half of this machine would have been testing nothing.
+        # Stat first: rewriting a room to shift its records restamps its mtime, so
+        # reading it afterwards would age the file from *now* and every advance after the
+        # first would reset its age to one step. The reaper reads mtime, so the whole idle
+        # half of this machine would have been testing nothing.
         stat = path.stat()
         if path.suffix == ".jsonl":
             _shift_records(path, seconds)
@@ -123,13 +110,10 @@ class StoreLifecycle(RuleBasedStateMachine):
             # A ring a few messages wide, so compaction is part of an ordinary run.
             "MAX_ROOM_BYTES": RING_BYTES,
             "COMPACT_KEEP_BYTES": RING_BYTES // 2,
-            # Every write reaps. The production throttle would make "did this step reap?"
-            # a function of wall-clock time, which is the one thing a model must not have
-            # to guess; at zero the answer is always yes and the machine can hold the
-            # reaper to its rule on every step.
+            # Every write reaps. The production throttle makes "did this step reap?" a
+            # function of wall-clock time, which is the one thing a model must not guess.
             "REAP_EVERY": 0,
-            # Snapshots are a sampled digest of the same numbers, taken on the write path.
-            # They would add a second file to age and nothing to check.
+            # A sampled digest of the same numbers: another file to age, nothing to check.
             "SNAPSHOT_EVERY": 1 << 30,
         }
         self.saved = {name: getattr(store, name) for name in tuning}
@@ -155,10 +139,9 @@ class StoreLifecycle(RuleBasedStateMachine):
 
     # ------------------------------------------------------------------ the reaper, modelled
     #
-    # Both verdict functions answer "gone", "kept", or None — None meaning an age sits
-    # close enough to a threshold that the model and the reaper's real clock could
-    # disagree, and nothing may be asserted either way. Every caller either acts on a
-    # definite verdict or leaves the state to `_resync` to read back off the disk.
+    # "gone", "kept", or None — None when an age sits close enough to a threshold that the
+    # model and the reaper's real clock could disagree. Callers either act on a definite
+    # verdict or leave the state to `_resync` to read back off the disk.
 
     def _room_verdict(self, room: str) -> str | None:
         on_disk = len(self.said[room])
@@ -187,11 +170,10 @@ class StoreLifecycle(RuleBasedStateMachine):
             return None
         if age < store.IDLE_SECONDS:
             return "kept"
-        # Past its own idle window. A guard note goes only when the room it guards does:
-        # an allow-list that expired first would hand write access back to everyone, and a
-        # replay counter that expired first would let a captured signed URL re-add a key
-        # the owner had revoked. Tied to the room rather than exempt outright, so the state
-        # stays bounded — once the room goes, its guards go with it.
+        # Past its own idle window. A guard note goes only when its room does: an
+        # allow-list that expired first hands write access back to everyone, and a replay
+        # counter that expired first lets a captured URL re-add a revoked key. Tied to the
+        # room rather than exempt outright, so the state stays bounded.
         if ns in store.ROOM_GUARD_NS and name in ROOMS:
             return "gone" if not self.said[name] else self._room_verdict(name)
         return "gone"
@@ -209,11 +191,10 @@ class StoreLifecycle(RuleBasedStateMachine):
                 self.notes.pop(key, None)
 
     def _resync(self) -> None:
-        """Adopt what is actually on disk, having first checked it against the model.
+        """Check the disk against the model, then adopt it.
 
         Anything the model could only guess at — which records compaction kept, whether an
-        age inside the guard band tipped the reaper — is read back here rather than
-        predicted, so the following steps reason about the store as it now is.
+        age inside the guard band tipped the reaper — is read back rather than predicted.
         """
         for room in ROOMS:
             records = _on_disk(self.root, room)
@@ -251,9 +232,8 @@ class StoreLifecycle(RuleBasedStateMachine):
         texts=st.lists(SAFE_TEXT, min_size=1, max_size=4),
     )
     def say(self, room: str, nick: str, texts: list[str]) -> None:
-        """A burst rather than one line, because a step budget spent one message at a time
-        never fills a ring: compaction, and the expiry that rides it, are only reachable
-        from a room with a history."""
+        """A burst rather than one line: a step budget spent one message at a time never
+        fills a ring, and compaction is only reachable from a room with a history."""
         self._reap_model()
         for text in texts:
             record = store.append(self.root, room, nick, text)
@@ -310,10 +290,9 @@ class StoreLifecycle(RuleBasedStateMachine):
 
     @rule(room=st.sampled_from(ROOMS))
     def last_seq_never_goes_backwards(self, room: str) -> None:
-        """The counter is read back off the newest record, so it has to survive everything
-        that rewrites the file. It restarts only when the file itself is gone — expiry
-        hiding every record is not that, which is why `_compact` keeps the newest one even
-        when it is expired."""
+        """The counter is read off the newest record, so it must survive everything that
+        rewrites the file. It restarts only when the file is gone — expiry hiding every
+        record is not that, which is why `_compact` keeps the newest one regardless."""
         assert store.last_seq(self.root, room) == self.seq[room]
 
     @rule(key=st.sampled_from(NOTES), value=SAFE_TEXT)
@@ -326,10 +305,9 @@ class StoreLifecycle(RuleBasedStateMachine):
 
     @rule(key=st.sampled_from(NOTES), value=SAFE_TEXT, use_current=st.booleans())
     def compare_and_set(self, key: tuple[str, str], value: str, use_current: bool) -> None:
-        """CAS is the only ordering primitive a note has, and it is what an accumulator or
-        an acceptance record is built on: it must win exactly when the value it was handed
-        is still there, and lose with the *actual* value attached so the loser can rebase
-        without a second read."""
+        """The only ordering primitive a note has, and what an accumulator is built on: it
+        must win exactly when the value it was handed is still there, and lose with the
+        *actual* value attached so the loser can rebase without a second read."""
         self._reap_model()
         current = self.notes.get(key)
         expect = current if (use_current and current is not None) else f"stale-{value}"
@@ -361,8 +339,8 @@ class StoreLifecycle(RuleBasedStateMachine):
             self.note_age[key] = 0
         self._resync()
 
-    # 61 rather than 60, and so on: an age that lands exactly on a threshold is the one
-    # case the guard band has to throw away, so the steps are chosen not to aim at one.
+    # 61 rather than 60: an age landing exactly on a threshold is what the guard band has
+    # to throw away, so the steps are chosen not to aim at one.
     @rule(
         seconds=st.sampled_from(
             [
@@ -370,9 +348,8 @@ class StoreLifecycle(RuleBasedStateMachine):
                 store.EPHEMERAL_TTL_SECONDS + 61,
                 store.STILLBORN_SECONDS + 61,
                 # Just short of the idle rule, so one step can put a note past its own
-                # window while leaving the room it guards inside its. That gap is the only
-                # state in which the guard-note exemption does anything at all, and
-                # reaching it by summing smaller steps takes more of them than a run has.
+                # window while leaving its room inside its — the only state in which the
+                # guard exemption does anything, and unreachable by summing smaller steps.
                 store.IDLE_SECONDS - 3600,
                 store.IDLE_SECONDS + 61,
             ]
@@ -389,8 +366,8 @@ class StoreLifecycle(RuleBasedStateMachine):
 
     @rule()
     def reap(self) -> None:
-        """The reaper is what makes the caps survivable: without it a hard limit only says
-        who got there first. It has to take what is genuinely idle and nothing else."""
+        """What makes the caps survivable — without it a hard limit only says who got
+        there first. It must take what is genuinely idle and nothing else."""
         expected_rooms = {room for room in ROOMS if self._room_verdict(room) == "gone"}
         survivors = {room for room in ROOMS if self._room_verdict(room) == "kept"}
         expected_notes = {key for key in NOTES if self._note_verdict(key) == "gone"}
@@ -420,15 +397,15 @@ class StoreLifecycle(RuleBasedStateMachine):
 
     @invariant()
     def no_room_exceeds_its_ring(self) -> None:
-        """Compaction has to leave the file *under* the ring, not merely at it — otherwise
-        the next append re-triggers it and every write pays a full rewrite."""
+        """Under the ring, not merely at it: otherwise the next append re-triggers
+        compaction and every write pays a full rewrite."""
         for path in (self.root / "rooms").glob("*.jsonl"):
             assert path.stat().st_size <= store.MAX_ROOM_BYTES, f"{path.name} is over its ring"
 
     @invariant()
     def every_record_on_disk_is_one_record(self) -> None:
-        """One JSON object per line, always: a torn or fused line loses the record after it
-        as well as itself, and the whole read path is built on the line being the frame."""
+        """One JSON object per line: the read path is built on the line being the frame, so
+        a fused line loses the record after it as well as itself."""
         for path in (self.root / "rooms").glob("*.jsonl"):
             for raw in path.read_bytes().splitlines():
                 if raw.strip():
@@ -436,9 +413,9 @@ class StoreLifecycle(RuleBasedStateMachine):
 
     @invariant()
     def lifetime_counters_only_go_up(self) -> None:
-        """Nothing else in the store is monotonic — seq dies with its room, compaction drops
-        lines, the reaper deletes files — so a digest that reports "messages since" has
-        these four and nothing else."""
+        """Nothing else in the store is monotonic — seq dies with its room, compaction
+        drops lines, the reaper deletes files — so a "messages since" digest has only
+        these four."""
         counters = store.counters(self.root)
         previous = getattr(self, "_counters", dict.fromkeys(store.COUNTER_KEYS, 0))
         for name in store.COUNTER_KEYS:
@@ -450,11 +427,10 @@ StoreLifecycle.TestCase.settings = settings(
     max_examples=40,
     stateful_step_count=60,
     deadline=None,
-    # Every rule fsyncs, and `advance` rewrites the whole store. Slow by construction, and
-    # slow is not the same as wrong.
+    # Every rule fsyncs and `advance` rewrites the whole store: slow by construction.
     suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
-    # A suite that finds a different bug on every run cannot be bisected, and CI is where
-    # this runs. `--hypothesis-seed=random` still explores when someone wants it to.
+    # CI cannot bisect a suite that finds a different bug every run.
+    # `--hypothesis-seed=random` still explores when someone wants it to.
     derandomize=True,
 )
 
@@ -462,10 +438,9 @@ TestStoreLifecycle = StoreLifecycle.TestCase
 
 
 def test_the_model_and_the_sweep_agree_on_these_values():
-    """The machine records the value it sent, not the value the store kept, which is only
-    sound while the two are the same string. `clean_text` rewrites anything invisible and
-    trims the ends, so the generator is built to produce neither — and this is what keeps
-    that true if either the alphabet or the sweep changes."""
+    """The machine records the value it sent, not the value the store kept — sound only
+    while the two are the same string. These hold that if either the alphabet or the sweep
+    changes."""
     for sample in ("a", "hello world", "é日🙂", "a-b_c.d,e:f!g?h", "0123456789"):
         assert store.clean_text(sample) == sample
 

--- a/tests/test_store_stateful.py
+++ b/tests/test_store_stateful.py
@@ -1,0 +1,475 @@
+"""Hypothesis state machines over the store's lifecycle.
+
+Run: uv run --group dev python -m pytest tests/test_store_stateful.py
+
+Why a state machine and not more example tests. Every rule in `store.py` is easy to state
+and easy to satisfy on its own; what is hard is satisfying all of them at once, in an order
+nobody wrote a test for. Compaction rewrites a room, expiry hides records the file still
+holds, the reaper deletes the file outright, and a conditional note write has to see the
+value the last write left — so the interesting bugs live in the *sequences*: a seq reused
+after a compaction that kept nothing, a cursor that skips a record because expiry and
+`since` disagree about which end of the file to stop at, a guard note reclaimed while the
+room it guards is still busy. Hypothesis generates those orderings; these machines say what
+must be true after every one of them.
+
+The model deliberately does not predict compaction byte-for-byte. Compaction's contract is
+"keep the newest records that fit, drop the rest, never reorder and never renumber" — so
+the machine reads back what survived and holds *that* to the contract, rather than
+re-implementing `_compact` and testing the copy.
+
+Time is modelled by moving the whole store into the past — every file's mtime *and* every
+record's `ts`. Both, because the two lifetimes read different clocks: the reaper stats the
+file, the `e-` class parses the record. Ageing one without the other produces a store that
+has never existed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from hypothesis.stateful import RuleBasedStateMachine, invariant, rule
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import store  # noqa: E402
+
+# Every threshold is compared against a real clock — `time.time()` at the moment the
+# reaper or the read runs — while the model counts whole seconds of simulated ageing. The
+# two differ by however long the step took, so an age that lands *on* a threshold is
+# genuinely ambiguous. Assertions are one-sided outside this band and skipped inside it:
+# a test that flakes on its own timing teaches nothing about the code.
+GUARD_SECONDS = 5
+
+# Small enough that a handful of appends rotates a room, so compaction is reached inside a
+# default-length run instead of being a case only a 10 MiB test could see. A record is
+# ~90-140 bytes, so a room rotates every three or four messages.
+RING_BYTES = 512
+
+# Three rooms, not one per class. Every extra name divides the same step budget, and a run
+# that touches five rooms twice each never reaches compaction; `store.py` distinguishes
+# exactly two things about a name here — whether it is ephemeral and whether it is the
+# events room — so one of each plus a plain room covers the behaviour and leaves the steps
+# to go deep. Which names are unlisted or mailboxes is app.py's business, not the store's.
+ROOMS = ("lobby", "e-fast", "d-owned")
+NICKS = ("alice", "bob")
+# `room-owners` is a *guard* namespace: its notes are exempt from the idle rule for as long
+# as the room they name is still live, which is a rule with no meaning unless a note and a
+# room of the same name are both in play. Hence the `d-owned` key.
+NOTES = (("plans", "next"), ("topic", "lobby"), ("room-owners", "d-owned"))
+
+# No character here is in INVISIBLE_CATEGORIES, so the value the model records is the value
+# the store stores — `test_the_model_and_the_sweep_agree_on_these_values` holds that line
+# rather than leaving it to a comment. Built to be non-empty and unpadded by construction
+# rather than by `.filter()`: `clean_text` trims the ends and refuses what is left empty,
+# and a filter that rejects most of what it is offered spends the budget on retries.
+_VISIBLE = "abcdefghijklmnopqrstuvwxyz0123456789-_.,:!?éü日🙂"
+SAFE_TEXT = st.builds(
+    lambda first, rest: first + rest,
+    st.sampled_from(_VISIBLE),
+    st.text(alphabet=_VISIBLE + " ", max_size=23).map(str.rstrip),
+)
+
+
+def _shift_records(path: Path, seconds: int) -> None:
+    """Rewrite a room file with every `ts` moved `seconds` into the past."""
+    lines = []
+    for raw in path.read_bytes().splitlines():
+        if not raw.strip():
+            continue
+        rec = json.loads(raw)  # every line here was written by store.append
+        stamped = datetime.strptime(rec["ts"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=UTC)
+        rec["ts"] = (stamped - timedelta(seconds=seconds)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        lines.append(json.dumps(rec, ensure_ascii=False, separators=(",", ":")).encode() + b"\n")
+    path.write_bytes(b"".join(lines))
+
+
+def _age_world(root: Path, seconds: int) -> None:
+    for path in sorted(root.rglob("*")):
+        if path.is_dir():
+            continue
+        # Stat first. Rewriting a room to shift its records also stamps it with the
+        # current mtime, so reading the mtime afterwards would age the file from *now*
+        # instead of from where it already was — and every advance after the first would
+        # silently reset the file's age to one step. The reaper reads mtime, so the whole
+        # idle half of this machine would have been testing nothing.
+        stat = path.stat()
+        if path.suffix == ".jsonl":
+            _shift_records(path, seconds)
+        os.utime(path, (stat.st_atime - seconds, stat.st_mtime - seconds))
+
+
+def _on_disk(root: Path, room: str) -> list[dict]:
+    path = store.room_path(root, room)
+    if not path.exists():
+        return []
+    return [json.loads(raw) for raw in path.read_bytes().splitlines() if raw.strip()]
+
+
+class StoreLifecycle(RuleBasedStateMachine):
+    """append / read / expire / compact / reap / CAS, in whatever order Hypothesis picks."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.root = Path(tempfile.mkdtemp(prefix="chat-stateful-"))
+        tuning = {
+            # A ring a few messages wide, so compaction is part of an ordinary run.
+            "MAX_ROOM_BYTES": RING_BYTES,
+            "COMPACT_KEEP_BYTES": RING_BYTES // 2,
+            # Every write reaps. The production throttle would make "did this step reap?"
+            # a function of wall-clock time, which is the one thing a model must not have
+            # to guess; at zero the answer is always yes and the machine can hold the
+            # reaper to its rule on every step.
+            "REAP_EVERY": 0,
+            # Snapshots are a sampled digest of the same numbers, taken on the write path.
+            # They would add a second file to age and nothing to check.
+            "SNAPSHOT_EVERY": 1 << 30,
+        }
+        self.saved = {name: getattr(store, name) for name in tuning}
+        for name, value in tuning.items():
+            setattr(store, name, value)
+
+        # seq assigned so far, per room: the store's own counter, which must never go
+        # backwards while the room's file survives.
+        self.seq: dict[str, int] = dict.fromkeys(ROOMS, 0)
+        # What each surviving seq should say, so compaction can be checked for having
+        # dropped records rather than rewritten them.
+        self.said: dict[str, dict[int, tuple[str, str]]] = {room: {} for room in ROOMS}
+        # Simulated seconds since each record was written, and since each file last was.
+        self.record_age: dict[str, dict[int, int]] = {room: {} for room in ROOMS}
+        self.room_age: dict[str, int] = dict.fromkeys(ROOMS, 0)
+        self.note_age: dict[tuple[str, str], int] = dict.fromkeys(NOTES, 0)
+        self.notes: dict[tuple[str, str], str] = {}
+
+    def teardown(self) -> None:
+        for name, value in self.saved.items():
+            setattr(store, name, value)
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    # ------------------------------------------------------------------ the reaper, modelled
+    #
+    # Both verdict functions answer "gone", "kept", or None — None meaning an age sits
+    # close enough to a threshold that the model and the reaper's real clock could
+    # disagree, and nothing may be asserted either way. Every caller either acts on a
+    # definite verdict or leaves the state to `_resync` to read back off the disk.
+
+    def _room_verdict(self, room: str) -> str | None:
+        on_disk = len(self.said[room])
+        if not on_disk:
+            return None  # nothing there for the reaper to take or to spare
+        age = self.room_age[room]
+        if abs(age - store.IDLE_SECONDS) <= GUARD_SECONDS:
+            return None
+        if age > store.IDLE_SECONDS:
+            return "gone"
+        # The stillborn rule counts what is *on disk*, so a compacted room can become
+        # stillborn again — one surviving record and nobody has spoken for a day.
+        if on_disk <= store.STILLBORN_MESSAGES:
+            if abs(age - store.STILLBORN_SECONDS) <= GUARD_SECONDS:
+                return None
+            if age > store.STILLBORN_SECONDS:
+                return "gone"
+        return "kept"
+
+    def _note_verdict(self, key: tuple[str, str]) -> str | None:
+        ns, name = key
+        if key not in self.notes:
+            return None
+        age = self.note_age[key]
+        if abs(age - store.IDLE_SECONDS) <= GUARD_SECONDS:
+            return None
+        if age < store.IDLE_SECONDS:
+            return "kept"
+        # Past its own idle window. A guard note goes only when the room it guards does:
+        # an allow-list that expired first would hand write access back to everyone, and a
+        # replay counter that expired first would let a captured signed URL re-add a key
+        # the owner had revoked. Tied to the room rather than exempt outright, so the state
+        # stays bounded — once the room goes, its guards go with it.
+        if ns in store.ROOM_GUARD_NS and name in ROOMS:
+            return "gone" if not self.said[name] else self._room_verdict(name)
+        return "gone"
+
+    def _reap_model(self) -> None:
+        """Apply the reaper's rules to the model, wherever the store would have run a pass
+        — which, with REAP_EVERY at zero, is before every append and every note write."""
+        for room in ROOMS:
+            if self._room_verdict(room) == "gone":
+                self.seq[room] = 0
+                self.said[room].clear()
+                self.record_age[room].clear()
+        for key in NOTES:
+            if self._note_verdict(key) == "gone":
+                self.notes.pop(key, None)
+
+    def _resync(self) -> None:
+        """Adopt what is actually on disk, having first checked it against the model.
+
+        Anything the model could only guess at — which records compaction kept, whether an
+        age inside the guard band tipped the reaper — is read back here rather than
+        predicted, so the following steps reason about the store as it now is.
+        """
+        for room in ROOMS:
+            records = _on_disk(self.root, room)
+            seqs = [rec["seq"] for rec in records]
+            assert seqs == sorted(seqs), f"{room}: records are out of order on disk"
+            assert len(set(seqs)) == len(seqs), f"{room}: a seq appears twice on disk"
+            if seqs:
+                assert seqs == list(range(seqs[0], seqs[-1] + 1)), (
+                    f"{room}: compaction left a hole at {seqs}"
+                )
+                assert seqs[-1] == self.seq[room], (
+                    f"{room}: newest on disk is {seqs[-1]}, {self.seq[room]} was assigned"
+                )
+            for rec in records:
+                if rec["seq"] in self.said[room]:
+                    assert (rec["from"], rec["text"]) == self.said[room][rec["seq"]], (
+                        f"{room}: seq {rec['seq']} was rewritten, not merely retained"
+                    )
+            kept = set(seqs)
+            self.said[room] = {s: v for s, v in self.said[room].items() if s in kept}
+            self.record_age[room] = {s: a for s, a in self.record_age[room].items() if s in kept}
+            if not seqs and not store.room_path(self.root, room).exists():
+                # The file is gone, so the store's counter is gone with it: the next write
+                # starts this room over at 1. Nothing else in the store restarts.
+                self.seq[room] = 0
+        for key in list(self.notes):
+            if store.note_get(self.root, *key) is None:
+                del self.notes[key]
+
+    # ------------------------------------------------------------------ rules
+
+    @rule(
+        room=st.sampled_from(ROOMS),
+        nick=st.sampled_from(NICKS),
+        texts=st.lists(SAFE_TEXT, min_size=1, max_size=4),
+    )
+    def say(self, room: str, nick: str, texts: list[str]) -> None:
+        """A burst rather than one line, because a step budget spent one message at a time
+        never fills a ring: compaction, and the expiry that rides it, are only reachable
+        from a room with a history."""
+        self._reap_model()
+        for text in texts:
+            record = store.append(self.root, room, nick, text)
+            assert record["seq"] == self.seq[room] + 1, (
+                f"{room}: seq jumped from {self.seq[room]} to {record['seq']}"
+            )
+            self.seq[room] = record["seq"]
+            self.said[room][record["seq"]] = (nick, text)
+            self.record_age[room][record["seq"]] = 0
+            self.room_age[room] = 0
+        self._resync()
+
+    @rule(
+        room=st.sampled_from(ROOMS),
+        limit=st.integers(min_value=1, max_value=8),
+        since=st.one_of(st.none(), st.integers(min_value=0, max_value=40)),
+    )
+    def read(self, room: str, limit: int, since: int | None) -> None:
+        view = store.read_messages(self.root, room, limit=limit, since=since)
+
+        assert view["room"] == room
+        assert view["count"] == len(view["messages"]) <= limit
+        seqs = [m["seq"] for m in view["messages"]]
+        assert seqs == sorted(set(seqs)), "a read must be ordered oldest-first, no repeats"
+        if since is not None:
+            assert all(s > since for s in seqs), "`since` returned something already seen"
+        assert view["first_seq"] == (seqs[0] if seqs else None)
+        assert view["last_seq"] == (seqs[-1] if seqs else (since or 0))
+        for message in view["messages"]:
+            assert (message["from"], message["text"]) == self.said[room][message["seq"]]
+
+        expected = self._expected_read(room, limit, since)
+        if expected is not None:
+            assert seqs == expected, f"{room}: read {seqs}, expected {expected}"
+
+    def _expected_read(self, room: str, limit: int, since: int | None) -> list[int] | None:
+        """What the read must return, or None when an age sits on the expiry boundary."""
+        ttl = store.EPHEMERAL_TTL_SECONDS if store.is_ephemeral(room) else None
+        out: list[int] = []
+        for seq in sorted(self.said[room], reverse=True):
+            if since is not None and seq <= since:
+                break
+            if ttl is not None:
+                age = self.record_age[room][seq]
+                if abs(age - ttl) <= GUARD_SECONDS:
+                    return None  # too close to call against a real clock
+                if age > ttl:
+                    break
+            out.append(seq)
+            if len(out) >= limit:
+                break
+        out.reverse()
+        return out
+
+    @rule(room=st.sampled_from(ROOMS))
+    def last_seq_never_goes_backwards(self, room: str) -> None:
+        """The counter is read back off the newest record, so it has to survive everything
+        that rewrites the file. It restarts only when the file itself is gone — expiry
+        hiding every record is not that, which is why `_compact` keeps the newest one even
+        when it is expired."""
+        assert store.last_seq(self.root, room) == self.seq[room]
+
+    @rule(key=st.sampled_from(NOTES), value=SAFE_TEXT)
+    def write_note(self, key: tuple[str, str], value: str) -> None:
+        self._reap_model()
+        store.note_set(self.root, *key, value)
+        self.notes[key] = value
+        self.note_age[key] = 0
+        self._resync()
+
+    @rule(key=st.sampled_from(NOTES), value=SAFE_TEXT, use_current=st.booleans())
+    def compare_and_set(self, key: tuple[str, str], value: str, use_current: bool) -> None:
+        """CAS is the only ordering primitive a note has, and it is what an accumulator or
+        an acceptance record is built on: it must win exactly when the value it was handed
+        is still there, and lose with the *actual* value attached so the loser can rebase
+        without a second read."""
+        self._reap_model()
+        current = self.notes.get(key)
+        expect = current if (use_current and current is not None) else f"stale-{value}"
+        try:
+            store.note_set(self.root, *key, value, expect=expect)
+        except store.StoreConflictError as lost:
+            assert expect != current, f"CAS lost against the value it was given: {expect!r}"
+            assert lost.current == current, (
+                f"409 carried {lost.current!r}, the note holds {current!r}"
+            )
+        else:
+            assert expect == current, f"CAS won against {current!r} while expecting {expect!r}"
+            self.notes[key] = value
+            self.note_age[key] = 0
+        self._resync()
+
+    @rule(key=st.sampled_from(NOTES), value=SAFE_TEXT)
+    def create_if_absent(self, key: tuple[str, str], value: str) -> None:
+        self._reap_model()
+        existed = self.notes.get(key)
+        try:
+            store.note_set(self.root, *key, value, expect_absent=True)
+        except store.StoreConflictError as lost:
+            assert existed is not None, "create-if-absent lost against a note that is not there"
+            assert lost.current == existed
+        else:
+            assert existed is None, f"create-if-absent won against an existing {existed!r}"
+            self.notes[key] = value
+            self.note_age[key] = 0
+        self._resync()
+
+    # 61 rather than 60, and so on: an age that lands exactly on a threshold is the one
+    # case the guard band has to throw away, so the steps are chosen not to aim at one.
+    @rule(
+        seconds=st.sampled_from(
+            [
+                61,
+                store.EPHEMERAL_TTL_SECONDS + 61,
+                store.STILLBORN_SECONDS + 61,
+                # Just short of the idle rule, so one step can put a note past its own
+                # window while leaving the room it guards inside its. That gap is the only
+                # state in which the guard-note exemption does anything at all, and
+                # reaching it by summing smaller steps takes more of them than a run has.
+                store.IDLE_SECONDS - 3600,
+                store.IDLE_SECONDS + 61,
+            ]
+        )
+    )
+    def advance(self, seconds: int) -> None:
+        _age_world(self.root, seconds)
+        for room in ROOMS:
+            self.room_age[room] += seconds
+            for seq in self.record_age[room]:
+                self.record_age[room][seq] += seconds
+        for key in NOTES:
+            self.note_age[key] += seconds
+
+    @rule()
+    def reap(self) -> None:
+        """The reaper is what makes the caps survivable: without it a hard limit only says
+        who got there first. It has to take what is genuinely idle and nothing else."""
+        expected_rooms = {room for room in ROOMS if self._room_verdict(room) == "gone"}
+        survivors = {room for room in ROOMS if self._room_verdict(room) == "kept"}
+        expected_notes = {key for key in NOTES if self._note_verdict(key) == "gone"}
+        kept_notes = {key for key in self.notes if self._note_verdict(key) == "kept"}
+
+        (self.root / ".reaped").unlink(missing_ok=True)
+        store._reap(self.root)
+
+        for room in expected_rooms:
+            assert not store.room_path(self.root, room).exists(), f"{room} outlived its idle rule"
+        for room in survivors:
+            assert store.room_path(self.root, room).exists(), f"{room} was reaped while live"
+        for key in expected_notes:
+            assert store.note_get(self.root, *key) is None, f"note {key} outlived its idle rule"
+        for key in kept_notes:
+            assert store.note_get(self.root, *key) == self.notes[key], f"note {key} was reaped"
+
+        self._reap_model()
+        self._resync()
+
+    # ------------------------------------------------------------------ invariants
+
+    @invariant()
+    def notes_hold_what_was_written(self) -> None:
+        for key, value in self.notes.items():
+            assert store.note_get(self.root, *key) == value, f"note {key} does not hold {value!r}"
+
+    @invariant()
+    def no_room_exceeds_its_ring(self) -> None:
+        """Compaction has to leave the file *under* the ring, not merely at it — otherwise
+        the next append re-triggers it and every write pays a full rewrite."""
+        for path in (self.root / "rooms").glob("*.jsonl"):
+            assert path.stat().st_size <= store.MAX_ROOM_BYTES, f"{path.name} is over its ring"
+
+    @invariant()
+    def every_record_on_disk_is_one_record(self) -> None:
+        """One JSON object per line, always: a torn or fused line loses the record after it
+        as well as itself, and the whole read path is built on the line being the frame."""
+        for path in (self.root / "rooms").glob("*.jsonl"):
+            for raw in path.read_bytes().splitlines():
+                if raw.strip():
+                    assert store._parse(raw) is not None, f"{path.name}: unparseable {raw[:60]!r}"
+
+    @invariant()
+    def lifetime_counters_only_go_up(self) -> None:
+        """Nothing else in the store is monotonic — seq dies with its room, compaction drops
+        lines, the reaper deletes files — so a digest that reports "messages since" has
+        these four and nothing else."""
+        counters = store.counters(self.root)
+        previous = getattr(self, "_counters", dict.fromkeys(store.COUNTER_KEYS, 0))
+        for name in store.COUNTER_KEYS:
+            assert counters[name] >= previous[name], f"{name} went backwards"
+        self._counters = counters
+
+
+StoreLifecycle.TestCase.settings = settings(
+    max_examples=40,
+    stateful_step_count=60,
+    deadline=None,
+    # Every rule fsyncs, and `advance` rewrites the whole store. Slow by construction, and
+    # slow is not the same as wrong.
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+    # A suite that finds a different bug on every run cannot be bisected, and CI is where
+    # this runs. `--hypothesis-seed=random` still explores when someone wants it to.
+    derandomize=True,
+)
+
+TestStoreLifecycle = StoreLifecycle.TestCase
+
+
+def test_the_model_and_the_sweep_agree_on_these_values():
+    """The machine records the value it sent, not the value the store kept, which is only
+    sound while the two are the same string. `clean_text` rewrites anything invisible and
+    trims the ends, so the generator is built to produce neither — and this is what keeps
+    that true if either the alphabet or the sweep changes."""
+    for sample in ("a", "hello world", "é日🙂", "a-b_c.d,e:f!g?h", "0123456789"):
+        assert store.clean_text(sample) == sample
+
+
+@given(SAFE_TEXT)
+def test_the_generator_only_produces_text_the_sweep_leaves_alone(sample):
+    assert store.clean_text(sample) == sample

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "anyio"
@@ -13,6 +18,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -101,6 +115,137 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/27/78873dc8b6a56357517b74b6bb9568b80450e7bb4f6ef7e3fa9d22aa0bd7/charset_normalizer-3.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b6d1386bf0096d26d3a863dc0a487a5b4eb9aa93cf5ba69683d29dde6b9d60f", size = 344456, upload-time = "2026-08-15T08:17:10.072Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4c/be49ada26b1f0232d57aa89bbebf997a5cc2332a5616b6eca26ff680044d/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4582c27e8c889d64811987b5967fbd3ae0c823fe1fd933b543d55ac20bb475fa", size = 238530, upload-time = "2026-08-15T08:17:11.563Z" },
+    { url = "https://files.pythonhosted.org/packages/76/84/6f1290fa07ae6978d3960caa3eb1b8019bf9284ab7c2297b00c099ef4250/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1d1c7a53a6c2103925cdd6d7229f8c567379f211c869793df679f2e9f738c369", size = 230200, upload-time = "2026-08-15T08:17:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a0/47b18adeed31c8f16ba9700f32c1b18594cfa09f47eb672a488c273c22bf/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e6621fb2a4988d6e53eedc455e5903e2679f3967b8acb3d639f1b63c14a2e893", size = 262222, upload-time = "2026-08-15T08:17:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fe/341861ac118dae06f3ec0eb487488af52128f2ef2faf0b11003944d22259/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c0c10730342b0c9b35dd1d619beb8214e520bd96a1f870f452680b238aab3e0", size = 258951, upload-time = "2026-08-15T08:17:16.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08", size = 248801, upload-time = "2026-08-15T08:17:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ba/ef83ae3aca816393decfa3530976f38a79812d707b80b580ac33b83f9877/charset_normalizer-3.5.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9f8405c2c758532c74fed975dbee57be1f31a6e865c031870c79a6ed3212ada", size = 244070, upload-time = "2026-08-15T08:17:19.191Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0b/c5292a2462d69b7378ea89793bbb5b2b6fcf6f7dd6d1667f9619094ad553/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:96fef3e886d6a9874b14f27fc193fbdc69d5d8035783d86aa4e1cea594e695f9", size = 240110, upload-time = "2026-08-15T08:17:20.547Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/111e5be3b740d5c2a5bfcedb3d237b6591e5c2e82ae9d6ffcb121fe0909c/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5d8531a6569d025f68e2321e7638fb7978f23db58e5f69f56913837aae03816e", size = 232836, upload-time = "2026-08-15T08:17:21.895Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d2/d2aad6fe0dbb44b194bf3becb60f5a0ac48446ade999a47fe7bb41eb09a7/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:aae2ee51122d3ae968a3837d97dc24a0aeebb0dea23694422cd172bd30017cd6", size = 262712, upload-time = "2026-08-15T08:17:23.727Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5a/337e4663a5eae6de99db940ee8066d4145caafb61327db62deda15313cce/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7235dc28fc6dd9d832ac7c7bce95367dedb85929f17368a0c2bee1e080b9acbf", size = 242977, upload-time = "2026-08-15T08:17:25.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/85/f82f8a92e31c7519410e2e1afdc630f28ec47490ce2c09a11c1a43cbb459/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4abdc5f9ad448c1ecbfae2974b820535d6bc6e7eef63babbab3d81cf46968c71", size = 260207, upload-time = "2026-08-15T08:17:26.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/52/643d11ffd60e9ac2fd1fb87e167a19285b9eefeff4a40e63c87cbfbeab36/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba501e667c17d8411f98e67a022d9604ef179aff0e459b7e292c796837c13573", size = 250562, upload-time = "2026-08-15T08:17:27.971Z" },
+    { url = "https://files.pythonhosted.org/packages/62/16/46556278c2168d12df9da7fede5dc6fc70e60301b26a82bbeec238c9cfe3/charset_normalizer-3.5.1-cp312-cp312-win32.whl", hash = "sha256:cfa1c0cc3a8f9f53f1243a5a99ac36fd003880199383b37672e86ddda9cb07e2", size = 178507, upload-time = "2026-08-15T08:17:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/4c6c298171e6b3e745633180ff59350fc0ca0db1ffd28df1e369e0579f71/charset_normalizer-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3617ac3cfd8b9888f145ad89dd6e692285834b0201c6074a5eeaad3fd4d668c2", size = 200551, upload-time = "2026-08-15T08:17:30.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d7/eb95a042f0dd22e304b0b6472b154f3546a1a039a9ee89ccb2a7f61591fc/charset_normalizer-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:88e85ab89cb822c1e635f51d6d32e488f94e002e70e2f492bdb8b945543f345a", size = 180700, upload-time = "2026-08-15T08:17:32.028Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/61/2cb6ad133dbbb449fa2d37ccae973232f4827e799af258d15e589a3d1e9e/charset_normalizer-3.5.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:4f298bdadb8f0b9e5672877f647d1be9373ef5320c9e2f049795e26cad28b6a9", size = 211584, upload-time = "2026-08-15T08:17:33.597Z" },
+    { url = "https://files.pythonhosted.org/packages/18/57/a305c968be1ca13f3dd1b32f445877e97addf55d80b65c7cb35fac82b777/charset_normalizer-3.5.1-cp313-cp313-android_24_x86_64.whl", hash = "sha256:88ca277405c2d3b71c4e1c2ee0e7966e807bcba86a69d11e19ba199d18ae4491", size = 223359, upload-time = "2026-08-15T08:17:35.022Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/d3646670292ce8d8f8cc11ac067d44885e697a5591f57a9221128da5e7b3/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9362dd90aa7dab48c0054a21187791ccf05473f7dba5d92b8033ae62164675e7", size = 194464, upload-time = "2026-08-15T08:17:36.452Z" },
+    { url = "https://files.pythonhosted.org/packages/de/93/d51ec556e01042fed6f993ea859311bc7917b466684182fbbceb6ca24762/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:977cdbd483a9cff38179bea4fd754289a6f2195c7abd414aba85410b3e66cc5e", size = 197676, upload-time = "2026-08-15T08:17:37.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a0/562247944386f7d4ef94467e84876600cc1e0f1b93239aaa9213d2bc3cbd/charset_normalizer-3.5.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e90251c0c7bdd54a100a0dce3c07b7e637278c93af29dbf78ebb89a58c4bac7d", size = 340473, upload-time = "2026-08-15T08:17:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e7/1d994be1b93d41e9502b8b0460eaa88a1dd8df335df415db87d6c3e91ab2/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94d78ecec2605a8d0398b0f365d5f12a63248438516f5dac536a5eff7337df4a", size = 240156, upload-time = "2026-08-15T08:17:40.66Z" },
+    { url = "https://files.pythonhosted.org/packages/09/53/27923ce5cc6cbccb832037b27dca98882d9c53e9b69e866bbbef4aae7fc8/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d59b75732e9b6f27388e10c14b0259cc5f2e48c78627d185e6a177b58ad3cffe", size = 228246, upload-time = "2026-08-15T08:17:42.003Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5a97e84d63af1d55c07439cb80e56d99a8efb4295700eb4e18c0d1615d2c/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0d929fc574b4d6fd9e7c0f5c2ede8716a41911923aa7fa5fce38e0818aa4a1ac", size = 263660, upload-time = "2026-08-15T08:17:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/071575791dcc88316c0a9a65ce38897a82e4cfe4a325f0f7fe1b1ac47bcf/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:394fea06235c8543390050ed5f529187074b029fb027213f6c46ac11ab5d950e", size = 260354, upload-time = "2026-08-15T08:17:45.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3", size = 250638, upload-time = "2026-08-15T08:17:46.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/66/70dfad64f15be09c15ccfee81330a7e515895dbe296dd23114e9a231268a/charset_normalizer-3.5.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa48b1b63d639f9483e0633e092f5851e2348c352f1f9bb6c8182f87884ef876", size = 244583, upload-time = "2026-08-15T08:17:47.963Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/24/ef36367d38b9ddd4bccbf72888c342e8de1f5ae506fa0b2dcf970e2732a1/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c71fb0d56c920c269cd3e2e3fe7c610e3f1fdb21a6ce60efa6430ff63676cea6", size = 242038, upload-time = "2026-08-15T08:17:49.481Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ab/55e683ba0fff2e43adafc10daa3001eac90fdaa419a97227d5a7067eedde/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:485a0d363cafefcd2538a73c7c838daa2035f09b2c9f9b5e3133f80c6aeb84c2", size = 233677, upload-time = "2026-08-15T08:17:50.845Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/67/0f40eaf8d1b6e7cf15e82382a2965efaca787fc1c2794b7021d37aaf5036/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0ea61a470e070686aa30892fed79e297d2c8d0ab46b8bcdf027d38c51da591", size = 264491, upload-time = "2026-08-15T08:17:52.61Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/64/12b4c2a11ee8df4fcc518c78b0d93e3a92bd3d5253d1617ce74ff0e8c7ef/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90b7481fb62fbe172c558bc6fd1c4c98d82004a54a7551f20e11ac9bf0b8708c", size = 245196, upload-time = "2026-08-15T08:17:54.023Z" },
+    { url = "https://files.pythonhosted.org/packages/37/2e/651d910af6d0fba325eee1cda37ec5443462ed25360e666c144166eb6091/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:35fe081843b35aad20ffeccec3eeffbe637b15d14f3fb22cc1b59cd8ec17e93c", size = 261660, upload-time = "2026-08-15T08:17:55.491Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c6/b09e05e6db7f64338e0dc067c79577b1138da86c1e38369096851d96be88/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd0350afdc3aabd5576f60ea109228bd5538139713c7b094c5cd27c73a98bc6f", size = 252618, upload-time = "2026-08-15T08:17:57.025Z" },
+    { url = "https://files.pythonhosted.org/packages/76/4e/362d4f9fdcdf5556fb2aa3ce7d4a58ebce03ed1ff03aa1d9aca8d02f13f3/charset_normalizer-3.5.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:9d9a0dc7cbe9bec24c3f767c9122c41fe5a1bc43f47cd099d00d393e09769de4", size = 140362, upload-time = "2026-08-15T08:17:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d4/703be739b26acce318bd29eb3b25b7209e1b1f527f9eae3d1f1f01fdde2b/charset_normalizer-3.5.1-cp313-cp313-win32.whl", hash = "sha256:d63600d620ad0064c3a748b950ac5ea38a80190e5498532efefa4b7b3f1da1f3", size = 177755, upload-time = "2026-08-15T08:18:00.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/56d97ade41c8db611e727168c52ae46c9224c362ec28d4b65d7e9869e8da/charset_normalizer-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:aea996a6aba25260827c9ea511d1addfde2da9eb686ac961838509086188b7e6", size = 199295, upload-time = "2026-08-15T08:18:01.506Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/75/5b20dd1e6573a01a08158fe104104fa2c8abf941745596954185726cd46c/charset_normalizer-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:fd0a274c0e5f9a21565cd9d3dd749b61f96b7aa1e20a93aa1ba4029518f2e5c0", size = 179856, upload-time = "2026-08-15T08:18:02.929Z" },
+    { url = "https://files.pythonhosted.org/packages/29/cd/2b812ce5e888f1ce69a5350281e58aab07ae64a958ecae8912f30865718e/charset_normalizer-3.5.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:774d157f112367ff4abd29019f38f023c24e00e56edc7829c20e358a5a913ad8", size = 212318, upload-time = "2026-08-15T08:18:04.403Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/a6ee107430768a5334e6d63f31f148a04a1a491ef161a1ac9415a73f2fa8/charset_normalizer-3.5.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:26422d45fd13551cf564c58932f7d72b4f58b93b0fcf18c35ba6be12b46bb102", size = 224897, upload-time = "2026-08-15T08:18:05.997Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/35ae3f64f29d0179c35c3baefe575904df2913dde519129c7f75995a2b1d/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:09a7bba9f739468c8e78c36a75c33768e53cb1959fc638f510454c14683f00d5", size = 194848, upload-time = "2026-08-15T08:18:07.397Z" },
+    { url = "https://files.pythonhosted.org/packages/74/76/f2fc7380f056cc273a53af37f50d08ad54b2c59f61078f31432edcf1c2bd/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4c9548dc78002099910abaebc0a72ac58b7d30931869e0351c09b507dff4ece3", size = 198163, upload-time = "2026-08-15T08:18:08.989Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/40/095ce62fa078483cccc1fa2b36e6bc9580b85422a20ee9f925341c50e44f/charset_normalizer-3.5.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c428c6c31eb5f4277d7f8eccaf767fbd548ddd5ce3c8b4f4cbbfab3d96b5904c", size = 341823, upload-time = "2026-08-15T08:18:10.458Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/5a/0e58b1c04a1596e0256f407274a92d5fb2ee21324409d1fab1da48a65b5b/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f06b7eae9dbe77fe1d644ca244dad508de8d302870a43f3c559b521270938a0", size = 242458, upload-time = "2026-08-15T08:18:11.989Z" },
+    { url = "https://files.pythonhosted.org/packages/22/95/b4618ce912e6db0b1aae89ba788e38e8a7eba0f3025cc66e8c0699f977b2/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b7430cf5728e68f6c462254009a6ef4086e1bea43cf2f57aa9c55fb4f50ff96", size = 226717, upload-time = "2026-08-15T08:18:13.401Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/76/c681192bbda3d55356db5dadd64381d5202b37c6b598fcda5282e88b5d3d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab743e9bc90c1f73552ec33e10e3331315acd2c397b36065b591b0181de533cc", size = 266111, upload-time = "2026-08-15T08:18:14.961Z" },
+    { url = "https://files.pythonhosted.org/packages/88/be/55127bfca72c0cff6c022488d140d7c5b04c771e3b72e9bdb4836d54979d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6f7deae3feb4edfa2efaf7c574fe88cbf055038a6abdb40188e4fff66d5699f", size = 263128, upload-time = "2026-08-15T08:18:16.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/91/39c3af510b0aa32bbda03374259200f28430febfd1bf5e511fe765282ce5/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15f024313246a4ed976c60f440bb8d257815513a681d212ff74fd46f7d715a90", size = 251240, upload-time = "2026-08-15T08:18:18.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a5/cbe418bbc6ecdfc3e05a0116002897c4b403a5e838d697e64c78e9f0190d/charset_normalizer-3.5.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:823f82903d189af463d7df250ef1f7f696f3cee08cc8d91deb565e8d425f6506", size = 245282, upload-time = "2026-08-15T08:18:19.625Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a4/689bb42e8e7cd492f3cb64907c6bc00ad247ec9a3628cd3f8eed126e8ae1/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:01e93745f7f219b703b60ba7afead36cfc4242782be5af484673fc500df12da5", size = 244597, upload-time = "2026-08-15T08:18:21.121Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ce/9962938e179cf9f699d3f1e7b3114b5d7642dee6a893745229f9dd04f274/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329fc3ccb63ad22d867d84c2adea759a64079a37ba4a343433b02c7a2816871e", size = 231376, upload-time = "2026-08-15T08:18:22.57Z" },
+    { url = "https://files.pythonhosted.org/packages/85/54/46000450ada53bd9eac5429a2c8c54cd2d9b39c0c255f229aea9af0948a5/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:bb57753e36e4855b8ca375069482250a6246372331a3e4f3407eaebb007443f5", size = 266715, upload-time = "2026-08-15T08:18:24.235Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/bb/618749d70f792b44252a777bf89bfb86823b9bbc1ea13fe8ce759b07f38a/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fce8cbd4997efeb450bd298b54f755dcdff18d496f7a5ddbb4867c6d7c88fdc3", size = 245848, upload-time = "2026-08-15T08:18:25.726Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3f/ffb64458527c7668031d5eb095d978de561958dc9f5b53f8e488a533e603/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6c9cdde8becb25a7fde49924511aa2644d6f8081cc8df8e9452724303348d8e3", size = 264521, upload-time = "2026-08-15T08:18:27.193Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ab/74a55fd803916a35ac461daf002708191aac19b546b80dc8cabfedc63d98/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9ac4444d8d4fd4c4bd08bf451ed3167aa9e7ec6cdb41b648794f1d1103652e36", size = 253054, upload-time = "2026-08-15T08:18:28.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2a/6a9034b7d3c60b17499afb482df5878bf9fa20b50cc3887d5ef017a833db/charset_normalizer-3.5.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:f03ac127268b43ef4fe9e6ab6794a6794b49485a0cc0c1db79876d2f33f75bc7", size = 140580, upload-time = "2026-08-15T08:18:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/46/1d362e1a00d035d66b9869e1281eee115907f7e390a16a07824ab5737360/charset_normalizer-3.5.1-cp314-cp314-win32.whl", hash = "sha256:1f5883d77fd409a261abb5dc8ccbe335720d798b1de4abb3b1d47ccbbc76b53b", size = 180325, upload-time = "2026-08-15T08:18:31.877Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/7c/4938c329b6a9d446f6a59aa2092ff7118f274209b5ed0e26893d1d30a63c/charset_normalizer-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:c658c50ac0c98cd755a2dd50b7977d3bca7df401dcc47fbdfa87db53ef7d4e8b", size = 204175, upload-time = "2026-08-15T08:18:33.466Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/33/eeb384dbd8dec570661354592f4f2e1b2fcc92585624d146a000caf53841/charset_normalizer-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:4bea7f8ebe90bbd7f0e4a2de42ca6924ba23e3e76418c408ff82f1d46fabd687", size = 184123, upload-time = "2026-08-15T08:18:34.913Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/6c/c73fa9d5a85f6ab05395de61c5f6984e0a9ff40bb5ff888d46dff02526c6/charset_normalizer-3.5.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:fbc597639158fd7c14d55e808718848319540f51b0e6746e3eefa59723a4a348", size = 381682, upload-time = "2026-08-15T08:18:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c7/63565f860921457feba93bae6c86fb7746deb4cffeed2f375cb845318146/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e71c909f353863b2b89c83de2ebed71ea6d0df8a6ef65a128193c5e650766bef", size = 240826, upload-time = "2026-08-15T08:18:37.887Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ae/7ae8807410dfa33f8e6f1715740adeaafa8a816cc4cb33508f54b1f7c896/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7ac76cf9afd34929d76eb7fcb63be476a4853d8a96f0dcf2d0db68a0cbdf9885", size = 227861, upload-time = "2026-08-15T08:18:39.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a3/887c1642f0da26000b0e0652d91071113c0e72cea33952e225cf589f49a9/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a3a370082ce34d0612f421e15fe011c53bb1feff21a26d06ad4fb244dab5a375", size = 260758, upload-time = "2026-08-15T08:18:40.88Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/11/e6f5b9a3d0e55b0ef7505cd3765cdd48f22db89994c947b316f52f801fd8/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:256dd4d85d9e4dc595e2bc983c980e73f62ddeb3165c58b4c3dfe78c5c8548c1", size = 259950, upload-time = "2026-08-15T08:18:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ee/e4e10a94d51cd1ee638aa7e00b65399e6b2a4e8376ab6d2eac9f95586671/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58d4aa13a59c969dbfdf9e6a9560e242cbfd9e8a8f50c2747714df1a423adf65", size = 249329, upload-time = "2026-08-15T08:18:43.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/25/d5f4198819e6059735a84e8d0bfb72dc33976da67b97adcd3fb5a5e07ec6/charset_normalizer-3.5.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0c6dfb5ca6723eeed15aa8e564a014d69fcb8812f94eef11fe3631e0508199f5", size = 243137, upload-time = "2026-08-15T08:18:45.368Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e925ca7569cf9fb9701fd82503fee73eea5268fdb856bdd64947092d3daa/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c010f5581d9c612804cc59fcf7b524b707fbcb72828551237ab545bb5c7034af", size = 242820, upload-time = "2026-08-15T08:18:46.842Z" },
+    { url = "https://files.pythonhosted.org/packages/34/17/672c251a888ed2aebcdd2fe830ad0104e25ff83c43f5c4f9c15e9fc6853c/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:52ec005752a56ae79547a05c0139ca2501a0c866390b6115008456b9f0e7cde1", size = 230504, upload-time = "2026-08-15T08:18:48.353Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/fc/f6a85abebd42ce4da2f1db0aa56cc6a0df1995e318b3875d14401b8381d1/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2bced4061f000f7187254a02ad3433ae17eaf991747ceea2f478422590a5bba9", size = 263087, upload-time = "2026-08-15T08:18:49.859Z" },
+    { url = "https://files.pythonhosted.org/packages/98/66/7c42677e739ba66746b297e2046918d793078094dc239e1e72768cffccc6/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9eea3ab2597a5e65fe65296e2d6a84570845a6b55532d90333d740d48bbc850a", size = 243269, upload-time = "2026-08-15T08:18:51.601Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d8/a50b79237f417af10f8c2a501ce8d1ca87829a22e69117891ca4ba20a69e/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:496846868fea80e479324862fa877f02411f2fd0f83b79ccee2607aa68b2a032", size = 258766, upload-time = "2026-08-15T08:18:53.23Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1d/0fc91aeaeb3c83b748f532399ce67cf84604b48297405d740000f7a9e786/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:85d5855daafc240cc045c026d7a15fd198a09b0fc8ff6f5ecbb5297b509cb11e", size = 250814, upload-time = "2026-08-15T08:18:54.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/10/3d8c777cf9024615295aa1b808324ad5b4a77855869c00824bad74ffaf8a/charset_normalizer-3.5.1-cp314-cp314t-win32.whl", hash = "sha256:58d3e12c88e0950bca850ae1f7c256055c097639c2edb9eb123af9807d8b15e4", size = 191074, upload-time = "2026-08-15T08:18:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/81/ae557d3c44d1a1d688696d60563413a0866a91b7ebc50f20df838be3d8c8/charset_normalizer-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:acaf604462bf330b0d07e7a07c1d6e4adac79e5fb13e9c5140590542cafacc00", size = 216476, upload-time = "2026-08-15T08:18:57.889Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e9/61c01fb8b804692569c036b3fc50495814502dcf13a60649c6055390b02c/charset_normalizer-3.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:fdb8a068947befafba9952162645dc2fecaeb400e64584829ed5e9b2fbe21a7f", size = 194115, upload-time = "2026-08-15T08:18:59.418Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4e/8544831ef59d8f27ce92c80871380fdacc8076a8a56ed62f82e54f991333/charset_normalizer-3.5.1-cp315-cp315-macosx_10_15_universal2.whl", hash = "sha256:9085f87b0e38a2b92b8923059b4e8789fe40d9279712d15dcc670048d77079af", size = 342048, upload-time = "2026-08-15T08:19:01.054Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a6/e3b46852424246065355644f4fb6dbccc0239a42a2eee27ecfc8957f0bcd/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2679de311c7946dde5d3b6f44941844133ff5c7cb86099c0061ab1e8901c20a8", size = 242997, upload-time = "2026-08-15T08:19:02.492Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3b/0cc9a26777334ab2f2e3089b948bbf4e4fe72ea70b897715ef6415043ec8/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:baf3775a2635e5a11fbd5e4e64ee69c7e86875d224a5c72aca4c141064589a90", size = 237014, upload-time = "2026-08-15T08:19:03.943Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c2/027335f0aa337a2a2e121bac1ad88c4f02ba6053ea0926802784f3db11af/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ac8c94b6539074e0f40899301273ac8402b9b3e01c7b7ba269ff30340aaaf20", size = 266174, upload-time = "2026-08-15T08:19:05.598Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d3/e367787febe4e74769dec0f406f2c3c8d1b955fce5aee1fd0f94e8367a45/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8fe532b3c966d1fb794e0698e4589d0444017ae77fc0b31edea13c0e35bcc449", size = 263361, upload-time = "2026-08-15T08:19:07.251Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3d/391b193eb9f3e84b02f9314088c386debdc0debee843535aaea2e2c6715d/charset_normalizer-3.5.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c84bec0ab5ae0c64bfe73a7d2adcb5ce73b467523fc27fd6a28ab2aa6cbe35a", size = 252143, upload-time = "2026-08-15T08:19:08.816Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/57/de221f1745a90d418199761967e2776bfe2c275a1194220985e8c1d37833/charset_normalizer-3.5.1-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:854066be00447fa8de2ccbbe893e2ffc4b123ef16d897af794c1e18bd4a714b0", size = 252086, upload-time = "2026-08-15T08:19:10.255Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/d119f86a01f9331e8186175f24873b1d74a7ee9e2e4b4d68f9947dae5afd/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:21b82d8082f6f5e7f456ef0bd16323d08de1266efbfeb476e64b2a91d1471a4e", size = 245231, upload-time = "2026-08-15T08:19:11.807Z" },
+    { url = "https://files.pythonhosted.org/packages/26/de/d8e48c135ae480879539cdb179c8d3b50c7879497d75dd899b5763b69cee/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:838648accb3a7fd9803fd45c87bce8509648eb0c11bc34e216141300977244f2", size = 241546, upload-time = "2026-08-15T08:19:13.416Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c4/217755fd1abc50d326c252922cd642002758095a81ff45010337b8b3ef65/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:195ce897c6153c0700078142cf8efe3e6454ca4cf4357499e4078dfd83396626", size = 267033, upload-time = "2026-08-15T08:19:14.981Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/34d8e404e358d2adcc5a228c2134643af00104c8fb0bf525f3688d756f05/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:978eab16f55b4ab2c2a745be9a0a840bf8f09a7f227d9c76eb30214d078865a5", size = 252045, upload-time = "2026-08-15T08:19:16.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/fa/40414471acf0aa0692ca77305aa00e434fcd8288f0941c93c30e9a5f8f2f/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_s390x.whl", hash = "sha256:cc0329df4caaceb950d2f580b5ac716a377f7059624a0bafaeaf8a218c6ed774", size = 264866, upload-time = "2026-08-15T08:19:18.101Z" },
+    { url = "https://files.pythonhosted.org/packages/32/90/fcc850bae791abd2e0c041847f13e270aa08692a79f3e00de6d2dce1cb50/charset_normalizer-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:687c9ca3035544b113bea2055e180af96fb63c0c476e22a9180f51925186e7b7", size = 253932, upload-time = "2026-08-15T08:19:19.734Z" },
+    { url = "https://files.pythonhosted.org/packages/af/af/53afe99068b3c10b4cbae592a52ef72a7c92c0188440e83ee3a078fd8f75/charset_normalizer-3.5.1-cp315-cp315-win32.whl", hash = "sha256:706bfd38730a5ac7a365793269a00f4e988178cec121391f4248d84ad8c972e9", size = 180320, upload-time = "2026-08-15T08:19:21.37Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/bc/f46a132041b29e4a8779ed712d3df1bf112e94ca8de58b66d7ec2c0cf8b9/charset_normalizer-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:92caef967d287a407085d61176fce4012b1dd62daed4eb6d5ceb26d3d2538712", size = 204174, upload-time = "2026-08-15T08:19:23.088Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5d/9ed554480eda8e447b673648628fdc29574d23dbad01fe11837adedd1cae/charset_normalizer-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:5fc45d653ea8c9a20479167e11d4a0f8cb2fa3470737ab6f9c827532313187b7", size = 184126, upload-time = "2026-08-15T08:19:24.471Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/32/9b8929bf384061ee1fe5d9c27c6f9776d3d824039ad4e14c88ec00c7808e/charset_normalizer-3.5.1-cp315-cp315t-macosx_10_15_universal2.whl", hash = "sha256:59171c6e45bf07d0d5cab3b0bf81d945035530f6873398b3b531c31184d46663", size = 381441, upload-time = "2026-08-15T08:19:26.038Z" },
+    { url = "https://files.pythonhosted.org/packages/96/10/e9aa7923d3ddac652c99a1c5f7be494e737e151566a44abe018daf757f2c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9dbdd9205662134957cf0c324f639bdc5031c0ca056e2369e238db75187c0f11", size = 241742, upload-time = "2026-08-15T08:19:27.532Z" },
+    { url = "https://files.pythonhosted.org/packages/28/53/a2d249ebddf47b889a100c0bdcb61a2f9dbb8bc24ef325cc062e4f476877/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e4b018dc5a0eee4676e38fe84a47a427816c590b93b55d9025274ec4d6ffc2dc", size = 235298, upload-time = "2026-08-15T08:19:29.274Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/07/469f78af590f7d5cd48e20d8dbfa3d66deeff9ba37768c04d886b5afd45c/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced3fdd71aaa83ce593746c2edb42b7a59cb4c19c8b5c407781c72e493aae55a", size = 262500, upload-time = "2026-08-15T08:19:30.955Z" },
+    { url = "https://files.pythonhosted.org/packages/55/66/3bb56a47f7dcba014055b1a1d33c6f08bbe9c1e74dba154cfa25f90ae885/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:19a3dd5aa73cef1c99687c4fc57db016a9c17104ae1185da88ba566a5d3bebe4", size = 258888, upload-time = "2026-08-15T08:19:32.458Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c1/2adc2800903fb013210349313b710a5376856578d9e33e6b9a1d8b36714a/charset_normalizer-3.5.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc5d36d96478aa9c60654bd932525bf32964c62a7281eafdf16d85003a8d6004", size = 250243, upload-time = "2026-08-15T08:19:33.94Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b5/a18d0dd1157ab655cc2cb14a545f4a4784bbad70ab3502412e36097502d9/charset_normalizer-3.5.1-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:04368edf83514385ffc3e1cfd4546e595f4f1272dd23ba437a93a9cc3741d47b", size = 249871, upload-time = "2026-08-15T08:19:35.413Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c3/525f508cd1e58d0450ac55ed40ac75bc3a97482c59def5278456a5fbf03c/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:9b5db6052055d34d41230fb78d7c439c23dc536a9896f6cb039e8dd92cfc1263", size = 243580, upload-time = "2026-08-15T08:19:36.886Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c1/49a91fe7e97c8140094ca5c64161ab623a70d9f636bf834eace14048acb5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:252d099029bcbea642f2a06c4ed5046bdf8b5a8150b64afa5e027e88b106e5ee", size = 239807, upload-time = "2026-08-15T08:19:38.392Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/58/56a48c296601274c4689b864a8e2dfb209b81dfcb39472753ce95eea662b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:6199d5606e2bbf2b096cf64d03f8b6790c91081d5ac866b8e7bb6422738cc60c", size = 264083, upload-time = "2026-08-15T08:19:39.856Z" },
+    { url = "https://files.pythonhosted.org/packages/10/4c/dc48409274a1817ff349711d26c62aa0c597df865d4d69ef79160c859193/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:77efcff2b23071c349402ac1066667a3d011f62398d81408c9b88ad991747c9e", size = 250317, upload-time = "2026-08-15T08:19:41.53Z" },
+    { url = "https://files.pythonhosted.org/packages/81/58/d325912115caec62d6bdd77bbab5e0b7da5d234a9f20affdffcbcb530d0b/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_s390x.whl", hash = "sha256:a5cbd90ecf0fc62e64726917ad083b73001f0563657a87ec3c0b504e277dc90d", size = 258173, upload-time = "2026-08-15T08:19:43.07Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f7/b13b1ccae2c8ec63980d13be1890eb73f8aeabbfce02a24aabc0908788f5/charset_normalizer-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:4d26f14f041e83dd8edfd61f4cd4fa7285d31798b5bf1f28e70c367ba6c41d61", size = 251960, upload-time = "2026-08-15T08:19:44.587Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/25/ed3f9919c5aef8cc818be1f972f565f7610d7b2076b8ebb98839516ffc3c/charset_normalizer-3.5.1-cp315-cp315t-win32.whl", hash = "sha256:ac13b004224fb341e1e25a1ed5e19d32f57cdb2a403e01f003b46f051a550f6f", size = 191186, upload-time = "2026-08-15T08:19:46.293Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/43c2b3e9d8267092b913eb8b0603f0f71993c395632886bd37a7223f96cf/charset_normalizer-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:35aea775dc2bd5f54cd84a1cd2696cc3207c479cb9cf0bd346f0d343e4300ddb", size = 215947, upload-time = "2026-08-15T08:19:47.853Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/9aad3e9c8865e5e0efa9a7f6f81c37a67635a985145ecd44528a81e088ee/charset_normalizer-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:fb78f6e7fcd8ad785d28cd577168bc1aaee827b25bb8755638f694794ea98f0a", size = 193909, upload-time = "2026-08-15T08:19:49.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -119,6 +264,105 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.15.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/c3/4f2195f512fb172aa425a8803a874b2baa9ba7f80ff7b6080998761fc701/coverage-7.15.4.tar.gz", hash = "sha256:0548198fff07ccf4faf469520bce1c2eceb1ce3e62891921138dec10907f9d00", size = 936952, upload-time = "2026-08-06T13:50:24.442Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/48/bc8d4ba7b37551a767bd863f15b3f80182b271c2f55975356f5f7dbe94c2/coverage-7.15.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4fedd1f7f428f9fe83b1ead5e7cc87a43427be31aadafbac3ac0636dc7abb22", size = 222543, upload-time = "2026-08-06T13:47:37.562Z" },
+    { url = "https://files.pythonhosted.org/packages/20/dd/88d6f83f1fffc974a3691a34a97951c5b12df7512a6782c5963883cbc058/coverage-7.15.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:37e2f0cdf58e2e1fed4e4d5a8f8786ae2f7eb80b478016876667dc4a01d60a97", size = 222905, upload-time = "2026-08-06T13:47:38.927Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/5c/54ee0d4748585bb0acab9891cd8d92f2d3593165b4e59fc9de113bfb3140/coverage-7.15.4-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fb55d0e70bb15f2e81477613627286581414693d74ac7963c93a790dd453ca9d", size = 254407, upload-time = "2026-08-06T13:47:40.488Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3f/f0642a372f494bd0d7dad3b497083b910194a5f1c88be2c94fef707c3b59/coverage-7.15.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:899b9da30f3c6c336566e3707495bb23e8302d39d862f01fa78c48b99b9437e2", size = 257145, upload-time = "2026-08-06T13:47:41.931Z" },
+    { url = "https://files.pythonhosted.org/packages/71/17/8b46d0ed68251016002ec972c8fc0119961a765d0984cafb8bf317c43758/coverage-7.15.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d15715e8c46552827e5e4f30a35575a2dbcad14454cf3284c54483946bd16931", size = 258257, upload-time = "2026-08-06T13:47:43.527Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b8/8498a0e72d0adbe15477dd07463d2b3bb2c9f6a4815e8589e50939e2c3ae/coverage-7.15.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:002a438859f7b430bc99afeaf01a6d187dad1d0dc907b64cdeffc632a5db8fd8", size = 260517, upload-time = "2026-08-06T13:47:45.121Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e1/7dce19c3bdb1e3dd63e769508216500edad81bd5f69a26d724e32aceaf78/coverage-7.15.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e4193a04b518f7968f3099755f5509ee7cccc6dc2b92a6b14841934d22e222c9", size = 254785, upload-time = "2026-08-06T13:47:46.541Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/b1/e1494703c675a2561723cd9b89f45c9168782c31280c611b1f767851e57c/coverage-7.15.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e98dcc55d572b38e69d117da7e8e8efb8500f1f5eaf81ecd460a63220790b839", size = 256176, upload-time = "2026-08-06T13:47:48.155Z" },
+    { url = "https://files.pythonhosted.org/packages/73/76/a5629d270fb638a43a4b10466f51e2f49d532c1aa4da2913cbbb150bbe0a/coverage-7.15.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:af6c538498ce66c10d3fd541c2a8d5b03da5850355add34e6cba564210cb9e72", size = 254321, upload-time = "2026-08-06T13:47:49.757Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4f/9c44447218435d5766b911534f9d798144a5560f85e9a54ebe5f3f5d19f9/coverage-7.15.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1d10025d96ea89fc2f73714dbc4cbd433fe012c1ac9e23f895d7728b238b6e52", size = 258390, upload-time = "2026-08-06T13:47:51.248Z" },
+    { url = "https://files.pythonhosted.org/packages/de/36/c1e127616fb3fa18a9ff71e76c417f2fd7424332a4870015ac224ef4c039/coverage-7.15.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d802e1947603162ded419bff83ac7489820355d2b856dfb09206574e3a37ac0c", size = 253894, upload-time = "2026-08-06T13:47:52.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/b9/fdb92c8ae7a8bb9b850cc253b7b3b9c8526f68130002048b5671cd510d09/coverage-7.15.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c2de40895718f91951b86712b4c5b694acaf9a0a49be13874896f599a1eed3f4", size = 255763, upload-time = "2026-08-06T13:47:54.296Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/a7d51b2587c7bdb76e71b0896d2565bf7d60436b5122fc83e511adb1f7cd/coverage-7.15.4-cp312-cp312-win32.whl", hash = "sha256:5c3431b2161279b7db5c2a1aa58ae02e5cb8c3c42d93a5094be3f5537bd5b11b", size = 224597, upload-time = "2026-08-06T13:47:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b9/5c5f80cc55f5acaaca6dee677626bfcec8c87204a7809b438b08e84f4571/coverage-7.15.4-cp312-cp312-win_amd64.whl", hash = "sha256:6befeab5fb2b51c958ca4ac6c5d141a1e8240f4f76e46350f1911963deda49cd", size = 225135, upload-time = "2026-08-06T13:47:57.52Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/2a4561f89ff6bf7c925c287d0f2cce8bdf139c3a33735c87e3203401cf94/coverage-7.15.4-cp312-cp312-win_arm64.whl", hash = "sha256:67bc345491ab55b837277d76f5775d057e8c7f1ac44d890d8c2c82adde258c6f", size = 224515, upload-time = "2026-08-06T13:47:58.977Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/84/651a9310859673aaa3b3203f1aa1641ca60fcf2494683e1c9474c7172780/coverage-7.15.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c705b28feb2775dc82a25f1d473a370bc37ff93f5177f4e29ce2425f560f6921", size = 222565, upload-time = "2026-08-06T13:48:00.796Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f9/4dcf700137e8af550670f4d74d1b63828ce93e1e2b05e5f10710eb2ea987/coverage-7.15.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3ff205ab5e3ecc670f6a4dd19d9cbf12ede53dd41cfc1e15716ec961ea6d314e", size = 222936, upload-time = "2026-08-06T13:48:02.391Z" },
+    { url = "https://files.pythonhosted.org/packages/07/4a/612ff1e780b3fbfd637486f542f84adc5503873d8b5d279dec1ffeef9414/coverage-7.15.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5172326e861a38b48b48befca15e0f477a26b283337a33a739c8fed229934e36", size = 253926, upload-time = "2026-08-06T13:48:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/04/d1cff1c2ead4708a6a79c01d3736b6a25bd38a36678398f72a8dd33dfad9/coverage-7.15.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:12b59c90084e3234fb11184886bf4a40f4f16a8c8f867be2e087b81f8e8868d4", size = 256523, upload-time = "2026-08-06T13:48:05.996Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/80/d34e13fb4b293cbdb9665838cf5522077b8ad14ef947550631a4bced36a5/coverage-7.15.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349062d66f00b40fa2c1c222438bad25fabf755631b5d82937fe985c8008615c", size = 257759, upload-time = "2026-08-06T13:48:08.036Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e7/2c5fe7636fdb0732fe0f09f308a5b066864078b7fc61f6678e8478554f2e/coverage-7.15.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4256ced708e598e05209bc1a8ab4074e04a51dba4c62fb45926a229af675ace7", size = 259890, upload-time = "2026-08-06T13:48:09.834Z" },
+    { url = "https://files.pythonhosted.org/packages/92/28/9689f0858dfff59c2ea688938ab9fa2925631235df67126a42b6c5c70ae1/coverage-7.15.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d80f974b20782d9612c8b4c9beeca867074c7cf4079d1419843fa25a26428b25", size = 254121, upload-time = "2026-08-06T13:48:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e2/785077c230c157243eb5aa9a26c3be260ecd02001bead54a3cada3df8e03/coverage-7.15.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2e179f19bfe1d31f8eeeaa12990194d761c4f62f0759661000bca6cd8729f40b", size = 255891, upload-time = "2026-08-06T13:48:13.209Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/90/e20371b17b40f912f21305c2db2f30efa3de306f7320fc916804872c85a4/coverage-7.15.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8bc16bb47b7679670eceff71d78bfb7d6e5b143f6c2cd117487ec7c75e0d4b78", size = 253859, upload-time = "2026-08-06T13:48:14.736Z" },
+    { url = "https://files.pythonhosted.org/packages/05/49/25371987ee459a5f67c0427fb75c74f9358e65f2c71fe75bf41c1b6c5fcb/coverage-7.15.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1cd685005cd2c4200adfc14cf39a603b9320efab3f18a8f7f156d20c9cc3345f", size = 258011, upload-time = "2026-08-06T13:48:16.464Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6e/32e67467f6154bf4f1c4f63b05acc5097cba4237d45bbeeea446b52e8ac1/coverage-7.15.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:337399ad2c93b3acd2a937627dae8b3e86b66707cd3d3e856347999aadf1ef8d", size = 253676, upload-time = "2026-08-06T13:48:18.493Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c1/8b24192e89286399765155251f99ee9f070a9d637109018ac23d99b99f6f/coverage-7.15.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:96e257121228ec5cd2bb919276e94ac11074471bc37d68dbae0e8308cce15fff", size = 255453, upload-time = "2026-08-06T13:48:20.057Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6f/8b41ebdf67c87854e17c035336a90f1cfbad0c14c2a584301be6ff148718/coverage-7.15.4-cp313-cp313-win32.whl", hash = "sha256:c65a9e0dfc6143491879da4e13b5e30f8be192055de508d737fb14601edbd22c", size = 224605, upload-time = "2026-08-06T13:48:21.655Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/e2/2946c7f0b42b152ecb21ff1bdad72e3d301e790c0c487e4a86e8c9f69347/coverage-7.15.4-cp313-cp313-win_amd64.whl", hash = "sha256:2ff8f5e9b8f7a94f0c11c45631eee103dbcb7d63274edd12c56efe1be690b3b4", size = 225148, upload-time = "2026-08-06T13:48:23.376Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/83/3f4a69957f48ae7a0aba76c34743f88963d607b19e03f3f8e66f91cae0f9/coverage-7.15.4-cp313-cp313-win_arm64.whl", hash = "sha256:6e0a8a5083b096487d6cfced94cdd514d8f5db6f113610fb36c0620edb1028cf", size = 224536, upload-time = "2026-08-06T13:48:25.117Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ac/748cf29eeb2d6be34a3176ce26a4f49e38085ee08e8935f05f6f26ed7e0f/coverage-7.15.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:770e9325ab5ea6d56f77e59b29ecfe0ac20b57a82a601876f90494a4dda0386f", size = 222608, upload-time = "2026-08-06T13:48:26.806Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/02/1abbf5c984677b0aa439cdacaccbf38d248939d8ef8fe1cc7a50d73edb77/coverage-7.15.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d12b33a3a50a1676b7784dc8d00a0c6d66a9f2add4b85a041c19b6a7e53ef23c", size = 222940, upload-time = "2026-08-06T13:48:28.432Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e1/ff8f9f53d9fcf586125b55d0b1f04ec1c14955fee41e83d5814bee141bb5/coverage-7.15.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5669c8378ebde86f5def7a25d29586631b58acc27ffde04399f678f3dfc6e082", size = 253985, upload-time = "2026-08-06T13:48:29.995Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/26/595759762e514e81be1d7d01ed03444303bcd152226a6529998d253f9201/coverage-7.15.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ff97a14362eef486483ed44042ca2027ea257df6ff768e62358ee0c9776925ac", size = 256492, upload-time = "2026-08-06T13:48:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/b79aabac54d482be23b5fcdd4f4662bff24a78edc4ee29201726929936d5/coverage-7.15.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a325e815318638aed1655d9c06e6d7c2d3d46c09231ce988070428a8762d734", size = 257837, upload-time = "2026-08-06T13:48:33.186Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0f/bf7f297885a5bf6fd71e5782404e0ff059ca09e8711ceb3a08544abde45a/coverage-7.15.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:474223409d88eb20d2d6a0d37ea60e8647a65a90cc008dc1f0410af5f64f1e0d", size = 260152, upload-time = "2026-08-06T13:48:34.75Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/f1/296744e854ff8368542343457414380465e9ceefb9192342feb9d3bc461d/coverage-7.15.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7f2f62ae3cd189dd2e13aece758c57b3eecbd27be070dbd4cbd10936049e5dbf", size = 253978, upload-time = "2026-08-06T13:48:36.434Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b0/bbdb2e9057493e66220a2e149ca2d301ba0e3a58a83bd6b90de9826d16f3/coverage-7.15.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39ece820e29e0a2ba34b3ecb3be83c27e997eed8926f2ba6fe7ce7a0bda5843b", size = 255846, upload-time = "2026-08-06T13:48:38.317Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e4/38015b2b6d21258713bd17e76b59d033b191efb5703589cffd037dfbca20/coverage-7.15.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f21b56dcace11dfe013014201f577dcd592b2a9b72182d930361b47cf6f73f25", size = 253808, upload-time = "2026-08-06T13:48:39.993Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/64/0d515c1e60ee6fbfd1a0e79c07cd87d388a233b7adc37758735677203808/coverage-7.15.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:93a3a0b662abcc10c73a47cbc72cd60f63618d6989fb2d1286e50eacd974f303", size = 258081, upload-time = "2026-08-06T13:48:41.971Z" },
+    { url = "https://files.pythonhosted.org/packages/91/71/04d9e7a3642146c6351338aef4ef85ab11dbbb54744c13245caba1aad1c0/coverage-7.15.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:141fae2cabf5569b782c10afc4c850ce10f618c13f8db54765cba99cc839da1f", size = 253624, upload-time = "2026-08-06T13:48:43.731Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a7/6c28b74c81ebff66987b0e2522ba5cffa3e90b0c33cb6a2eb264d4ee8cf1/coverage-7.15.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:81294c7e6ab30c5f74c0353b11b2fd6320e72d9bee6ac73b357caa8b916323a5", size = 255280, upload-time = "2026-08-06T13:48:45.58Z" },
+    { url = "https://files.pythonhosted.org/packages/52/af/bc19996a7014b98d7bbb0f0939453c67074af65784a3aa16a789a07381fa/coverage-7.15.4-cp314-cp314-win32.whl", hash = "sha256:7bbd7d6418e0dab31a206af5203bd43ae36edb8e7fba1940b055d3e9249290d7", size = 224768, upload-time = "2026-08-06T13:48:47.525Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/219484e476d6e101ba0a444852579e05f5b75c37c611a42ed1190f73ef62/coverage-7.15.4-cp314-cp314-win_amd64.whl", hash = "sha256:f0204ed122758782970526057093f448051a39db9d810d4e344bb87a3546f425", size = 225259, upload-time = "2026-08-06T13:48:49.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/66/fa77daf4e383e5f776dac62c2409b6af81910ae6fe326bd5170dba74cc63/coverage-7.15.4-cp314-cp314-win_arm64.whl", hash = "sha256:9e71e7bc71c686a123347ae47a0de33a175e797a85bb57b791492adf4eec8ed8", size = 224684, upload-time = "2026-08-06T13:48:51.235Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5b/f03bf0ce362bbf3f785fa5219620d00778d4ac6fc9e407734828e9c672f6/coverage-7.15.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7c922735321eef3f87c280a3d39afff6b646723a2880b862cda4ac7a093b8aa8", size = 223338, upload-time = "2026-08-06T13:48:52.896Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/76/e77d0ae22501831cc9f92193e8a957a5caa1dd177f90a6d1d9b106242d92/coverage-7.15.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f41c17c4668a655ce96d090d8d5ffdc24ef64b5a02f9753884d08483e8a4a41a", size = 223609, upload-time = "2026-08-06T13:48:54.688Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1a/b1f089da8d38ac612fa2dd6dc7f4a1a7657d12f3e261d2996edd3a838d0b/coverage-7.15.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:46822e9b6ff1c6a72b518c162c44a8f45a61a1d609c51084bf5b16c023c5037b", size = 264970, upload-time = "2026-08-06T13:48:56.403Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/31/e66d98d6e9c7fcc88470f1e234eaf6b1950dc0dfbf797f7282c1c861da24/coverage-7.15.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d6f4955b73b5445271379a59e3792b0d978f42d4a01e0cf7a67d9c33a3bb0a5", size = 267088, upload-time = "2026-08-06T13:48:58.41Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a1/ae94eb2c541add426378408379f233591e069040b1e2cdb33df9498a0682/coverage-7.15.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3fc9e047706fb4a9abb54f719d3aa643e80e5bb3818182c40aee01ac0f0247ba", size = 269508, upload-time = "2026-08-06T13:49:00.42Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c7/88a10694a1c6a213569766aba9f25847b28155d4ac731b13226db216356d/coverage-7.15.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05e491d4f3165d62d4f5c8fd48dfeabf2ae8f42cbbd484319af33ea851b78982", size = 270629, upload-time = "2026-08-06T13:49:02.234Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/34/d8b8232e5e55169933b59aabcef2fedfa4b9d8897361bb80fcbda146505f/coverage-7.15.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:226c66e80ec0598d3b9b4874123df167ccca342aca8714f77cac6829688ee09c", size = 264043, upload-time = "2026-08-06T13:49:04.102Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/35/58b009dbf8c471c7224716478b9fed4a7e1af15320e1ed41660978504663/coverage-7.15.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac41cc14bebda0dbfb0628036b7f75706935c95bcc07fefe9a0f93614aa60a57", size = 266963, upload-time = "2026-08-06T13:49:05.821Z" },
+    { url = "https://files.pythonhosted.org/packages/62/aa/57fbda1b42c892968273c56b6ee9dc0f1310850859230a507bc7873b1f65/coverage-7.15.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8af623e5cd92080acddd02b38f2f406a2c3a0893c38950b211890361448fbf26", size = 264569, upload-time = "2026-08-06T13:49:07.706Z" },
+    { url = "https://files.pythonhosted.org/packages/98/8a/360e6e7f24d477b7e889703af0afa878d15b6d4d8d2a822b2835c169a879/coverage-7.15.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07545711d4f0f32852a18f18ad11f76f0109909d09e78b9008b4cfc67e829429", size = 268299, upload-time = "2026-08-06T13:49:09.587Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/89/6f701261aee21b6b5fa8f7872229406dc917e125069448292223bf213606/coverage-7.15.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a0865421cfdc53654b342d515e5a233187590882d20b95752150e53f65460017", size = 263413, upload-time = "2026-08-06T13:49:11.604Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/0f/6f04036edc260ed425af83e834f627fad48941ce97b50bfe6edd8b6fa623/coverage-7.15.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:460115e32ee40566476db5048f9bec1e842c127ad8e6f8be745aad3ac9cbc839", size = 265725, upload-time = "2026-08-06T13:49:13.38Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ce/d19b5d4d5c49a7bfb925fd74310fee7d28bc99520ac3367ccbc54e662518/coverage-7.15.4-cp314-cp314t-win32.whl", hash = "sha256:cbde877ef9dd7baf272b9bfef2b8a25edd45d9170fc326951dd20eb480335e85", size = 225079, upload-time = "2026-08-06T13:49:15.265Z" },
+    { url = "https://files.pythonhosted.org/packages/26/bb/7aa1b3b173faee0679037ca950bbbe1247273656697994d8d13f80f8d4b4/coverage-7.15.4-cp314-cp314t-win_amd64.whl", hash = "sha256:3da9e92d1c551fd7563833e9ade686efb0c4b7363ab7681a94283958c950bf5e", size = 225911, upload-time = "2026-08-06T13:49:17.279Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1c/4ea9e47426d80038d9222db3c4534cb6021a74b237d3ff97ffd33b6600dd/coverage-7.15.4-cp314-cp314t-win_arm64.whl", hash = "sha256:3a54f5a0d85050c73a38f6793090ee83974531e67fe5e57a1da9bee11398aa5e", size = 225219, upload-time = "2026-08-06T13:49:19.293Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c4/dc5d2ac8f9142e7ec7de66e7bf0591db29d78955a040bd915870d9c0e657/coverage-7.15.4-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:2c9872e4d9dc5d3cf616bf4b382f5a00359305a5be666a3dd0b5cdb4e49597f9", size = 222604, upload-time = "2026-08-06T13:49:21.279Z" },
+    { url = "https://files.pythonhosted.org/packages/70/39/33e63df81fe2ee100897451841c821467635923e58e37c6bd4b46dd8106c/coverage-7.15.4-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:e101dbb4b9b72f0cddd8cdc8c9c5b47f456766f5e0ac82dbfb75e5c55409b78a", size = 222944, upload-time = "2026-08-06T13:49:23.187Z" },
+    { url = "https://files.pythonhosted.org/packages/99/1f/ef3ffb5557febc75a0d97aa459d0266d7d741110265121cc6d8539343d44/coverage-7.15.4-cp315-cp315-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7d1abebdb047729e852b9c77a00497dfbeb11eb3a117e037d7dbc3ac8e5f5c54", size = 254050, upload-time = "2026-08-06T13:49:25.008Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/f5/1f0f6f77698c3601ca0ae7431e34b24c62ca2f06fecb23b73ed1f651d2be/coverage-7.15.4-cp315-cp315-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d28a4a899354d0ea6214cc59b4fa19eefbce1b9ff1688ab579acf49e894bd3fb", size = 256967, upload-time = "2026-08-06T13:49:26.896Z" },
+    { url = "https://files.pythonhosted.org/packages/03/7a/2ed9bed79925f4367c83c77f66a89e5ca7229c288d2d19ad5f36d1ca0070/coverage-7.15.4-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffb3c2aacea411cc7e1d27712490c11108e2de1d39019ae32915493a59a8b9ed", size = 258587, upload-time = "2026-08-06T13:49:28.692Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8c/fa34044f71b7cc4ecb6da9c2408770959b0591fa9b5fb6fb6bca38f94298/coverage-7.15.4-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a9447978a92f405d301123cfd39ff49895490efb769a758fe2734c7f631bf8ce", size = 260785, upload-time = "2026-08-06T13:49:30.472Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/54/d5727ce36b4524a7394ab9f5f1df378e1f23affcdab01037dc8655185cc7/coverage-7.15.4-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:050467a7983b8e2fe7dd41a78bb30c3e7f8c0b8cafda14b1c46f8b5e3cf2dd3c", size = 254545, upload-time = "2026-08-06T13:49:32.271Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/e6/6e3783e576719590194bdffb6dd6d85490801785b7c331e35a245d8cb8b5/coverage-7.15.4-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:d003b7a5708ddad5c206c79607a6b92abb6fc13c57d99d8a4468cc03a2941ced", size = 256682, upload-time = "2026-08-06T13:49:34.089Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f2/bacdbde18b69ed2de424fcf64d9fb0a4913753d4f0eca8bae9daad69f4bd/coverage-7.15.4-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c38efe30fd74e5c19e9433f11fb1f5dc9c6522770971b7c6145bbaa413dc8800", size = 254560, upload-time = "2026-08-06T13:49:36.052Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a3/1fb927196e3477c1b48831169ab58ba08f451ba87ae311ff1de68b26a616/coverage-7.15.4-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:1f4f826d70f772ab8b0c052329580d7fe8b8abd191e4ce0c8f81aec6614665d3", size = 258792, upload-time = "2026-08-06T13:49:38.01Z" },
+    { url = "https://files.pythonhosted.org/packages/41/58/30d4c149c69053de0edfe325614c1d28d508f62b1783e0e4a234d2e49136/coverage-7.15.4-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:4a4bf917c9953f57c957be31c1cd504e3bd2f34d4a352b9d391a3025336f6768", size = 253968, upload-time = "2026-08-06T13:49:39.934Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e4/77f639371b918aad30dda4051f95404b43578f7f2e2f87ba73e02ed1ff37/coverage-7.15.4-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:1c9bf40ebef178a45192c75c4964760bb261b0e6ad725da5fc4c93f674f19753", size = 255893, upload-time = "2026-08-06T13:49:41.825Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/62/13be29b3ddab35f14c87967a4820a05106d2a3eccb4fa4ff550bf30b75e0/coverage-7.15.4-cp315-cp315-win32.whl", hash = "sha256:43619d04c3671792d2c4706ae8bf45e265dc87bbd4078189ef8b847ea1e74be2", size = 224768, upload-time = "2026-08-06T13:49:44.08Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/70/af0c6be0f964af6954f6b74bc109b0dbca02824696d2520fb17fe1ab06e3/coverage-7.15.4-cp315-cp315-win_amd64.whl", hash = "sha256:be619439dbcd31a2eab10b32de9fff62c26ed4bab69dc32b8363fdaaa0882809", size = 225242, upload-time = "2026-08-06T13:49:45.899Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2d/f3bd3aab899fc9efc18b53133ee68f5f98574ef480649b23e12962226387/coverage-7.15.4-cp315-cp315-win_arm64.whl", hash = "sha256:def597967dafc2e8d97c9097ea453c464e0bb8ed38f193a43070f10dc623bb6d", size = 224674, upload-time = "2026-08-06T13:49:48.322Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/ca/f69251cd63eabc6438321aea22148754cce758a26bde07dd490e3fe7cfc5/coverage-7.15.4-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c7dbc748ac8a1e3e59a2b28bea47675e6e778081dbbf081bde0d75def2fcbe1d", size = 223333, upload-time = "2026-08-06T13:49:50.293Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/a7/037b53b2885b0d8447064432491a4d5a1014cd9f97a594d53acd0c04541a/coverage-7.15.4-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:2413074a5ecbb61a01a7888fc72db0ca324d13588c5b38bc0dd8564cdcdfea26", size = 223630, upload-time = "2026-08-06T13:49:52.637Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4f/152b8a4779ae90da11bb24f7467df8a59f0be48a5c52acb856325ca48289/coverage-7.15.4-cp315-cp315t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4e6f6f632b7b2f714bf7a1346e8f97b650ee71f3c298aaad42a2ab60f0f07645", size = 264489, upload-time = "2026-08-06T13:49:54.52Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2d/84b4b9e0e1dd6528a51920ff7031f35b789382e467a28ec6a5a578cb8812/coverage-7.15.4-cp315-cp315t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8df457da2249d3c75ca2e5e835d59c725abfe92d27fdff6cd99eed85b51d5e9a", size = 267567, upload-time = "2026-08-06T13:49:56.721Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fc/ba01cc25299f9f8a2c8b02d3b28c53f3543d9fbfbe4e74fa2760b48f163e/coverage-7.15.4-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:050f66a08805acb5b8a23c6d4a517b1ecf82c08e81ed0e4bd727df065e5c6624", size = 270123, upload-time = "2026-08-06T13:49:58.736Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/d0/db2647cbf40b14f8c308f94ff7bf89c06d564e59f396906edf50086ec788/coverage-7.15.4-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1587fb771d1ccceef708fdde1e5af8c7ed24b486b61d13a321acb7d8145390aa", size = 271107, upload-time = "2026-08-06T13:50:00.811Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/4d2d17924552c458bb4f77dd631f0e3bc92fbbdf2d2d916cd4b33bbfd5b1/coverage-7.15.4-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8b4f1c3a69ca580f3fbd6b2046915f536d7f586874f25c1bb23add2a3c88d50f", size = 264955, upload-time = "2026-08-06T13:50:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/de/dc010c7a3691f396d93bbc26bfcafa1c2a3a351cd520470f15faf5795bd5/coverage-7.15.4-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:ffb58d7eff5b7f6ecc6fa21d6288ab7f968a212cb67d682c269c09b9eba3b66f", size = 267949, upload-time = "2026-08-06T13:50:05.557Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ea/dc96a11375e83c045c2f7c61fb6918277cfe9401db7c0f7b1d111a84b2e5/coverage-7.15.4-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:d9df165544774574ee004b953023d1bebada1894a80b1052a43d798b0f676e67", size = 264421, upload-time = "2026-08-06T13:50:07.612Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/86/b77131a0f9503ce461cd577076147d7a9040f0c5dda772686f729e2cc9cb/coverage-7.15.4-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:f9de0a24a4079b53e523b5c5e2c5945ec251ab486652659955187cf255a259bc", size = 269121, upload-time = "2026-08-06T13:50:09.58Z" },
+    { url = "https://files.pythonhosted.org/packages/24/24/944bc35007862955e7ebf05754e645419dcf5d7526c52735cfa2715e8ebf/coverage-7.15.4-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:150089274bdc9f940628552cb92844e0223c987f1902ab8efe9f45a2ec758d88", size = 264565, upload-time = "2026-08-06T13:50:11.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/cc/a3bb9f93e7e740659163e2ea584f8196ddcd2c456a5dbe15f6c50105fec1/coverage-7.15.4-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:a58a94fed5da6997d258e8f7668c1e195fbd04a691d781b7558f1e468f9e68bc", size = 266522, upload-time = "2026-08-06T13:50:13.786Z" },
+    { url = "https://files.pythonhosted.org/packages/49/dd/e0e40f3560d878d888c580698ff5ad1179f5e1c3ac949684ef66b41a3817/coverage-7.15.4-cp315-cp315t-win32.whl", hash = "sha256:ebd5a6d8466ff30836572f3ba2cae8a5e8f85029b1c6d5e2ed338dc472a5166a", size = 225068, upload-time = "2026-08-06T13:50:15.825Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/7e/37732ea80eebc30e976e4cdab15c190bc42d96959a42e38ddf6f8c60468f/coverage-7.15.4-cp315-cp315t-win_amd64.whl", hash = "sha256:288bde2a2d7ab6b6c2d7252fcde8b524387f2d970bdba9658fc6f8bbcaef0f9b", size = 225895, upload-time = "2026-08-06T13:50:17.928Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/08/1e00f7923eaaba45fb3d51dd794125fc766304b1df264f3a9c6557bfb30e/coverage-7.15.4-cp315-cp315t-win_arm64.whl", hash = "sha256:68be5e1de60ff13c9095bbec0e5a7fa45b33b101752215b91345ea1f61c4a278", size = 225213, upload-time = "2026-08-06T13:50:19.981Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d9/e70c286c979378f061d8266e279b686ab0b0b688e1fe0af864684f23a77d/coverage-7.15.4-py3-none-any.whl", hash = "sha256:964730a1e9de9c0cf11be6a1a3c79ce419c34882842abd256086ba4698705e84", size = 214332, upload-time = "2026-08-06T13:50:22.192Z" },
 ]
 
 [[package]]
@@ -172,12 +416,30 @@ wheels = [
 ]
 
 [[package]]
+name = "graphql-core"
+version = "3.2.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/90/f2aff026ab4aebd80eb71905106a0885f4cfde85dcf965543f45bed0d9ee/graphql_core-3.2.11.tar.gz", hash = "sha256:e7e156d10beb127cab5c89ff0da71416fc73d27c484a4757d3b2d35633774802", size = 528407, upload-time = "2026-06-05T13:45:22.915Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/15/b92b4e1d88d02c6eff9733c9eea21846ab435cc4d813d84ccc5d335955df/graphql_core-3.2.11-py3-none-any.whl", hash = "sha256:0b3e35ff41e9adba53021ab0cef475eb18f57c7f53f0f2ca55567fbf3c537ea0", size = 214879, upload-time = "2026-06-05T13:45:21.245Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "harfile"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/0e/ffbb98cd1910f1f898ddc62d649dbf0e3d68026ee9313d3cff035206b727/harfile-0.5.0.tar.gz", hash = "sha256:c1524b8f0a39dd9f19365760aefb3adbba951818310d17b2eaa293de1f4c170a", size = 10293, upload-time = "2026-05-29T11:50:03.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/21/949c004d730d610dac63bcf5964f2585e98aa7bd44ff570ef8844472e76b/harfile-0.5.0-py3-none-any.whl", hash = "sha256:ab8a01d0d21d3b7f5ad57e7dc56b8b829f6a8855c1fa143aad464e7e8169f5e3", size = 7172, upload-time = "2026-05-29T11:50:02.206Z" },
 ]
 
 [[package]]
@@ -256,6 +518,91 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.165.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/e2/0fad246d2b6330e1f78479bfc566b5c22be82aee8a865cde9a08f648487d/hypothesis-6.165.10.tar.gz", hash = "sha256:68b45e09834cd80523cb1eb274463073c7a9af4e4ef7cff34d9615f355572d32", size = 503703, upload-time = "2026-08-16T22:56:15.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/c1/9a9538e6d185baf5cc7f15bc3b76e08efbb3de4b3c782f234356449c0dd7/hypothesis-6.165.10-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f839d29d0cc12048cf073d88ca4fdf94d420bc2b8afd69641ff6d496422ccd4f", size = 783243, upload-time = "2026-08-16T22:55:44.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/30/b70d9d79e871a75cbdeccd9067f20ecdb9eb2a1dfa03c630be3ad13b8b30/hypothesis-6.165.10-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e10858f57ed0e74baa04393845f469fe8ad502c16ece4499bef7700c575611bd", size = 778815, upload-time = "2026-08-16T22:55:46.948Z" },
+    { url = "https://files.pythonhosted.org/packages/db/52/6f0a9b7aab24b0635e2238f3fbddea5b54b17879ac813df42a3cc3384c5c/hypothesis-6.165.10-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76a7be86d986223b9f1bdb7e7cbcdb048649901fdb956c598ef73bdab1786cd5", size = 1108009, upload-time = "2026-08-16T22:54:53.082Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/06/8d0d4e11ff02350d09ec9f9e90af354158e59e16a8907ba5199a4ff2d7e8/hypothesis-6.165.10-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:717aea574e0e5edba2868aa66b1caae335d8f1ad3fb29f01dd6502953fa823a1", size = 1136596, upload-time = "2026-08-16T22:54:54.443Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/01a1e440f2e38dc1ccf5d597af5b8a0bee5f21b674c99c123b5554de9690/hypothesis-6.165.10-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4334058033e0214475f019e15492a50f3854fe8728cf51fe25c6191a2c3f8e52", size = 1135234, upload-time = "2026-08-16T22:55:08.911Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/18/8a26c24d3d9db20265f39df341ab265858c094e209571e3179cf237935f4/hypothesis-6.165.10-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2abb50cf1cf77d721de0a24c3f99d9c4ffdeb2cbd1e12aebb5a7a93e2b6b6d1f", size = 1157528, upload-time = "2026-08-16T22:56:02.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/8e/ce3c829b1937402d7944420ca26a05a0c8563e894dcff03d34ffa279d306/hypothesis-6.165.10-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:3de69aa8b924b400291a3cc42aaf78e6ab65c905a3e7e1a5dc39d95ef1b428cb", size = 1112870, upload-time = "2026-08-16T22:54:55.919Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/1b/4c4926d6c9a2b5d7cc090cc1e91219d6796102aa2a2c4b8f961c939e60b5/hypothesis-6.165.10-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5841331c504e02d7c334591681cb8587cdd59dee7e149db6d3db8e3f9e9f02eb", size = 1149683, upload-time = "2026-08-16T22:55:30.567Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f9/df24eb28412f82465e2b7707f0ff1ec274d580bce389d4d9156617dc7bba/hypothesis-6.165.10-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2d0e0f8263d34dd8fa3b39eaa9a50bba56a8470b3dd9ebf6672d10840abe063e", size = 1283402, upload-time = "2026-08-16T22:54:18.054Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/07/c2b2a761300cf60b90ccebba4328175331e67d34f4fbd39429a7ddcdce49/hypothesis-6.165.10-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:0c4e6869817c3cfdf5a2b4d348497b95159bdecb3365be732c9b8570e36a4eef", size = 1409948, upload-time = "2026-08-16T22:54:22.343Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ec/1c2bf1acdd0e273d81f833f85caf0ae5423db68a783554992fca36e6c541/hypothesis-6.165.10-cp310-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:9f07ae36c3b093e13687a894e79fe69e98a94c0b67fef656c575247682218143", size = 1265023, upload-time = "2026-08-16T22:54:41.402Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a8/7f984908b7391160c7801b84e51ca8e4ba88c89e8d8811aa1aa7c03de73c/hypothesis-6.165.10-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:aff1f584c9538e8979cd180b1d70bf99bc16be19d4666414f49e5942b21a4f2c", size = 1282698, upload-time = "2026-08-16T22:56:06.998Z" },
+    { url = "https://files.pythonhosted.org/packages/48/78/3a5d91c2d0250521736c42dfa2402b75049bc5fe2fb716c10bc84bb91ed1/hypothesis-6.165.10-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1f2c4db25fb8ec1a16a8dba580666337b8ffb1887c4cf1750cc954313897cef7", size = 1324816, upload-time = "2026-08-16T22:54:46.675Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/99/27450763853a034bca1574d3e0a315164b33ff49c3862df6872dda45e25e/hypothesis-6.165.10-cp310-abi3-win32.whl", hash = "sha256:b33dc30170a7402e03c180f2c5ef69dc077152f35b91621e9cebcde9c7d71746", size = 669039, upload-time = "2026-08-16T22:55:11.962Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fc/ff2988b72b5705ad9ca500444bf3f43e3c2f41edfa034bbfeb23b215791a/hypothesis-6.165.10-cp310-abi3-win_amd64.whl", hash = "sha256:e9f924aa610c0618445e1e8738c822c3190ce2a2699a0cb48ec3a351a96761f2", size = 675213, upload-time = "2026-08-16T22:55:01.697Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/8b/821810d36f78d9d9421cd2c5d9d36983b45bb3575c3086276cc5c76f9f73/hypothesis-6.165.10-cp310-abi3-win_arm64.whl", hash = "sha256:1d305448e9bd8e2f4f3cea0eafd809efdaab4e998a0019bc615650c8463e42f1", size = 673537, upload-time = "2026-08-16T22:54:47.898Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/45/cde4f78afe2b9e29caecf38319eedc1deb76aebcacbdd128e03cbb2511c3/hypothesis-6.165.10-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:637445c1593a2a9d1024fda50082f07bb56baedda78d90a25f64b8111727ef94", size = 784835, upload-time = "2026-08-16T22:54:45.429Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/847f30b81cbfd07607296b3ce43067cf4f80799bd9244167f587de9c8081/hypothesis-6.165.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:713f4ce4e82c26b53031f139de959bc9e8b54d3995aa824b89bbdf8229df2a45", size = 776419, upload-time = "2026-08-16T22:55:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/04/66/4c71c5be7a49d84b8c3a9278c1807c4c81181ab5474beb27df9d4c40dc0e/hypothesis-6.165.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9ff356e97e3ab09db07c8b675efa67340103874a0bae7465acb83dad7a35f7f", size = 1106830, upload-time = "2026-08-16T22:55:10.389Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/e2cbd2810e79f7a452a8ea9f6c6438ee718ce938d8cc12252cf0b36a81d3/hypothesis-6.165.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a380bc99aa3b035e6a95a2201bf792d4082a04ca75babcc21849c2d0914bb28", size = 1156952, upload-time = "2026-08-16T22:55:53.35Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/8b/794ced36864825492ac3712d5acab5a257b4601e6a9dc2ccdd3937198f87/hypothesis-6.165.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e9acb2c4d9cb532c3fedea74159f7b923c8c036328c9239b4049e7aa073bdd81", size = 1280780, upload-time = "2026-08-16T22:54:34.983Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2d/550525442cdbcc2daf1f9bdd8ba35bcbde63db7c7a22f2ef137fbb49df2f/hypothesis-6.165.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8660572b2d424bf5369ea8990985225f70bd1615b76ecd9c25588a3b9307009f", size = 1324130, upload-time = "2026-08-16T22:55:48.659Z" },
+    { url = "https://files.pythonhosted.org/packages/74/59/6caf69dd5fe03499ada94c9cec016bffcc164511c6b93fe680f01209b9ff/hypothesis-6.165.10-cp312-cp312-win_amd64.whl", hash = "sha256:3376f2594763aef14faa519b0fb27cae7ce9eeaab4c69efa07777499110306c9", size = 672337, upload-time = "2026-08-16T22:54:49.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/fb/c82c5bd92864ffcf319772fedc8c9bf2dbe4ca14baa0fee6e49e67b5ba1c/hypothesis-6.165.10-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9d77c3be7b429875036ad0f0597c6e5cc6bb17894a4da005e3807de64d2673ad", size = 784726, upload-time = "2026-08-16T22:54:32.371Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b9/3d7acd08506da85557e65147b7f3fca8c47684e33be90bee0acb523920db/hypothesis-6.165.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:490c56b830772b0eca3b4b2cecb3741a1ed26b1d7206a279e1525dbf0aa95ee4", size = 776375, upload-time = "2026-08-16T22:55:13.303Z" },
+    { url = "https://files.pythonhosted.org/packages/38/6b/922e8b3f9a706dd89d440b9545d2c6231c65e74da1c1fee3ff36c251b9c4/hypothesis-6.165.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed68e27b8a61e57a3ccdc7c5a14499e00b54dfe223087204d5d40b3b5ef58b6d", size = 1106763, upload-time = "2026-08-16T22:55:06.129Z" },
+    { url = "https://files.pythonhosted.org/packages/01/39/f5b9a5d390d4edd1ad472334493ac442963ebeb4daaa74ff4bdac6ef292f/hypothesis-6.165.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6caadcd1afb62630ff5c5ff353626eaa616553a5971295ad6dc2b19ca8a39620", size = 1156778, upload-time = "2026-08-16T22:54:33.824Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/5f/5fbe1be4326337fd6acefe2d18ed44007ee1dc1f98fe5b3c0eb22942364d/hypothesis-6.165.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9145fe43ebb22e66672967c3fab411793b226ed776e4fe282271bca6ad3c0bb", size = 1280756, upload-time = "2026-08-16T22:55:54.834Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c0/cf6f9e1ef632a1a75694eed0db3a02e6fc75c367a363e94acee52f043c64/hypothesis-6.165.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:79900a9920a0b1d3a626c03a90ac6bf7042e78d46906a565b86a0dbe926f1d96", size = 1323889, upload-time = "2026-08-16T22:55:56.567Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/cc/662b94880f260b0a88de1fdcf60fc9984f6e2a796da549542adc10a7bc83/hypothesis-6.165.10-cp313-cp313-win_amd64.whl", hash = "sha256:c01dd04044c472e47193b54f68e84e08d6ebf4f29551885aa959b015f7cd9747", size = 672346, upload-time = "2026-08-16T22:56:03.792Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/77/55e020c9c576532ff7d20bf8b1dfa052ecbd5ada1949b02f76c44c966f7e/hypothesis-6.165.10-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:9ccac776b2ca93b324806facd526ccb45da0fd035001c899a35b02c44431e209", size = 784833, upload-time = "2026-08-16T22:55:21.255Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/f2/01da2adf829cf549eaddcabb8e8072077fb3d26da4275f4c1e89b2c0af74/hypothesis-6.165.10-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e5f95f7b622e4171096d92175dda0a560f0955ade9b8a3a07bdcf151f7359611", size = 776545, upload-time = "2026-08-16T22:56:10.159Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/58d4f842895220b793c53fc94a6489705b3665bb4d0ae4d338ce03fdf9fb/hypothesis-6.165.10-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f76d1562643693b8a40066f1f96af795b93fd9bcfc9690a1af2ff4c5867ee29e", size = 1107271, upload-time = "2026-08-16T22:54:50.266Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b8/206468912d2153306bb8a41afdfc59e45b7a73a0495bbe4b9cb4f0e79c1d/hypothesis-6.165.10-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60cab3ab4ea468d31a33739ffd7e94ec3e37dea891d65a6582ecc8a477175191", size = 1156915, upload-time = "2026-08-16T22:54:25.89Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d3/bf5a22929b70a4cfd3edf69c5642b029b27ddb5cfda48fa295d384b01abb/hypothesis-6.165.10-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:22cf19388f0ff6ced8eb3e49c903d14938e4ed909d93bf28383eef451511e424", size = 1281205, upload-time = "2026-08-16T22:54:44.083Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a2/d7b2ba444d36fc84d4779f4431e74dd9b023dc63bcf282199f6e48ad39f4/hypothesis-6.165.10-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:057d0232f1224dcd0b7698902551a4341a7399f90670b036db6c4376715fe889", size = 1324243, upload-time = "2026-08-16T22:55:41.123Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/95/afe6b531fd01928c6f63d394ee413fa2338d088b2b44efcc23596b54477e/hypothesis-6.165.10-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:ab0f2e9d7d7d4db257f7cf53de3706c2baf124269571f20ffc2bcd6781f03063", size = 616382, upload-time = "2026-08-16T22:55:18.449Z" },
+    { url = "https://files.pythonhosted.org/packages/48/86/9b4fb75f520a028edec50ffc904a94d724180395d71feb6d7a0ce7bb6f00/hypothesis-6.165.10-cp314-cp314-win_amd64.whl", hash = "sha256:d1ea02fa8ab3d33eb1125eade81f7136341eb429152c6dbe2ae6f8bc33b3fbdd", size = 672145, upload-time = "2026-08-16T22:54:24.831Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ba/f7bbaae0c789bab7ddb764d2056ee1a463cc95a8acbccc90d4184e48b242/hypothesis-6.165.10-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:ed1a5891e59472884a03cb9875483e8fc131c80a275c60967f8afc5458a0c8ff", size = 783287, upload-time = "2026-08-16T22:54:23.751Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/83/01ef80772b4abd335c49405576dc503cede94fb5da30ba2643a119013aea/hypothesis-6.165.10-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:09772e328a26e50486ac572be34f9887f9aa185efe7ebb16bde4e8f6038db1f4", size = 774991, upload-time = "2026-08-16T22:55:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/0b/f47506241f9d5a5a2efe4c65b6bf4830e9d9576e5d3779007a260699e608/hypothesis-6.165.10-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cf3b612542ba174c9da4000b59a4f4c81e8d66f87509be85d3a1b71b5c36413", size = 1105499, upload-time = "2026-08-16T22:54:51.864Z" },
+    { url = "https://files.pythonhosted.org/packages/84/fe/abb3909b7089835112fbe75bf00d817d733b3a8032759783db0a24ff1e56/hypothesis-6.165.10-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f69ec5be85ef508e206153bed8eafd03f7995dc464356c8bbb279a1e2b7d56f3", size = 1155685, upload-time = "2026-08-16T22:54:30.94Z" },
+    { url = "https://files.pythonhosted.org/packages/73/2f/1964738921640184067121ae77414522fc3f0463fc26c6e25a4f3b8e42ca/hypothesis-6.165.10-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:dd207497bb985918409a1bb5db85d1875f74e1269487332113b73d1ee7c77647", size = 1279177, upload-time = "2026-08-16T22:54:40.179Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c5/312af8ae038d3af9cf3f7f1021c1abfe31c0d9035e4cf63519e0a7dc983e/hypothesis-6.165.10-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:00de0abdcf8c05c9d0eab735a3c49a276376b55151e6fcb903c2b39a90e5e5c3", size = 1322921, upload-time = "2026-08-16T22:54:42.7Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e7/b0a2fde7570c090a1b914026266a421c751ef10138fffe37fe0ef9e675c0/hypothesis-6.165.10-cp314-cp314t-win_amd64.whl", hash = "sha256:cc2da5aa4edf14743fa9257e5ba3513963999f01211635702479d8e92b8207c8", size = 672147, upload-time = "2026-08-16T22:55:27.527Z" },
+    { url = "https://files.pythonhosted.org/packages/47/fd/985aa564d6ffd06483d45a62b40d319df0a703cd8bc1d041de17d102fbaa/hypothesis-6.165.10-cp315-abi3.abi3t-macosx_10_12_x86_64.whl", hash = "sha256:eeab73050ea58c13dd56e329f594c1dfe32ebd7bb169bbdf4f8ceefbc31ec6b5", size = 782882, upload-time = "2026-08-16T22:55:37.93Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2c/6cc11151e450f72353a490940cd0db704680d07b78dc75dcc9f480e0d0e1/hypothesis-6.165.10-cp315-abi3.abi3t-macosx_11_0_arm64.whl", hash = "sha256:4c68e983d0007d014bb01ad4bcbba78bc432c73a1755ff36d5102ceefa18299a", size = 774584, upload-time = "2026-08-16T22:55:51.822Z" },
+    { url = "https://files.pythonhosted.org/packages/10/39/ef26fa79c1738dfe9cdb1a3584fb6717d26429ca6c9d011cc4fdf08130c2/hypothesis-6.165.10-cp315-abi3.abi3t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7730d8197086f65d8969a991d6728a1d420a51b19fea06535c896cb43a1e05d0", size = 1104876, upload-time = "2026-08-16T22:54:58.937Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f4/3fcc84e7637f42bf00d987093b9418083ac8db81b87392608a60f4b7c5fd/hypothesis-6.165.10-cp315-abi3.abi3t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7a7980a898a3e6ebe4de1896a0507e3d519edb53fb9b4bda478c9fbeb6514558", size = 1133353, upload-time = "2026-08-16T22:54:28.635Z" },
+    { url = "https://files.pythonhosted.org/packages/35/59/21c5c14179c38f8d0de3560e7f1825c083311b3013b63f817d7dc78dfcbd/hypothesis-6.165.10-cp315-abi3.abi3t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b5820d009aedb7ae9cfd32f98b1ab0c0bbd6268379c4fab042218b6b655c63f8", size = 1132300, upload-time = "2026-08-16T22:56:08.539Z" },
+    { url = "https://files.pythonhosted.org/packages/14/af/fbb56059961e416b2de7b9dc5352db2e8572bd5ea46892957e4c1e5548ab/hypothesis-6.165.10-cp315-abi3.abi3t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37a7ac3d34220800e1107871cc391bca1b00439875925d7d821878b8b791f245", size = 1155175, upload-time = "2026-08-16T22:55:19.824Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/53/77fb0c2dad445858555429c4e06cf94a59ae8d2407dd6426b5af97c84828/hypothesis-6.165.10-cp315-abi3.abi3t-manylinux_2_31_riscv64.whl", hash = "sha256:dafa7c9dbe3d802f9bcdf261b29c8a70700fb22839947f06e471f62c46b6257f", size = 1109881, upload-time = "2026-08-16T22:55:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/7b/d187f673ff30e6ada640953636f978ffe64a6332f756b64163c2277f8d0c/hypothesis-6.165.10-cp315-abi3.abi3t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:90915635b9648071129b0f72c0673cf8eac9eb84cfd445c5bedef30c714b1ec2", size = 1144963, upload-time = "2026-08-16T22:56:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/60/31d504e364134d60af23e5f6365db0da3cf4a51b3ed3d4836e5a2cff12cf/hypothesis-6.165.10-cp315-abi3.abi3t-musllinux_1_2_aarch64.whl", hash = "sha256:e1bbeb7c506b07ee0422cf9b2f7212fefa4240957f03526d38d27bc6743a0a48", size = 1278684, upload-time = "2026-08-16T22:55:22.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e6/89d26834a08c02f8da149e541dd40d7a96f68d9722f43146e69a77436ed7/hypothesis-6.165.10-cp315-abi3.abi3t-musllinux_1_2_armv7l.whl", hash = "sha256:2b36aaffc88625a44f91074c5bbedfdefb9b376c38d1b3c342edcd2e4c8ed16c", size = 1407202, upload-time = "2026-08-16T22:55:14.949Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/20d1e72246867ea195440092e8bb422c7ddc2f271b87b5b65679d5532719/hypothesis-6.165.10-cp315-abi3.abi3t-musllinux_1_2_ppc64le.whl", hash = "sha256:18a3ea838ddea183388f8788750afa8494d79abb5358823be9782585f34445d3", size = 1261395, upload-time = "2026-08-16T22:56:05.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9b/ebab6c3c2b90a16abb4119198178652d12aff83cc8ec2cfde5276c69fb1e/hypothesis-6.165.10-cp315-abi3.abi3t-musllinux_1_2_riscv64.whl", hash = "sha256:2a2567b3a03a4a5a7c575c191cfcce321a967df3727803817e75bffbbeaecabe", size = 1279213, upload-time = "2026-08-16T22:55:35.066Z" },
+    { url = "https://files.pythonhosted.org/packages/23/78/69b219b524231d36eb20c792e1f01e7cb037e02bd0af1c29f77ed9a969c0/hypothesis-6.165.10-cp315-abi3.abi3t-musllinux_1_2_x86_64.whl", hash = "sha256:8001925fa3dde51cb574e4c9de4c7efe77c4e4d64bd2fd2ef61d5651f9d04f3d", size = 1322367, upload-time = "2026-08-16T22:54:21.279Z" },
+    { url = "https://files.pythonhosted.org/packages/55/63/ad5cc153dcc72ae5e7905fb9b3585f3e48ce892a2d6366f90163e867a69d/hypothesis-6.165.10-cp315-abi3.abi3t-win32.whl", hash = "sha256:c6559380469295c4009215fe1cab561301591a3bee2e2fb3f4f96d2273a3affc", size = 666038, upload-time = "2026-08-16T22:56:11.797Z" },
+    { url = "https://files.pythonhosted.org/packages/80/32/b62307b73fbc99f0a4381d6f9456df76fbcbb7a27ef7256e26f0376f48ea/hypothesis-6.165.10-cp315-abi3.abi3t-win_amd64.whl", hash = "sha256:30797f20ca45e57f526d2df872f63ba453cb4e1091ad542184a7a951af8da79d", size = 671941, upload-time = "2026-08-16T22:55:00.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/dd/e0f98add0548ef73ea7afac45da1fb8efc854d7f9931db568754d0f963f3/hypothesis-6.165.10-cp315-abi3.abi3t-win_arm64.whl", hash = "sha256:c53e9b1c36350df9965ec44d6c0d4e0bbbb38f720dd2b0e1256dc6524d411015", size = 669931, upload-time = "2026-08-16T22:55:50.205Z" },
+]
+
+[[package]]
+name = "hypothesis-graphql"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "graphql-core" },
+    { name = "hypothesis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/1d/b0b5167874abfbc41d3558efeffc74ec1b676ab2557c40a6640919f9647d/hypothesis_graphql-0.13.1.tar.gz", hash = "sha256:b0b34f0accb87af40140f5dd54a784ab899401db37ba52fac39a4b37c24b2f6c", size = 751115, upload-time = "2026-07-14T15:00:45.722Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/14/69680e51829138b4203535a5f5cee8eca5154c2af81e5b70d2af57e4d74f/hypothesis_graphql-0.13.1-py3-none-any.whl", hash = "sha256:1f014c8781e552a72d535f52d9d0752f21fef7af12badf70caa7d557866c7d75", size = 22816, upload-time = "2026-07-14T15:00:44.562Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -274,12 +621,236 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema-rs"
+version = "0.50.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/4c/884abc9056018c2867da5769cf233813cad8273a2c882dd06aacec156d7b/jsonschema_rs-0.50.0.tar.gz", hash = "sha256:35e332764f46f5250fc752ea7ac7c975117f1727c324dbff09eb3d162a42b734", size = 2576063, upload-time = "2026-08-20T17:28:17.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/08/681c26df13ddf5d7300a26693c5e047e90a7e88f9b8bb38d8b390eae5987/jsonschema_rs-0.50.0-cp310-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:46197af4ff05d24aea2046cea5f68ad3a6ae4f786e3d8732e1fb2ecd254b5ab4", size = 10154081, upload-time = "2026-08-20T17:27:37.222Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d3/7658e30f6482080257906832c017aca665d763822e2892f44aadd170099b/jsonschema_rs-0.50.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f539542a016803300c8ad2b7813866aed087d48132c57b989882e0f571e1181b", size = 5294693, upload-time = "2026-08-20T17:27:39.317Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a9/bc7c3a4f4915e99a83f13f4e80a49ee48d2a9109a2c8a7290bb49f90a276/jsonschema_rs-0.50.0-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:64516ee89fa08ff8a4a1f5ebb0f6a2b0354484c17ad32c1b8214dfa069bed9f4", size = 5172184, upload-time = "2026-08-20T17:27:40.863Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/ce61a6aaf0e9fb4f36fc56d55c8aaa7f0a740b423f64cc94ab6be7515d8c/jsonschema_rs-0.50.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a6b0cab12d8c8dce9385adf3ca047a210b493dc62a37125dcbe9f2f7ba27c45", size = 5416317, upload-time = "2026-08-20T17:27:42.498Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d7/b91eb42d68a31df9de7d1198ba8d7bccd4b481b5aa84d2247c7afd52085a/jsonschema_rs-0.50.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2233a15efe94dcf5648e9b7f7191e48647ba63a9adb7d1beccba6c70bd3e3a71", size = 5003780, upload-time = "2026-08-20T17:27:44.121Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2e/451bbd41c84a724b5e5e4c916752675f371d2a7ff4add084466a26218f8e/jsonschema_rs-0.50.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:35cf7cf06ffc4ff6e4af64655bb427d7ae1490731dfe76f5892b6e965fbfa32c", size = 5187892, upload-time = "2026-08-20T17:27:45.516Z" },
+    { url = "https://files.pythonhosted.org/packages/15/47/102b2877ae378feac6b7318970880276430d26d5e70f1fd353c8c5ad1211/jsonschema_rs-0.50.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fc7967fe78c24c169a4258bce96db9104249df6b38432aa38e09f5cca1ee01b", size = 5660250, upload-time = "2026-08-20T17:27:47.38Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e8/6ccca3e565cb889954051560d1f7b65336825e39ec6347641e70b58cf997/jsonschema_rs-0.50.0-cp310-abi3-win32.whl", hash = "sha256:368c458dd2f3c80793f56b484c838d9767f0a1f39f713e08302b75494d24d788", size = 4629130, upload-time = "2026-08-20T17:27:48.968Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7e/5fa09de407c65acaa6fb8f31d1f949f3278f824fdaec54a58dd557971070/jsonschema_rs-0.50.0-cp310-abi3-win_amd64.whl", hash = "sha256:81e88b2d93429a3b1564d12f417ca22be111721ac4d1b7f2f5cd9c6db03e4b73", size = 5388627, upload-time = "2026-08-20T17:27:50.3Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/eb/63c023f3657feaea9a5a0c91b4c6694fc11d6be588e59971f4084c7d5411/jsonschema_rs-0.50.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8ab80f4045261dd48581f5d573010c5ec97dbd7d9b1e36efb8181b6c991014f1", size = 5304756, upload-time = "2026-08-20T17:27:52.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/93f243d92c3461a6859df3a5a7f56f0b9c68048222d4aaf482e1751a0a9c/jsonschema_rs-0.50.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:869e9c27f23b7f10b68cea85348f67bbb6d8fb189b5961945652dfa90d576cdd", size = 4896032, upload-time = "2026-08-20T17:27:53.386Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7f/de8918e98c382e65223ed97aa3cad63d55b5694a21dc69f422214e72d672/jsonschema_rs-0.50.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f9180d2702cb665d5b66816659e306d46530a04252bc1fccefbf1446f55b9", size = 5411739, upload-time = "2026-08-20T17:27:54.762Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/34/3f2b6d8c47b3dcc516e1a372167d49c5c4dadbc97f7899287dd4cf086727/jsonschema_rs-0.50.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:54a321d695b9e26492a4c70640970ef2efd4b4ff9f069a8073a4f59a64e0ec2c", size = 5000001, upload-time = "2026-08-20T17:27:56.219Z" },
+    { url = "https://files.pythonhosted.org/packages/74/24/237ee940fc2b7bad33496c01acf397f8295871cb2b8e71d72514b9121d49/jsonschema_rs-0.50.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:530b33d1ba1db16de6214281d510487d4fed9f6dd030296f3d4461454c3cfb55", size = 5184126, upload-time = "2026-08-20T17:27:57.639Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/79/4fdabcbb0ec87d17d48a992ebdd9b07222cbc0a80eaa36e0b4b6194381e5/jsonschema_rs-0.50.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:daa8687efdbe6095beca6d3afc49019441636c0e06bb8bdac8256ac1c1fab418", size = 5655321, upload-time = "2026-08-20T17:27:59.003Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/28/c13d7aef01e0d7a1d8b5ce64d65856a5b8e114653fc768614bbfcf44943f/jsonschema_rs-0.50.0-cp314-cp314t-win_amd64.whl", hash = "sha256:86e61b510a766e18844ad8d3063171b4579c7019a4ddb435ccc4a16a144e1c11", size = 5379605, upload-time = "2026-08-20T17:28:00.44Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/52/910ada60387eb362beb607bad620f390f9271bc38885dd62217da38da463/jsonschema_rs-0.50.0-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:820feaf6d6a24a15f6d31e38e1bd7a2e429f6e6fda3ea111077386d0087b444f", size = 5304811, upload-time = "2026-08-20T17:28:01.701Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c4/2380906eb60bde90948a70be97a7896469b3ec6a57ea3a89aa23ce810ea5/jsonschema_rs-0.50.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:476b21521dcb54c90fe84a11eb73a88696ba8145dcabc89f3343c349c9c8ccff", size = 4895803, upload-time = "2026-08-20T17:28:03.254Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c4/e4262a0a5931ed095d198427219a0262ab2672885d605ab4ebd5b477cf25/jsonschema_rs-0.50.0-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:799a95c0b9fb5b764e6d81364429809339942bf790a005b58c430df010f99b27", size = 5411564, upload-time = "2026-08-20T17:28:04.648Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6c/3a16ae6c361b0555a8b0da62862921c24cbde85619f22eb4c738470e8671/jsonschema_rs-0.50.0-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:dab31ea8bf0ab62355b3eb2fc5a01082954e733542a3b63e2289af92e3d64472", size = 5000487, upload-time = "2026-08-20T17:28:05.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/86/be7d16808b8a16e38f347da533b11497e1ddea9fdf6187264aad67257877/jsonschema_rs-0.50.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:ba2e7b8c6d45d95cc86e71820a81ac01140b449faeb5276782181a1e5264e37c", size = 5183898, upload-time = "2026-08-20T17:28:07.449Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/87/941f1b8ddb205f90f01aa483277d8435241b37f6d1ab68f9079c24596037/jsonschema_rs-0.50.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ae065ba6def64229406a57af211d0ab5fb90ce5fd96def6169da3a7a7124dbc4", size = 5655022, upload-time = "2026-08-20T17:28:08.954Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ee/ebbb655af4109b0c215140b9fa30c171cf23ae6a743ee88ea37f07cfa1d9/jsonschema_rs-0.50.0-cp315-cp315t-win_amd64.whl", hash = "sha256:9e1360267ba41e5bc4c753ba731b431265e14ae47d2bdf6859774a38cddc0a6b", size = 5380067, upload-time = "2026-08-20T17:28:10.453Z" },
+]
+
+[[package]]
+name = "libcst"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml", marker = "python_full_version != '3.13.*'" },
+    { name = "pyyaml-ft", marker = "python_full_version == '3.13.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/c0/098e5c91ff1537f00c85a6438b6cb1863d17144680cc91f47c87f104a200/libcst-1.9.0.tar.gz", hash = "sha256:087b58a9afe076bb08e2d726478e1f16cb928d67ffa9092817e033c335de522a", size = 914739, upload-time = "2026-07-29T21:28:43.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/bb/d22c37c33dfe18084634f5ef89f8f0749ffe7b6e0ad312722aafd86bbbdb/libcst-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cd1a3500c41784075c4946a995d5ad89f68fa0d226b63ff3c4d78f6ea6dd23e5", size = 2043159, upload-time = "2026-07-29T19:24:49.013Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b8/2dedef84d72e7271119217503b69ed6dc5d0b2077685e163caae669d9c70/libcst-1.9.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:611cebd3bbc2014576f4dcc7b845b3c594c96ddc287a3db9b78f22eff156a7d3", size = 2203245, upload-time = "2026-07-29T19:24:50.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/90/e02ac2dad647423f947bb11f8322bfdba8ccfdd380e6c7b695add2d1acd4/libcst-1.9.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:8d731abe1307720ea1a52d447555e8443a6d130e0e520243c0634a58f6edbc9d", size = 2255388, upload-time = "2026-07-29T19:24:52.21Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5f/6089a51518cfd2ff40950eb26bcc36951d7b6d4f4213568aa0290265aff7/libcst-1.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8bc5351d92ca6ac1cc32e097700e1161ad1ceaa4d9b2cca5abadb1e94576b325", size = 2268982, upload-time = "2026-07-29T19:24:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/78/26881ec466fb70cbc129dca26ccb5a52a0061face2c5822e4b61f00f9699/libcst-1.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03165a264653bb77f6a11b412ae09c08bdb0c25864f3b8d42b816ac64b9d4b9e", size = 2378174, upload-time = "2026-07-29T19:24:55.175Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/7a/a4dba5f11faf12a12ffba06d18019987851aab33b590242a602ffd4fb1bd/libcst-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:b755ed4a4bc2faee849b54820023137d60d4c199e0a0822f0ff0c1bc49e49b48", size = 2103462, upload-time = "2026-07-29T19:24:56.966Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/13/57cb129093e0d6744b3c914ba6cbbdf51ed1b2c823882936c553a3a0cf1b/libcst-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:6e50576bad7d56459d9792cd0b0dfe5469dad13646e9a9c0a8b1ba20b269f332", size = 1979825, upload-time = "2026-07-29T19:24:58.403Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b1/befc0544283bb3923a928accf79ed685e5a725524bdb3491826670affc07/libcst-1.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b8b9df30f524317b097dc53065b25dda33d6a4cc3c7c8bf4fc83ca7559c58cc0", size = 2043754, upload-time = "2026-07-29T19:24:59.885Z" },
+    { url = "https://files.pythonhosted.org/packages/45/50/fef7c172a8457c95894edf5fb04805024899cdfea41fa01b0636587b79e1/libcst-1.9.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e465a7bc9c2b9533eb9e06d2391f8819f811b5112919d4064c9fb8565aaafa08", size = 2203548, upload-time = "2026-07-29T19:25:01.323Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ff/764cd2be1fd99d774fc44039c319dc0ed1d9d9afeaa02759a05121cccd4b/libcst-1.9.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8504b422c95676a8c27b517e1ac01413ece91bf356865c587ca9bdcd5708a2f7", size = 2255274, upload-time = "2026-07-29T19:25:02.764Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a7/474748a27a02fa83e3556b260d5f5236ca48164fa7beffecf3b2cad24dca/libcst-1.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bcb9f9d4fcfe2ec7a40d2c26e03a538d5d9dc189c38551eb3f94ab661afee7c0", size = 2269126, upload-time = "2026-07-29T19:25:04.158Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/b7/655e45363b8cf87b91e41e060b21c89e5316c7ef36eb14a1a498b27bb71e/libcst-1.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8d671c39a431c309476099b8ec811e412503ec0f4465f6fc907cb51c70e8e6b", size = 2378602, upload-time = "2026-07-29T19:25:06.424Z" },
+    { url = "https://files.pythonhosted.org/packages/db/13/6da63f0902ece43bf9d737017251ad7ad06edd9d3c4e1856450403cb4473/libcst-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:4d382fba04077eb556a1ea4295a4482e192aa93639c5a07ba0885841965ea0c0", size = 2103486, upload-time = "2026-07-29T19:25:07.979Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ff/dccb1a55e38b4e47256a97242d61d2bef5366c744faf88fb087d4fa0f995/libcst-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:a621e261990148c1cfbe26c1798bd2375c131cf358a44a7a4659fc41c1a336e1", size = 1979907, upload-time = "2026-07-29T19:25:09.532Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2a/4943c71d90975bc59034a057dea346b365c276f308c1d31f5cf2bd85492d/libcst-1.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:eccf4c57d273cdd3fe1c67b72cf9bb1bbd4547aa011824e96ccf5b7136057aa4", size = 2044529, upload-time = "2026-07-29T19:25:11.04Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ed/1168b98c2a0f338be3a44753647baab051feaf6167cc887bf4447f8fd920/libcst-1.9.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32395244edfe6538e0ea2bf82051d60103d3f54861274805c4fb3745efb70a85", size = 2203519, upload-time = "2026-07-29T19:25:12.543Z" },
+    { url = "https://files.pythonhosted.org/packages/25/7d/2eaa697a80f899bcf2245680bbfcc1e478eb3b3328c21d4b2880bdf00dac/libcst-1.9.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:444e84c76cd035cd2fe136838c1a524d34b08216521f6f5093df8a6f6cfa5799", size = 2255879, upload-time = "2026-07-29T19:25:14.137Z" },
+    { url = "https://files.pythonhosted.org/packages/90/03/793b9fd96dd52d202f5f2b88d7e54f05ebed767d1bb3b32395a1817bf6ab/libcst-1.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bb5d0946f2b4c6711b5d69fe4f833b364f9e7a1a2b08f88b98619dc18975099a", size = 2269807, upload-time = "2026-07-29T19:25:15.647Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/f4/1bc7aaea03971c45e8a885fed9fc1c73176dbbd00b0296a3cde9529bafd6/libcst-1.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:45808c03528b3ad40b14095348a918e08d98c47b4a125d631cb78e817c0a5b16", size = 2378171, upload-time = "2026-07-29T19:25:17.289Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f7/bc49e367d2bc8817213594dd52cf6b2da2dbbda90b5382d60653999274ac/libcst-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:568288cdbfe3b4ca3ae4852cb0a439ff053dd54c841bc4995bf2b71238b5de40", size = 2177847, upload-time = "2026-07-29T19:25:19.35Z" },
+    { url = "https://files.pythonhosted.org/packages/87/80/4d81577a22e6d535d1a3409f3a1c6903e09036f0e17fc47f92169dbc3501/libcst-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:107593af46945593e7825821793393262bc4fa1d3ea24c3ed487b61269bbbdf8", size = 2058134, upload-time = "2026-07-29T19:25:20.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7f/c3f3a0e7a1a2adaa76e815e82a7814d6bfe7d49432276bba652248c68d0b/libcst-1.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f6248cb07444ab9a6733a855737a9febed8b9adca51347019348b09a3ac7dfe9", size = 2036102, upload-time = "2026-07-29T19:25:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/af/2f5543255b2c7d749b966adeccc6bfb1652cf8b425afb913d0f3f025a865/libcst-1.9.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:496c24e0d3240bc7da45dae543aff3f5b6509978c39262d6b84ed2fb999dded2", size = 2194806, upload-time = "2026-07-29T19:25:24.017Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/5b/03f4cddce426d005e208b39ea7b2d456e667cdee0f1891360f0fc8430f20/libcst-1.9.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ea490fa8540503db5f321f0268becab46eb50f710e8cec8041e241fd66f6874f", size = 2246762, upload-time = "2026-07-29T19:25:25.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/31/9d5fe1e43dc3dbcc74f70f3e0e73fcdd8d84effc1059d8b45974f0d0d2eb/libcst-1.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:50ab94bb2524b419056d4003032b8c67102ac800f8d85b3c4260a01746d94dbb", size = 2259633, upload-time = "2026-07-29T19:25:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2b/6752b28d88c3a19b3bc0b9e1838443b6760d5c862b4f4b37955402659e24/libcst-1.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a2faaf92500d0226358125630f5aab4758e8aad3f2d70a10892ec3c700781a54", size = 2368043, upload-time = "2026-07-29T19:25:28.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/94/775825b2637f8ab05694b6a4b3802ae6783b4e799f9b58d2400c7e2d4369/libcst-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0c7b548512db25af9c2997a95fa731bd6b6928ecbad6c0915d7482d8bb42d34f", size = 2176432, upload-time = "2026-07-29T19:25:29.921Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3d/88ad67427c6fd9db929e087912b0a540e5140e5cb77e7ca4170edaac8531/libcst-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:497d5329345f1f5df84e41b0bbd00204b64a2fd30dfe3cfaeaebca633a31e877", size = 2052931, upload-time = "2026-07-29T19:25:31.397Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e4/ad790b043a38b10cea13166c8dd716654ad8b227c20f12eebf6326191cd9/libcst-1.9.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:a5068bf6114f6f4d79af7a6c80a28d1deb50441150ea1db13b5458ab34bec159", size = 2043987, upload-time = "2026-08-11T05:54:02.122Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6b/d3cd8275cc54ffc9817ade91442b3e6e9edd1a4518bd4e6dda13e3152dbe/libcst-1.9.0-cp315-cp315-manylinux_2_28_aarch64.whl", hash = "sha256:7acfd18adcdd32dcf41ce676cf121002afcbe9ad2c72dc0c18d78465beedc228", size = 2204003, upload-time = "2026-08-11T05:54:04.031Z" },
+    { url = "https://files.pythonhosted.org/packages/da/62/87eddccb11d5d221d50ac4fff4b6e9b8d48c547028d01f7d0fbc5c8a1d75/libcst-1.9.0-cp315-cp315-manylinux_2_28_x86_64.whl", hash = "sha256:86361e2b426bd1b403e52375703c8b764e226e571adcb30442510710681edbf0", size = 2256053, upload-time = "2026-08-11T05:54:06.228Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/a44126aeb9fca8b4e342e0cc803ea00ca8f6cd5712619a7897b3eba13797/libcst-1.9.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8c14abe844bec8b021111b3985474e49f5af799c020e8e40dedcac87c97a40c5", size = 2270576, upload-time = "2026-08-11T05:54:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/51/3af3dd44b117d66486e0ed61e43a16b7fc8cc5c372e1dd4ca0e70b888d46/libcst-1.9.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:8930971d2299b7006bb5d10c10038f44efb6da89d5bca2823595e31a9cdb96af", size = 2378573, upload-time = "2026-08-11T05:54:10.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e8/e545087d298dbf6494e84a8092f0f5dbd62eedacabd4ecd6b364367b4804/libcst-1.9.0-cp315-cp315-win_amd64.whl", hash = "sha256:5891ce9cff815077614f509e3a23888c5ddb8081d6188e8ba1172c0ccc369022", size = 2177937, upload-time = "2026-08-11T05:54:12.168Z" },
+    { url = "https://files.pythonhosted.org/packages/84/17/93a00a8e03494a84db102dd0e3d35b8876b1084ca2c194b331a168d86eb1/libcst-1.9.0-cp315-cp315-win_arm64.whl", hash = "sha256:1260b5d070a3324447a53a00387225a55472a62077ce01922d30a2a78cc4b138", size = 2058633, upload-time = "2026-08-11T05:54:13.817Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/00/c3751b12eb81822ea0b6131d374a98bc6c024c4b9ec5f6ea8f53dc23e967/libcst-1.9.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:02ee2dbdb5c218116f16a021350fc267a14be205b50d81c33f5d73857ab6fbf7", size = 2036178, upload-time = "2026-08-11T05:54:15.545Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/12/48ff486eb5adc593f4818569e8896b74b672414ab4722a74b17e4c4cf31e/libcst-1.9.0-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:3e5b684191a0462b2d40a73261ea7f4da6a49e7a030b7e0fceca46bebb51dfe5", size = 2195496, upload-time = "2026-08-11T05:54:17.625Z" },
+    { url = "https://files.pythonhosted.org/packages/51/18/b13a4669864d41a4801fed7b86ede1049dc9a1e1dde250a7ee1f9c3b1285/libcst-1.9.0-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:2b150c4f298fe54eb0fe73abf71f57db74d070796140a8c206c9615b6861f01e", size = 2245769, upload-time = "2026-08-11T05:54:19.343Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c7/cf2d46744825e84afbd7228fdeeea8d23cf6c4b2074253c27efb7705c653/libcst-1.9.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:50b913e37187f00a6fb88962009364e1cf1b1284aa1762304f34b52b972f2218", size = 2260576, upload-time = "2026-08-11T05:54:21.444Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/5433d3d62250b2e4325938db101766bcab2a006819684713bcccb6259a88/libcst-1.9.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:9f92c75283030fd58fb7d6e560168a00381e0e3368ec8a026a3ec8a828a05f93", size = 2368709, upload-time = "2026-08-11T05:54:23.276Z" },
+    { url = "https://files.pythonhosted.org/packages/87/39/9f0e1690727623f99489895db0e42048a3e1e8cea0627517c593e437fd83/libcst-1.9.0-cp315-cp315t-win_amd64.whl", hash = "sha256:4adf97bb1aff8039b0bd4991e2f838be6e4fad552821b26b71a5d1a653c2582f", size = 2177866, upload-time = "2026-08-11T05:54:25.144Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/79/9dc7811883e67ea771057e8937bc536eb3e77f3635fc5a93cd85b6fe1ea8/libcst-1.9.0-cp315-cp315t-win_arm64.whl", hash = "sha256:8f0dd08a5773d7051e105250b2a2c73d8065ea9b2d68e7e1bdc5244660e75f93", size = 2052908, upload-time = "2026-08-11T05:54:26.835Z" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mutmut"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "coverage" },
+    { name = "libcst" },
+    { name = "pytest" },
+    { name = "setproctitle" },
+    { name = "textual" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/f9/a63500696f3f35c443ef566528e55630bf7e064436416278927f7bc9c408/mutmut-3.7.0.tar.gz", hash = "sha256:dc93260fabb3a6fd3693aa8d1746825885cb6f9e66c7f9cc1a0f34fc6388e14a", size = 63735, upload-time = "2026-07-31T10:52:58.876Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/16/93e3e6aa30e5bc4141724463ae9d9bcc283d08b02aa85dbf5a2b665f3108/mutmut-3.7.0-py3-none-any.whl", hash = "sha256:1d2f9a1bfa4a474b2213df6b17223150b492bf4a85af0eda4fb322297337fb32", size = 59070, upload-time = "2026-07-31T10:53:00.005Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/d7/e7bfbc86e9f99ff7807e24de7703f032e9c9ba80bb355cf26e0e9bc5a75e/platformdirs-4.11.3.tar.gz", hash = "sha256:66a73d38a849810252df809a3d8bcbda8e26f6c189920e7535ad608a48dbb5ab", size = 33050, upload-time = "2026-08-13T22:43:27.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/a9/c34aebedd3a4c9afe5101b1b8713710b3fec18087c8a36c35d2f909861bd/platformdirs-4.11.3-py3-none-any.whl", hash = "sha256:5ed065d443751de711da036041a7a214122efc4a4de393b3f4137ba5576540e7", size = 23491, upload-time = "2026-08-13T22:43:26.121Z" },
 ]
 
 [[package]]
@@ -307,6 +878,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyrate-limiter"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/27/e564f33ea085c63d5540f707b31aeb50a4992eac2da655dc02435a760a07/pyrate_limiter-4.4.0.tar.gz", hash = "sha256:2c0c720c4fa16c5d8199e4821bf34507fb49c007a25b786cec6fb94ffd0844aa", size = 90955, upload-time = "2026-06-14T10:52:03.021Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/77/2b5ea2e5e343fd7f74ba9c50a282d7cb66d1be3d12bd647510338d78fcf1/pyrate_limiter-4.4.0-py3-none-any.whl", hash = "sha256:f738dfa3c7ac1222a5ea3d31e00cfd31b5592b13ade4077afe9e8ac6293381f5", size = 43102, upload-time = "2026-06-14T10:52:01.334Z" },
 ]
 
 [[package]]
@@ -381,6 +961,58 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml-ft"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/eb/5a0d575de784f9a1f94e2b1288c6886f13f34185e13117ed530f32b6f8a8/pyyaml_ft-8.0.0.tar.gz", hash = "sha256:0c947dce03954c7b5d38869ed4878b2e6ff1d44b08a0d84dc83fdad205ae39ab", size = 141057, upload-time = "2025-06-10T15:32:15.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/ba/a067369fe61a2e57fb38732562927d5bae088c73cb9bb5438736a9555b29/pyyaml_ft-8.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8c1306282bc958bfda31237f900eb52c9bedf9b93a11f82e1aab004c9a5657a6", size = 187027, upload-time = "2025-06-10T15:31:48.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c5/a3d2020ce5ccfc6aede0d45bcb870298652ac0cf199f67714d250e0cdf39/pyyaml_ft-8.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30c5f1751625786c19de751e3130fc345ebcba6a86f6bddd6e1285342f4bbb69", size = 176146, upload-time = "2025-06-10T15:31:50.584Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bb/23a9739291086ca0d3189eac7cd92b4d00e9fdc77d722ab610c35f9a82ba/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fa992481155ddda2e303fcc74c79c05eddcdbc907b888d3d9ce3ff3e2adcfb0", size = 746792, upload-time = "2025-06-10T15:31:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c2/e8825f4ff725b7e560d62a3609e31d735318068e1079539ebfde397ea03e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cec6c92b4207004b62dfad1f0be321c9f04725e0f271c16247d8b39c3bf3ea42", size = 786772, upload-time = "2025-06-10T15:31:54.712Z" },
+    { url = "https://files.pythonhosted.org/packages/35/be/58a4dcae8854f2fdca9b28d9495298fd5571a50d8430b1c3033ec95d2d0e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06237267dbcab70d4c0e9436d8f719f04a51123f0ca2694c00dd4b68c338e40b", size = 778723, upload-time = "2025-06-10T15:31:56.093Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ed/fed0da92b5d5d7340a082e3802d84c6dc9d5fa142954404c41a544c1cb92/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8a7f332bc565817644cdb38ffe4739e44c3e18c55793f75dddb87630f03fc254", size = 758478, upload-time = "2025-06-10T15:31:58.314Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/69/ac02afe286275980ecb2dcdc0156617389b7e0c0a3fcdedf155c67be2b80/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7d10175a746be65f6feb86224df5d6bc5c049ebf52b89a88cf1cd78af5a367a8", size = 799159, upload-time = "2025-06-10T15:31:59.675Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ac/c492a9da2e39abdff4c3094ec54acac9747743f36428281fb186a03fab76/pyyaml_ft-8.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:58e1015098cf8d8aec82f360789c16283b88ca670fe4275ef6c48c5e30b22a96", size = 158779, upload-time = "2025-06-10T15:32:01.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/9b/41998df3298960d7c67653669f37710fa2d568a5fc933ea24a6df60acaf6/pyyaml_ft-8.0.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:e64fa5f3e2ceb790d50602b2fd4ec37abbd760a8c778e46354df647e7c5a4ebb", size = 191331, upload-time = "2025-06-10T15:32:02.602Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/16/2710c252ee04cbd74d9562ebba709e5a284faeb8ada88fcda548c9191b47/pyyaml_ft-8.0.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8d445bf6ea16bb93c37b42fdacfb2f94c8e92a79ba9e12768c96ecde867046d1", size = 182879, upload-time = "2025-06-10T15:32:04.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/40/ae8163519d937fa7bfa457b6f78439cc6831a7c2b170e4f612f7eda71815/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c56bb46b4fda34cbb92a9446a841da3982cdde6ea13de3fbd80db7eeeab8b49", size = 811277, upload-time = "2025-06-10T15:32:06.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/28d82dbff7f87b96f0eeac79b7d972a96b4980c1e445eb6a857ba91eda00/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dab0abb46eb1780da486f022dce034b952c8ae40753627b27a626d803926483b", size = 831650, upload-time = "2025-06-10T15:32:08.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/df/161c4566facac7d75a9e182295c223060373d4116dead9cc53a265de60b9/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd48d639cab5ca50ad957b6dd632c7dd3ac02a1abe0e8196a3c24a52f5db3f7a", size = 815755, upload-time = "2025-06-10T15:32:09.435Z" },
+    { url = "https://files.pythonhosted.org/packages/05/10/f42c48fa5153204f42eaa945e8d1fd7c10d6296841dcb2447bf7da1be5c4/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:052561b89d5b2a8e1289f326d060e794c21fa068aa11255fe71d65baf18a632e", size = 810403, upload-time = "2025-06-10T15:32:11.051Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d2/e369064aa51009eb9245399fd8ad2c562bd0bcd392a00be44b2a824ded7c/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3bb4b927929b0cb162fb1605392a321e3333e48ce616cdcfa04a839271373255", size = 835581, upload-time = "2025-06-10T15:32:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/28/26534bed77109632a956977f60d8519049f545abc39215d086e33a61f1f2/pyyaml_ft-8.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:de04cfe9439565e32f178106c51dd6ca61afaa2907d143835d501d84703d3793", size = 171579, upload-time = "2025-06-10T15:32:14.34Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.16.2"
 source = { registry = "https://pypi.org/simple" }
@@ -406,6 +1038,97 @@ wheels = [
 ]
 
 [[package]]
+name = "schemathesis"
+version = "4.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "harfile" },
+    { name = "hypothesis" },
+    { name = "hypothesis-graphql" },
+    { name = "jsonschema-rs" },
+    { name = "pyrate-limiter" },
+    { name = "pytest" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "starlette-testclient" },
+    { name = "typing-extensions" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/e0/bba6582674338e217d3f21b989dd761c90e613f115aa16c0801c8eb415b6/schemathesis-4.25.0.tar.gz", hash = "sha256:656b945fd3ec4fc13fbf9922be0bf2b75234d02067ae2c8b4d399bd3a5b8f8aa", size = 2526211, upload-time = "2026-08-20T23:04:28.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/7a/08c28af467594d8262ae653ca69d5dd48a0b129146b73125a3d35d935864/schemathesis-4.25.0-py3-none-any.whl", hash = "sha256:e98adc7ccd8943cc76aeaf4117d62b2db9b12ff24c54ebe9c0c6340ae4d08b5e", size = 882094, upload-time = "2026-08-20T23:04:26.349Z" },
+]
+
+[[package]]
+name = "setproctitle"
+version = "1.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/48/49393a96a2eef1ab418b17475fb92b8fcfad83d099e678751b05472e69de/setproctitle-1.3.7.tar.gz", hash = "sha256:bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e", size = 27002, upload-time = "2025-09-05T12:51:25.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/f0/2dc88e842077719d7384d86cc47403e5102810492b33680e7dadcee64cd8/setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2dc99aec591ab6126e636b11035a70991bc1ab7a261da428491a40b84376654e", size = 18049, upload-time = "2025-09-05T12:49:36.241Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b4/50940504466689cda65680c9e9a1e518e5750c10490639fa687489ac7013/setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cdd8aa571b7aa39840fdbea620e308a19691ff595c3a10231e9ee830339dd798", size = 13079, upload-time = "2025-09-05T12:49:38.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/99/71630546b9395b095f4082be41165d1078204d1696c2d9baade3de3202d0/setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2906b6c7959cdb75f46159bf0acd8cc9906cf1361c9e1ded0d065fe8f9039629", size = 32932, upload-time = "2025-09-05T12:49:39.271Z" },
+    { url = "https://files.pythonhosted.org/packages/50/22/cee06af4ffcfb0e8aba047bd44f5262e644199ae7527ae2c1f672b86495c/setproctitle-1.3.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6915964a6dda07920a1159321dcd6d94fc7fc526f815ca08a8063aeca3c204f1", size = 33736, upload-time = "2025-09-05T12:49:40.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/a5949a8bb06ef5e7df214fc393bb2fb6aedf0479b17214e57750dfdd0f24/setproctitle-1.3.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cff72899861c765bd4021d1ff1c68d60edc129711a2fdba77f9cb69ef726a8b6", size = 35605, upload-time = "2025-09-05T12:49:42.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3a/50caca532a9343828e3bf5778c7a84d6c737a249b1796d50dd680290594d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7cb05bd446687ff816a3aaaf831047fc4c364feff7ada94a66024f1367b448c", size = 33143, upload-time = "2025-09-05T12:49:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/14/b843a251296ce55e2e17c017d6b9f11ce0d3d070e9265de4ecad948b913d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3a57b9a00de8cae7e2a1f7b9f0c2ac7b69372159e16a7708aa2f38f9e5cc987a", size = 34434, upload-time = "2025-09-05T12:49:45.31Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b7/06145c238c0a6d2c4bc881f8be230bb9f36d2bf51aff7bddcb796d5eed67/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d8828b356114f6b308b04afe398ed93803d7fca4a955dd3abe84430e28d33739", size = 32795, upload-time = "2025-09-05T12:49:46.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/dc/ef76a81fac9bf27b84ed23df19c1f67391a753eed6e3c2254ebcb5133f56/setproctitle-1.3.7-cp312-cp312-win32.whl", hash = "sha256:b0304f905efc845829ac2bc791ddebb976db2885f6171f4a3de678d7ee3f7c9f", size = 12552, upload-time = "2025-09-05T12:49:47.635Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5b/a9fe517912cd6e28cf43a212b80cb679ff179a91b623138a99796d7d18a0/setproctitle-1.3.7-cp312-cp312-win_amd64.whl", hash = "sha256:9888ceb4faea3116cf02a920ff00bfbc8cc899743e4b4ac914b03625bdc3c300", size = 13247, upload-time = "2025-09-05T12:49:49.16Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2f/fcedcade3b307a391b6e17c774c6261a7166aed641aee00ed2aad96c63ce/setproctitle-1.3.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3736b2a423146b5e62230502e47e08e68282ff3b69bcfe08a322bee73407922", size = 18047, upload-time = "2025-09-05T12:49:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ae/afc141ca9631350d0a80b8f287aac79a76f26b6af28fd8bf92dae70dc2c5/setproctitle-1.3.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3384e682b158d569e85a51cfbde2afd1ab57ecf93ea6651fe198d0ba451196ee", size = 13073, upload-time = "2025-09-05T12:49:51.46Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ed/0a4f00315bc02510395b95eec3d4aa77c07192ee79f0baae77ea7b9603d8/setproctitle-1.3.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0564a936ea687cd24dffcea35903e2a20962aa6ac20e61dd3a207652401492dd", size = 33284, upload-time = "2025-09-05T12:49:52.741Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e4/adf3c4c0a2173cb7920dc9df710bcc67e9bcdbf377e243b7a962dc31a51a/setproctitle-1.3.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5d1cb3f81531f0eb40e13246b679a1bdb58762b170303463cb06ecc296f26d0", size = 34104, upload-time = "2025-09-05T12:49:54.416Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4f/6daf66394152756664257180439d37047aa9a1cfaa5e4f5ed35e93d1dc06/setproctitle-1.3.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a7d159e7345f343b44330cbba9194169b8590cb13dae940da47aa36a72aa9929", size = 35982, upload-time = "2025-09-05T12:49:56.295Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/62/f2c0595403cf915db031f346b0e3b2c0096050e90e0be658a64f44f4278a/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0b5074649797fd07c72ca1f6bff0406f4a42e1194faac03ecaab765ce605866f", size = 33150, upload-time = "2025-09-05T12:49:58.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/29/10dd41cde849fb2f9b626c846b7ea30c99c81a18a5037a45cc4ba33c19a7/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:61e96febced3f61b766115381d97a21a6265a0f29188a791f6df7ed777aef698", size = 34463, upload-time = "2025-09-05T12:49:59.424Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3c/cedd8eccfaf15fb73a2c20525b68c9477518917c9437737fa0fda91e378f/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:047138279f9463f06b858e579cc79580fbf7a04554d24e6bddf8fe5dddbe3d4c", size = 32848, upload-time = "2025-09-05T12:50:01.107Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3e/0a0e27d1c9926fecccfd1f91796c244416c70bf6bca448d988638faea81d/setproctitle-1.3.7-cp313-cp313-win32.whl", hash = "sha256:7f47accafac7fe6535ba8ba9efd59df9d84a6214565108d0ebb1199119c9cbbd", size = 12544, upload-time = "2025-09-05T12:50:15.81Z" },
+    { url = "https://files.pythonhosted.org/packages/36/1b/6bf4cb7acbbd5c846ede1c3f4d6b4ee52744d402e43546826da065ff2ab7/setproctitle-1.3.7-cp313-cp313-win_amd64.whl", hash = "sha256:fe5ca35aeec6dc50cabab9bf2d12fbc9067eede7ff4fe92b8f5b99d92e21263f", size = 13235, upload-time = "2025-09-05T12:50:16.89Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a4/d588d3497d4714750e3eaf269e9e8985449203d82b16b933c39bd3fc52a1/setproctitle-1.3.7-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10e92915c4b3086b1586933a36faf4f92f903c5554f3c34102d18c7d3f5378e9", size = 18058, upload-time = "2025-09-05T12:50:02.501Z" },
+    { url = "https://files.pythonhosted.org/packages/05/77/7637f7682322a7244e07c373881c7e982567e2cb1dd2f31bd31481e45500/setproctitle-1.3.7-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:de879e9c2eab637f34b1a14c4da1e030c12658cdc69ee1b3e5be81b380163ce5", size = 13072, upload-time = "2025-09-05T12:50:03.601Z" },
+    { url = "https://files.pythonhosted.org/packages/52/09/f366eca0973cfbac1470068d1313fa3fe3de4a594683385204ec7f1c4101/setproctitle-1.3.7-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c18246d88e227a5b16248687514f95642505000442165f4b7db354d39d0e4c29", size = 34490, upload-time = "2025-09-05T12:50:04.948Z" },
+    { url = "https://files.pythonhosted.org/packages/71/36/611fc2ed149fdea17c3677e1d0df30d8186eef9562acc248682b91312706/setproctitle-1.3.7-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7081f193dab22df2c36f9fc6d113f3793f83c27891af8fe30c64d89d9a37e152", size = 35267, upload-time = "2025-09-05T12:50:06.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a4/64e77d0671446bd5a5554387b69e1efd915274686844bea733714c828813/setproctitle-1.3.7-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cc9b901ce129350637426a89cfd650066a4adc6899e47822e2478a74023ff7c", size = 37376, upload-time = "2025-09-05T12:50:07.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/ad9c664fe524fb4a4b2d3663661a5c63453ce851736171e454fa2cdec35c/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:80e177eff2d1ec172188d0d7fd9694f8e43d3aab76a6f5f929bee7bf7894e98b", size = 33963, upload-time = "2025-09-05T12:50:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/a36de7caf2d90c4c28678da1466b47495cbbad43badb4e982d8db8167ed4/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:23e520776c445478a67ee71b2a3c1ffdafbe1f9f677239e03d7e2cc635954e18", size = 35550, upload-time = "2025-09-05T12:50:10.791Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/68/17e8aea0ed5ebc17fbf03ed2562bfab277c280e3625850c38d92a7b5fcd9/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5fa1953126a3b9bd47049d58c51b9dac72e78ed120459bd3aceb1bacee72357c", size = 33727, upload-time = "2025-09-05T12:50:12.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/33/90a3bf43fe3a2242b4618aa799c672270250b5780667898f30663fd94993/setproctitle-1.3.7-cp313-cp313t-win32.whl", hash = "sha256:4a5e212bf438a4dbeece763f4962ad472c6008ff6702e230b4f16a037e2f6f29", size = 12549, upload-time = "2025-09-05T12:50:13.074Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/0e/50d1f07f3032e1f23d814ad6462bc0a138f369967c72494286b8a5228e40/setproctitle-1.3.7-cp313-cp313t-win_amd64.whl", hash = "sha256:cf2727b733e90b4f874bac53e3092aa0413fe1ea6d4f153f01207e6ce65034d9", size = 13243, upload-time = "2025-09-05T12:50:14.146Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c7/43ac3a98414f91d1b86a276bc2f799ad0b4b010e08497a95750d5bc42803/setproctitle-1.3.7-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:80c36c6a87ff72eabf621d0c79b66f3bdd0ecc79e873c1e9f0651ee8bf215c63", size = 18052, upload-time = "2025-09-05T12:50:17.928Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2c/dc258600a25e1a1f04948073826bebc55e18dbd99dc65a576277a82146fa/setproctitle-1.3.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b53602371a52b91c80aaf578b5ada29d311d12b8a69c0c17fbc35b76a1fd4f2e", size = 13071, upload-time = "2025-09-05T12:50:19.061Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/26/8e3bb082992f19823d831f3d62a89409deb6092e72fc6940962983ffc94f/setproctitle-1.3.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fcb966a6c57cf07cc9448321a08f3be6b11b7635be502669bc1d8745115d7e7f", size = 33180, upload-time = "2025-09-05T12:50:20.395Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/ae692a20276d1159dd0cf77b0bcf92cbb954b965655eb4a69672099bb214/setproctitle-1.3.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46178672599b940368d769474fe13ecef1b587d58bb438ea72b9987f74c56ea5", size = 34043, upload-time = "2025-09-05T12:50:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b2/6a092076324dd4dac1a6d38482bedebbff5cf34ef29f58585ec76e47bc9d/setproctitle-1.3.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7f9e9e3ff135cbcc3edd2f4cf29b139f4aca040d931573102742db70ff428c17", size = 35892, upload-time = "2025-09-05T12:50:23.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1a/8836b9f28cee32859ac36c3df85aa03e1ff4598d23ea17ca2e96b5845a8f/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14c7eba8d90c93b0e79c01f0bd92a37b61983c27d6d7d5a3b5defd599113d60e", size = 32898, upload-time = "2025-09-05T12:50:25.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/22/8fabdc24baf42defb599714799d8445fe3ae987ec425a26ec8e80ea38f8e/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9e64e98077fb30b6cf98073d6c439cd91deb8ebbf8fc62d9dbf52bd38b0c6ac0", size = 34308, upload-time = "2025-09-05T12:50:26.827Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/b9bee9de6c8cdcb3b3a6cb0b3e773afdb86bbbc1665a3bfa424a4294fda2/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b91387cc0f02a00ac95dcd93f066242d3cca10ff9e6153de7ee07069c6f0f7c8", size = 32536, upload-time = "2025-09-05T12:50:28.5Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0c/75e5f2685a5e3eda0b39a8b158d6d8895d6daf3ba86dec9e3ba021510272/setproctitle-1.3.7-cp314-cp314-win32.whl", hash = "sha256:52b054a61c99d1b72fba58b7f5486e04b20fefc6961cd76722b424c187f362ed", size = 12731, upload-time = "2025-09-05T12:50:43.955Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/acddbce90d1361e1786e1fb421bc25baeb0c22ef244ee5d0176511769ec8/setproctitle-1.3.7-cp314-cp314-win_amd64.whl", hash = "sha256:5818e4080ac04da1851b3ec71e8a0f64e3748bf9849045180566d8b736702416", size = 13464, upload-time = "2025-09-05T12:50:45.057Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6d/20886c8ff2e6d85e3cabadab6aab9bb90acaf1a5cfcb04d633f8d61b2626/setproctitle-1.3.7-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6fc87caf9e323ac426910306c3e5d3205cd9f8dcac06d233fcafe9337f0928a3", size = 18062, upload-time = "2025-09-05T12:50:29.78Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/60/26dfc5f198715f1343b95c2f7a1c16ae9ffa45bd89ffd45a60ed258d24ea/setproctitle-1.3.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6134c63853d87a4897ba7d5cc0e16abfa687f6c66fc09f262bb70d67718f2309", size = 13075, upload-time = "2025-09-05T12:50:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/21/9c/980b01f50d51345dd513047e3ba9e96468134b9181319093e61db1c47188/setproctitle-1.3.7-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1403d2abfd32790b6369916e2313dffbe87d6b11dca5bbd898981bcde48e7a2b", size = 34744, upload-time = "2025-09-05T12:50:32.777Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b4/82cd0c86e6d1c4538e1a7eb908c7517721513b801dff4ba3f98ef816a240/setproctitle-1.3.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7c5bfe4228ea22373e3025965d1a4116097e555ee3436044f5c954a5e63ac45", size = 35589, upload-time = "2025-09-05T12:50:34.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4f/9f6b2a7417fd45673037554021c888b31247f7594ff4bd2239918c5cd6d0/setproctitle-1.3.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:585edf25e54e21a94ccb0fe81ad32b9196b69ebc4fc25f81da81fb8a50cca9e4", size = 37698, upload-time = "2025-09-05T12:50:35.524Z" },
+    { url = "https://files.pythonhosted.org/packages/20/92/927b7d4744aac214d149c892cb5fa6dc6f49cfa040cb2b0a844acd63dcaf/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:96c38cdeef9036eb2724c2210e8d0b93224e709af68c435d46a4733a3675fee1", size = 34201, upload-time = "2025-09-05T12:50:36.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0c/fd4901db5ba4b9d9013e62f61d9c18d52290497f956745cd3e91b0d80f90/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:45e3ef48350abb49cf937d0a8ba15e42cee1e5ae13ca41a77c66d1abc27a5070", size = 35801, upload-time = "2025-09-05T12:50:38.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e3/54b496ac724e60e61cc3447f02690105901ca6d90da0377dffe49ff99fc7/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1fae595d032b30dab4d659bece20debd202229fce12b55abab978b7f30783d73", size = 33958, upload-time = "2025-09-05T12:50:39.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a8/c84bb045ebf8c6fdc7f7532319e86f8380d14bbd3084e6348df56bdfe6fd/setproctitle-1.3.7-cp314-cp314t-win32.whl", hash = "sha256:02432f26f5d1329ab22279ff863c83589894977063f59e6c4b4845804a08f8c2", size = 12745, upload-time = "2025-09-05T12:50:41.377Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b6/3a5a4f9952972791a9114ac01dfc123f0df79903577a3e0a7a404a695586/setproctitle-1.3.7-cp314-cp314t-win_amd64.whl", hash = "sha256:cbc388e3d86da1f766d8fc2e12682e446064c01cea9f88a88647cfe7c011de6a", size = 13469, upload-time = "2025-09-05T12:50:42.67Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -419,6 +1142,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette-testclient"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/64/6debec8fc6e9abde0c7042145dc27a562bd1cd79350a55b80bf612a10ccb/starlette_testclient-0.4.1.tar.gz", hash = "sha256:9e993ffe12fab45606116257813986612262fe15c1bb6dc9e39cc68693ac1fc5", size = 12480, upload-time = "2024-04-29T10:54:28.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/44/f5209b889a344b1331a103aec4e9f906c7f67f9295fd287fdaa818179d95/starlette_testclient-0.4.1-py3-none-any.whl", hash = "sha256:dcf0eb237dc47f062ef5925f98330af46f67e547cb587119c9ae78c17ae6c1d1", size = 8143, upload-time = "2024-04-29T10:54:25.728Z" },
+]
+
+[[package]]
 name = "technocore-chat"
 version = "0.7.0"
 source = { virtual = "." }
@@ -429,11 +1165,18 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+contract = [
+    { name = "schemathesis" },
+]
 dev = [
     { name = "httpx2" },
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
+]
+mutation = [
+    { name = "mutmut" },
 ]
 
 [package.metadata]
@@ -444,11 +1187,31 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+contract = [{ name = "schemathesis", specifier = "==4.25.0" }]
 dev = [
     { name = "httpx2", specifier = ">=2.10.0" },
+    { name = "hypothesis", specifier = ">=6.165.10" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.16.1" },
     { name = "ty", specifier = ">=0.0.71" },
+]
+mutation = [{ name = "mutmut", specifier = "==3.7.0" }]
+
+[[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
 ]
 
 [[package]]
@@ -492,6 +1255,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -722,4 +1503,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/2c/9d9c1da5a7ea9af307b386d25f64d1dead4729644198d2b92e36db5dfd41/websockets-17.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:bb31f42ea095ea826463c770829aa188a86c9a5c976b1467cbbf583c811de833", size = 213094, upload-time = "2026-07-31T11:31:15.367Z" },
     { url = "https://files.pythonhosted.org/packages/5b/24/a585e7573e128070605d003b5544729bcd58d9756c7e99d550818ca4b916/websockets-17.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dbfae8e75b342e31fc6fd1a8bbb393b7cbb91d6cfd581650300a94381e7b7e2b", size = 213009, upload-time = "2026-07-31T11:31:16.776Z" },
     { url = "https://files.pythonhosted.org/packages/09/ce/3929538b2b9918f5eee623fbf3346893973191f6df93f19bbda097bd7bb7/websockets-17.0.1-py3-none-any.whl", hash = "sha256:c6be9cba65c65cc76dfa3d4619e359ff02a4476c74e179b215236c11a0b32345", size = 206718, upload-time = "2026-07-31T11:31:26.037Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
 ]


### PR DESCRIPTION
## What

A 405 now carries `Allow`, and `/openapi.json` describes the service the server actually is —
nine corrections, from an unbounded `did:key` pattern that accepted `did:key:z6Mk` as a whole
DID to a `POST /r/events` the contract said did not exist. The `?wait=` ceiling is tunable as
`CHAT_MAX_WAIT` and every document that publishes it now generates it from the enforced value.

A caller sees: `Allow: GET, HEAD, POST` on the paths that take POST (the header was absent, and
Starlette's own would have said `GET, HEAD` there); refusal statuses it was never told could
happen — 400 on `GET /kv/<ns>/<key>`, 403 on `say-signed`, 409 on `set-signed`, 404 on the four
URL write lanes — now documented; and `minLength: 1` on `text`/`value`, which `required` alone
never implied. No response body, path or status changed. Additive for a client that looks
statuses up, breaking only for one asserting the document's exact shape.

Behind that, three checks that are not example tests, because the failures worth catching here
are not example-shaped: a Hypothesis state machine over the store's lifecycle, a contract job
that fuzzes every PR against the `/openapi.json` that instance serves, and a weekly scoped
mutation run. The suite goes 242 → 264.

## Why

The 405 was a plain protocol bug: RFC 9110 §15.5.6 makes `Allow` mandatory and it was missing,
so the one machine-readable part of that answer was not there.

The OpenAPI mismatches are the same failure in a different register. `src/manifest.py` exists
because "a published limit that disagrees with the enforced one is worse than no published
limit, because a machine reader believes it" — and the document had drifted into saying things
the server does not do. The signed lane published three different `did`/`sig`/`nonce` shapes,
and a client is built against whichever copy it found, so the weakest one was the real contract.
They now come from one set of regexes in `didkey.py`, beside the code that enforces them.

The checks are there so this does not recur by hand. The contract job found three of the nine
mismatches on its own, including the `POST /r/events` 403 that a client reading the old document
would have met as a 405. **None of the three found a defect in the service** — every mutation
survivor reviewed was an equivalent mutant, a wording change that left the correction intact, or
a real behaviour nothing pinned; the last category became tests.

Follows on from nothing open, and subsumes nothing. Deliberately left alone: the exact-threshold
`>`/`>=` comparisons on the idle and expiry rules — the state machine skips ages within five
seconds of a threshold because it counts whole simulated seconds against a real clock, and a test
that flakes on its own timing is worth less than the boundary it pins.

`tests/mutation_scope.py` and `.github/workflows/mutation.yml` are severable if you would rather
take the mutation job separately; nothing else depends on them.

## Checks

- [x] `uv run python -m pytest tests -q` — 264 passed
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: the manual in `src/app.py` generates its `WAITING`
      ceiling and the 404 route map from `MAX_WAIT` through the placeholder mechanism it already
      uses for the caps; `README.md`, `CONTRIBUTING.md` and `CHANGELOG.md` cover the three new
      checks. `SKILL.md` and `src/patterns.md` keep an illustrative `wait=10` — both are served
      byte-for-byte and cannot carry a per-deployment number, and the server clamps rather than
      refusing, so the example still works. `mcp/README.md` is unaffected: no MCP surface changed.
- [x] New surface on a world-writable service: **nothing new**. No route, parameter or persistent
      state is added, and no refusal is relaxed — the change is a required response header plus
      documentation of statuses the server already returned. `CHAT_MAX_WAIT` is operator-only and
      cannot raise the ceiling past what an operator sets; the `?wait=` clamp, the waiter caps and
      the rate limits are untouched.

## Notes for review

- Worth a look: `allowed_methods()` in `src/app.py` unions across every route matching the path.
  Two routes share `/r/<room>` and two share `/kv/<ns>/<key>`, and Starlette builds `Allow` from
  whichever partially matched first — so the union is the only answer that is true of the resource
  rather than of one registration of it.
- The contract job excludes two Schemathesis defaults on purpose (`negative_data_rejection`,
  `positive_data_acceptance`): this service ignores a mistyped `?wait=` rather than refusing it,
  and refuses schema-valid writes to mailboxes and reserved namespaces. Reasoning is in
  `.github/workflows/ci.yml`.
- `uv.lock` grows by 793 lines for three dev-only tools (hypothesis, schemathesis, mutmut). The
  runtime dependency set is unchanged, and the image still builds with `--no-dev`.


---
_Generated by [Claude Code](https://claude.ai/code/session_014W21eX5k7fB6WJtcK74CTx)_