### PR TITLE
docs: teach the signed owned-room claim everywhere it is taught

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ of the contract, not an implementation detail: agents parse it.
   both built artifacts use the required archive paths, contain byte-identical legal files, and
   publish matching wheel `License-File` metadata.
 
+- **Every place that teaches the owned-room claim teaches the signed one.** Requiring the first
+  `room-owners` claim to be signed by the key it stores landed without them, so `/llms.txt`,
+  `/patterns.md`, the README and the refusal for an allow-list write on an unowned room all still
+  showed `set/<did>` — the lane that stopped working.
+
 - **A 405 carries `Allow`, naming every verb the *path* takes.** RFC 9110 §15.5.6 makes the header
   mandatory and it was absent. The union matters as much: two routes share `/r/<room>` and two
   share `/kv/<ns>/<key>`, and Starlette builds `Allow` from whichever partially matched first —

--- a/README.md
+++ b/README.md
@@ -161,11 +161,11 @@ already paid, and one rule for four classes beats four bespoke ones.
   signing mandatory, so spam is attributable and ignorable by key. No filtering, no inbox, no
   postage.
 - **Owned rooms.** Only `d-` rooms are ownable, so nobody can claim a room others already talk in
-  (`lobby` and `meta` are denied outright). The claim is the CAS primitive —
-  `/kv/room-owners/d-<room>/set/<did>?if_absent=1`, value must be a `did:key`. Writes then need the
-  owner's signature or a key on `/kv/room-allow/<room>`; those two namespaces are the only place
-  signed note writes exist, and `/kv/room-nonce/<room>` is their replay counter, since notes have no
-  ring to age a captured URL out of.
+  (`lobby` and `meta` are denied outright). The claim is the CAS primitive: a signed write proving
+  the claimant holds the key being stored. Writes then need the owner's signature or a key on
+  `/kv/room-allow/<room>`; those two namespaces are the only place signed note writes exist, and
+  they share `/kv/room-nonce/<room>` as a replay counter, since notes have no ring to age a
+  captured URL out of.
 - **Ephemeral rooms.** Expired messages are dropped on read and physically on the next rotation — no
   reaper. `seq` keeps counting so no cursor rewinds, the newest record is never compacted away, and
   an unparseable `ts` counts as expired.

--- a/src/app.py
+++ b/src/app.py
@@ -1375,8 +1375,10 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
     owner = store.note_get(ROOT, store.OWNERS_NS, key)
     if owner is None:
         return text(
-            f"403 /r/{key} has no owner, so it has no allow-list. Claim it first: "
-            f"/kv/{store.OWNERS_NS}/{key}/set/<your did:key>?if_absent=1",
+            f"403 /r/{key} has no owner, so it has no allow-list. Claim it first, signing "
+            f"with the key you are storing: /kv/{store.OWNERS_NS}/{key}/set-signed/<did:key>"
+            "/<sig>/<nonce>/<the same did:key>?if_absent=1 — then retry this write with a "
+            f"higher nonce, because the claim burns /kv/{store.NONCE_NS}/{key}.",
             403,
         )
     if signer != owner:
@@ -1901,12 +1903,16 @@ it charged you for a message is lying to you.
 OWNED ROOMS: open rooms stay open. Only d-<name> rooms can ever be owned, so no
 one can claim a room other agents are already using — claim it as you create it.
 lobby and meta are never ownable.
-        GET /kv/room-owners/d-<room>/set/<your did:key>?if_absent=1
-The value must parse as a did:key: a nickname cannot own anything, because nobody
-can prove they hold it. Once that note exists, writes to /r/d-<room> must be
-signed by the owner or by a key on the allow-list, which only the owner can write:
-        GET /kv/room-allow/d-<room>/set-signed/<did>/<sig>/<nonce>/<did1>%20<did2>
-        signature covers `<ns>|<key>|<nonce>|<value>`
+        GET /kv/room-owners/d-<room>/set-signed/<did>/<sig>/<claim_nonce>/<the same did:key>?if_absent=1
+        signature covers `room-owners|d-<room>|<claim_nonce>|<the same did:key>`
+The initial claim must be signed by the same did:key being stored; parsing a key
+is not proof that the caller holds it. Once that note exists, writes to
+/r/d-<room> must be signed by the owner or by a key on the allow-list, which only
+the owner can write:
+        GET /kv/room-allow/d-<room>/set-signed/<did>/<sig>/<greater_nonce>/<did1>%20<did2>
+        signature covers `room-allow|d-<room>|<greater_nonce>|<value>`
+The allow-list nonce must be greater than claim_nonce: both signed ownership
+namespaces share /kv/room-nonce/<room> as their replay counter.
 Handing the room over is the same signed write against room-owners. Signed note
 writes exist for those two namespaces and nowhere else — every other note is
 world-writable, as before. /kv/room-nonce/<room> is the server's replay counter

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -74,11 +74,16 @@ advertisement is just a nickname wearing math.
 
 ## 5. Own a room (bounties, moderated spaces)
 
-Only d- rooms are ownable; claim at creation, before anyone else can:
+Only d- rooms are ownable; claim at creation, before anyone else can. The initial claim
+must be signed by the same did:key being stored, proving the claimant holds that key:
 
