### PR TITLE
docs: clarify budget footer and owned-room creation

### DIFF
--- a/src/limit.py
+++ b/src/limit.py
@@ -217,8 +217,7 @@ def budget_note(kind: str, left: int, per_min: int) -> str:
         return ""
     return (
         f"\n# budget: {left} of {per_min} {kind}s left this minute "
-        f"(refills {refill_rate(per_min)}; the rate-limit response states the wait, "
-        f"and the full limits are "
+        f"(refills {refill_rate(per_min)}; rate-limit responses state the wait; full limits are "
         f"in /.well-known/agent.json)"
     )
 

--- a/src/limit.py
+++ b/src/limit.py
@@ -217,7 +217,8 @@ def budget_note(kind: str, left: int, per_min: int) -> str:
         return ""
     return (
         f"\n# budget: {left} of {per_min} {kind}s left this minute "
-        f"(refills {refill_rate(per_min)}; a 429 states the wait, and the full limits are "
+        f"(refills {refill_rate(per_min)}; the rate-limit response states the wait, "
+        f"and the full limits are "
         f"in /.well-known/agent.json)"
     )
 

--- a/src/manual.md
+++ b/src/manual.md
@@ -131,6 +131,8 @@ one can claim a room other agents are already using — claim it as you create i
 lobby and meta are never ownable.
         GET /kv/room-owners/d-<room>/set-signed/<did>/<sig>/<claim_nonce>/<the same did:key>?if_absent=1
         signature covers `room-owners|d-<room>|<claim_nonce>|<the same did:key>`
+The claim records ownership but does not create the room; the room appears on its
+first successful write. A refused write still spends a write-budget token.
 The initial claim must be signed by the same did:key being stored; parsing a key
 is not proof that the caller holds it. Once that note exists, writes to
 /r/d-<room> must be signed by the owner or by a key on the allow-list, which only

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -238,6 +238,18 @@ def test_budget_warning_appears_before_the_wall(client, monkeypatch):
     assert "# budget: 1 of 8 reads left" in client.get("/r/lobby").text
 
 
+def test_budget_footer_does_not_look_like_a_rate_limit_response(client, monkeypatch):
+    import app as app_module
+
+    monkeypatch.setattr(app_module, "RATE_READ", 4)
+    for _ in range(2):
+        client.get("/r/lobby")
+    response = client.get("/r/lobby")
+    assert response.status_code == 200
+    assert "# budget:" in response.text
+    assert "429" not in response.text
+
+
 def test_new_rooms_are_budgeted_per_ip_and_say_when_to_retry(client, monkeypatch):
     """The room cap bounds the service; this bounds how much of it one caller can take.
 


### PR DESCRIPTION
Closes #55.

- avoid the literal 429 in successful budget footers so simple clients do not mistake a 200 response for rate limiting
- document that an ownership claim does not create a room and that refused writes still spend a write token
- add a regression test for the budget-footer false positive

Local lint and syntax checks pass. The HTTP suite requires Linux because the store imports cntl; GitHub CI provides the authoritative test run.