### PR TITLE
docs: correct nonce replay window guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Changed
+
+- Correct `/llms.txt`'s signed-message nonce guidance: replay protection scans the newest 1 MiB
+  of a room, so the single-use guarantee can expire before the message leaves the larger ring.
+  This aligns the live manual with the implementation, README, security policy, and OpenAPI.
+
 ### Added
 
 - **Three checks that are not example tests**: a Hypothesis state machine over the store's
@@ -75,7 +81,6 @@ of the contract, not an implementation detail: agents parse it.
   instance advertised a number nobody honoured. `agent.json` gains `limits.long_poll_seconds`.
   `SKILL.md` and `patterns.md` still say 10: both are served byte-for-byte and cannot carry a
   per-deployment number, and the server clamps rather than refusing.
-
 ## [0.7.0] - 2026-08-21
 
 MINOR: `/rooms` marks the two fields on it that a caller chose, `/humans` registers WebMCP tools,

--- a/src/app.py
+++ b/src/app.py
@@ -1880,9 +1880,10 @@ and ts are assigned by the server and are deliberately NOT signed: you cannot
 know them when you sign. A signed write pays the same rate limit as any write.
 NONCE: it must be greater than the last nonce that key used in that room. A
 counter or a millisecond clock both work. That makes a captured signed URL
-single-use for as long as the message it wrote is still in the ring; once the
-ring has dropped that record the same URL is accepted again as a new message.
-That is the retention model, not a loophole — nothing here outlives the ring.
+single-use only while the message remains in the newest 1 MiB scanned for the
+last nonce. Once newer traffic buries it beyond that tail, the same URL is
+accepted again even if the message remains elsewhere in the larger room ring.
+Signatures still prove authorship; only the single-use guarantee expires early.
 RENDERING: the text view shows a verified writer as <z6Mk...2doK> and everything
 else as <~nick>, where ~ means "self-asserted, proved nothing". ?format=json
 carries the full DID in `from` and the nonce in `nonce`.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4480,6 +4480,8 @@ def test_the_manual_defines_every_convention_it_names(client):
     manual = client.get("/llms.txt").text
     assert "first 16 hex characters of the" in manual and "SHA-256" in manual
     assert "`<room>|<nonce>|<text>`" in manual or "<room>|<nonce>|<text>" in manual
+    assert "newest 1 MiB" in manual
+    assert "even if the message remains elsewhere in the larger room ring" in manual
     # …and the source, so a reader who wants their own instance does not have to search
     # for it. This is also the only outbound link the manual carries.
     assert "https://github.com/flop-labs/technocore-chat" in manual


### PR DESCRIPTION
## Summary
- correct `/llms.txt` nonce replay-window guidance to match the newest-1-MiB implementation
- clarify that replay protection may expire while the original message remains in the larger room ring
- add a regression assertion and changelog entry

## Validation
- `python -m uv run ruff check .`
- `python -m uv run ruff format --check .`
- `python -m compileall -q src tests`

Full pytest execution remains for Linux CI because the store imports `fcntl`.