### PR TITLE
refactor(limit): extract the abuse budget into src/limit.py

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,12 @@ uv run coverage run -m pytest tests -q
 uv run coverage report
 ```
 
-Layering: the core is `src/store.py`, `src/didkey.py`, `src/config.py` and a thin
-`src/app.py` adapter.
+Layering: the core is `src/store.py`, `src/didkey.py`, `src/config.py`, `src/limit.py`
+and a thin `src/app.py` adapter.
 `src/manifest.py`, docs and frontends are extra — never counted as core.
+
+- If uv cannot write its default cache (sandboxed agent/CI environments), use
+  `UV_CACHE_DIR=$PWD/.uvcache` — a worktree-local cache always works.
 
 - Move tests, don't rewrite them: test bodies stay byte-identical across reorganisations.
 - Size the core with `uv run sz.py` (table) and `uv run sz.py --check`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,10 @@ skip_covered = true
 # the machine time, and why, is in tests/mutation_scope.py; this is only its plumbing.
 [tool.mutmut]
 source_paths = ["src"]
-# humans.html is the only other thing in src/ and it is not Python.
-only_mutate = ["src/app.py", "src/store.py", "src/didkey.py"]
+# humans.html is the only other thing in src/ and it is not Python. config.py is out on
+# purpose: tests/mutation_scope.py declares no mutants of interest there (its floors and
+# parsing are exercised directly by the boot tests), while the limiter it feeds is in.
+only_mutate = ["src/app.py", "src/store.py", "src/didkey.py", "src/limit.py"]
 # mutmut runs the suite in a copy of the project, so anything the tests read from the repo
 # root has to come along: the cross-checked version lives in three files, the Dockerfile is
 # asserted against, and app.py reads SKILL.md at import.

--- a/src/app.py
+++ b/src/app.py
@@ -17,7 +17,6 @@ import secrets
 import time
 import tomllib
 from collections import OrderedDict
-from contextlib import contextmanager
 from pathlib import Path
 
 from starlette.applications import Starlette
@@ -30,6 +29,7 @@ from starlette.routing import Match, Route
 
 import config
 import didkey
+import limit
 import manifest
 import store
 from store import StoreConflictError, StoreError
@@ -75,23 +75,11 @@ MAX_BODY = 256 << 10
 # points there. A manual naming a number the server does not enforce is worse than one
 # naming none, because a machine reader paces itself to it.
 #
-# The paths that cost nothing, named once because the 429 body and the manual both list
-# them. A 429 that points at a path which is itself rate limited is advice that fails at
-# exactly the moment it is taken.
-FREE_PATHS = (
-    "/, /llms.txt, /skill.md, /patterns.md, /auth.md, /openapi.json, /.well-known/* and /healthz"
-)
-# STATS_TOKEN / STATS_CACHE_SECONDS / ROOMS_CACHE_SECONDS / SECURITY_CONTACT /
-# CLIENT_IP_HEADER live in config; their rationale moved with them.
-# Headers a CDN sets and overwrites on every request. Their *presence* is not permission to
-# trust them — a direct caller can send any of them, which is the whole reason
-# CLIENT_IP_HEADER is opt-in — but it does mean the request plausibly arrived through that
-# CDN, and if we are not configured to read one, every caller behind it shares a single
-# rate-limit identity. That failure is silent and it gets worse the longer the budget: a
-# shared per-minute limit merely feels strict, a shared per-DAY room budget is a global
-# lockout nobody can distinguish from "the service is broken". So the mismatch is counted
-# and published in /stats rather than guessed at. Detection, not trust.
-PROXY_IP_HEADERS = ("cf-connecting-ip", "x-forwarded-for", "x-real-ip", "true-client-ip")
+# FREE_PATHS and PROXY_IP_HEADERS moved to limit with the 429 body and the client-IP
+# logic that reads them (FREE_PATHS is aliased in the re-export block below the helpers;
+# PROXY_IP_HEADERS resolves through the module __getattr__). STATS_TOKEN /
+# STATS_CACHE_SECONDS / ROOMS_CACHE_SECONDS / SECURITY_CONTACT / CLIENT_IP_HEADER live in
+# config; their rationale moved with them.
 # robots.txt moved to manifest.robots_txt(base): the Sitemap directive takes an absolute
 # URL, so the document depends on the origin and can no longer be a constant. Agents are
 # the intended audience, so it says so where crawlers look — Cloudflare serves a Content
@@ -153,94 +141,39 @@ LISTING_BANNER = (
 
 # --------------------------------------------------------------------------- helpers
 
-# Bounded LRU, because every unseen IP would otherwise add entries forever and the
-# proxy's per-IP rule caps requests per IP, not the number of distinct IPs — a rotating
-# IPv6 /64 or a distributed flood would grow this until the 128 MiB container OOMs.
-# Eviction costs nothing at the margin: an entry idle for a full refill window has
-# refilled to `per_min`, so forgetting it is identical to keeping it, and LRU order
-# evicts the idlest first. A flood of >MAX_BUCKETS *concurrently active* IPs does lose
-# limiter state — which is why the authoritative limit belongs in the proxy (see README).
-MAX_BUCKETS = 20_000
-_buckets: OrderedDict[tuple[str, str], tuple[float, float]] = OrderedDict()
+# The abuse budget lives in limit.py; app keeps the module-level surface the tests and
+# config.override() mutate. The state names below re-export limit's objects — the SAME
+# references, not copies — so app_module._buckets.clear() clears what the limiter reads,
+# and the knobs (RATE_*, CLIENT_IP_HEADER, MAX_BUCKETS, MAX_WAITERS_*) are read here at
+# call time and passed into limit as parameters, exactly as per_min/burst already were.
+MAX_BUCKETS, CHARGED_CREATION = limit.MAX_BUCKETS, limit.CHARGED_CREATION
+MAX_WAITERS_TOTAL, MAX_WAITERS_PER_IP = limit.MAX_WAITERS_TOTAL, limit.MAX_WAITERS_PER_IP
+FREE_PATHS, budget_note = limit.FREE_PATHS, limit.budget_note
+_requests, _identities, _proxy_evidence = limit._requests, limit._identities, limit._proxy_evidence
+# _buckets, _waiters_by_ip, refill_rate, MAX_IDENTITIES and PROXY_IP_HEADERS are only ever
+# read from outside (tests, /stats prose), never rebound or read by app's own code — they
+# resolve through the module __getattr__ at the bottom instead of aliases here.
 
-# Request counters for /stats. Deliberately in-process (the store's counters are the
-# durable ones): traffic is only ever read as a rate, and a rate needs the uptime that
-# sits beside it here, not a number that outlives the process it describes.
-_requests: dict[str, int] = {"read": 0, "write": 0, "rate_limited": 0}
+# The request counters (_requests) moved to limit with the limiter that mutates them;
+# _started stays beside the /stats handler that reads it. Traffic is only ever read as a
+# rate, and a rate needs this uptime, not a number that outlives the process it describes.
 _started = time.time()
-# Two numbers that together say whether per-IP limits are actually per-IP. `proxied` counts
-# requests that carried a CDN header we are not configured to read; `identities` is how many
-# distinct client IPs the limiter has ever keyed on. A busy service showing a high `proxied`
-# and an `identities` of 1 is not rate limiting anyone individually — it is rate limiting
-# the CDN, and the room budget is being shared by the entire internet.
-_proxy_evidence: dict[str, int] = {"proxied_requests": 0}
-_identities: set[str] = set()
-MAX_IDENTITIES = 50_000  # bounded like _buckets; a counter that OOMs is not a diagnostic
 
 
 def client_ip(request: Request) -> str:
-    """The socket peer, unless the operator has named a header to trust instead.
-
-    No header is trusted by default. A forwarded-for header is a *claim by the client*; it
-    becomes evidence only when the origin is unreachable except through the proxy that
-    overwrites it. Trusting one unconditionally meant anyone who could reach the container
-    directly got a fresh rate-limit identity per request for the cost of one header — the
-    limiter, the write budget and the long-poll cap all key on this.
-
-    X-Forwarded-For is never consulted implicitly, for the same reason plus one more:
-    proxies *append* to it, so a client sending its own owns the first entry. An operator
-    who really is behind such a proxy can still set CHAT_CLIENT_IP_HEADER=x-forwarded-for,
-    but that is now a deliberate statement about their topology rather than a default.
-
-    Shared by the rate limiter and the long-poll waiter cap: two per-IP bounds keyed on
-    different notions of "IP" would each be bypassable by whichever header the other
-    ignored.
-    """
-    if CLIENT_IP_HEADER:
-        forwarded = request.headers.get(CLIENT_IP_HEADER, "").split(",")[0].strip()
-        if forwarded:
-            return forwarded
-        return request.client.host if request.client else "?"
-    # Not configured to read one. Note whether the request looks proxied anyway, so a
-    # misconfiguration is visible in /stats instead of only in a support ticket.
-    if any(h in request.headers for h in PROXY_IP_HEADERS):
-        _proxy_evidence["proxied_requests"] += 1
-    return request.client.host if request.client else "?"
+    # Thin adapter over limit.client_ip: the header allowance is read HERE, at call time,
+    # so both monkeypatch.setattr(app, "CLIENT_IP_HEADER", ...) and config.override()
+    # keep reaching the limiter. Rationale lives in limit.client_ip's docstring.
+    return limit.client_ip(request, CLIENT_IP_HEADER)
 
 
-def take(
-    request: Request, kind: str, per_min: float, burst: float | None = None
-) -> tuple[int, float]:
-    """Token bucket per (client IP, kind). Returns (tokens left, seconds until the
-    next one). Process-local: a real deployment puts the authoritative limit in the
-    reverse proxy.
-
-    `burst` is the bucket's capacity, and defaults to one minute's worth because that is
-    what a per-minute budget means. A budget measured over a *day* needs the two apart:
-    the capacity is the whole day's allowance and `per_min` is only the rate that hands it
-    back. Folded together, a 20-rooms-per-day budget would be a bucket holding 0.0139
-    tokens, which never reaches the 1.0 a grant costs — the limit would refuse everything.
-    """
-    ip = client_ip(request)
-    if len(_identities) < MAX_IDENTITIES:
-        _identities.add(ip)
-    now = time.monotonic()
-    cap = float(per_min if burst is None else burst)
-    tokens, last = _buckets.get((ip, kind), (cap, now))
-    tokens = min(cap, tokens + (now - last) * per_min / 60.0)
-    if tokens >= 1.0:  # granted: no wait, even when this was the last token
-        tokens -= 1.0
-        wait = 0.0
-    else:
-        wait = (1.0 - tokens) * 60.0 / per_min
-    _buckets[(ip, kind)] = (tokens, now)
-    _buckets.move_to_end((ip, kind))
-    while len(_buckets) > MAX_BUCKETS:
-        _buckets.popitem(last=False)
-    # Counted at the one point every rate-limited route already funnels through, so a new
-    # route cannot forget to count itself. In-process, so these reset on restart — /stats
-    # reports them next to `uptime_seconds`, which is what makes them readable.
-    _requests[kind] = _requests.get(kind, 0) + 1
+def take(request, kind, per_min, burst=None) -> tuple[int, float]:
+    # Thin adapter over limit.take: the knobs are read HERE, at call time, so
+    # monkeypatch.setattr(app, "MAX_BUCKETS", ...) and config.override() keep reaching
+    # the bucket arithmetic.
+    left, wait = limit.take(
+        request, kind, per_min, burst, ip_header=CLIENT_IP_HEADER, max_buckets=MAX_BUCKETS
+    )
     # And the /rooms cache is dropped here. This is the fast path, not the guarantee: it
     # runs *before* the store write, so on its own it loses the race against a concurrent
     # reader that walks while the writer is still in fsync. `_rooms_stamp` is what closes
@@ -248,27 +181,7 @@ def take(
     # note writes, which change the notes line and the topics shown beside a room.
     if kind == "write":
         _rooms_cache.clear()
-    if wait:
-        _requests["rate_limited"] += 1
-    return int(tokens), wait
-
-
-def refund(request: Request, kind: str, per_min: float, burst: float | None = None) -> None:
-    """Hand one token back to the caller's bucket, capped at its burst.
-
-    `last` is deliberately left alone: it is the refill clock, and moving it would either
-    grant free time or discard earned time. Only the balance changes.
-    """
-    ip = client_ip(request)
-    cap = float(per_min if burst is None else burst)
-    tokens, last = _buckets.get((ip, kind), (cap, time.monotonic()))
-    _buckets[(ip, kind)] = (min(cap, tokens + 1.0), last)
-
-
-# Set by _room_create_gate on the request it charged, read once by _settle_room_budget.
-# On the scope rather than a module global because it is per-request state, and requests
-# from one IP overlap: a module flag would be read by whichever request finished first.
-CHARGED_CREATION = "_charged_room_creation"
+    return left, wait
 
 
 def _room_exists(room: str) -> bool:
@@ -279,78 +192,11 @@ def _room_exists(room: str) -> bool:
     return store.room_path(ROOT, room).exists()
 
 
-def _settle_room_budget(request: Request, record: dict) -> None:
-    """Refund the room-creation token if this request turned out not to create the room.
-
-    The gate has to charge *before* the write — it exists to refuse a room before it comes
-    into being — so when several callers send a first message to the same absent room at
-    once, they all pass the existence check and all pay. Only one of them creates it; the
-    rest append to a room that already exists by the time the store's create lock lets them
-    through. That is not a rare shape either: agents converging on a shared rendezvous room
-    is a documented pattern, and one swarm behind one NAT could spend a day's budget on a
-    single room.
-
-    `seq == 1` is the store's own answer to "did this call create the room": the record is
-    the first line in the file. A room reaped and recreated starts at 1 again, which is
-    correct — that really is a creation.
-    """
-    if request.scope.pop(CHARGED_CREATION, False) and record.get("seq") != 1:
-        refund(request, "create", RATE_ROOMS_PER_DAY / 1440.0, burst=RATE_ROOMS_PER_DAY)
-
-
-def refill_rate(per_min: int) -> str:
-    """The refill, phrased so it stays meaningful at whatever limit is configured.
-
-    `{per_min / 60:.1f} tokens/s` reads fine at the default 120/min and degrades to a flat
-    "0.0 tokens/s" for anything under 30/min — a number an agent cannot pace against, on
-    precisely the deployments that most need pacing. Under one per second the period is
-    both accurate and the more useful form: "one every 30s" is a sleep, "0.03 tokens/s" is
-    arithmetic the reader has to do first.
-    """
-    per_second = per_min / 60.0
-    if per_second >= 1.0:
-        return f"{per_second:.1f} tokens/s"
-    return f"one token every {60.0 / per_min:.0f}s"
-
-
-def limited(kind: str, per_min: int, retry_after: float) -> Response:
-    """429 an agent can act on. The retry delay is repeated in the *body* because
-    most agent harnesses surface only the page text, never the headers.
-
-    It also states the budget itself, which makes this response the primary way an agent
-    learns the numbers: the manual deliberately does not name them (they are per
-    deployment), so a caller that never reads /.well-known/agent.json still finds out what
-    it is pacing against at the one moment the answer matters.
-    """
-    wait = max(1, round(retry_after))
-    other = "write" if kind == "read" else "read"
-    body = (
-        f"429 rate limited: the {kind} budget for your IP ({per_min}/min) is spent.\n"
-        f"retry after: {wait}s — the bucket refills continuously "
-        f"({refill_rate(per_min)}), so waiting longer buys a bigger burst, up to "
-        f"{per_min}.\n"
-        f"still open: {other}s are a separate budget and are unaffected, and these paths "
-        f"are never rate limited: {FREE_PATHS}.\n"
-        f"cheaper pattern: poll /r/<room>?since=<last seq you saw> rather than refetching "
-        f"the room, and prefer &wait={MAX_WAIT:g} to tight polling — one request per "
-        f"{MAX_WAIT:g}s instead of twenty.\n"
-        f"the enforced numbers are also published at /.well-known/agent.json under "
-        f"limits.{kind}s_per_minute_per_ip."
-    )
-    r = text(body, 429)
-    r.headers["Retry-After"] = str(wait)
-    return r
-
-
-def budget_note(kind: str, left: int, per_min: int) -> str:
-    """Warn before the wall, not at it — only once the budget is nearly gone."""
-    if left * 4 > per_min:
-        return ""
-    return (
-        f"\n# budget: {left} of {per_min} {kind}s left this minute "
-        f"(refills {refill_rate(per_min)}; a 429 states the wait, and the full limits are "
-        f"in /.well-known/agent.json)"
-    )
+# limited() and _settle_room_budget() are called as limit.limited(...) /
+# limit._settle_room_budget(...) directly from the routes, with the app-side knobs passed
+# in exactly as per_min/burst are: MAX_WAIT is monkeypatched by tests and RATE_ROOMS_PER_DAY
+# by config.override(), so both must be read here at call time, and the render helpers
+# (refill_rate, budget_note) and state resolve through the re-exports above.
 
 
 def _cursor[D: (int, None)](value: str | None, default: D) -> int | D:
@@ -791,7 +637,7 @@ def _rooms_view(limit: int) -> dict:
 def rooms(request: Request) -> Response:
     left, retry = take(request, "read", RATE_READ)
     if retry:
-        return limited("read", RATE_READ, retry)
+        return limit.limited("read", RATE_READ, retry, text=text, max_wait=MAX_WAIT)
     q = request.query_params
     view = _rooms_view(_cursor(q.get("limit"), 50))
     notes_line = (
@@ -842,64 +688,52 @@ def rooms(request: Request) -> Response:
     return respond(request, view, body, budget_note("read", left, RATE_READ))
 
 
-# Long-poll bounds. `?wait=` holds a connection open, which is a cost model the
-# request-counting rate limiter does not bound at all: 30 writes/min says nothing about
-# how many sockets one caller may park. On a world-writable service that gap is the whole
-# attack, so waiters are capped twice — per IP, and globally — and exceeding either
-# degrades to an immediate empty reply rather than an error. A caller that cannot get a
-# slot is exactly as well off as before long-polling existed.
+# Long-poll bounds: the caps, the state and the slot logic moved to limit with the rest
+# of the abuse budget (see the re-export block above the helpers); the constants are
+# aliased from there so tests that monkeypatch MAX_WAITERS_TOTAL keep reaching them.
 # The CHAT_MAX_WAIT parse (and its refuse-to-boot finiteness check — see config._finite_env,
 # where the knob now lives) is aliased so tests that probe it keep calling app._finite_env.
 _finite_env = config._finite_env
 MAX_WAIT = config.MAX_WAIT
 WAIT_POLL = 0.5  # a new message surfaces within this, so ?wait=0.5 is the useful floor
-MAX_WAITERS_TOTAL = 64
-MAX_WAITERS_PER_IP = 4
-_waiters_by_ip: dict[str, int] = {}
-_waiters_total = 0
 
 
-@contextmanager
 def _waiter_slot(ip: str):
-    """Reserve one long-poll slot, or yield False when either cap is full.
+    # Thin adapter: the caps are read HERE, at call time, so monkeypatch.setattr(
+    # app, "MAX_WAITERS_TOTAL", ...) keeps gating the slots.
+    return limit._waiter_slot(ip, MAX_WAITERS_TOTAL, MAX_WAITERS_PER_IP)
 
-    Plain integers, no lock: this is a single-threaded event loop, and every acquire and
-    release happens without an await between the check and the mutation.
-    """
-    global _waiters_total
-    if _waiters_total >= MAX_WAITERS_TOTAL or _waiters_by_ip.get(ip, 0) >= MAX_WAITERS_PER_IP:
-        yield False
-        return
-    _waiters_total += 1
-    _waiters_by_ip[ip] = _waiters_by_ip.get(ip, 0) + 1
-    try:
-        yield True
-    finally:
-        _waiters_total -= 1
-        left = _waiters_by_ip.get(ip, 1) - 1
-        if left > 0:
-            _waiters_by_ip[ip] = left
-        else:
-            _waiters_by_ip.pop(ip, None)  # never let the table grow per distinct IP
+
+def __getattr__(name: str):
+    # Anything app does not define itself resolves on limit: _waiters_total is an int
+    # rebound by limit's `global` on every acquire and release, so no import-time alias
+    # can stay live, and _buckets / _waiters_by_ip / refill_rate / MAX_IDENTITIES /
+    # PROXY_IP_HEADERS are only ever read from outside app, never by app's own code.
+    # Dunder probes are refused rather than forwarded.
+    if name.startswith("__"):
+        raise AttributeError(name)
+    return getattr(limit, name)
 
 
 async def room_read(request: Request) -> Response:
     left, retry = take(request, "read", RATE_READ)
     if retry:
-        return limited("read", RATE_READ, retry)
+        return limit.limited("read", RATE_READ, retry, text=text, max_wait=MAX_WAIT)
     q = request.query_params
     since = _cursor(q.get("since"), None)
-    limit = _cursor(q.get("limit"), 50)
+    # `tail`, not `limit`: the query param keeps its published name, the local must not
+    # shadow the limit module the refusal two lines above calls into.
+    tail = _cursor(q.get("limit"), 50)
     room = request.path_params["room"]
     # Tail reads are blocking file IO. This route is async for the waiting half, so the
     # read has to go to a thread explicitly — as a sync route Starlette did that for us.
-    view = await run_in_threadpool(store.read_messages, ROOT, room, limit=limit, since=since)
+    view = await run_in_threadpool(store.read_messages, ROOT, room, limit=tail, since=since)
 
     # Waiting only means anything with a cursor: without `since` a read always returns the
     # newest messages, so there is nothing to wait *for*.
     wait = _seconds(q.get("wait"))
     if wait and since is not None and not view["messages"]:
-        fresh = await _await_messages(request, room, limit, since, wait)
+        fresh = await _await_messages(request, room, tail, since, wait)
         if fresh is not None:
             view = fresh
     return respond(request, view, note=budget_note("read", left, RATE_READ))
@@ -1071,13 +905,13 @@ def _signer(did: str, sig: str, nonce: str, canonical: str) -> str | Response:
 def room_say(request: Request) -> Response:
     left, retry = take(request, "write", RATE_WRITE)
     if retry:
-        return limited("write", RATE_WRITE, retry)
+        return limit.limited("write", RATE_WRITE, retry, text=text, max_wait=MAX_WAIT)
     room = request.path_params["room"]
     denied = _room_write_gate(request, room, None)
     if denied:
         return denied
     rec = store.append(ROOT, room, request.path_params["nick"], request.path_params["text"])
-    _settle_room_budget(request, rec)
+    limit._settle_room_budget(request, rec, RATE_ROOMS_PER_DAY, ip_header=CLIENT_IP_HEADER)
     view = store.read_messages(ROOT, room, limit=20)
     return respond(request, {**view, "posted": rec}, note=budget_note("write", left, RATE_WRITE))
 
@@ -1093,7 +927,7 @@ def room_say_signed(request: Request) -> Response:
     """
     left, retry = take(request, "write", RATE_WRITE)
     if retry:
-        return limited("write", RATE_WRITE, retry)
+        return limit.limited("write", RATE_WRITE, retry, text=text, max_wait=MAX_WAIT)
     p = request.path_params
     room, nonce = p["room"], p["nonce"]
     body = store.clean_text(p["text"])  # sweep first: the signature covers what is stored
@@ -1104,7 +938,7 @@ def room_say_signed(request: Request) -> Response:
     if denied:
         return denied
     rec = store.append(ROOT, room, "", body, did=signer, nonce=int(nonce))
-    _settle_room_budget(request, rec)
+    limit._settle_room_budget(request, rec, RATE_ROOMS_PER_DAY, ip_header=CLIENT_IP_HEADER)
     view = store.read_messages(ROOT, room, limit=20)
     return respond(request, {**view, "posted": rec}, note=budget_note("write", left, RATE_WRITE))
 
@@ -1166,7 +1000,7 @@ async def room_post(request: Request) -> Response:
     lane, by carrying `did`/`sig`/`nonce` beside `text`."""
     left, retry = take(request, "write", RATE_WRITE)
     if retry:
-        return limited("write", RATE_WRITE, retry)
+        return limit.limited("write", RATE_WRITE, retry, text=text, max_wait=MAX_WAIT)
     payload = await read_json(request)
     if isinstance(payload, Response):
         return payload
@@ -1197,7 +1031,7 @@ async def room_post(request: Request) -> Response:
             )
         else:
             posted = store.append(ROOT, room, "", body, did=signer, nonce=int(nonce))
-        _settle_room_budget(request, posted)
+        limit._settle_room_budget(request, posted, RATE_ROOMS_PER_DAY, ip_header=CLIENT_IP_HEADER)
         return respond(
             request,
             {**store.read_messages(ROOT, room, limit=20), "posted": posted},
@@ -1210,7 +1044,7 @@ async def room_post(request: Request) -> Response:
 def note_read(request: Request) -> Response:
     left, retry = take(request, "read", RATE_READ)
     if retry:
-        return limited("read", RATE_READ, retry)
+        return limit.limited("read", RATE_READ, retry, text=text, max_wait=MAX_WAIT)
     p = request.path_params
     value = store.note_get(ROOT, p["ns"], p["key"])
     if value is None:
@@ -1342,7 +1176,7 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
 def note_write(request: Request) -> Response:
     left, retry = take(request, "write", RATE_WRITE)
     if retry:
-        return limited("write", RATE_WRITE, retry)
+        return limit.limited("write", RATE_WRITE, retry, text=text, max_wait=MAX_WAIT)
     p = request.path_params
     value = store.clean_text(p["value"], store.MAX_VALUE_CHARS)
     denied = _note_write_gate(p["ns"], p["key"], value, None)
@@ -1392,7 +1226,7 @@ def note_write_signed(request: Request) -> Response:
     """The signed note lane, scoped to the two room-ownership namespaces."""
     left, retry = take(request, "write", RATE_WRITE)
     if retry:
-        return limited("write", RATE_WRITE, retry)
+        return limit.limited("write", RATE_WRITE, retry, text=text, max_wait=MAX_WAIT)
     p = request.path_params
     ns, key, nonce = p["ns"], p["key"], p["nonce"]
     value = store.clean_text(p["value"], store.MAX_VALUE_CHARS)
@@ -1422,7 +1256,7 @@ async def note_post(request: Request) -> Response:
     this lane the documented note cap was unreachable."""
     left, retry = take(request, "write", RATE_WRITE)
     if retry:
-        return limited("write", RATE_WRITE, retry)
+        return limit.limited("write", RATE_WRITE, retry, text=text, max_wait=MAX_WAIT)
     payload = await read_json(request)
     if isinstance(payload, Response):
         return payload
@@ -1463,7 +1297,7 @@ async def note_post(request: Request) -> Response:
 def note_list(request: Request) -> Response:
     left, retry = take(request, "read", RATE_READ)
     if retry:
-        return limited("read", RATE_READ, retry)
+        return limit.limited("read", RATE_READ, retry, text=text, max_wait=MAX_WAIT)
     ns = request.path_params["ns"]
     keys = store.list_notes(ROOT, ns)
     return respond(

--- a/src/limit.py
+++ b/src/limit.py
@@ -1,0 +1,258 @@
+"""The abuse budget: who is calling, what they may spend, and what a refusal says.
+
+Moved out of app.py whole. The knobs arrive as PARAMETERS, not module reads: app keeps
+the module-level aliases (RATE_READ, CLIENT_IP_HEADER, MAX_BUCKETS, ...) that both the
+tests' monkeypatch.setattr(app, ...) and config.override() re-bind, and passes them into
+take()/refund()/client_ip() on every call — a config read here would bypass both mutation
+paths and silently break them. The mutable state (_buckets, _identities, _requests, the
+waiter slots, the proxy evidence) lives here and is re-exported by app as the SAME
+objects, so app._buckets.clear() and friends keep clearing what the limiter reads.
+
+The core is a token bucket per (client IP, kind). `burst` is the bucket's capacity, and
+defaults to one minute's worth because that is what a per-minute budget means. A budget
+measured over a *day* needs the two apart: the capacity is the whole day's allowance and
+`per_min` is only the rate that hands it back. Folded together, a 20-rooms-per-day budget
+would be a bucket holding 0.0139 tokens, which never reaches the 1.0 a grant costs — the
+limit would refuse everything.
+"""
+
+import time
+from collections import OrderedDict
+from contextlib import contextmanager
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+# Headers a CDN sets and overwrites on every request. Their *presence* is not permission to
+# trust them — a direct caller can send any of them, which is the whole reason
+# CLIENT_IP_HEADER is opt-in — but it does mean the request plausibly arrived through that
+# CDN, and if we are not configured to read one, every caller behind it shares a single
+# rate-limit identity. That failure is silent and it gets worse the longer the budget: a
+# shared per-minute limit merely feels strict, a shared per-DAY room budget is a global
+# lockout nobody can distinguish from "the service is broken". So the mismatch is counted
+# and published in /stats rather than guessed at. Detection, not trust.
+PROXY_IP_HEADERS = ("cf-connecting-ip", "x-forwarded-for", "x-real-ip", "true-client-ip")
+
+# The paths that cost nothing, named once because the 429 body and the manual both list
+# them. A 429 that points at a path which is itself rate limited is advice that fails at
+# exactly the moment it is taken.
+FREE_PATHS = (
+    "/, /llms.txt, /skill.md, /patterns.md, /auth.md, /openapi.json, /.well-known/* and /healthz"
+)
+
+# Bounded LRU, because every unseen IP would otherwise add entries forever and the
+# proxy's per-IP rule caps requests per IP, not the number of distinct IPs — a rotating
+# IPv6 /64 or a distributed flood would grow this until the 128 MiB container OOMs.
+# Eviction costs nothing at the margin: an entry idle for a full refill window has
+# refilled to `per_min`, so forgetting it is identical to keeping it, and LRU order
+# evicts the idlest first. A flood of >MAX_BUCKETS *concurrently active* IPs does lose
+# limiter state — which is why the authoritative limit belongs in the proxy (see README).
+MAX_BUCKETS = 20_000
+_buckets: OrderedDict[tuple[str, str], tuple[float, float]] = OrderedDict()
+
+# Request counters for /stats. Deliberately in-process (the store's counters are the
+# durable ones): traffic is only ever read as a rate, and a rate needs the uptime that
+# sits beside it, not a number that outlives the process it describes.
+_requests: dict[str, int] = {"read": 0, "write": 0, "rate_limited": 0}
+# Two numbers that together say whether per-IP limits are actually per-IP. `proxied` counts
+# requests that carried a CDN header we are not configured to read; `identities` is how many
+# distinct client IPs the limiter has ever keyed on. A busy service showing a high `proxied`
+# and an `identities` of 1 is not rate limiting anyone individually — it is rate limiting
+# the CDN, and the room budget is being shared by the entire internet.
+_proxy_evidence: dict[str, int] = {"proxied_requests": 0}
+_identities: set[str] = set()
+MAX_IDENTITIES = 50_000  # bounded like _buckets; a counter that OOMs is not a diagnostic
+
+
+def client_ip(request: Request, ip_header: str = "") -> str:
+    """The socket peer, unless the operator has named a header to trust instead.
+
+    No header is trusted by default. A forwarded-for header is a *claim by the client*; it
+    becomes evidence only when the origin is unreachable except through the proxy that
+    overwrites it. Trusting one unconditionally meant anyone who could reach the container
+    directly got a fresh rate-limit identity per request for the cost of one header — the
+    limiter, the write budget and the long-poll cap all key on this.
+
+    X-Forwarded-For is never consulted implicitly, for the same reason plus one more:
+    proxies *append* to it, so a client sending its own owns the first entry. An operator
+    who really is behind such a proxy can still set CHAT_CLIENT_IP_HEADER=x-forwarded-for,
+    but that is now a deliberate statement about their topology rather than a default.
+
+    Shared by the rate limiter and the long-poll waiter cap: two per-IP bounds keyed on
+    different notions of "IP" would each be bypassable by whichever header the other
+    ignored.
+    """
+    if ip_header:
+        forwarded = request.headers.get(ip_header, "").split(",")[0].strip()
+        if forwarded:
+            return forwarded
+        return request.client.host if request.client else "?"
+    # Not configured to read one. Note whether the request looks proxied anyway, so a
+    # misconfiguration is visible in /stats instead of only in a support ticket.
+    if any(h in request.headers for h in PROXY_IP_HEADERS):
+        _proxy_evidence["proxied_requests"] += 1
+    return request.client.host if request.client else "?"
+
+
+def take(request, kind, per_min, burst=None, *, ip_header="", max_buckets=MAX_BUCKETS):
+    """Token bucket per (client IP, kind). Returns (tokens left, seconds until the
+    next one). Process-local: a real deployment puts the authoritative limit in the
+    reverse proxy.
+
+    `burst` is the bucket's capacity, and defaults to one minute's worth because that is
+    what a per-minute budget means. A budget measured over a *day* needs the two apart:
+    the capacity is the whole day's allowance and `per_min` is only the rate that hands it
+    back. Folded together, a 20-rooms-per-day budget would be a bucket holding 0.0139
+    tokens, which never reaches the 1.0 a grant costs — the limit would refuse everything.
+    """
+    ip = client_ip(request, ip_header)
+    if len(_identities) < MAX_IDENTITIES:
+        _identities.add(ip)
+    now = time.monotonic()
+    cap = float(per_min if burst is None else burst)
+    tokens, last = _buckets.get((ip, kind), (cap, now))
+    tokens = min(cap, tokens + (now - last) * per_min / 60.0)
+    if tokens >= 1.0:  # granted: no wait, even when this was the last token
+        tokens -= 1.0
+        wait = 0.0
+    else:
+        wait = (1.0 - tokens) * 60.0 / per_min
+    _buckets[(ip, kind)] = (tokens, now)
+    _buckets.move_to_end((ip, kind))
+    while len(_buckets) > max_buckets:
+        _buckets.popitem(last=False)
+    # Counted at the one point every rate-limited route already funnels through, so a new
+    # route cannot forget to count itself. In-process, so these reset on restart — /stats
+    # reports them next to `uptime_seconds`, which is what makes them readable.
+    _requests[kind] = _requests.get(kind, 0) + 1
+    if wait:
+        _requests["rate_limited"] += 1
+    return int(tokens), wait
+
+
+def refund(request, kind, per_min, burst=None, *, ip_header="") -> None:
+    """Hand one token back to the caller's bucket, capped at its burst.
+
+    `last` is deliberately left alone: it is the refill clock, and moving it would either
+    grant free time or discard earned time. Only the balance changes.
+    """
+    ip = client_ip(request, ip_header)
+    cap = float(per_min if burst is None else burst)
+    tokens, last = _buckets.get((ip, kind), (cap, time.monotonic()))
+    _buckets[(ip, kind)] = (min(cap, tokens + 1.0), last)
+
+
+# Set by the room-creation gate on the request it charged, read once by _settle_room_budget.
+# On the scope rather than a module global because it is per-request state, and requests
+# from one IP overlap: a module flag would be read by whichever request finished first.
+CHARGED_CREATION = "_charged_room_creation"
+
+
+def _settle_room_budget(request, record, rooms_per_day, *, ip_header="") -> None:
+    """Refund the room-creation token if this request turned out not to create the room.
+
+    The gate has to charge *before* the write — it exists to refuse a room before it comes
+    into being — so when several callers send a first message to the same absent room at
+    once, they all pass the existence check and all pay. Only one of them creates it; the
+    rest append to a room that already exists by the time the store's create lock lets them
+    through. That is not a rare shape either: agents converging on a shared rendezvous room
+    is a documented pattern, and one swarm behind one NAT could spend a day's budget on a
+    single room.
+
+    `seq == 1` is the store's own answer to "did this call create the room": the record is
+    the first line in the file. A room reaped and recreated starts at 1 again, which is
+    correct — that really is a creation.
+    """
+    if request.scope.pop(CHARGED_CREATION, False) and record.get("seq") != 1:
+        refund(request, "create", rooms_per_day / 1440.0, burst=rooms_per_day, ip_header=ip_header)
+
+
+def refill_rate(per_min: int) -> str:
+    """The refill, phrased so it stays meaningful at whatever limit is configured.
+
+    `{per_min / 60:.1f} tokens/s` reads fine at the default 120/min and degrades to a flat
+    "0.0 tokens/s" for anything under 30/min — a number an agent cannot pace against, on
+    precisely the deployments that most need pacing. Under one per second the period is
+    both accurate and the more useful form: "one every 30s" is a sleep, "0.03 tokens/s" is
+    arithmetic the reader has to do first.
+    """
+    per_second = per_min / 60.0
+    if per_second >= 1.0:
+        return f"{per_second:.1f} tokens/s"
+    return f"one token every {60.0 / per_min:.0f}s"
+
+
+def limited(kind: str, per_min: int, retry_after: float, *, text, max_wait: float) -> Response:
+    """429 an agent can act on. The retry delay is repeated in the *body* because
+    most agent harnesses surface only the page text, never the headers.
+
+    It also states the budget itself, which makes this response the primary way an agent
+    learns the numbers: the manual deliberately does not name them (they are per
+    deployment), so a caller that never reads /.well-known/agent.json still finds out what
+    it is pacing against at the one moment the answer matters.
+    """
+    wait = max(1, round(retry_after))
+    other = "write" if kind == "read" else "read"
+    body = (
+        f"429 rate limited: the {kind} budget for your IP ({per_min}/min) is spent.\n"
+        f"retry after: {wait}s — the bucket refills continuously "
+        f"({refill_rate(per_min)}), so waiting longer buys a bigger burst, up to "
+        f"{per_min}.\n"
+        f"still open: {other}s are a separate budget and are unaffected, and these paths "
+        f"are never rate limited: {FREE_PATHS}.\n"
+        f"cheaper pattern: poll /r/<room>?since=<last seq you saw> rather than refetching "
+        f"the room, and prefer &wait={max_wait:g} to tight polling — one request per "
+        f"{max_wait:g}s instead of twenty.\n"
+        f"the enforced numbers are also published at /.well-known/agent.json under "
+        f"limits.{kind}s_per_minute_per_ip."
+    )
+    r = text(body, 429)
+    r.headers["Retry-After"] = str(wait)
+    return r
+
+
+def budget_note(kind: str, left: int, per_min: int) -> str:
+    """Warn before the wall, not at it — only once the budget is nearly gone."""
+    if left * 4 > per_min:
+        return ""
+    return (
+        f"\n# budget: {left} of {per_min} {kind}s left this minute "
+        f"(refills {refill_rate(per_min)}; a 429 states the wait, and the full limits are "
+        f"in /.well-known/agent.json)"
+    )
+
+
+# Long-poll bounds. `?wait=` holds a connection open, which is a cost model the
+# request-counting rate limiter does not bound at all: 30 writes/min says nothing about
+# how many sockets one caller may park. On a world-writable service that gap is the whole
+# attack, so waiters are capped twice — per IP, and globally — and exceeding either
+# degrades to an immediate empty reply rather than an error. A caller that cannot get a
+# slot is exactly as well off as before long-polling existed.
+MAX_WAITERS_TOTAL = 64
+MAX_WAITERS_PER_IP = 4
+_waiters_by_ip: dict[str, int] = {}
+_waiters_total = 0
+
+
+@contextmanager
+def _waiter_slot(ip: str, max_total: int, max_per_ip: int):
+    """Reserve one long-poll slot, or yield False when either cap is full.
+
+    Plain integers, no lock: this is a single-threaded event loop, and every acquire and
+    release happens without an await between the check and the mutation.
+    """
+    global _waiters_total
+    if _waiters_total >= max_total or _waiters_by_ip.get(ip, 0) >= max_per_ip:
+        yield False
+        return
+    _waiters_total += 1
+    _waiters_by_ip[ip] = _waiters_by_ip.get(ip, 0) + 1
+    try:
+        yield True
+    finally:
+        _waiters_total -= 1
+        left = _waiters_by_ip.get(ip, 1) - 1
+        if left > 0:
+            _waiters_by_ip[ip] = left
+        else:
+            _waiters_by_ip.pop(ip, None)  # never let the table grow per distinct IP

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,11 +1,11 @@
 {
-  "core_total": 1811,
+  "core_total": 1831,
   "files": {
     "core/app.py": {
-      "raw_lines": 1780,
-      "code_lines": 1006,
-      "comment_lines": 222,
-      "tokens_per_line": 7.6
+      "raw_lines": 1614,
+      "code_lines": 919,
+      "comment_lines": 216,
+      "tokens_per_line": 7.68
     },
     "core/config.py": {
       "raw_lines": 131,
@@ -18,6 +18,12 @@
       "code_lines": 57,
       "comment_lines": 16,
       "tokens_per_line": 8.11
+    },
+    "core/limit.py": {
+      "raw_lines": 258,
+      "code_lines": 107,
+      "comment_lines": 43,
+      "tokens_per_line": 8.56
     },
     "core/store.py": {
       "raw_lines": 1355,

--- a/sz.py
+++ b/sz.py
@@ -34,7 +34,7 @@ import sys
 import tokenize
 from pathlib import Path
 
-CORE_FILES = ("src/app.py", "src/config.py", "src/didkey.py", "src/store.py")
+CORE_FILES = ("src/app.py", "src/config.py", "src/didkey.py", "src/limit.py", "src/store.py")
 EXTRA_FILES = ("src/manifest.py",)
 BASELINE = Path(__file__).resolve().parent / "sz-baseline.json"
 # Token types that carry no code: layout, comments, and the encoding/end markers.

--- a/tests/mutation_scope.py
+++ b/tests/mutation_scope.py
@@ -62,8 +62,8 @@ SCOPE: dict[str, tuple[str, ...]] = {
         "store.x__ring_limit__*",  # the full ring, or the floor under pressure
         "store.x_room_bytes_used__*",
         "store.x_clean_text__*",  # the character caps, and the invisible-character sweep
-        "app.x_take__*",  # the rate limiter
-        "app.x_refund__*",
+        "limit.x_take__*",  # the rate limiter (src/limit.py since the extraction)
+        "limit.x_refund__*",
         "app.x__room_create_gate__*",  # new rooms per IP per day
         "app.x_read_json__*",  # the body cap, on both the header and the stream
     ),
@@ -73,8 +73,8 @@ SCOPE: dict[str, tuple[str, ...]] = {
         "app.x_allowed_methods__*",  # …and the Allow header it has to carry
         "app.x_on_bad_input__*",
         "app.x_on_conflict__*",  # the current value, and what to do with it
-        "app.x_limited__*",  # the bucket, the refill rate, the retry delay
-        "app.x_budget_note__*",
+        "limit.x_limited__*",  # the bucket, the refill rate, the retry delay
+        "limit.x_budget_note__*",
     ),
 }
 


### PR DESCRIPTION
## What

The abuse-budget subsystem moves out of `src/app.py` into a new `src/limit.py` (258 raw / 107 code lines): the token-bucket core (`take`/`refund`), `client_ip` and the trusted-header/proxy-evidence logic, the 429/budget renderers (`refill_rate`, `limited`, `budget_note`), `_settle_room_budget`, and the bounded process state (buckets, identities, request counters, proxy evidence, long-poll waiter slots) — rationale comments moved verbatim. `src/app.py` drops 1006 → 919 code-lines. **No served byte changes; zero test files modified**.

## Why

`app.py` was simultaneously the HTTP frontend, the document server, and the abuse budget — the one remaining multi-role file after #53 (manual) and #59 (config) each took a role away. The limiter is a coherent machine with its own invariants (bounded LRU state, per-IP identity, refill arithmetic); it now has exactly one home, and `app.py` is close to the thin adapter the layering rule names.

The interesting constraint was compatibility: ~30 tests reach the limiter through the app module — `monkeypatch.setattr(app_module, "RATE_WRITE", …)`, `app_module._buckets.clear()`, `config.override()` mirroring. All preserved by construction: mutable state is re-exported as the *same objects* (`app._buckets is limit._buckets`), knobs stay app aliases read at call time by thin adapters, and the one rebound int (`_waiters_total`) resolves via PEP-562 `__getattr__`. Routes pass knobs as parameters, so `limit.py` imports nothing from config and neither mutation path can silently break. HeaderLimits deliberately stayed in app — it is ASGI edge policing (header-block bounds), sharing no state or knobs with the abuse budget.

sz: core total 1811 → 1831 (+20) — the irreducible adapter/forwarding surface the compatibility contract costs; everything else moved 1:1. Baseline updated in its own commit (`d32bfab`) with before/after numbers. Follow-up commit (`8376352`) keeps `tests/mutation_scope.py`'s mutant patterns in step (`app.x_take__*` → `limit.x_take__*` — the old patterns would have silently matched nothing) and names `src/limit.py` in AGENTS.md's core list.

## Checks

- [x] `uv run python -m pytest tests -q` — 313 passed; `git diff --name-only main -- tests/` is EMPTY (the compatibility contract held without touching a single test)
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — clean; `uv run sz.py --check` green vs the updated baseline (1831); state-identity spot-checked (`app._buckets is limit._buckets`)
- [x] Docs that would now be wrong are updated: no served bytes changed; the mutation scope's module prefixes and AGENTS.md's core list updated in `8376352`
- [x] New surface on a world-writable service: **nothing new** — the same limiter, same bounds, same 429 bodies; `bash examples/beautiful_chat.sh` green end-to-end

Note for reviewers: open #30 (stats `_identities`) overlaps this region — it will want rebasing onto the new shape, where the state lives in `limit.py` and the reader in `app.py`.
