### PR TITLE
fix(humans): align name input limits with server

### DIFF
--- a/src/humans.html
+++ b/src/humans.html
@@ -372,7 +372,7 @@
 
   <h2 id="room-heading">Room</h2>
   <div class="row">
-    <input id="room" value="lobby" maxlength="32" aria-label="Room name" spellcheck="false">
+    <input id="room" value="lobby" maxlength="48" aria-label="Room name" spellcheck="false">
     <button id="join" class="btn-secondary">Open</button>
     <span id="status" class="badge" role="status" aria-live="polite"></span>
   </div>
@@ -380,7 +380,7 @@
   <div id="log"><div class="empty">Loading…</div></div>
 
   <div class="row">
-    <input id="nick" value="human" maxlength="32" aria-label="Your nickname" spellcheck="false">
+    <input id="nick" value="human" maxlength="48" aria-label="Your nickname" spellcheck="false">
     <input id="text" placeholder="Say something…" maxlength="2000" aria-label="Message">
     <button id="send" class="btn-primary">Send</button>
   </div>

--- a/tests/test_humans_name_input_limit.py
+++ b/tests/test_humans_name_input_limit.py
@@ -1,0 +1,32 @@
+import re
+import sys
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def _maxlength(html: str, field: str) -> int:
+    match = re.search(rf'<input id="{field}"[^>]*maxlength="(\d+)"', html)
+    assert match is not None, f"missing maxlength for #{field}"
+    return int(match.group(1))
+
+
+@pytest.mark.parametrize("field", ["room", "nick"])
+def test_humans_name_inputs_match_the_server_name_limit(field: str):
+    import app as app_module
+    import store
+
+    # Exercise the page as served, not the source file directly: the browser-visible
+    # maxlength must agree with the same validator every room/nick route reaches.
+    html = TestClient(app_module.app).get("/humans").text
+    limit = _maxlength(html, field)
+
+    accepted = "a" * limit
+    assert store.valid_name(accepted) == accepted
+
+    with pytest.raises(store.StoreError):
+        store.valid_name("a" * (limit + 1))


### PR DESCRIPTION
## Summary

`/humans` still caps the room and nickname inputs at 32 characters even though the server and the page's JavaScript validator both accept names up to 48 characters.

This completes the earlier `/humans` name-length fix: the JavaScript `NAME_RE` was widened to the server's 48-character contract, but the HTML `maxlength` attributes were left at 32. As a result, a person typing a valid 33–48 character room or nickname into the page is stopped by the browser before the server ever sees it.

## Changes

- Raise the `/humans` room input `maxlength` from 32 to 48.
- Raise the `/humans` nickname input `maxlength` from 32 to 48.
- Add a focused regression test that reads the served `/humans` page and checks that each input limit matches the server-side name validator boundary.

## Scope

- No HTTP API changes.
- No server validation changes.
- No persistence, authentication, or authorization changes.
- No new public surface or abuse impact.
- The message input limit is intentionally unchanged.

## Validation

The regression test fails against the previous behavior because the page advertises a 32-character input limit while `store.valid_name()` still accepts 33 characters. With this change, 48 characters are accepted and 49 are rejected, matching the server contract.

The branch is based on the current upstream `main` and contains one focused commit touching only `src/humans.html` and the regression test.