### PR TITLE
fix(mcp): reject falsey non-object request params

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -309,7 +309,7 @@ class Server:
             return _error(None, INVALID_REQUEST, "request id must be a string or integer")
         if not _is_request(message):
             return _error(ident, INVALID_REQUEST, "missing method")
-        params = message.get("params") or {}
+        params = message.get("params", {})
         if not isinstance(params, dict):
             # By-position params: legal JSON-RPC, but no method here takes them, and
             # guessing which argument a client meant is worse than saying so.

--- a/tests/test_mcp_falsey_params.py
+++ b/tests/test_mcp_falsey_params.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "mcp" / "src"))
+
+
+@pytest.mark.parametrize("params", [[], "", 0, False, None])
+def test_falsey_non_object_params_are_rejected(params):
+    """Present falsey params must not be collapsed into the missing-params default."""
+    from technocore_mcp import protocol
+
+    server = protocol.Server("test", "0")
+    reply = server.handle({"jsonrpc": "2.0", "id": 1, "method": "ping", "params": params})
+    assert reply == {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {
+            "code": protocol.INVALID_PARAMS,
+            "message": "params must be an object",
+        },
+    }


### PR DESCRIPTION
## What

Preserve the distinction between an omitted MCP `params` member and an explicitly supplied falsey non-object value.

`Server.handle()` currently uses:

```python
params = message.get("params") or {}
```

That turns `[]`, `""`, `0`, `false`, and `null` into `{}` before the existing object-shape check runs. Requests such as `ping` with one of those malformed values can therefore succeed instead of returning `-32602 INVALID_PARAMS`.

This changes the defaulting to:

```python
params = message.get("params", {})
```

so only a missing `params` member defaults to an empty object. Explicit non-object values reach the existing `isinstance(params, dict)` guard and are rejected as intended.

## Regression coverage

Adds a focused parameterized regression test covering:

- `[]`
- `""`
- `0`
- `false`
- `null`

against `ping`, which is enough to exercise the shared request dispatcher before method dispatch. Existing tests already cover the valid case where `params` is omitted entirely.

The regression fails against the previous `or {}` behavior and passes with this change.

## Compatibility / scope

- No HTTP API change.
- No new route, persistent state, permission, or authentication behavior.
- No documentation change: this aligns runtime validation with the MCP request shape and the server's existing `params must be an object` contract.
- No abuse impact / new public surface.

## Checks

- Targeted red/green regression behavior verified.
- Python syntax check for the added test passed.
- Full repository lint, format, type, test/coverage, package, image, and contract checks are left to the repository CI in this environment.