### PR TITLE
feat(config): one overridable home for the CHAT_* knobs (src/config.py)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ uv run coverage run -m pytest tests -q
 uv run coverage report
 ```
 
-Layering: the core is `src/store.py`, `src/didkey.py` and a thin `src/app.py` adapter.
+Layering: the core is `src/store.py`, `src/didkey.py`, `src/config.py` and a thin
+`src/app.py` adapter.
 `src/manifest.py`, docs and frontends are extra — never counted as core.
 
 - Move tests, don't rewrite them: test bodies stay byte-identical across reorganisations.

--- a/src/app.py
+++ b/src/app.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-import math
-import os
 import secrets
 import time
 import tomllib
@@ -30,12 +28,28 @@ from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 from starlette.routing import Match, Route
 
+import config
 import didkey
 import manifest
 import store
 from store import StoreConflictError, StoreError
 
-ROOT = Path(os.environ.get("CHAT_ROOT", "/data"))
+# The CHAT_* knobs are read from the environment exactly once, in config — the only
+# module in src/ that reads it — and re-bound here so request handlers (and the
+# tests that monkeypatch app.RATE_WRITE &c.) keep reading plain module globals. Tests that
+# need a different value for a whole request use config.override(...), which re-binds both
+# copies and restores them on exit.
+ROOT = config.ROOT
+RATE_READ = config.RATE_READ  # requests/min/IP
+RATE_WRITE = config.RATE_WRITE
+RATE_ROOMS_PER_DAY = config.RATE_ROOMS_PER_DAY
+CORS_ORIGINS = config.CORS_ORIGINS
+STATS_TOKEN = config.STATS_TOKEN
+STATS_CACHE_SECONDS = config.STATS_CACHE_SECONDS
+ROOMS_CACHE_SECONDS = config.ROOMS_CACHE_SECONDS
+SECURITY_CONTACT = config.SECURITY_CONTACT
+CLIENT_IP_HEADER = config.CLIENT_IP_HEADER
+PUBLIC_URL = config.PUBLIC_URL
 
 # Sized from what the wire actually carries, not from what a parser tolerates. A real
 # agent request through Cloudflare — Host, UA, Accept, CF-Connecting-IP, CF-Ray,
@@ -55,20 +69,8 @@ MAX_HEADER_BYTES = 8192
 # each, ~192 KiB before the envelope. 256 KiB leaves room for keys and signed credentials
 # while keeping the container's per-request memory bound explicit.
 MAX_BODY = 256 << 10
-# Floored at 1: the bucket arithmetic divides by this, so a zero or negative value
-# configured by hand would turn every rate-limited route into a 500 rather than into the
-# refusal the operator presumably meant. There is no "disable" setting for the same reason
-# the limiter exists at all.
-RATE_READ = max(1, int(os.environ.get("CHAT_RATE_READ", "120")))  # requests/min/IP
-RATE_WRITE = max(1, int(os.environ.get("CHAT_RATE_WRITE", "30")))
-# A per-IP budget on bringing *new rooms into existence*, measured over a day rather than a
-# minute. RATE_WRITE bounds how fast one caller can talk; nothing bounded how many rooms one
-# caller could create, and those are not the same resource. At RATE_WRITE a single caller
-# exhausts MAX_ROOMS in a matter of hours, and the slots it takes are everyone's — the
-# next caller, whoever they are, gets the fail-closed refusal. This is what makes MAX_ROOMS
-# a cap on the service rather than a race won by whoever creates rooms fastest.
-RATE_ROOMS_PER_DAY = max(1, int(os.environ.get("CHAT_RATE_ROOMS_PER_DAY", "20")))
-# Both of the above are per deployment, which is why no document states them as prose:
+# RATE_READ / RATE_WRITE / RATE_ROOMS_PER_DAY live in config; the comment that floors them
+# moved with them. Both are per deployment, which is why no document states them as prose:
 # /.well-known/agent.json publishes what this process actually enforces, and the manual
 # points there. A manual naming a number the server does not enforce is worse than one
 # naming none, because a machine reader paces itself to it.
@@ -79,40 +81,8 @@ RATE_ROOMS_PER_DAY = max(1, int(os.environ.get("CHAT_RATE_ROOMS_PER_DAY", "20"))
 FREE_PATHS = (
     "/, /llms.txt, /skill.md, /patterns.md, /auth.md, /openapi.json, /.well-known/* and /healthz"
 )
-CORS_ORIGINS = [o for o in os.environ.get("CHAT_CORS_ORIGINS", "").split(",") if o]
-# /stats is the one internal surface. Growth numbers are not published — the design doc's
-# §I.2.3 caution against count-based marketing is exactly why they stay off the public
-# service — so the endpoint exists only when a token is configured, and answers 404 rather
-# than 401 to anyone without it: a 401 would confirm the endpoint is there to probe.
-#
-# It is the only credential the service has, which is worth the narrow exception: the
-# token reads aggregate counters and can write nothing, so holding it grants strictly less
-# than the anonymous write lane every stranger already has. Gate the path at your proxy too
-# if you want the check off the host entirely — the code gate stays, so a misconfigured
-# proxy rule cannot silently publish the numbers.
-STATS_TOKEN = os.environ.get("CHAT_STATS_TOKEN", "")
-STATS_CACHE_SECONDS = int(os.environ.get("CHAT_STATS_CACHE_SECONDS", "60"))
-# /rooms walks every room for size and mtime and every note for the capacity line — at the
-# caps that is ~46k stat calls, and it was doing it per request. It is also the most polled
-# read on the service: /humans refreshes it every 5s per open tab, and it is how an agent
-# discovers what exists. Nothing in it is per-caller, so N pollers within the window can
-# share one walk. Short, because the view's whole job is to be current: a few seconds is
-# below the resolution anyone reads it at (idle times are rendered in whole seconds) and
-# still collapses a crowd into one pass. 0 disables it.
-ROOMS_CACHE_SECONDS = float(os.environ.get("CHAT_ROOMS_CACHE_SECONDS", "3"))
-# Empty by default, and that default is a security property rather than a convenience.
-# A client-supplied header is only trustworthy when the origin cannot be reached except
-# through the proxy that sets it; if anyone can hit the container directly they mint a
-# fresh rate-limit identity per request just by varying the header. Opting in is therefore
-# also an assertion that the origin is locked to that proxy.
-# Where /.well-known/security.txt sends a reporter. Configurable because this image is
-# published: a third party running it would otherwise advertise the upstream project's
-# mailbox for a problem with *their* instance, and misrouted vulnerability reports are the
-# failure this document exists to prevent. The default is the project's own channel, which
-# is the right answer for a bug in the software rather than in a deployment — an operator
-# who wants reports about their instance sets this to their own address.
-SECURITY_CONTACT = os.environ.get("CHAT_SECURITY_CONTACT", "security@flop.finance").strip()
-CLIENT_IP_HEADER = os.environ.get("CHAT_CLIENT_IP_HEADER", "").strip().lower()
+# STATS_TOKEN / STATS_CACHE_SECONDS / ROOMS_CACHE_SECONDS / SECURITY_CONTACT /
+# CLIENT_IP_HEADER live in config; their rationale moved with them.
 # Headers a CDN sets and overwrites on every request. Their *presence* is not permission to
 # trust them — a direct caller can send any of them, which is the whole reason
 # CLIENT_IP_HEADER is opt-in — but it does mean the request plausibly arrived through that
@@ -122,13 +92,6 @@ CLIENT_IP_HEADER = os.environ.get("CHAT_CLIENT_IP_HEADER", "").strip().lower()
 # lockout nobody can distinguish from "the service is broken". So the mismatch is counted
 # and published in /stats rather than guessed at. Detection, not trust.
 PROXY_IP_HEADERS = ("cf-connecting-ip", "x-forwarded-for", "x-real-ip", "true-client-ip")
-# The origin to print in /openapi.json and /.well-known/agent.json. Unset is fine — those
-# documents then derive it from the request, or fall back to relative URLs when the Host
-# header is not a plausible hostname (see manifest.public_base). Set it when the service
-# sits behind a proxy that rewrites Host, or when you want the published URLs to be one
-# fixed string no matter who asks.
-PUBLIC_URL = os.environ.get("CHAT_PUBLIC_URL", "").strip()
-
 # robots.txt moved to manifest.robots_txt(base): the Sitemap directive takes an absolute
 # URL, so the document depends on the origin and can no longer be a constant. Agents are
 # the intended audience, so it says so where crawlers look — Cloudflare serves a Content
@@ -885,31 +848,10 @@ def rooms(request: Request) -> Response:
 # attack, so waiters are capped twice — per IP, and globally — and exceeding either
 # degrades to an immediate empty reply rather than an error. A caller that cannot get a
 # slot is exactly as well off as before long-polling existed.
-def _finite_env(name: str, default: str) -> float:
-    """A float from the environment, or refuse to start.
-
-    Every other numeric setting here goes through `int()`, which raises on junk and takes
-    the process down at import — the loudest possible way to report bad configuration.
-    `float()` does not: it accepts `inf` and `nan` happily, and this is the one knob whose
-    value is *published*. A non-finite ceiling reaches /openapi.json and
-    /.well-known/agent.json as the bare token `Infinity`, which Python's json module emits
-    and reads back but RFC 8259 does not permit — so every strict parser rejects the whole
-    document: a browser, a Go or Rust client, a validating registry. A discovery service
-    answering with undiscoverable documents is worse off than one that refused to boot,
-    which is exactly what the settings beside it already do.
-    """
-    raw = os.environ.get(name, default)
-    value = float(raw)  # ValueError takes the process down, as int() does elsewhere
-    if not math.isfinite(value):
-        raise ValueError(f"{name} must be a finite number, got {raw!r}")
-    return value
-
-
-# Ceiling on ?wait=, tunable because the useful value is whatever the proxy in front will
-# hold. Passed into both manifest builders rather than hardcoded there: three documents
-# publish this number, and a tuned instance still saying 10 is the drift manifest.py
-# exists to prevent.
-MAX_WAIT = max(0.0, _finite_env("CHAT_MAX_WAIT", "10"))
+# The CHAT_MAX_WAIT parse (and its refuse-to-boot finiteness check — see config._finite_env,
+# where the knob now lives) is aliased so tests that probe it keep calling app._finite_env.
+_finite_env = config._finite_env
+MAX_WAIT = config.MAX_WAIT
 WAIT_POLL = 0.5  # a new message surfaces within this, so ?wait=0.5 is the useful floor
 MAX_WAITERS_TOTAL = 64
 MAX_WAITERS_PER_IP = 4

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,131 @@
+"""The CHAT_* knobs — the environment, read once, here.
+
+The environment stays the operator interface: Dockerfile, uvicorn and CI set these
+exactly as before. This module is only the binding site — nothing else in src/ reads
+os.environ — so each knob's default, floor and normalization live in exactly one place.
+
+Tests need different values without re-importing whole modules, so override(**kwargs)
+re-binds these as plain module attributes for the body of a `with` and always
+restores them, exception or not. Plain module attributes, deliberately NOT
+contextvars.ContextVar: Starlette's TestClient serves the ASGI app in a separate
+portal thread, so a ContextVar set in the test thread never reaches a request
+handler — a thread-visible module namespace is the whole point.
+"""
+
+import math
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+ROOT = Path(os.environ.get("CHAT_ROOT", "/data"))
+
+# Floored at 1: the bucket arithmetic divides by this, so a zero or negative value
+# configured by hand would turn every rate-limited route into a 500 rather than into the
+# refusal the operator presumably meant. There is no "disable" setting for the same reason
+# the limiter exists at all.
+RATE_READ = max(1, int(os.environ.get("CHAT_RATE_READ", "120")))  # requests/min/IP
+RATE_WRITE = max(1, int(os.environ.get("CHAT_RATE_WRITE", "30")))
+# A per-IP budget on bringing *new rooms into existence*, measured over a day rather than a
+# minute. RATE_WRITE bounds how fast one caller can talk; nothing bounded how many rooms one
+# caller could create, and those are not the same resource. At RATE_WRITE a single caller
+# exhausts MAX_ROOMS in a matter of hours, and the slots it takes are everyone's — the
+# next caller, whoever they are, gets the fail-closed refusal. This is what makes MAX_ROOMS
+# a cap on the service rather than a race won by whoever creates rooms fastest.
+RATE_ROOMS_PER_DAY = max(1, int(os.environ.get("CHAT_RATE_ROOMS_PER_DAY", "20")))
+CORS_ORIGINS = [o for o in os.environ.get("CHAT_CORS_ORIGINS", "").split(",") if o]
+# /stats is the one internal surface. Growth numbers are not published — the design doc's
+# §I.2.3 caution against count-based marketing is exactly why they stay off the public
+# service — so the endpoint exists only when a token is configured, and answers 404 rather
+# than 401 to anyone without it: a 401 would confirm the endpoint is there to probe.
+#
+# It is the only credential the service has, which is worth the narrow exception: the
+# token reads aggregate counters and can write nothing, so holding it grants strictly less
+# than the anonymous write lane every stranger already has. Gate the path at your proxy too
+# if you want the check off the host entirely — the code gate stays, so a misconfigured
+# proxy rule cannot silently publish the numbers.
+STATS_TOKEN = os.environ.get("CHAT_STATS_TOKEN", "")
+STATS_CACHE_SECONDS = int(os.environ.get("CHAT_STATS_CACHE_SECONDS", "60"))
+# /rooms walks every room for size and mtime and every note for the capacity line — at the
+# caps that is ~46k stat calls, and it was doing it per request. It is also the most polled
+# read on the service: /humans refreshes it every 5s per open tab, and it is how an agent
+# discovers what exists. Nothing in it is per-caller, so N pollers within the window can
+# share one walk. Short, because the view's whole job is to be current: a few seconds is
+# below the resolution anyone reads it at (idle times are rendered in whole seconds) and
+# still collapses a crowd into one pass. 0 disables it.
+ROOMS_CACHE_SECONDS = float(os.environ.get("CHAT_ROOMS_CACHE_SECONDS", "3"))
+# Empty by default, and that default is a security property rather than a convenience.
+# A client-supplied header is only trustworthy when the origin cannot be reached except
+# through the proxy that sets it; if anyone can hit the container directly they mint a
+# fresh rate-limit identity per request just by varying the header. Opting in is therefore
+# also an assertion that the origin is locked to that proxy.
+# Where /.well-known/security.txt sends a reporter. Configurable because this image is
+# published: a third party running it would otherwise advertise the upstream project's
+# mailbox for a problem with *their* instance, and misrouted vulnerability reports are the
+# failure this document exists to prevent. The default is the project's own channel, which
+# is the right answer for a bug in the software rather than in a deployment — an operator
+# who wants reports about their instance sets this to their own address.
+SECURITY_CONTACT = os.environ.get("CHAT_SECURITY_CONTACT", "security@flop.finance").strip()
+CLIENT_IP_HEADER = os.environ.get("CHAT_CLIENT_IP_HEADER", "").strip().lower()
+# The origin to print in /openapi.json and /.well-known/agent.json. Unset is fine — those
+# documents then derive it from the request, or fall back to relative URLs when the Host
+# header is not a plausible hostname (see manifest.public_base). Set it when the service
+# sits behind a proxy that rewrites Host, or when you want the published URLs to be one
+# fixed string no matter who asks.
+PUBLIC_URL = os.environ.get("CHAT_PUBLIC_URL", "").strip()
+# Lazy expiry for the `e-` class: nothing sweeps in the background, records are simply not
+# returned once they are older than this, and physically leave on the next compaction or
+# when the IDLE_SECONDS reaper takes the file.
+EPHEMERAL_TTL_SECONDS = int(os.environ.get("CHAT_EPHEMERAL_TTL_SECONDS", "900"))
+
+
+def _finite_env(name: str, default: str) -> float:
+    """A float from the environment, or refuse to start.
+
+    Every other numeric setting here goes through `int()`, which raises on junk and takes
+    the process down at import — the loudest possible way to report bad configuration.
+    `float()` does not: it accepts `inf` and `nan` happily, and this is the one knob whose
+    value is *published*. A non-finite ceiling reaches /openapi.json and
+    /.well-known/agent.json as the bare token `Infinity`, which Python's json module emits
+    and reads back but RFC 8259 does not permit — so every strict parser rejects the whole
+    document: a browser, a Go or Rust client, a validating registry. A discovery service
+    answering with undiscoverable documents is worse off than one that refused to boot,
+    which is exactly what the settings beside it already do.
+    """
+    raw = os.environ.get(name, default)
+    value = float(raw)  # ValueError takes the process down, as int() does elsewhere
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be a finite number, got {raw!r}")
+    return value
+
+
+# Ceiling on ?wait=, tunable because the useful value is whatever the proxy in front will
+# hold. Passed into both manifest builders rather than hardcoded there: three documents
+# publish this number, and a tuned instance still saying 10 is the drift manifest.py
+# exists to prevent.
+MAX_WAIT = max(0.0, _finite_env("CHAT_MAX_WAIT", "10"))
+
+_NOT_THERE = object()
+
+
+@contextmanager
+def override(**kwargs):
+    """Re-bind named knobs for the body of the `with`, then restore them — always.
+
+    app and store re-bind these knobs into their own namespaces at import (handlers and
+    tests read them there, and monkeypatch.setattr(app, ...) expects to find them), so a
+    binding made here is mirrored into both when they are already loaded, and every copy
+    is restored on exit.
+    """
+    mods = [sys.modules[__name__]] + [sys.modules[n] for n in ("app", "store") if n in sys.modules]
+    saved = [(mod, name, mod.__dict__.get(name, _NOT_THERE)) for mod in mods for name in kwargs]
+    for mod, name, _ in saved:
+        setattr(mod, name, kwargs[name])
+    try:
+        yield
+    finally:
+        for mod, name, old in saved:
+            if old is _NOT_THERE:
+                delattr(mod, name)
+            else:
+                setattr(mod, name, old)

--- a/src/store.py
+++ b/src/store.py
@@ -21,6 +21,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 
+import config
 import didkey
 
 NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,47}$")
@@ -159,10 +160,10 @@ TOPIC_NS = "topic"  # /kv/topic/<room>      -> what the room is for
 # measured in kilobytes. The overview
 # carries a preview; /kv/topic/<room> carries the whole thing.
 TOPIC_PREVIEW_CHARS = 120
-# Lazy expiry for the `e-` class: nothing sweeps in the background, records are simply not
-# returned once they are older than this, and physically leave on the next compaction or
-# when the IDLE_SECONDS reaper takes the file.
-EPHEMERAL_TTL_SECONDS = int(os.environ.get("CHAT_EPHEMERAL_TTL_SECONDS", "900"))
+# Read from CHAT_EPHEMERAL_TTL_SECONDS once, in config — the only env reader in src/ — and
+# re-bound here so the cutoff (and the tests) read a plain module global; the lazy-expiry
+# rationale moved to config with the knob.
+EPHEMERAL_TTL_SECONDS = config.EPHEMERAL_TTL_SECONDS
 
 
 class StoreError(ValueError):

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,11 +1,17 @@
 {
-  "core_total": 1777,
+  "core_total": 1811,
   "files": {
-    "core/store.py": {
-      "raw_lines": 1354,
-      "code_lines": 708,
-      "comment_lines": 245,
-      "tokens_per_line": 7.04
+    "core/app.py": {
+      "raw_lines": 1780,
+      "code_lines": 1006,
+      "comment_lines": 222,
+      "tokens_per_line": 7.6
+    },
+    "core/config.py": {
+      "raw_lines": 131,
+      "code_lines": 39,
+      "comment_lines": 52,
+      "tokens_per_line": 10.87
     },
     "core/didkey.py": {
       "raw_lines": 120,
@@ -13,11 +19,11 @@
       "comment_lines": 16,
       "tokens_per_line": 8.11
     },
-    "core/app.py": {
-      "raw_lines": 2072,
-      "code_lines": 1012,
-      "comment_lines": 258,
-      "tokens_per_line": 7.75
+    "core/store.py": {
+      "raw_lines": 1355,
+      "code_lines": 709,
+      "comment_lines": 245,
+      "tokens_per_line": 7.02
     },
     "extra/manifest.py": {
       "raw_lines": 1582,

--- a/sz.py
+++ b/sz.py
@@ -5,8 +5,8 @@
 # ///
 """Measure the size of the core, and only the core.
 
-Core is src/store.py, src/didkey.py and src/app.py; src/manifest.py is reported under an
-"extra" label and never counted in the core total. Two numbers per file:
+Core is src/app.py, src/config.py, src/didkey.py and src/store.py; src/manifest.py is
+reported under an "extra" label and never counted in the core total. Two numbers per file:
 
 - code lines: lines carrying executable tokens, with docstrings and comments stripped.
   This is the only number --check guards — the core must not grow.
@@ -34,7 +34,7 @@ import sys
 import tokenize
 from pathlib import Path
 
-CORE_FILES = ("src/store.py", "src/didkey.py", "src/app.py")
+CORE_FILES = ("src/app.py", "src/config.py", "src/didkey.py", "src/store.py")
 EXTRA_FILES = ("src/manifest.py",)
 BASELINE = Path(__file__).resolve().parent / "sz-baseline.json"
 # Token types that carry no code: layout, comments, and the encoding/end markers.

--- a/tests/_client.py
+++ b/tests/_client.py
@@ -1,7 +1,6 @@
 """Run: uv run --group dev python -m pytest tests"""
 
 import os
-import sys
 import time
 from contextlib import contextmanager
 
@@ -10,13 +9,20 @@ from starlette.testclient import TestClient
 
 
 @pytest.fixture()
-def client(tmp_path, monkeypatch):
-    os.environ["CHAT_ROOT"] = str(tmp_path)
-    for mod in ("app", "store"):
-        sys.modules.pop(mod, None)
+def client(tmp_path):
+    """One shared app, a fresh ROOT per test: config.override re-binds the knob (and app's
+    copy of it) for exactly this test, where the old fixture re-imported app against a
+    CHAT_ROOT env var. The limiter buckets and the /rooms cache are process state a fresh
+    import used to reset for free, so they are cleared here instead."""
     import app as app_module
+    import config
 
-    return TestClient(app_module.app)
+    app_module._buckets.clear()
+    app_module._rooms_cache.clear()
+    app_module._identities.clear()
+    app_module._proxy_evidence["proxied_requests"] = 0
+    with config.override(ROOT=tmp_path):
+        yield TestClient(app_module.app)
 
 
 # --------------------------------------------------------------------------- shared helpers

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -2,7 +2,6 @@
 
 import json
 import re
-import sys
 import time
 from pathlib import Path
 
@@ -340,7 +339,6 @@ def test_a_published_ceiling_is_a_number_json_can_carry(client, monkeypatch):
     service answering with undiscoverable documents is worse off than one that refused to
     boot. Review catch on #40.
     """
-    import importlib
     import json as json_module
 
     import app as app_module
@@ -356,12 +354,15 @@ def test_a_published_ceiling_is_a_number_json_can_carry(client, monkeypatch):
     # …and the ceiling is actually wired through it. Checking the helper alone would pass
     # against a MAX_WAIT that still called bare `float()`, which is the mistake this
     # guards: the process has to refuse to start, not merely own a function that could
-    # have refused.
+    # have refused. config is where the knob is parsed now, so a fresh exec of it —
+    # under a name of its own, no sys.modules surgery — is that boot path.
+    import runpy
+
+    import config
+
     monkeypatch.setenv("CHAT_MAX_WAIT", "inf")
-    for module in ("app", "store"):
-        sys.modules.pop(module, None)
     with pytest.raises(ValueError, match="must be a finite number"):
-        importlib.import_module("app")
+        runpy.run_path(config.__file__)  # executes config afresh, no sys.modules surgery
 
     # Whatever survives that, the documents stay strict JSON — no bare Infinity or NaN.
     for raw in (client.get("/openapi.json").text, client.get("/.well-known/agent.json").text):

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -354,15 +354,23 @@ def test_a_published_ceiling_is_a_number_json_can_carry(client, monkeypatch):
     # …and the ceiling is actually wired through it. Checking the helper alone would pass
     # against a MAX_WAIT that still called bare `float()`, which is the mistake this
     # guards: the process has to refuse to start, not merely own a function that could
-    # have refused. config is where the knob is parsed now, so a fresh exec of it —
-    # under a name of its own, no sys.modules surgery — is that boot path.
-    import runpy
+    # have refused. A fresh interpreter importing the real chain — app importing config
+    # importing the environment — is that boot: no sys.modules surgery in this process,
+    # and unlike a re-exec of config alone it fails if app ever stops importing config
+    # (review: PR #59).
+    import os
+    import subprocess
+    import sys
 
-    import config
-
-    monkeypatch.setenv("CHAT_MAX_WAIT", "inf")
-    with pytest.raises(ValueError, match="must be a finite number"):
-        runpy.run_path(config.__file__)  # executes config afresh, no sys.modules surgery
+    src = repr(str(Path(__file__).resolve().parents[2] / "src"))
+    boot = subprocess.run(
+        [sys.executable, "-c", f"import sys; sys.path.insert(0, {src}); import app"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CHAT_MAX_WAIT": "inf"},
+    )
+    assert boot.returncode != 0, "app booted with a non-finite CHAT_MAX_WAIT"
+    assert "must be a finite number" in boot.stderr
 
     # Whatever survives that, the documents stay strict JSON — no bare Infinity or NaN.
     for raw in (client.get("/openapi.json").text, client.get("/.well-known/agent.json").text):

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -173,20 +173,34 @@ def test_the_429_names_the_budget_the_manual_deliberately_does_not(client, monke
 
 def test_a_zero_rate_limit_refuses_rather_than_crashing(monkeypatch, tmp_path):
     """The bucket arithmetic divides by the limit, so CHAT_RATE_WRITE=0 turned every write
-    into a 500 on the limiter itself. Floored at import instead — at config import now,
-    which is the one place the environment is read, so a fresh exec of that module with the
-    bad value is the boot path."""
-    import runpy
+    into a 500 on the limiter itself. Floored at import instead — and the floor has to
+    arrive in the app module the service actually runs, so this boots the real chain
+    (app importing config importing the environment) in a fresh interpreter: no
+    sys.modules surgery in this process, and unlike a re-exec of config alone it fails
+    if app ever stops propagating the value (review: PR #59)."""
+    import os
+    import subprocess
+    import sys
+
+    src = repr(str(Path(__file__).resolve().parents[2] / "src"))
+    boot = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"import sys; sys.path.insert(0, {src}); import app; print(app.RATE_WRITE)",
+        ],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CHAT_ROOT": str(tmp_path), "CHAT_RATE_WRITE": "0"},
+    )
+    assert boot.returncode == 0, boot.stderr
+    assert boot.stdout.strip() == "1"
 
     import app as app_module
     import config
 
-    monkeypatch.setenv("CHAT_RATE_WRITE", "0")
-    fresh = runpy.run_path(config.__file__)  # executes config afresh, no sys.modules surgery
-    assert fresh["RATE_WRITE"] == 1
-
     app_module._buckets.clear()
-    with config.override(ROOT=tmp_path, RATE_WRITE=fresh["RATE_WRITE"]):
+    with config.override(ROOT=tmp_path, RATE_WRITE=1):
         assert TestClient(app_module.app).get("/r/lobby/say/bot/hi").status_code == 200
 
 

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -2,7 +2,6 @@
 
 import json
 import re
-import sys
 import time
 from pathlib import Path
 
@@ -174,15 +173,21 @@ def test_the_429_names_the_budget_the_manual_deliberately_does_not(client, monke
 
 def test_a_zero_rate_limit_refuses_rather_than_crashing(monkeypatch, tmp_path):
     """The bucket arithmetic divides by the limit, so CHAT_RATE_WRITE=0 turned every write
-    into a 500 on the limiter itself. Floored at import instead."""
-    monkeypatch.setenv("CHAT_ROOT", str(tmp_path))
-    monkeypatch.setenv("CHAT_RATE_WRITE", "0")
-    for mod in ("app", "store"):
-        sys.modules.pop(mod, None)
-    import app as app_module
+    into a 500 on the limiter itself. Floored at import instead — at config import now,
+    which is the one place the environment is read, so a fresh exec of that module with the
+    bad value is the boot path."""
+    import runpy
 
-    assert app_module.RATE_WRITE == 1
-    assert TestClient(app_module.app).get("/r/lobby/say/bot/hi").status_code == 200
+    import app as app_module
+    import config
+
+    monkeypatch.setenv("CHAT_RATE_WRITE", "0")
+    fresh = runpy.run_path(config.__file__)  # executes config afresh, no sys.modules surgery
+    assert fresh["RATE_WRITE"] == 1
+
+    app_module._buckets.clear()
+    with config.override(ROOT=tmp_path, RATE_WRITE=fresh["RATE_WRITE"]):
+        assert TestClient(app_module.app).get("/r/lobby/say/bot/hi").status_code == 200
 
 
 def test_every_path_the_429_calls_free_really_is_free(client, monkeypatch):

--- a/tests/http/test_stats.py
+++ b/tests/http/test_stats.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import sys
 from pathlib import Path
 
 import _client
@@ -31,14 +30,20 @@ def test_stats_says_whether_per_ip_limits_are_actually_per_ip(client, monkeypatc
 @pytest.fixture()
 def stats_client(tmp_path, monkeypatch):
     """A client whose service has the stats token configured (the deployed shape)."""
-    monkeypatch.setenv("CHAT_ROOT", str(tmp_path))
-    monkeypatch.setenv("CHAT_STATS_TOKEN", "s3cret")
-    monkeypatch.setenv("CHAT_STATS_CACHE_SECONDS", "0")  # every call recomputes, so
-    for mod in ("app", "store"):  # a test can observe its own writes
-        sys.modules.pop(mod, None)
     import app as app_module
+    import config
 
-    return TestClient(app_module.app)
+    # Test bodies read CHAT_ROOT back for direct store access; the knob itself comes from
+    # config.override now, not the environment.
+    monkeypatch.setenv("CHAT_ROOT", str(tmp_path))
+    app_module._buckets.clear()
+    app_module._rooms_cache.clear()
+    app_module._identities.clear()
+    app_module._proxy_evidence["proxied_requests"] = 0
+    with config.override(  # every stats call recomputes, so a test can observe its writes
+        ROOT=tmp_path, STATS_TOKEN="s3cret", STATS_CACHE_SECONDS=0
+    ):
+        yield TestClient(app_module.app)
 
 
 def test_stats_does_not_exist_without_a_token(client):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import email.message
 import io
 import json
-import os
 import sys
 import urllib.error
 import urllib.request
@@ -29,46 +28,50 @@ sys.path.insert(0, str(ROOT / "mcp" / "src"))
 
 @pytest.fixture()
 def mcp(tmp_path, monkeypatch):
-    """The MCP server, wired to a fresh instance of the real app."""
-    os.environ["CHAT_ROOT"] = str(tmp_path)
-    for mod in ("app", "store"):
-        sys.modules.pop(mod, None)
-    from technocore_mcp import protocol
-    from technocore_mcp import server as mcp_server
-
+    """The MCP server, wired to the real app, ROOT pointed at this test's tmp dir by
+    config.override (where the old fixture re-imported app against a CHAT_ROOT env var)."""
     import app as app_module
+    import config
 
-    client = TestClient(app_module.app)
+    app_module._buckets.clear()
+    app_module._rooms_cache.clear()
+    app_module._identities.clear()
+    app_module._proxy_evidence["proxied_requests"] = 0
+    with config.override(ROOT=tmp_path):
+        from technocore_mcp import protocol
+        from technocore_mcp import server as mcp_server
 
-    class _Body:
-        def __init__(self, text: str):
-            self._text = text
+        client = TestClient(app_module.app)
 
-        def read(self) -> bytes:
-            return self._text.encode()
+        class _Body:
+            def __init__(self, text: str):
+                self._text = text
 
-        def __enter__(self):
-            return self
+            def read(self) -> bytes:
+                return self._text.encode()
 
-        def __exit__(self, *exc) -> None:
-            return None
+            def __enter__(self):
+                return self
 
-    def fake_urlopen(request, timeout=None):
-        assert request.full_url.startswith(mcp_server.BASE_URL)
-        response = client.get(request.full_url[len(mcp_server.BASE_URL) :])
-        if response.status_code >= 400:
-            raise urllib.error.HTTPError(
-                request.full_url,
-                response.status_code,
-                "error",
-                email.message.Message(),
-                io.BytesIO(response.text.encode()),
-            )
-        return _Body(response.text)
+            def __exit__(self, *exc) -> None:
+                return None
 
-    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
-    monkeypatch.setattr(mcp_server, "DEFAULT_NICK", "")
-    return mcp_server.server, protocol
+        def fake_urlopen(request, timeout=None):
+            assert request.full_url.startswith(mcp_server.BASE_URL)
+            response = client.get(request.full_url[len(mcp_server.BASE_URL) :])
+            if response.status_code >= 400:
+                raise urllib.error.HTTPError(
+                    request.full_url,
+                    response.status_code,
+                    "error",
+                    email.message.Message(),
+                    io.BytesIO(response.text.encode()),
+                )
+            return _Body(response.text)
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(mcp_server, "DEFAULT_NICK", "")
+        yield mcp_server.server, protocol
 
 
 def call(server, name: str, arguments: dict, ident: int = 1) -> dict:


### PR DESCRIPTION
## What

New `src/config.py` (stdlib-only, 39 code lines): every `CHAT_*` knob — all **13**, including the `CHAT_MAX_WAIT`/`_finite_env` reader the plan had missed — is read from the environment once, at import, in one module, with defaults/floors/normalization copied exactly and the rationale comments moved with the code. `config.override(**kwargs)` is a contextmanager for tests: plain module-attribute mutation, always restored — **deliberately not `contextvars.ContextVar`**, because TestClient runs the app in a separate portal thread a test-thread ContextVar never reaches (the comment in the file says exactly this). `src/app.py` and `src/store.py` keep module-level aliases bound from config; `override()` mirrors each binding into already-imported app/store so both mutation styles work. **No served byte changes; the operator interface (env vars in Docker/uvicorn/CI) is untouched.**

## Why

Every knob was read at import time in `app.py`/`store.py`, so any test needing a different value had to `sys.modules.pop("app"); sys.modules.pop("store")` and re-import — a module-reload dance at five sites, with its real cost being the process state a fresh import silently reset (rate buckets, the rooms cache, identities). All five sites are gone (that meant also touching `tests/test_mcp.py` and `tests/http/test_docs.py` — two more than planned, minimally, in their fixture/reload blocks only); fixtures now yield inside `config.override(ROOT=tmp_path, …)` and clear the volatile state explicitly, which is honest about what a fresh import used to hide. The zero-rate-limit test asserts the floor via a `runpy` fresh-exec of config, then drives the endpoint under `override(RATE_WRITE=1)`.

**Two deviations from the plan, both deliberate:**
1. **Five reload sites, not three** — the acceptance grep (no `sys.modules.pop` anywhere in `tests/`) was the real spec; the count in the plan was stale.
2. **sz core grows 1777 → 1811 (+34), not the hoped <15** — the lower number is only reachable by pointing handlers straight at `config.X`, which silently breaks ~30 untouched tests that `monkeypatch.setattr(app_module, "RATE_WRITE", …)`. Aliases + mirroring keep those tests intact; a follow-up can migrate them to `config.override` and then drop the aliases and reclaim the lines. Baseline update is its own commit (`b2b1675`) with before/after in the message.

## Checks

- [x] `uv run python -m pytest tests -q` — 302 passed, count unchanged
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — clean; `uv run sz.py --check` green vs the updated baseline (1811)
- [x] Docs that would now be wrong are updated: served bytes identical (docs/manifest tests enforce); no published limit or route changed
- [x] New surface on a world-writable service: **nothing new** — no route, parameter, or state; `config.py` reads the same env the process always read, and `grep os.environ src/app.py src/store.py` is now empty by construction
