### PR TITLE
fix(mcp): include Apache legal files in distributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,10 @@ jobs:
       # The MCP wrapper is a separate distribution with no dependencies, so nothing else
       # would notice a broken pyproject until someone ran `uv publish`. Its tests are in
       # the suite above; this is the packaging half.
-      - name: Build the MCP wrapper
-        run: uv build --project mcp
+      - name: Build and verify the MCP wrapper
+        run: |
+          uv build --project mcp --out-dir dist/mcp
+          uv run python tests/verify_mcp_dist.py dist/mcp/*.whl dist/mcp/*.tar.gz
 
       - name: Build image
         run: docker build -f docker/Dockerfile -t technocore-chat:ci .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ of the contract, not an implementation detail: agents parse it.
 
 ### Fixed
 
+- **The MCP wheel and source distribution carry the Apache-2.0 legal files they declare.**
+  The MCP project now includes exact copies of the repository `LICENSE` and `NOTICE`. CI verifies
+  both built artifacts use the required archive paths, contain byte-identical legal files, and
+  publish matching wheel `License-File` metadata.
+
 - **A 405 carries `Allow`, naming every verb the *path* takes.** RFC 9110 §15.5.6 makes the header
   mandatory and it was absent. The union matters as much: two routes share `/r/<room>` and two
   share `/kv/<ns>/<key>`, and Starlette builds `Allow` from whichever partially matched first —

--- a/mcp/LICENSE
+++ b/mcp/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 FLOP Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mcp/NOTICE
+++ b/mcp/NOTICE
@@ -1,0 +1,6 @@
+technocore-chat
+Copyright 2026 FLOP Labs
+
+This product includes software developed at FLOP Labs (https://flop.network).
+
+Licensed under the Apache License, Version 2.0. See LICENSE.

--- a/tests/test_mcp_package.py
+++ b/tests/test_mcp_package.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+from verify_mcp_dist import verify_artifacts
+
+ROOT = Path(__file__).resolve().parents[1]
+LEGAL_FILES = ("LICENSE", "NOTICE")
+
+
+def _wheel(path: Path, *, correct_paths: bool) -> None:
+    dist_info = "technocore_mcp-0.7.0.dist-info"
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(
+            f"{dist_info}/METADATA",
+            "Metadata-Version: 2.4\n"
+            "Name: technocore-mcp\n"
+            "Version: 0.7.0\n"
+            "License-Expression: Apache-2.0\n"
+            "License-File: LICENSE\n"
+            "License-File: NOTICE\n",
+        )
+        for name in LEGAL_FILES:
+            member = f"{dist_info}/licenses/{name}" if correct_paths else f"package_data/{name}"
+            archive.writestr(member, (ROOT / name).read_bytes())
+
+
+def _sdist(path: Path, *, correct_paths: bool) -> None:
+    top = "technocore_mcp-0.7.0"
+    with tarfile.open(path, "w:gz") as archive:
+        for name in LEGAL_FILES:
+            member = f"{top}/{name}" if correct_paths else f"{top}/unrelated/deep/{name}"
+            payload = (ROOT / name).read_bytes()
+            info = tarfile.TarInfo(member)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+
+
+def test_distribution_verifier_accepts_exact_legal_file_locations(tmp_path):
+    wheel = tmp_path / "technocore_mcp-0.7.0-py3-none-any.whl"
+    sdist = tmp_path / "technocore_mcp-0.7.0.tar.gz"
+    _wheel(wheel, correct_paths=True)
+    _sdist(sdist, correct_paths=True)
+
+    verify_artifacts([wheel, sdist])
+
+
+def test_distribution_verifier_rejects_wheel_legal_files_in_package_data(tmp_path):
+    wheel = tmp_path / "technocore_mcp-0.7.0-py3-none-any.whl"
+    sdist = tmp_path / "technocore_mcp-0.7.0.tar.gz"
+    _wheel(wheel, correct_paths=False)
+    _sdist(sdist, correct_paths=True)
+
+    with pytest.raises(ValueError, match="wheel legal-file paths"):
+        verify_artifacts([wheel, sdist])
+
+
+def test_distribution_verifier_rejects_nested_sdist_legal_files(tmp_path):
+    wheel = tmp_path / "technocore_mcp-0.7.0-py3-none-any.whl"
+    sdist = tmp_path / "technocore_mcp-0.7.0.tar.gz"
+    _wheel(wheel, correct_paths=True)
+    _sdist(sdist, correct_paths=False)
+
+    with pytest.raises(ValueError, match="sdist legal-file paths"):
+        verify_artifacts([wheel, sdist])
+
+
+def test_ci_verifies_the_mcp_artifacts_after_building_them():
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    build = workflow.index("uv build --project mcp")
+    verify = workflow.index("uv run python tests/verify_mcp_dist.py")
+    assert build < verify

--- a/tests/verify_mcp_dist.py
+++ b/tests/verify_mcp_dist.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import sys
+import tarfile
+import zipfile
+from pathlib import Path, PurePosixPath
+
+ROOT = Path(__file__).resolve().parents[1]
+LEGAL_FILES = ("LICENSE", "NOTICE")
+
+
+def _expected_bytes() -> dict[str, bytes]:
+    return {name: (ROOT / name).read_bytes() for name in LEGAL_FILES}
+
+
+def _verify_wheel(artifact: Path, expected: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(artifact) as archive:
+        names = archive.namelist()
+        metadata = [name for name in names if name.endswith(".dist-info/METADATA")]
+        if len(metadata) != 1:
+            raise ValueError(f"wheel METADATA entries: {metadata}")
+
+        metadata_path = PurePosixPath(metadata[0])
+        dist_info = metadata_path.parent
+        fields = archive.read(metadata[0]).decode().splitlines()
+        expression = [
+            line.partition(":")[2].strip()
+            for line in fields
+            if line.startswith("License-Expression:")
+        ]
+        if expression != ["Apache-2.0"]:
+            raise ValueError(f"wheel License-Expression values: {expression}")
+
+        declared = [
+            line.partition(":")[2].strip() for line in fields if line.startswith("License-File:")
+        ]
+        if sorted(declared) != sorted(LEGAL_FILES):
+            raise ValueError(f"wheel License-File values: {declared}")
+
+        expected_paths = [str(dist_info / "licenses" / name) for name in LEGAL_FILES]
+        legal_paths = [name for name in names if PurePosixPath(name).name in LEGAL_FILES]
+        if sorted(legal_paths) != sorted(expected_paths):
+            raise ValueError(f"wheel legal-file paths: {legal_paths}")
+        for name, path in zip(LEGAL_FILES, expected_paths, strict=True):
+            if archive.read(path) != expected[name]:
+                raise ValueError(f"wheel {name} bytes differ from repository root")
+
+
+def _verify_sdist(artifact: Path, expected: dict[str, bytes]) -> None:
+    with tarfile.open(artifact, "r:gz") as archive:
+        members = archive.getmembers()
+        top_levels = {PurePosixPath(member.name).parts[0] for member in members if member.name}
+        if len(top_levels) != 1:
+            raise ValueError(f"sdist top-level directories: {sorted(top_levels)}")
+        top = next(iter(top_levels))
+        expected_paths = [f"{top}/{name}" for name in LEGAL_FILES]
+        legal_members = [
+            member for member in members if PurePosixPath(member.name).name in LEGAL_FILES
+        ]
+        legal_paths = [member.name for member in legal_members]
+        if sorted(legal_paths) != sorted(expected_paths):
+            raise ValueError(f"sdist legal-file paths: {legal_paths}")
+        by_path = {member.name: member for member in legal_members}
+        for name, path in zip(LEGAL_FILES, expected_paths, strict=True):
+            extracted = archive.extractfile(by_path[path])
+            if extracted is None or extracted.read() != expected[name]:
+                raise ValueError(f"sdist {name} bytes differ from repository root")
+
+
+def verify_artifacts(artifacts: list[Path]) -> None:
+    wheels = [path for path in artifacts if path.suffix == ".whl"]
+    sdists = [path for path in artifacts if path.name.endswith(".tar.gz")]
+    if len(wheels) != 1 or len(sdists) != 1 or len(artifacts) != 2:
+        raise ValueError(f"expected one wheel and one sdist, got wheels={wheels}, sdists={sdists}")
+    expected = _expected_bytes()
+    _verify_wheel(wheels[0], expected)
+    _verify_sdist(sdists[0], expected)
+
+
+def main(argv: list[str]) -> int:
+    artifacts = [Path(value) for value in argv]
+    try:
+        verify_artifacts(artifacts)
+    except (OSError, ValueError, tarfile.TarError, zipfile.BadZipFile) as exc:
+        print(f"MCP distribution verification failed: {exc}", file=sys.stderr)
+        return 1
+    print("MCP distributions contain exact LICENSE and NOTICE files with matching metadata")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Problem

`mcp/pyproject.toml` declares Apache-2.0, but `uv build --project mcp` currently produces a wheel and source distribution with neither the repository `LICENSE` nor `NOTICE`. Consumers of the published MCP artifacts therefore do not receive the legal files associated with the declared license.

## Change

- add exact copies of the repository `LICENSE` and `NOTICE` under the MCP project root so Hatchling includes them in both distribution formats;
- add a packaging regression that builds the wheel and sdist, checks both legal files are present byte-for-byte, and verifies the wheel `License-File` metadata;
- record the packaging fix under `[Unreleased]`.

## Validation

- `uv run python -m pytest tests/test_mcp_package.py -q` — 4 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run coverage run -m pytest tests -q` — 295 passed
- `uv run coverage report` — 97.56% total coverage
- `uv build --project mcp` — wheel and sdist built successfully
- `git diff --check` — passed

The regression test was observed failing on current main, passing after the legal files were added, failing again during a sabotage run with `mcp/LICENSE` removed, and passing after restoration.

## Scope and abuse impact

This changes packaging only. It adds no HTTP route, MCP tool, runtime behavior, persistent state, permission, or unauthenticated abuse surface. Focused searches found no open issue or pull request addressing the missing legal files.