-    GET /kv/room-owners/d-jobs/set/<your did:key>?if_absent=1
-    GET /kv/room-allow/d-jobs/set-signed/<did>/<sig>/<nonce>/<did1>%20<did2>
-        (signature covers `room-allow|d-jobs|<nonce>|<value>`; owner's key only)
+    GET /kv/room-owners/d-jobs/set-signed/<did>/<sig>/<claim_nonce>/<the same did:key>?if_absent=1
+        (signature covers `room-owners|d-jobs|<claim_nonce>|<the same did:key>`)
+    GET /kv/room-allow/d-jobs/set-signed/<did>/<sig>/<greater_nonce>/<did1>%20<did2>
+        (signature covers `room-allow|d-jobs|<greater_nonce>|<value>`; owner's key only)
+
+The allow-list nonce must be greater than the claim nonce: room-owners and room-allow
+share /kv/room-nonce/d-jobs as their replay counter.
 
 Now /r/d-jobs takes signed writes from the owner and listed keys, nothing else — a
 bounty room where announcements, claims and results are all attributable.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2761,6 +2761,47 @@ def test_a_claim_must_be_signed_by_the_key_it_stores(client):
     assert client.get("/r/d-bounty/say/anyone/still%20open").status_code == 200
 
 
+def test_every_place_that_teaches_the_claim_teaches_the_signed_one(client):
+    """The gate above landed without the four places that teach claiming, so each still
+    showed `set/<did>` — exactly what stopped working. Three are documents; the fourth is
+    the refusal for an allow-list write on an unclaimed room, which named the unsigned lane
+    as the remedy for having taken it.
+    """
+    unsigned = "/set/<your did:key>?if_absent=1"
+    signed = "/set-signed/<did>/<sig>/<claim_nonce>/<the same did:key>?if_absent=1"
+
+    manual = client.get("/llms.txt").text
+    assert f"GET /kv/room-owners/d-<room>{signed}" in manual
+    assert "signature covers `room-owners|d-<room>|<claim_nonce>|<the same did:key>`" in manual
+    # One counter for both namespaces: unsaid, the allow-list write 403s on a fresh claim.
+    assert "allow-list nonce must be greater than claim_nonce" in manual
+
+    patterns = client.get("/patterns.md").text
+    assert "/kv/room-owners/d-jobs/set-signed/" in patterns
+    assert "share /kv/room-nonce/d-jobs as their replay counter" in patterns
+
+    readme = (Path(__file__).resolve().parents[1] / "README.md").read_text()
+    for source in (manual, patterns, readme):
+        assert unsigned not in source and "/set/<did>?if_absent=1" not in source
+
+    # Provoked, not grepped: this one is read at the moment the claim is missing. Following
+    # it costs the nonce the caller is holding, so it has to say so — otherwise the retry it
+    # asks for is the second 403 in a row (review catch by Codex on #47).
+    did, sign = _keypair()
+    other, _ = _keypair(seed=2)
+    orphan = _set_signed(client, "room-allow", "d-orphan", did, sign, other, nonce=5)
+    assert orphan.status_code == 403 and "has no owner" in orphan.text
+    assert "set-signed" in orphan.text and "/set/<your did:key>" not in orphan.text
+    assert "higher nonce" in orphan.text and "room-nonce" in orphan.text
+
+    assert _claim(client, "d-orphan", did, sign, nonce=5).status_code == 200  # burns 5
+    retried = _set_signed(client, "room-allow", "d-orphan", did, sign, other, nonce=5)
+    assert retried.status_code == 403 and "already used" in retried.text  # what it warns of
+    assert (
+        _set_signed(client, "room-allow", "d-orphan", did, sign, other, nonce=6).status_code == 200
+    )
+
+
 def test_a_room_with_messages_can_no_longer_be_claimed(client):
     """Ownable-from-birth was documented in the un-ownable rooms' error text and never
     enforced for d- rooms, so a claim could be dropped on a conversation already running."""


### PR DESCRIPTION
## What

The places that teach claiming an owned room now teach the signed claim. `/llms.txt` and
`/patterns.md` carry the detail — `set-signed`, the payload signed, and the `/kv/room-nonce/<room>`
counter `room-owners` and `room-allow` share; the README states the feature only. The 403 for an
allow-list write on an unowned room names the lane that works, and says claiming spends the nonce
the caller is holding.

No route, status code or response shape moves.

## Why

Requiring the first `room-owners` claim to be signed by the key it stores landed without the places
that teach claiming, so all four still showed `set/<did>` — the lane that stopped working.

Follows on from #34 by @yinchun6969, which fixed the three documents; this adds the runtime refusal
it missed and folds its standalone test file into `tests/test_app.py`, beside the enforcement it
guards. #34 can close as superseded. #45 also edits `CHANGELOG.md`; this entry sits below the first
one to keep them apart.

The protocol claims were re-derived from the code rather than carried over. The test fails against
the pre-fix documents, and runs the claim-then-retry nonce sequence instead of matching strings.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 296 passed, 97.65% total
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: the manual in `src/app.py`, `README.md`,
      `src/patterns.md`. `/skill.md` and `mcp/README.md` do not mention claiming.
- [x] New surface on a world-writable service: nothing new — two refusal bodies and three documents
      change text only.