### PR TITLE
Add untrustedContentHint to write_note's WebMCP annotations

### DIFF
--- a/src/humans.html
+++ b/src/humans.html
@@ -1083,7 +1083,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
         'comes back carrying the value that is actually there, so you can merge and retry ' +
         'without re-reading — or `if_absent` to create without ' +
         'overwriting. Writing /kv/topic/<room> sets that room\'s topic, shown on this page.',
-      annotations: { readOnlyHint: false },
+      annotations: { readOnlyHint: false, untrustedContentHint: true },
       inputSchema: {
         type: 'object',
         properties: {

--- a/tests/humans_ui_probe.mjs
+++ b/tests/humans_ui_probe.mjs
@@ -269,7 +269,7 @@ const browser = await chromium.launch({
         named("readOnlyHint") === "get_manual,list_notes,list_rooms,read_note,read_room",
         named("readOnlyHint"));
   check("every tool returning agent-written text is marked untrustedContentHint",
-        named("untrustedContentHint") === "list_notes,list_rooms,post_message,read_note,read_room",
+        named("untrustedContentHint") === "list_notes,list_rooms,post_message,read_note,read_room,write_note",
         named("untrustedContentHint"));
 
   const exec = (name, input) =>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3297,7 +3297,14 @@ def test_webmcp_tools_say_which_results_a_stranger_wrote(client):
     untrusted = {n for n, ann in tools.items() if "untrustedContentHint: true" in ann}
 
     assert readers == {"list_rooms", "read_room", "list_notes", "read_note", "get_manual"}
-    assert untrusted == {"list_rooms", "read_room", "post_message", "list_notes", "read_note"}
+    assert untrusted == {
+        "list_rooms",
+        "read_room",
+        "post_message",
+        "list_notes",
+        "read_note",
+        "write_note",
+    }
     # get_manual is the one reader that is not untrusted: /llms.txt is written by the
     # server, and a model that cannot trust the manual cannot trust anything here.
     assert "untrustedContentHint" not in tools["get_manual"]


### PR DESCRIPTION
Fixes #41.

## What

Adds `untrustedContentHint: true` to `write_note`'s WebMCP annotations on `/humans`. A caller inspecting the page's tool list now sees `write_note` correctly flagged as capable of returning stranger-written content, matching the other five tools that already carry the hint.

## Why

`write_note`'s own 409-conflict response returns the value currently stored at that key — and since notes are world-writable, that value could be anyone's. That's exactly the rule this project already applies to `read_note`, `list_notes`, `read_room`, `list_rooms`, and `post_message`; `write_note` was the one tool the rule should have covered but didn't. Doesn't touch `src/manifest.py` (the plain-HTTP manifest) or the MCP-over-JSON-RPC surface in `tests/test_mcp.py` — `untrustedContentHint` is specific to the WebMCP tools embedded in `src/humans.html`, and neither of those surfaces defines it.

Also updates `tests/test_app.py::test_webmcp_tools_say_which_results_a_stranger_wrote` — the actual CI-enforced assertion on this annotation set — and the matching string in `tests/humans_ui_probe.mjs` (a manual Playwright gate, not part of CI, per its own header comment).

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — full suite passes, 291 passed
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — all clean
- [x] Docs that would now be wrong are updated: checked the manual/`/skill.md` builder in `src/app.py`, plus `README.md`, `src/patterns.md`, `mcp/README.md` — none enumerate this annotation set, nothing to update
- [x] New surface on a world-writable service: nothing new — this only changes an existing tool's metadata annotation, not what it does or what an abusive caller can already do
