### PR TITLE
chore: tinygrad adoptions closeout — sz caps, CHAT_DEBUG, three-lane parity, alias cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@ uv run coverage report
 Layering: the core is `src/store.py`, `src/didkey.py`, `src/config.py`, `src/limit.py`
 and a thin `src/app.py` adapter.
 `src/manifest.py`, docs and frontends are extra — never counted as core.
+Core size caps (code-lines, `uv run sz.py --caps`): app 919, config 48, didkey 57,
+limit 110, store 714 — total 1848. Growth past a cap needs a new primitive, or belongs
+in extra.
 
 - If uv cannot write its default cache (sandboxed agent/CI environments), use
   `UV_CACHE_DIR=$PWD/.uvcache` — a worktree-local cache always works.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,8 @@ Then check the health endpoint at <http://localhost:8080/healthz> or read the lo
 - No code golf. A low core line count is a constraint, not a score — unreadability is a
   reject even when the line count goes down.
 - Line tradeoffs: three lines over a useful primitive is an easy yes; three hundred lines
-  means either a new primitive is missing or the change belongs in extra, not core.
+  means either a new primitive is missing or the change belongs in extra, not core. The
+  numeric form is `uv run sz.py --caps` — the per-file caps in `sz-baseline.json`.
 - Benchmark claimed speedups against `tests/capacity_bench.py` — a number, not a hunch.
 - Removing dead code from core is a win on its own; open a pull request for it.
 

--- a/src/app.py
+++ b/src/app.py
@@ -35,21 +35,15 @@ import store
 from store import StoreConflictError, StoreError
 
 # The CHAT_* knobs are read from the environment exactly once, in config — the only
-# module in src/ that reads it — and re-bound here so request handlers (and the
-# tests that monkeypatch app.RATE_WRITE &c.) keep reading plain module globals. Tests that
-# need a different value for a whole request use config.override(...), which re-binds both
-# copies and restores them on exit.
-ROOT = config.ROOT
+# module in src/ that reads it — and read here as config.<name> at call time, so
+# config.override(...) reaches every reader with no second copy to keep in step. Four are
+# aliased anyway because tests still assert against them as app attributes (override
+# mirrors those copies); every other knob lost its alias when the last monkeypatch site
+# that needed one moved to override.
 RATE_READ = config.RATE_READ  # requests/min/IP
 RATE_WRITE = config.RATE_WRITE
 RATE_ROOMS_PER_DAY = config.RATE_ROOMS_PER_DAY
-CORS_ORIGINS = config.CORS_ORIGINS
-STATS_TOKEN = config.STATS_TOKEN
-STATS_CACHE_SECONDS = config.STATS_CACHE_SECONDS
-ROOMS_CACHE_SECONDS = config.ROOMS_CACHE_SECONDS
-SECURITY_CONTACT = config.SECURITY_CONTACT
 CLIENT_IP_HEADER = config.CLIENT_IP_HEADER
-PUBLIC_URL = config.PUBLIC_URL
 
 # Sized from what the wire actually carries, not from what a parser tolerates. A real
 # agent request through Cloudflare — Host, UA, Accept, CF-Connecting-IP, CF-Ray,
@@ -77,9 +71,8 @@ MAX_BODY = 256 << 10
 #
 # FREE_PATHS and PROXY_IP_HEADERS moved to limit with the 429 body and the client-IP
 # logic that reads them (FREE_PATHS is aliased in the re-export block below the helpers;
-# PROXY_IP_HEADERS resolves through the module __getattr__). STATS_TOKEN /
-# STATS_CACHE_SECONDS / ROOMS_CACHE_SECONDS / SECURITY_CONTACT / CLIENT_IP_HEADER live in
-# config; their rationale moved with them.
+# PROXY_IP_HEADERS resolves through the module __getattr__). The remaining CHAT_* knobs
+# live in config; their rationale moved with them.
 # robots.txt moved to manifest.robots_txt(base): the Sitemap directive takes an absolute
 # URL, so the document depends on the origin and can no longer be a constant. Agents are
 # the intended audience, so it says so where crawlers look — Cloudflare serves a Content
@@ -189,7 +182,7 @@ def _room_exists(room: str) -> bool:
     gate calls both see the room as absent — that race is what the refund below exists for,
     and reproducing it by timing alone is exactly the kind of test that passes by accident.
     """
-    return store.room_path(ROOT, room).exists()
+    return store.room_path(config.ROOT, room).exists()
 
 
 # limited() and _settle_room_budget() are called as limit.limited(...) /
@@ -432,7 +425,9 @@ def auth_md(request: Request) -> Response:
 
 
 def _base_url(request: Request) -> str:
-    return manifest.public_base(request.url.scheme, request.headers.get("host", ""), PUBLIC_URL)
+    return manifest.public_base(
+        request.url.scheme, request.headers.get("host", ""), config.PUBLIC_URL
+    )
 
 
 def _document(doc: dict) -> Response:
@@ -593,7 +588,7 @@ def _rooms_stamp() -> tuple:
     The clear in `take` stays because it is free and catches what the counters do not —
     note writes, which change the notes line and the topics shown beside a room.
     """
-    counted = store.counters(ROOT)
+    counted = store.counters(config.ROOT)
     return tuple(counted[key] for key in store.COUNTER_KEYS)
 
 
@@ -606,15 +601,15 @@ def _rooms_view(limit: int) -> dict:
     """
     now = time.monotonic()
     stamp = _rooms_stamp()  # before the walk, never after — see _rooms_stamp
-    if ROOMS_CACHE_SECONDS > 0:
+    if config.ROOMS_CACHE_SECONDS > 0:
         hit = _rooms_cache.get(limit)
-        if hit and hit[0] == stamp and now - hit[1] < ROOMS_CACHE_SECONDS:
+        if hit and hit[0] == stamp and now - hit[1] < config.ROOMS_CACHE_SECONDS:
             return hit[2]
-    view = store.room_stats(ROOT, limit=limit)
+    view = store.room_stats(config.ROOT, limit=limit)
     # Notes had no capacity surface at all: /kv/<ns> lists one namespace and namespaces are
     # unenumerable by design, so nothing showed how full the global note cap was. Aggregate
     # only — see store.note_stats for why a per-namespace breakdown must never appear here.
-    view["notes"] = store.note_stats(ROOT)
+    view["notes"] = store.note_stats(config.ROOT)
     # Unconditional, including when `rooms` is empty: it describes the schema, not the
     # payload. A field that shows up only once a hostile room exists is one clients parse
     # without, and the listing that needed it is the one that breaks. `fields` is the
@@ -626,7 +621,7 @@ def _rooms_view(limit: int) -> dict:
     view["engagement"]["windowed_note_to_message_ratio"] = (
         round(view["notes"]["total"] / seen, 4) if seen else None
     )
-    if ROOMS_CACHE_SECONDS > 0:
+    if config.ROOMS_CACHE_SECONDS > 0:
         _rooms_cache[limit] = (stamp, now, view)
         _rooms_cache.move_to_end(limit)
         while len(_rooms_cache) > MAX_ROOMS_CACHE:
@@ -727,7 +722,7 @@ async def room_read(request: Request) -> Response:
     room = request.path_params["room"]
     # Tail reads are blocking file IO. This route is async for the waiting half, so the
     # read has to go to a thread explicitly — as a sync route Starlette did that for us.
-    view = await run_in_threadpool(store.read_messages, ROOT, room, limit=tail, since=since)
+    view = await run_in_threadpool(store.read_messages, config.ROOT, room, limit=tail, since=since)
 
     # Waiting only means anything with a cursor: without `since` a read always returns the
     # newest messages, so there is nothing to wait *for*.
@@ -759,7 +754,7 @@ async def _await_messages(
             if await request.is_disconnected():
                 return None
             view = await run_in_threadpool(
-                store.read_messages, ROOT, room, limit=limit, since=since
+                store.read_messages, config.ROOT, room, limit=limit, since=since
             )
             if view["messages"]:
                 return view
@@ -785,14 +780,14 @@ def _reject_if_events_room(room: str) -> Response | None:
 
 def _allowed_keys(room: str) -> set[str]:
     """The keys an owned room accepts writes from: the owner plus /kv/room-allow/<room>."""
-    owner = store.note_get(ROOT, store.OWNERS_NS, room)
+    owner = store.note_get(config.ROOT, store.OWNERS_NS, room)
     if owner is None:
         return set()
     # A note that is not a DID cannot own anything, so the room fails closed rather than
     # falling back to open. note_write refuses to write one; this covers a value that
     # reached the volume some other way.
     keys = {owner} if didkey.is_did(owner) else set()
-    allow = store.note_get(ROOT, store.ALLOW_NS, room) or ""
+    allow = store.note_get(config.ROOT, store.ALLOW_NS, room) or ""
     return keys | {k for k in allow.split() if didkey.is_did(k)}
 
 
@@ -809,7 +804,7 @@ def _room_write_gate(request: Request, room: str, signer: str | None) -> Respons
             f"send: GET /r/{room}/say-signed/<did:key>/<sig>/<nonce>/<text> — see /llms.txt",
             403,
         )
-    if store.note_get(ROOT, store.OWNERS_NS, room) is not None:
+    if store.note_get(config.ROOT, store.OWNERS_NS, room) is not None:
         allowed = _allowed_keys(room)
         if signer is None:
             return text(
@@ -910,9 +905,9 @@ def room_say(request: Request) -> Response:
     denied = _room_write_gate(request, room, None)
     if denied:
         return denied
-    rec = store.append(ROOT, room, request.path_params["nick"], request.path_params["text"])
+    rec = store.append(config.ROOT, room, request.path_params["nick"], request.path_params["text"])
     limit._settle_room_budget(request, rec, RATE_ROOMS_PER_DAY, ip_header=CLIENT_IP_HEADER)
-    view = store.read_messages(ROOT, room, limit=20)
+    view = store.read_messages(config.ROOT, room, limit=20)
     return respond(request, {**view, "posted": rec}, note=budget_note("write", left, RATE_WRITE))
 
 
@@ -937,9 +932,9 @@ def room_say_signed(request: Request) -> Response:
     denied = _room_write_gate(request, room, signer)
     if denied:
         return denied
-    rec = store.append(ROOT, room, "", body, did=signer, nonce=int(nonce))
+    rec = store.append(config.ROOT, room, "", body, did=signer, nonce=int(nonce))
     limit._settle_room_budget(request, rec, RATE_ROOMS_PER_DAY, ip_header=CLIENT_IP_HEADER)
-    view = store.read_messages(ROOT, room, limit=20)
+    view = store.read_messages(config.ROOT, room, limit=20)
     return respond(request, {**view, "posted": rec}, note=budget_note("write", left, RATE_WRITE))
 
 
@@ -1027,14 +1022,14 @@ async def room_post(request: Request) -> Response:
             return denied
         if signer is None:
             posted = store.append(
-                ROOT, room, str(payload.get("from", "")), str(payload.get("text", ""))
+                config.ROOT, room, str(payload.get("from", "")), str(payload.get("text", ""))
             )
         else:
-            posted = store.append(ROOT, room, "", body, did=signer, nonce=int(nonce))
+            posted = store.append(config.ROOT, room, "", body, did=signer, nonce=int(nonce))
         limit._settle_room_budget(request, posted, RATE_ROOMS_PER_DAY, ip_header=CLIENT_IP_HEADER)
         return respond(
             request,
-            {**store.read_messages(ROOT, room, limit=20), "posted": posted},
+            {**store.read_messages(config.ROOT, room, limit=20), "posted": posted},
             note=budget_note("write", left, RATE_WRITE),
         )
 
@@ -1046,7 +1041,7 @@ def note_read(request: Request) -> Response:
     if retry:
         return limit.limited("read", RATE_READ, retry, text=text, max_wait=MAX_WAIT)
     p = request.path_params
-    value = store.note_get(ROOT, p["ns"], p["key"])
+    value = store.note_get(config.ROOT, p["ns"], p["key"])
     if value is None:
         # Absent and never-written are the same state here, and both are ordinary: notes
         # are created by writing them, so the useful reply is the URL that would create
@@ -1116,7 +1111,7 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
                 "they hold cannot own anything. Claim with the key you sign with.",
                 400,
             )
-        current = store.note_get(ROOT, store.OWNERS_NS, key)
+        current = store.note_get(config.ROOT, store.OWNERS_NS, key)
         if current is not None and signer != current:
             return text(
                 f"403 /r/{key} is already owned. Only the current owner can hand it over, "
@@ -1140,7 +1135,7 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
             )
         # "Claiming a room people are already talking in would lock them out" was documented
         # for the un-ownable rooms and never enforced for d- ones. Ownership is from birth.
-        if current is None and store.last_seq(ROOT, key) > 0:
+        if current is None and store.last_seq(config.ROOT, key) > 0:
             return text(
                 f"403 /r/{key} already has messages, so it can no longer be claimed — "
                 "a room is ownable from birth or not at all, or claiming becomes a way to "
@@ -1148,7 +1143,7 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
                 403,
             )
         return None
-    owner = store.note_get(ROOT, store.OWNERS_NS, key)
+    owner = store.note_get(config.ROOT, store.OWNERS_NS, key)
     if owner is None:
         return text(
             f"403 /r/{key} has no owner, so it has no allow-list. Claim it first, signing "
@@ -1184,7 +1179,7 @@ def note_write(request: Request) -> Response:
         return denied
     expect, expect_absent = _condition(dict(request.query_params))
     meta = store.note_set(
-        ROOT, p["ns"], p["key"], value, expect=expect, expect_absent=expect_absent
+        config.ROOT, p["ns"], p["key"], value, expect=expect, expect_absent=expect_absent
     )
     return respond(
         request,
@@ -1204,7 +1199,7 @@ def _burn_nonce(room: str, nonce: str) -> Response | None:
     the ordinary 409. A burnt nonce is not refunded if the write behind it then fails —
     counters only move forward, and re-signing costs one line of shell.
     """
-    current = store.note_get(ROOT, store.NONCE_NS, room)
+    current = store.note_get(config.ROOT, store.NONCE_NS, room)
     if current is not None and not (current.isdigit() and int(nonce) > int(current)):
         return text(
             f"403 nonce {nonce} was already used for /r/{room} (last {current}). A signed "
@@ -1212,7 +1207,7 @@ def _burn_nonce(room: str, nonce: str) -> Response | None:
             403,
         )
     store.note_set(
-        ROOT,
+        config.ROOT,
         store.NONCE_NS,
         room,
         nonce,
@@ -1240,7 +1235,7 @@ def note_write_signed(request: Request) -> Response:
     if denied:
         return denied
     expect, expect_absent = _condition(dict(request.query_params))
-    meta = store.note_set(ROOT, ns, key, value, expect=expect, expect_absent=expect_absent)
+    meta = store.note_set(config.ROOT, ns, key, value, expect=expect, expect_absent=expect_absent)
     return respond(
         request,
         meta,
@@ -1283,7 +1278,9 @@ async def note_post(request: Request) -> Response:
             burned = _burn_nonce(key, nonce)
             if burned:
                 return burned
-        meta = store.note_set(ROOT, ns, key, value, expect=expect, expect_absent=expect_absent)
+        meta = store.note_set(
+            config.ROOT, ns, key, value, expect=expect, expect_absent=expect_absent
+        )
         return respond(
             request,
             meta,
@@ -1299,7 +1296,7 @@ def note_list(request: Request) -> Response:
     if retry:
         return limit.limited("read", RATE_READ, retry, text=text, max_wait=MAX_WAIT)
     ns = request.path_params["ns"]
-    keys = store.list_notes(ROOT, ns)
+    keys = store.list_notes(config.ROOT, ns)
     return respond(
         request,
         {"ns": ns, "keys": keys},
@@ -1365,7 +1362,7 @@ def security_txt(request: Request) -> Response:
     reporting channel rather than anything a room wrote.
     """
     return text(
-        manifest.security_txt(_base_url(request), SECURITY_CONTACT),
+        manifest.security_txt(_base_url(request), config.SECURITY_CONTACT),
         index=True,
     )
 
@@ -1379,7 +1376,7 @@ _stats_cache: tuple[float, dict] = (0.0, {})
 
 def _stats_view() -> dict:
     """Live aggregates plus the stored history, in one blocking call for the threadpool."""
-    return {**store.service_stats(ROOT), "history": store.snapshots(ROOT)}
+    return {**store.service_stats(config.ROOT), "history": store.snapshots(config.ROOT)}
 
 
 async def stats(request: Request) -> Response:
@@ -1401,12 +1398,12 @@ async def stats(request: Request) -> Response:
     # The same bytes an unmatched path gets. The point of answering 404 rather than 401 is
     # that a prober cannot tell this endpoint from a path that was never routed, and a
     # distinctive body would give that back — so the two must not drift apart.
-    if not STATS_TOKEN or not secrets.compare_digest(supplied, STATS_TOKEN):
+    if not config.STATS_TOKEN or not secrets.compare_digest(supplied, config.STATS_TOKEN):
         return text(NOT_FOUND, 404)
     global _stats_cache
     fresh_at, cached = _stats_cache
     now = time.monotonic()
-    if cached and now - fresh_at < STATS_CACHE_SECONDS:
+    if cached and now - fresh_at < config.STATS_CACHE_SECONDS:
         view = cached
     else:
         view = await run_in_threadpool(_stats_view)
@@ -1600,7 +1597,7 @@ app = Starlette(
         Middleware(HeaderLimits),
         Middleware(
             CORSMiddleware,
-            allow_origins=CORS_ORIGINS,  # default: none, so no browser origin is trusted
+            allow_origins=config.CORS_ORIGINS,  # default: none, so no browser origin is trusted
             allow_methods=["GET", "POST"],
             allow_credentials=False,
         ),

--- a/src/app.py
+++ b/src/app.py
@@ -906,6 +906,7 @@ def room_say(request: Request) -> Response:
     if denied:
         return denied
     rec = store.append(config.ROOT, room, request.path_params["nick"], request.path_params["text"])
+    config._dbg(3, "write", room=room, seq=rec["seq"], chars=len(rec["text"]))
     limit._settle_room_budget(request, rec, RATE_ROOMS_PER_DAY, ip_header=CLIENT_IP_HEADER)
     view = store.read_messages(config.ROOT, room, limit=20)
     return respond(request, {**view, "posted": rec}, note=budget_note("write", left, RATE_WRITE))
@@ -933,6 +934,7 @@ def room_say_signed(request: Request) -> Response:
     if denied:
         return denied
     rec = store.append(config.ROOT, room, "", body, did=signer, nonce=int(nonce))
+    config._dbg(3, "write", room=room, seq=rec["seq"], chars=len(rec["text"]))
     limit._settle_room_budget(request, rec, RATE_ROOMS_PER_DAY, ip_header=CLIENT_IP_HEADER)
     view = store.read_messages(config.ROOT, room, limit=20)
     return respond(request, {**view, "posted": rec}, note=budget_note("write", left, RATE_WRITE))
@@ -1026,6 +1028,7 @@ async def room_post(request: Request) -> Response:
             )
         else:
             posted = store.append(config.ROOT, room, "", body, did=signer, nonce=int(nonce))
+        config._dbg(3, "write", room=room, seq=posted["seq"], chars=len(posted["text"]))
         limit._settle_room_budget(request, posted, RATE_ROOMS_PER_DAY, ip_header=CLIENT_IP_HEADER)
         return respond(
             request,

--- a/src/config.py
+++ b/src/config.py
@@ -105,6 +105,33 @@ def _finite_env(name: str, default: str) -> float:
 # exists to prevent.
 MAX_WAIT = max(0.0, _finite_env("CHAT_MAX_WAIT", "10"))
 
+# Operator debug ladder, stderr only. 1 = limiter take/refund verdicts with client
+# identity (limit.py); 2 = + store flock/compact/reap/CAS-conflict (store.py); 3 = + one
+# line per room write with room, seq and length (app.py). NEVER message content —
+# lengths, seqs and room names only — and never stdout or any room: stderr is operator
+# territory, and a debug line a caller could read is a disclosure, not a diagnostic. No
+# new HTTP surface; like every knob here it is overridable in tests
+# (config.override(DEBUG=2)). Junk floors to 0 with one warning rather than refusing to
+# boot, because a debug switch a tired operator can typo into an outage defeats itself.
+try:
+    DEBUG = min(3, max(0, int(os.environ.get("CHAT_DEBUG", "0"))))
+except ValueError:
+    print(f"CHAT_DEBUG={os.environ.get('CHAT_DEBUG')!r} is not 0-3; debug off", file=sys.stderr)
+    DEBUG = 0
+
+
+def _dbg(level: int, event: str, **fields) -> None:
+    """One stderr line — `event key=value ...` — when DEBUG >= level, nothing otherwise.
+
+    The level test is the first statement and the line is built only past it, so a
+    suppressed call is one comparison. Zero cost when off is the design constraint:
+    these sit on the hottest paths in the service.
+    """
+    if DEBUG < level:
+        return
+    print(" ".join([event, *(f"{k}={v}" for k, v in fields.items())]), file=sys.stderr)
+
+
 _NOT_THERE = object()
 
 

--- a/src/limit.py
+++ b/src/limit.py
@@ -23,6 +23,8 @@ from contextlib import contextmanager
 from starlette.requests import Request
 from starlette.responses import Response
 
+import config
+
 # Headers a CDN sets and overwrites on every request. Their *presence* is not permission to
 # trust them — a direct caller can send any of them, which is the whole reason
 # CLIENT_IP_HEADER is opt-in — but it does mean the request plausibly arrived through that
@@ -127,6 +129,7 @@ def take(request, kind, per_min, burst=None, *, ip_header="", max_buckets=MAX_BU
     _requests[kind] = _requests.get(kind, 0) + 1
     if wait:
         _requests["rate_limited"] += 1
+    config._dbg(1, "take", ip=ip, kind=kind, left=int(tokens), wait=round(wait, 3))
     return int(tokens), wait
 
 
@@ -140,6 +143,7 @@ def refund(request, kind, per_min, burst=None, *, ip_header="") -> None:
     cap = float(per_min if burst is None else burst)
     tokens, last = _buckets.get((ip, kind), (cap, time.monotonic()))
     _buckets[(ip, kind)] = (min(cap, tokens + 1.0), last)
+    config._dbg(1, "refund", ip=ip, kind=kind)
 
 
 # Set by the room-creation gate on the request it charged, read once by _settle_room_budget.

--- a/src/store.py
+++ b/src/store.py
@@ -318,6 +318,7 @@ def _locked(target: Path):
     lock = target.with_suffix(target.suffix + ".lock")
     with open(lock, "a+b") as lf:
         fcntl.flock(lf, fcntl.LOCK_EX)
+        config._dbg(2, "flock", path=target.name)
         try:
             yield
         finally:
@@ -788,6 +789,7 @@ def _reap(root: Path) -> None:
                     reason = _reapable(p, now, stillborn_rule)
                     if reason:
                         p.unlink(missing_ok=True)
+                        config._dbg(2, "reap", room=p.name, reason=reason)
                         if stillborn_rule:
                             reaped[f"reaped_{reason}"] += 1
             except OSError:
@@ -1262,6 +1264,7 @@ def _compact(path: Path, cutoff: float | None = None, keep: int = COMPACT_KEEP_B
         f.flush()
         os.fsync(f.fileno())
     os.replace(tmp, path)
+    config._dbg(2, "compact", room=path.name, kept=len(kept), bytes=total)
 
 
 def note_set(
@@ -1296,8 +1299,10 @@ def note_set(
         if expect_absent or expect is not None:
             current = path.read_text(encoding="utf-8") if path.exists() else None
             if expect_absent and current is not None:
+                config._dbg(2, "cas_conflict", ns=ns, key=key, found="exists")
                 raise StoreConflictError(f"note {ns}/{key} already exists", current)
             if expect is not None and current != expect:
+                config._dbg(2, "cas_conflict", ns=ns, key=key, found="changed")
                 raise StoreConflictError(f"note {ns}/{key} changed since you read it", current)
         tmp = path.with_suffix(".tmp")
         tmp.write_text(value, encoding="utf-8")

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,17 +1,25 @@
 {
-  "core_total": 1831,
+  "core_total": 1848,
+  "caps": {
+    "core/app.py": 919,
+    "core/config.py": 48,
+    "core/didkey.py": 57,
+    "core/limit.py": 110,
+    "core/store.py": 714,
+    "core_total": 1848
+  },
   "files": {
     "core/app.py": {
       "raw_lines": 1614,
       "code_lines": 919,
       "comment_lines": 216,
-      "tokens_per_line": 7.68
+      "tokens_per_line": 7.82
     },
     "core/config.py": {
-      "raw_lines": 131,
-      "code_lines": 39,
-      "comment_lines": 52,
-      "tokens_per_line": 10.87
+      "raw_lines": 158,
+      "code_lines": 48,
+      "comment_lines": 60,
+      "tokens_per_line": 11.35
     },
     "core/didkey.py": {
       "raw_lines": 120,
@@ -20,16 +28,16 @@
       "tokens_per_line": 8.11
     },
     "core/limit.py": {
-      "raw_lines": 258,
-      "code_lines": 107,
+      "raw_lines": 262,
+      "code_lines": 110,
       "comment_lines": 43,
-      "tokens_per_line": 8.56
+      "tokens_per_line": 8.78
     },
     "core/store.py": {
-      "raw_lines": 1355,
-      "code_lines": 709,
+      "raw_lines": 1360,
+      "code_lines": 714,
       "comment_lines": 245,
-      "tokens_per_line": 7.02
+      "tokens_per_line": 7.11
     },
     "extra/manifest.py": {
       "raw_lines": 1582,

--- a/sz.py
+++ b/sz.py
@@ -16,6 +16,11 @@ reported under an "extra" label and never counted in the core total. Two numbers
 tokens/line is the anti-golf metric: a code-line count held down by stripping names and
 packing statements shows up here. Stdlib ast + tokenize only.
 
+Per-file CAPS live beside the baseline in sz-baseline.json ("caps"): the baseline is a
+ratchet that only moves down, the caps are the policy ceiling it ratchets under. --check
+fails on growth past the baseline (naming the cap) and on any value past its cap even
+when the baseline was raised to match; --caps prints the table against the caps.
+
 Counting rules: a triple-quoted string literal is one token starting at one line, so an
 embedded prose document (app.py's MANUAL) counts as ~1 code line by design — embedded
 docs are effectively extra, and extracting one into a file will barely move code-lines.
@@ -111,15 +116,26 @@ def main():
     parser.add_argument(
         "--update-baseline", action="store_true", help="rewrite sz-baseline.json from the tree"
     )
+    parser.add_argument(
+        "--caps",
+        action="store_true",
+        help="print code-lines against the per-file caps (fails on any breach)",
+    )
     args = parser.parse_args()
 
     root = Path(__file__).resolve().parent
     files = measure_all(root)
     core_total = sum(v["code_lines"] for k, v in files.items() if k.startswith("core/"))
-
+    # {} rather than None when unneeded: every branch that subscripts baseline is guarded
+    # by the flag that loaded it, and a dict default keeps that local invariant legible.
+    baseline = json.loads(BASELINE.read_text(encoding="utf-8")) if args.check or args.caps else {}
+    # The caps are policy, not measurement: a baseline rewrite must carry them forward
+    # untouched, or --update-baseline would silently delete the ceiling it ratchets under.
+    caps = baseline.get("caps", {})
     if args.update_baseline:
+        caps = caps or json.loads(BASELINE.read_text(encoding="utf-8")).get("caps", {})
         BASELINE.write_text(
-            json.dumps({"core_total": core_total, "files": files}, indent=2) + "\n",
+            json.dumps({"core_total": core_total, "caps": caps, "files": files}, indent=2) + "\n",
             encoding="utf-8",
         )
         print(f"baseline written: core code-lines = {core_total}")
@@ -133,8 +149,38 @@ def main():
         )
     print(f"{'core total (code)':<24} {'':>6} {core_total:>6}")
 
+    # Past a cap is past a cap even when the baseline was raised to match: the ratchet
+    # may only move down. This is the guard against --update-baseline absorbing growth
+    # the caps exist to force a decision about.
+    over = [
+        label
+        for label, m in files.items()
+        if label.startswith("core/") and label in caps and m["code_lines"] > caps[label]
+    ]
+    if core_total > caps.get("core_total", core_total):
+        over.append("core_total")
+
+    if args.caps:
+        print()
+        print(f"{'file':<24} {'code':>6} {'cap':>6} {'headroom':>9}")
+        for label, m in files.items():
+            cap = caps.get(label)
+            shown = "-" if cap is None else str(cap)
+            room = "" if cap is None else f"{cap - m['code_lines']:>9}"
+            print(f"{label:<24} {m['code_lines']:>6} {shown:>6} {room}")
+        total_cap = caps.get("core_total")
+        print(
+            f"{'core total (code)':<24} {core_total:>6} {total_cap:>6} {total_cap - core_total:>9}"
+        )
+        if over:
+            detail = ", ".join(
+                f"{o} {files[o]['code_lines'] if o in files else core_total} > cap {caps.get(o)}"
+                for o in over
+            )
+            print(f"core code-lines past cap: {detail}", file=sys.stderr)
+            return 1
+
     if args.check:
-        baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
         grown = [
             label
             for label, m in files.items()
@@ -144,15 +190,24 @@ def main():
         if grown:
             detail = ", ".join(
                 f"{g} {baseline['files'][g]['code_lines']} -> {files[g]['code_lines']}"
+                f" (cap {caps.get(g, '?')})"
                 for g in grown
             )
             print(f"core code-lines grew vs sz-baseline.json: {detail}", file=sys.stderr)
             return 1
         if core_total > baseline["core_total"]:
             print(
-                f"core total grew vs baseline: {baseline['core_total']} -> {core_total}",
+                f"core total grew vs baseline: {baseline['core_total']} -> {core_total}"
+                f" (cap {caps.get('core_total', '?')})",
                 file=sys.stderr,
             )
+            return 1
+        if over:
+            detail = ", ".join(
+                f"{o} {files[o]['code_lines'] if o in files else core_total} > cap {caps.get(o)}"
+                for o in over
+            )
+            print(f"core code-lines past cap: {detail}", file=sys.stderr)
             return 1
         print(f"check ok: core code-lines <= baseline ({baseline['core_total']})")
     return 0

--- a/sz.py
+++ b/sz.py
@@ -19,7 +19,9 @@ packing statements shows up here. Stdlib ast + tokenize only.
 Per-file CAPS live beside the baseline in sz-baseline.json ("caps"): the baseline is a
 ratchet that only moves down, the caps are the policy ceiling it ratchets under. --check
 fails on growth past the baseline (naming the cap) and on any value past its cap even
-when the baseline was raised to match; --caps prints the table against the caps.
+when the baseline was raised to match; --caps prints the table against the caps. Every
+core label and core_total must have a cap — a missing entry is an error in the enforcing
+modes, not an exemption, so a file added to CORE_FILES cannot slip past the policy.
 
 Counting rules: a triple-quoted string literal is one token starting at one line, so an
 embedded prose document (app.py's MANUAL) counts as ~1 code line by design — embedded
@@ -149,16 +151,28 @@ def main():
         )
     print(f"{'core total (code)':<24} {'':>6} {core_total:>6}")
 
-    # Past a cap is past a cap even when the baseline was raised to match: the ratchet
-    # may only move down. This is the guard against --update-baseline absorbing growth
-    # the caps exist to force a decision about.
-    over = [
-        label
-        for label, m in files.items()
-        if label.startswith("core/") and label in caps and m["code_lines"] > caps[label]
-    ]
-    if core_total > caps.get("core_total", core_total):
-        over.append("core_total")
+    if args.check or args.caps:
+        # A core label missing from caps is a policy hole, not an exemption: a file added
+        # to CORE_FILES without a cap entry would sit outside the per-file policy
+        # entirely, its growth visible only to the (looser) aggregate — and a missing
+        # core_total cap disables even that. Adding a core file means deciding its cap,
+        # so the enforcing modes refuse to run until the table covers everything.
+        missing = [label for label in files if label.startswith("core/") and label not in caps]
+        if "core_total" not in caps:
+            missing.append("core_total")
+        if missing:
+            print(f"caps missing from sz-baseline.json: {', '.join(missing)}", file=sys.stderr)
+            return 1
+        # Past a cap is past a cap even when the baseline was raised to match: the
+        # ratchet may only move down. This is the guard against --update-baseline
+        # absorbing growth the caps exist to force a decision about.
+        over = [
+            label
+            for label, m in files.items()
+            if label.startswith("core/") and m["code_lines"] > caps[label]
+        ]
+        if core_total > caps["core_total"]:
+            over.append("core_total")
 
     if args.caps:
         print()
@@ -190,7 +204,7 @@ def main():
         if grown:
             detail = ", ".join(
                 f"{g} {baseline['files'][g]['code_lines']} -> {files[g]['code_lines']}"
-                f" (cap {caps.get(g, '?')})"
+                f" (cap {caps[g]})"
                 for g in grown
             )
             print(f"core code-lines grew vs sz-baseline.json: {detail}", file=sys.stderr)
@@ -198,7 +212,7 @@ def main():
         if core_total > baseline["core_total"]:
             print(
                 f"core total grew vs baseline: {baseline['core_total']} -> {core_total}"
-                f" (cap {caps.get('core_total', '?')})",
+                f" (cap {caps['core_total']})",
                 file=sys.stderr,
             )
             return 1

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -64,10 +64,10 @@ def test_security_txt_is_a_valid_rfc_9116_document(client):
 def test_the_security_contact_is_the_operators_to_set(client, monkeypatch):
     """This image is published. A third party running it must not end up advertising the
     upstream project's mailbox for a problem with their own deployment."""
-    import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "SECURITY_CONTACT", "someone@example.org")
-    assert "mailto:someone@example.org" in client.get("/.well-known/security.txt").text
+    with config.override(SECURITY_CONTACT="someone@example.org"):
+        assert "mailto:someone@example.org" in client.get("/.well-known/security.txt").text
 
 
 def test_the_served_manual_states_the_caps_it_actually_enforces(client):
@@ -111,7 +111,7 @@ def test_robots_keeps_rooms_out_of_indexes_but_invites_the_manual(client):
 
 
 def test_skill_md_is_the_same_manual_and_is_never_rate_limited(client, monkeypatch):
-    import app as app_module
+    import config
 
     # Same bytes as the installable SKILL.md — one artifact, so the skill an agent
     # installs and the skill it fetches can never drift.
@@ -119,23 +119,23 @@ def test_skill_md_is_the_same_manual_and_is_never_rate_limited(client, monkeypat
     assert client.get("/skill.md").text == skill
     assert client.get("/skill.md").headers["content-type"].startswith("text/plain")
     assert "/llms.txt" in client.get("/skill.md").text  # points at the full reference
-    monkeypatch.setattr(app_module, "RATE_READ", 1)
-    for _ in range(5):
-        assert client.get("/skill.md").status_code == 200
+    with config.override(RATE_READ=1):
+        for _ in range(5):
+            assert client.get("/skill.md").status_code == 200
     assert "/skill.md" not in client.get("/robots.txt").text  # nothing disallows it
 
 
 def test_patterns_are_served_unlimited_and_the_manual_points_there(client, monkeypatch):
-    import app as app_module
+    import config
 
     page = client.get("/patterns.md")
     assert page.status_code == 200
     assert page.headers["content-type"].startswith("text/plain")
     assert "E2E" in page.text and "choreography" in page.text
     assert "/patterns.md" in client.get("/llms.txt").text  # the manual points here
-    monkeypatch.setattr(app_module, "RATE_READ", 1)
-    for _ in range(5):
-        assert client.get("/patterns.md").status_code == 200  # never rate limited
+    with config.override(RATE_READ=1):
+        for _ in range(5):
+            assert client.get("/patterns.md").status_code == 200  # never rate limited
     assert "/patterns.md" not in "".join(  # nothing disallows it for crawlers
         line for line in client.get("/robots.txt").text.splitlines() if "Disallow" in line
     )
@@ -591,66 +591,73 @@ def test_every_published_limit_is_one_the_server_actually_honours(client, monkey
     require the table to cover every bound the document publishes, or the next parameter
     added with a limit nobody honours passes unnoticed the same way.
     """
-    import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "MAX_WAIT", 0.5)  # keep the long-poll case quick
-    doc = client.get("/openapi.json").json()
-    did, sign = _keypair()
-    longest_name = "a" * 48
+    # keep the long-poll case quick
+    with config.override(MAX_WAIT=0.5):
+        doc = client.get("/openapi.json").json()
+        did, sign = _keypair()
+        longest_name = "a" * 48
 
-    def wait_is_honoured():
-        published = next(
-            p for p in doc["paths"]["/r/{room}"]["get"]["parameters"] if p["name"] == "wait"
-        )["schema"]["maximum"]
-        started = time.monotonic()
-        client.get(f"/r/idle?since=1&wait={published}")
-        # It has to actually hold the connection, not return an immediate empty reply that
-        # a caller cannot tell from a quiet room.
-        assert time.monotonic() - started >= published * 0.8
+        def wait_is_honoured():
+            published = next(
+                p for p in doc["paths"]["/r/{room}"]["get"]["parameters"] if p["name"] == "wait"
+            )["schema"]["maximum"]
+            started = time.monotonic()
+            client.get(f"/r/idle?since=1&wait={published}")
+            # It has to actually hold the connection, not return an immediate empty reply
+            # that a caller cannot tell from a quiet room.
+            assert time.monotonic() - started >= published * 0.8
 
-    # (the bound as published, a request using it at its extreme)
-    checks = [
-        ('{"pattern": "^[a-z0-9][a-z0-9_-]{0,47}$"}', lambda: _ok(client, f"/r/{longest_name}")),
-        (
-            '{"maxLength": 4096, "minLength": 1}',
-            lambda: _ok(client, "/r/lobby", post={"from": "b", "text": "x" * 4096}),
-        ),
-        (
-            '{"maxLength": 8192, "minLength": 1}',
-            lambda: _ok(client, "/kv/plans/big", post={"value": "x" * 8192}),
-        ),
-        ('{"maximum": 200, "minimum": 1}', lambda: _ok(client, "/r/lobby?limit=200")),
-        ('{"minimum": 0}', lambda: _ok(client, "/r/lobby?since=0")),
-        ('{"minimum": 1}', lambda: _ok(client, "/rooms?limit=1")),
-        ('{"enum": ["json"]}', lambda: client.get("/r/lobby?format=json").json()),
-        ('{"enum": ["1"]}', lambda: _ok(client, "/kv/plans/fresh/set/v?if_absent=1")),
-        ('{"maximum": 0.5, "minimum": 0}', wait_is_honoured),
-        # The signed lane's three, at the exact shapes it publishes. A room each, because a
-        # nonce is single-use per key per room and the 19-digit one spends the ceiling —
-        # 10**19 - 1 being the largest the published pattern allows, and an int64 fits it.
-        (
-            '{"pattern": "^[0-9]{1,19}$"}',
-            lambda: _ok(
-                client, _say_signed(client, "big-nonce", did, sign, "hi", nonce=10**19 - 1)
+        # (the bound as published, a request using it at its extreme)
+        checks = [
+            (
+                '{"pattern": "^[a-z0-9][a-z0-9_-]{0,47}$"}',
+                lambda: _ok(client, f"/r/{longest_name}"),
             ),
-        ),
-        (
-            '{"maxLength": 56, "minLength": 56, '
-            '"pattern": "^did:key:z6Mk[1-9A-HJ-NP-Za-km-z]{44}$"}',
-            lambda: _ok(client, _say_signed(client, "signed-did", did, sign, "signed")),
-        ),
-        (
-            '{"maxLength": 86, "minLength": 86, "pattern": "^[A-Za-z0-9_-]{86}$"}',
-            lambda: _ok(client, _say_signed(client, "signed-sig", did, sign, "again")),
-        ),
-    ]
+            (
+                '{"maxLength": 4096, "minLength": 1}',
+                lambda: _ok(client, "/r/lobby", post={"from": "b", "text": "x" * 4096}),
+            ),
+            (
+                '{"maxLength": 8192, "minLength": 1}',
+                lambda: _ok(client, "/kv/plans/big", post={"value": "x" * 8192}),
+            ),
+            ('{"maximum": 200, "minimum": 1}', lambda: _ok(client, "/r/lobby?limit=200")),
+            ('{"minimum": 0}', lambda: _ok(client, "/r/lobby?since=0")),
+            ('{"minimum": 1}', lambda: _ok(client, "/rooms?limit=1")),
+            ('{"enum": ["json"]}', lambda: client.get("/r/lobby?format=json").json()),
+            ('{"enum": ["1"]}', lambda: _ok(client, "/kv/plans/fresh/set/v?if_absent=1")),
+            ('{"maximum": 0.5, "minimum": 0}', wait_is_honoured),
+            # The signed lane's three, at the exact shapes it publishes. A room each,
+            # because a nonce is single-use per key per room and the 19-digit one spends
+            # the ceiling — 10**19 - 1 being the largest the published pattern allows, and
+            # an int64 fits it.
+            (
+                '{"pattern": "^[0-9]{1,19}$"}',
+                lambda: _ok(
+                    client, _say_signed(client, "big-nonce", did, sign, "hi", nonce=10**19 - 1)
+                ),
+            ),
+            (
+                '{"maxLength": 56, "minLength": 56, '
+                '"pattern": "^did:key:z6Mk[1-9A-HJ-NP-Za-km-z]{44}$"}',
+                lambda: _ok(client, _say_signed(client, "signed-did", did, sign, "signed")),
+            ),
+            (
+                '{"maxLength": 86, "minLength": 86, "pattern": "^[A-Za-z0-9_-]{86}$"}',
+                lambda: _ok(client, _say_signed(client, "signed-sig", did, sign, "again")),
+            ),
+        ]
 
-    for _bound, exercise in checks:
-        exercise()
+        for _bound, exercise in checks:
+            exercise()
 
-    covered = {bound for bound, _ in checks}
-    published = _published_bounds(doc)
-    assert not published - covered, f"published but never exercised: {sorted(published - covered)}"
+        covered = {bound for bound, _ in checks}
+        published = _published_bounds(doc)
+        assert not published - covered, (
+            f"published but never exercised: {sorted(published - covered)}"
+        )
 
 
 def test_the_signed_lane_publishes_the_shape_it_actually_enforces(client):
@@ -798,11 +805,12 @@ def test_the_manual_and_the_429_agree_on_what_costs_nothing(client, monkeypatch)
     """Two lists of free paths would drift, and the 429's copy is the one an agent reads
     while it is actually throttled."""
     import app as app_module
+    import config
 
     assert app_module.FREE_PATHS in client.get("/llms.txt").text
-    monkeypatch.setattr(app_module, "RATE_WRITE", 1)
-    client.get("/r/lobby/say/bot/one")
-    assert app_module.FREE_PATHS in client.get("/r/lobby/say/bot/two").text
+    with config.override(RATE_WRITE=1):
+        client.get("/r/lobby/say/bot/one")
+        assert app_module.FREE_PATHS in client.get("/r/lobby/say/bot/two").text
 
 
 def test_openapi_omits_the_token_gated_stats_endpoint(client):
@@ -849,22 +857,22 @@ def test_metadata_urls_never_echo_an_untrusted_host(client):
 
 
 def test_configured_public_url_wins_over_the_request(client, monkeypatch):
-    import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "PUBLIC_URL", "https://technocore.chat/")
-    doc = client.get("/openapi.json", headers={"host": "127.0.0.1:8080"}).json()
-    assert doc["servers"] == [{"url": "https://technocore.chat"}]
+    with config.override(PUBLIC_URL="https://technocore.chat/"):
+        doc = client.get("/openapi.json", headers={"host": "127.0.0.1:8080"}).json()
+        assert doc["servers"] == [{"url": "https://technocore.chat"}]
 
 
 def test_metadata_is_never_rate_limited_and_is_crawlable(client, monkeypatch):
     """A registry crawler arrives without warning and re-fetches on a schedule; a 429 on
     the document that describes the service is a listing that never validates."""
-    import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "RATE_READ", 1)
-    for _ in range(5):
-        assert client.get("/openapi.json").status_code == 200
-        assert client.get("/.well-known/agent.json").status_code == 200
+    with config.override(RATE_READ=1):
+        for _ in range(5):
+            assert client.get("/openapi.json").status_code == 200
+            assert client.get("/.well-known/agent.json").status_code == 200
     robots = client.get("/robots.txt").text
     assert "/openapi.json" in robots and "/.well-known/agent.json" in robots
     assert "Disallow: /openapi.json" not in robots

--- a/tests/http/test_humans.py
+++ b/tests/http/test_humans.py
@@ -64,6 +64,7 @@ def test_the_note_framing_the_human_page_parses_is_a_contract(client, monkeypatc
     the failure mode worth a test.
     """
     import app as app_module
+    import config
 
     client.get("/kv/plans/next/set/ship%20it")
     lines = client.get("/kv/plans/next").text.split("\n")
@@ -81,12 +82,12 @@ def test_the_note_framing_the_human_page_parses_is_a_contract(client, monkeypatc
 
     # The warning goes last, after the value, and nothing follows it: that is what lets
     # the page drop it by inspecting the final line alone.
-    monkeypatch.setattr(app_module, "RATE_READ", 8)
-    for _ in range(5):
-        client.get("/kv/plans/next")
-    warned = client.get("/kv/plans/next").text.rstrip("\n").split("\n")
-    assert warned[2] == "ship it"
-    assert warned[-1].startswith("# budget:")
+    with config.override(RATE_READ=8):
+        for _ in range(5):
+            client.get("/kv/plans/next")
+        warned = client.get("/kv/plans/next").text.rstrip("\n").split("\n")
+        assert warned[2] == "ship it"
+        assert warned[-1].startswith("# budget:")
 
 
 def test_human_page_caps_its_log_rows(client):

--- a/tests/http/test_lane_parity.py
+++ b/tests/http/test_lane_parity.py
@@ -1,0 +1,185 @@
+"""One logical write, performed three ways, asserting they land identically.
+
+The three lanes to a room write: store.append directly against the root, the HTTP GET
+say lane, and the MCP wrapper (whose say builds the same GET — see tests/test_mcp.py for
+the urlopen-into-TestClient trick that makes the wrapper drive the real app here). If
+the three ever disagree about what a record IS, the disagreement is invisible to every
+single-lane test: this file is the differential check.
+
+Seed of the §6.5 port gate: the assertions below are phrased against the protocol (one
+JSONL record per write, field-identical modulo the fields named in each test; one
+rendered line per message), never against this implementation's internals, so pointing
+lanes (b) and (c) at a port of the service reuses this file as the gate unchanged.
+
+Run: uv run --group dev python -m pytest tests
+"""
+
+from __future__ import annotations
+
+import email.message
+import io
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT / "mcp" / "src"))
+
+
+@pytest.fixture()
+def lanes(tmp_path, monkeypatch):
+    """One root, one app, three writers aimed at it: the store, HTTP, the wrapper.
+
+    Modeled on the `mcp` fixture in tests/test_mcp.py, with the TestClient yielded
+    alongside the wrapper so the HTTP lane and the wrapper write the SAME tree — parity
+    only means anything when all three lanes share a root.
+    """
+    import app as app_module
+    import config
+
+    app_module._buckets.clear()
+    with config.override(ROOT=tmp_path):
+        from technocore_mcp import server as mcp_server
+
+        client = TestClient(app_module.app)
+
+        class _Body:
+            def __init__(self, text: str):
+                self._text = text
+
+            def read(self) -> bytes:
+                return self._text.encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc) -> None:
+                return None
+
+        def fake_urlopen(request, timeout=None):
+            assert request.full_url.startswith(mcp_server.BASE_URL)
+            response = client.get(request.full_url[len(mcp_server.BASE_URL) :])
+            if response.status_code >= 400:
+                raise urllib.error.HTTPError(
+                    request.full_url,
+                    response.status_code,
+                    "error",
+                    email.message.Message(),
+                    io.BytesIO(response.text.encode()),
+                )
+            return _Body(response.text)
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(mcp_server, "DEFAULT_NICK", "")
+        yield tmp_path, client, mcp_server
+
+
+def call(server, name: str, arguments: dict) -> dict:
+    reply = server.handle(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        }
+    )
+    assert reply is not None and not reply["result"].get("isError"), reply
+    return reply
+
+
+def text_of(reply: dict) -> str:
+    return reply["result"]["content"][0]["text"]
+
+
+def test_one_room_write_lands_identically_through_all_three_lanes(lanes):
+    """Three appends to one room file: the records must be the same shape and content.
+
+    Legitimately differing fields, and why: `seq` (assigned under the room lock in
+    arrival order, so the three sequential writes are 1, 2, 3 — that ordering IS the
+    parity being checked, not a divergence) and `ts` (microsecond wall clock at write
+    time). `nick` does NOT differ: the wrapper's nick argument becomes the same path
+    segment the bare GET carries, so all three lanes write `from`: bot. Unsigned
+    throughout — the signed lanes add `did`/`nonce` and are their own parity check.
+    """
+    import json
+
+    import store
+
+    root, client, mcp_server = lanes
+    text = "hello parity"
+    store.append(root, "parity", "bot", text)  # (a) the store, directly
+    # (b) the HTTP GET lane — %20 proves the encoding path both lanes must share
+    assert client.get("/r/parity/say/bot/hello%20parity").status_code == 200
+    # (c) the same write through the wrapper
+    call(mcp_server.server, "say", {"room": "parity", "text": text, "nick": "bot"})
+
+    records = [
+        json.loads(line)
+        for line in store.room_path(root, "parity").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [r["seq"] for r in records] == [1, 2, 3]
+    assert len({tuple(sorted(r)) for r in records}) == 1  # one field set, from every lane
+    assert {r["from"] for r in records} == {"bot"}
+    assert {r["text"] for r in records} == {text}
+
+
+def test_the_rendered_line_an_agent_sees_is_the_same_over_http_and_the_wrapper(lanes):
+    """The write reply of each lane, rendered: identical except where they must differ.
+
+    Two fresh rooms, because a write's reply is the room tail — a shared room would put
+    different seq and content in each reply. The two replies then differ only in the
+    room name (header and footer lines) and the `[seq] ts` prefix of the message line;
+    everything else — banner, counts, attribution, text — must be byte-identical.
+    """
+    root, client, mcp_server = lanes
+    http = client.get("/r/zz-http/say/bot/same%20words").text
+    wrapped = text_of(
+        call(mcp_server.server, "say", {"room": "zz-mcp", "text": "same words", "nick": "bot"})
+    )
+
+    def normalized(body: str, room: str) -> list[str]:
+        return [
+            re.sub(r"^\[\d+\] \S+ ", "[seq ts] ", line.replace(room, "<room>"))
+            for line in body.splitlines()
+        ]
+
+    assert normalized(http, "zz-http") == normalized(wrapped, "zz-mcp")
+    # …and the message line both agents see is the attribution and the text, nothing else.
+    assert [line for line in normalized(http, "zz-http") if line.startswith("[seq ts]")][0] == (
+        "[seq ts] <~bot> same words"
+    )
+
+
+def test_one_note_write_lands_identically_through_all_three_lanes(lanes):
+    """Notes fall out the same way: one value, three lanes, byte-identical files, and a
+    read surface with no timestamps at all — so the HTTP body and the wrapper's reply
+    text are byte-for-byte equal with nothing masked."""
+    import store
+
+    root, client, mcp_server = lanes
+    value = "parity value"
+    store.note_set(root, "zz-parity", "direct", value)  # (a) the store, directly
+    assert client.get("/kv/zz-parity/http/set/parity%20value").status_code == 200  # (b)
+    call(  # (c) the wrapper's write_note, which builds the same GET with safe="" quoting
+        mcp_server.server, "write_note", {"namespace": "zz-parity", "key": "mcp", "value": value}
+    )
+
+    files = {
+        key: store.note_path(root, "zz-parity", key).read_text(encoding="utf-8")
+        for key in ("direct", "http", "mcp")
+    }
+    assert set(files.values()) == {value}
+
+    # The read lane carries no per-write timestamp, so same key read both ways must be
+    # byte-identical — the strictest form of the rendered parity above.
+    http_read = client.get("/kv/zz-parity/http").text
+    wrapped_read = text_of(
+        call(mcp_server.server, "read_note", {"namespace": "zz-parity", "key": "http"})
+    )
+    assert wrapped_read == http_read

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -19,6 +19,7 @@ def test_a_fractional_wait_is_honoured_rather_than_silently_dropped(client, monk
     room. Review catch on #40.
     """
     import app as app_module
+    import config
 
     assert app_module._seconds("0.5") == 0.5
     assert app_module._seconds("2.5") == 2.5
@@ -27,9 +28,9 @@ def test_a_fractional_wait_is_honoured_rather_than_silently_dropped(client, monk
         assert app_module._seconds(junk) == 0.0, junk
     # The ceiling is applied here, so it cannot be enforced in one caller and forgotten in
     # another. Infinity is just an over-large number.
-    monkeypatch.setattr(app_module, "MAX_WAIT", 1.0)
-    assert app_module._seconds("10") == 1.0
-    assert app_module._seconds("inf") == 1.0
+    with config.override(MAX_WAIT=1.0):
+        assert app_module._seconds("10") == 1.0
+        assert app_module._seconds("inf") == 1.0
 
     # End to end: a fractional wait really does hold the connection open and then return.
     started = time.monotonic()
@@ -42,16 +43,17 @@ def test_an_instance_with_a_sub_second_ceiling_still_polls(client, monkeypatch):
     positive wait int-parsed to zero, so the feature the document advertised could not be
     used at all on that instance."""
     import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "MAX_WAIT", 0.5)
-    published = next(
-        p
-        for p in client.get("/openapi.json").json()["paths"]["/r/{room}"]["get"]["parameters"]
-        if p["name"] == "wait"
-    )["schema"]
-    assert published["maximum"] == 0.5
-    # The largest value the schema permits is a wait the server actually takes.
-    assert app_module._seconds(str(published["maximum"])) == 0.5
+    with config.override(MAX_WAIT=0.5):
+        published = next(
+            p
+            for p in client.get("/openapi.json").json()["paths"]["/r/{room}"]["get"]["parameters"]
+            if p["name"] == "wait"
+        )["schema"]
+        assert published["maximum"] == 0.5
+        # The largest value the schema permits is a wait the server actually takes.
+        assert app_module._seconds(str(published["maximum"])) == 0.5
 
 
 def test_the_body_cap_holds_when_nothing_declares_a_length(client):
@@ -82,23 +84,24 @@ def test_the_body_cap_holds_when_nothing_declares_a_length(client):
 
 
 def test_rate_limit_is_actionable_without_headers(client, monkeypatch):
-    import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "RATE_WRITE", 4)
-    codes = [client.get(f"/r/lobby/say/bot/m{i}").status_code for i in range(6)]
-    assert codes[:4] == [200] * 4 and codes[4:] == [429, 429]
-    r = client.get("/r/lobby/say/bot/again")
-    assert r.headers["retry-after"].isdigit()
-    # the wait is in the body too: harness webfetch shows page text, not headers
-    assert "retry after:" in r.text and "429 rate limited" in r.text
-    # …and it is the right order of magnitude. A bucket refilling at 4/min hands back a
-    # token in ~15s; the arithmetic that produces that is one character from reporting
-    # four minutes, and an agent that believes it sleeps through its own work.
-    assert 1 <= int(r.headers["retry-after"]) <= 60 // 4 + 1
-    assert f"retry after: {r.headers['retry-after']}s" in r.text  # header and body agree
-    # the manual stays reachable while throttled, so a limited agent can learn to back off
-    assert client.get("/llms.txt").status_code == 200
-    assert client.get("/r/lobby").status_code == 200  # reads have their own budget
+    with config.override(RATE_WRITE=4):
+        codes = [client.get(f"/r/lobby/say/bot/m{i}").status_code for i in range(6)]
+        assert codes[:4] == [200] * 4 and codes[4:] == [429, 429]
+        r = client.get("/r/lobby/say/bot/again")
+        assert r.headers["retry-after"].isdigit()
+        # the wait is in the body too: harness webfetch shows page text, not headers
+        assert "retry after:" in r.text and "429 rate limited" in r.text
+        # …and it is the right order of magnitude. A bucket refilling at 4/min hands back a
+        # token in ~15s; the arithmetic that produces that is one character from reporting
+        # four minutes, and an agent that believes it sleeps through its own work.
+        assert 1 <= int(r.headers["retry-after"]) <= 60 // 4 + 1
+        assert f"retry after: {r.headers['retry-after']}s" in r.text  # header and body agree
+        # the manual stays reachable while throttled, so a limited agent can learn to back
+        # off
+        assert client.get("/llms.txt").status_code == 200
+        assert client.get("/r/lobby").status_code == 200  # reads have their own budget
 
 
 def test_every_rate_limited_route_returns_the_same_recovery_plan(client, monkeypatch):
@@ -109,35 +112,35 @@ def test_every_rate_limited_route_returns_the_same_recovery_plan(client, monkeyp
     attacker can amplify, so malformed signed traffic has to spend its token before parsing.
     """
     import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "RATE_READ", 1)
-    monkeypatch.setattr(app_module, "RATE_WRITE", 1)
-    signed = "/kv/room-owners/d-rate/set-signed/not-a-did/not-a-signature/1/not-a-did"
-    routes = (
-        ("read", "room read", lambda: client.get("/r/rate-tail")),
-        ("read", "note read", lambda: client.get("/kv/rate/missing")),
-        ("read", "note listing", lambda: client.get("/kv/rate")),
-        (
-            "write",
-            "room POST",
-            lambda: client.post("/r/rate-post", json={"from": "bot", "text": "hi"}),
-        ),
-        ("write", "note GET write", lambda: client.get("/kv/rate/get/set/value")),
-        ("write", "signed note write", lambda: client.get(signed)),
-        ("write", "note POST", lambda: client.post("/kv/rate/post", json={"value": "v"})),
-    )
+    with config.override(RATE_READ=1, RATE_WRITE=1):
+        signed = "/kv/room-owners/d-rate/set-signed/not-a-did/not-a-signature/1/not-a-did"
+        routes = (
+            ("read", "room read", lambda: client.get("/r/rate-tail")),
+            ("read", "note read", lambda: client.get("/kv/rate/missing")),
+            ("read", "note listing", lambda: client.get("/kv/rate")),
+            (
+                "write",
+                "room POST",
+                lambda: client.post("/r/rate-post", json={"from": "bot", "text": "hi"}),
+            ),
+            ("write", "note GET write", lambda: client.get("/kv/rate/get/set/value")),
+            ("write", "signed note write", lambda: client.get(signed)),
+            ("write", "note POST", lambda: client.post("/kv/rate/post", json={"value": "v"})),
+        )
 
-    for kind, label, call_route in routes:
-        app_module._buckets.clear()
-        first = call_route()
-        refused = call_route()
-        assert first.status_code != 429, label
-        assert refused.status_code == 429, label
-        assert f"the {kind} budget" in refused.text, label
-        assert "retry after:" in refused.text, label
-        assert "still open:" in refused.text, label
-        assert "prefer &wait=10 to tight polling" in refused.text, label
-        assert "/.well-known/agent.json" in refused.text, label
+        for kind, label, call_route in routes:
+            app_module._buckets.clear()
+            first = call_route()
+            refused = call_route()
+            assert first.status_code != 429, label
+            assert refused.status_code == 429, label
+            assert f"the {kind} budget" in refused.text, label
+            assert "retry after:" in refused.text, label
+            assert "still open:" in refused.text, label
+            assert "prefer &wait=10 to tight polling" in refused.text, label
+            assert "/.well-known/agent.json" in refused.text, label
 
 
 def test_the_429_names_the_budget_the_manual_deliberately_does_not(client, monkeypatch):
@@ -145,30 +148,31 @@ def test_the_429_names_the_budget_the_manual_deliberately_does_not(client, monke
     if the responses carry them — otherwise removing them from the manual just loses them.
     """
     import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "RATE_WRITE", 2)
-    for i in range(3):
-        r = client.get(f"/r/lobby/say/bot/m{i}")
-    assert r.status_code == 429
-    assert "(2/min)" in r.text  # the enforced number, not a documented one
-    assert "one token every 30s" in r.text  # …and the refill, as a sleep
-    # what still works while throttled, and where to read the limits up front
-    assert "reads are a separate budget" in r.text
-    assert "limits.writes_per_minute_per_ip" in r.text
-    # The poll advice names the ceiling this instance enforces, not a hardcoded 10 — the
-    # same reason the manual states no rate limit it cannot guarantee.
-    assert f"&wait={app_module.MAX_WAIT:g}" in r.text
+    with config.override(RATE_WRITE=2):
+        for i in range(3):
+            r = client.get(f"/r/lobby/say/bot/m{i}")
+        assert r.status_code == 429
+        assert "(2/min)" in r.text  # the enforced number, not a documented one
+        assert "one token every 30s" in r.text  # …and the refill, as a sleep
+        # what still works while throttled, and where to read the limits up front
+        assert "reads are a separate budget" in r.text
+        assert "limits.writes_per_minute_per_ip" in r.text
+        # The poll advice names the ceiling this instance enforces, not a hardcoded 10 —
+        # the same reason the manual states no rate limit it cannot guarantee.
+        assert f"&wait={app_module.MAX_WAIT:g}" in r.text
 
-    # The read bucket is the other half, and it is the one an agent hits first. `other` is
-    # computed from `kind`, so a 429 that names the wrong budget as "still open" sends the
-    # caller straight back into the bucket it just emptied.
-    monkeypatch.setattr(app_module, "RATE_READ", 1)
-    for _ in range(2):
-        read = client.get("/r/lobby")
-    assert read.status_code == 429
-    assert "the read budget for your IP (1/min) is spent" in read.text
-    assert "writes are a separate budget" in read.text
-    assert "limits.reads_per_minute_per_ip" in read.text
+        # The read bucket is the other half, and it is the one an agent hits first.
+        # `other` is computed from `kind`, so a 429 that names the wrong budget as
+        # "still open" sends the caller straight back into the bucket it just emptied.
+        with config.override(RATE_READ=1):
+            for _ in range(2):
+                read = client.get("/r/lobby")
+            assert read.status_code == 429
+            assert "the read budget for your IP (1/min) is spent" in read.text
+            assert "writes are a separate budget" in read.text
+            assert "limits.reads_per_minute_per_ip" in read.text
 
 
 def test_a_zero_rate_limit_refuses_rather_than_crashing(monkeypatch, tmp_path):
@@ -208,34 +212,35 @@ def test_every_path_the_429_calls_free_really_is_free(client, monkeypatch):
     """Advice that fails at the moment it is taken is worse than no advice: a throttled
     agent following this list must not meet a second 429."""
     import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "RATE_READ", 1)
-    client.get("/rooms")
-    assert client.get("/rooms").status_code == 429  # the budget really is spent
+    with config.override(RATE_READ=1):
+        client.get("/rooms")
+        assert client.get("/rooms").status_code == 429  # the budget really is spent
 
-    named = app_module.FREE_PATHS.replace(" and ", ", ").split(", ")
-    concrete = {
-        "/.well-known/*": [
-            "/.well-known/agent.json",
-            "/.well-known/api-catalog",
-            "/.well-known/ai-catalog.json",
-            "/.well-known/agent-skills/index.json",
-        ]
-    }
-    paths = [p for name in named for p in concrete.get(name.strip(), [name.strip()])]
-    assert len(paths) >= 8
-    for path in paths:
-        assert client.get(path).status_code == 200, f"{path} is advertised as free but is not"
+        named = app_module.FREE_PATHS.replace(" and ", ", ").split(", ")
+        concrete = {
+            "/.well-known/*": [
+                "/.well-known/agent.json",
+                "/.well-known/api-catalog",
+                "/.well-known/ai-catalog.json",
+                "/.well-known/agent-skills/index.json",
+            ]
+        }
+        paths = [p for name in named for p in concrete.get(name.strip(), [name.strip()])]
+        assert len(paths) >= 8
+        for path in paths:
+            assert client.get(path).status_code == 200, f"{path} is advertised as free but is not"
 
 
 def test_budget_warning_appears_before_the_wall(client, monkeypatch):
-    import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "RATE_READ", 8)
-    assert "# budget:" not in client.get("/r/lobby").text
-    for _ in range(5):
-        client.get("/r/lobby")
-    assert "# budget: 1 of 8 reads left" in client.get("/r/lobby").text
+    with config.override(RATE_READ=8):
+        assert "# budget:" not in client.get("/r/lobby").text
+        for _ in range(5):
+            client.get("/r/lobby")
+        assert "# budget: 1 of 8 reads left" in client.get("/r/lobby").text
 
 
 def test_new_rooms_are_budgeted_per_ip_and_say_when_to_retry(client, monkeypatch):
@@ -244,39 +249,41 @@ def test_new_rooms_are_budgeted_per_ip_and_say_when_to_retry(client, monkeypatch
     Without it, MAX_ROOMS is not a cap so much as a race: at the write limit a single IP
     exhausts it in hours, and everyone else meets the fail-closed refusal.
     """
-    import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "RATE_ROOMS_PER_DAY", 3)
-    for i in range(3):
-        assert client.get(f"/r/fresh{i}/say/bot/hi").status_code == 200
+    with config.override(RATE_ROOMS_PER_DAY=3):
+        for i in range(3):
+            assert client.get(f"/r/fresh{i}/say/bot/hi").status_code == 200
 
-    r = client.get("/r/one-too-many/say/bot/hi")
-    assert r.status_code == 429
-    assert int(r.headers["Retry-After"]) > 0  # machine-readable...
-    assert "retry after:" in r.text  # ...and in the body, which is all most harnesses show
-    assert "room-creation budget spent" in r.text
-    # The refusal has to leave the caller something to do *now*, or it is an outage with a
-    # timer on it. Rooms that exist are the answer, so the reply has to say so.
-    assert "ALREADY EXISTS" in r.text and "/r/lobby" in r.text
-    assert "one-too-many" not in client.get("/rooms").text  # and nothing was created
+        r = client.get("/r/one-too-many/say/bot/hi")
+        assert r.status_code == 429
+        assert int(r.headers["Retry-After"]) > 0  # machine-readable...
+        assert "retry after:" in r.text  # ...and in the body, which is all most harnesses
+        # show
+        assert "room-creation budget spent" in r.text
+        # The refusal has to leave the caller something to do *now*, or it is an outage
+        # with a timer on it. Rooms that exist are the answer, so the reply has to say so.
+        assert "ALREADY EXISTS" in r.text and "/r/lobby" in r.text
+        assert "one-too-many" not in client.get("/rooms").text  # and nothing was created
 
-    # The budget refills rather than resetting: no cliff, no stampede at a window boundary.
-    assert "refills continuously" in r.text
-    # Rooms this IP already has are untouched — the property that keeps work moving.
-    assert client.get("/r/fresh0/say/bot/still%20here").status_code == 200
+        # The budget refills rather than resetting: no cliff, no stampede at a window
+        # boundary.
+        assert "refills continuously" in r.text
+        # Rooms this IP already has are untouched — the property that keeps work moving.
+        assert client.get("/r/fresh0/say/bot/still%20here").status_code == 200
 
 
 def test_writing_to_an_existing_room_never_spends_the_room_budget(client, monkeypatch):
     """The budget is on *creation*. A long conversation in one room must cost exactly one."""
-    import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "RATE_ROOMS_PER_DAY", 2)
-    monkeypatch.setattr(app_module, "RATE_WRITE", 500)  # isolate this from the write limit
-    assert client.get("/r/only/say/bot/hi").status_code == 200
-    for i in range(40):
-        assert client.get(f"/r/only/say/bot/msg{i}").status_code == 200
-    assert client.get("/r/second/say/bot/hi").status_code == 200  # the 2nd and last
-    assert client.get("/r/third/say/bot/hi").status_code == 429
+    # 500 writes/min isolates this from the write limit
+    with config.override(RATE_ROOMS_PER_DAY=2, RATE_WRITE=500):
+        assert client.get("/r/only/say/bot/hi").status_code == 200
+        for i in range(40):
+            assert client.get(f"/r/only/say/bot/msg{i}").status_code == 200
+        assert client.get("/r/second/say/bot/hi").status_code == 200  # the 2nd and last
+        assert client.get("/r/third/say/bot/hi").status_code == 429
 
 
 def test_only_the_request_that_creates_a_room_pays_for_it(client, monkeypatch):
@@ -287,30 +294,32 @@ def test_only_the_request_that_creates_a_room_pays_for_it(client, monkeypatch):
     loser appends to a room that exists by the time it gets through, and is refunded.
     """
     import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "RATE_ROOMS_PER_DAY", 3)
+    with config.override(RATE_ROOMS_PER_DAY=3):
+        # The race, made deterministic: the first two gate checks both see the room as
+        # absent, which is exactly what two concurrent first-writers see. Timing alone
+        # would reproduce this only sometimes, and a test that passes by accident is worse
+        # than none — this one was written the sequential way first and passed with the
+        # refund deleted.
+        real = app_module._room_exists
+        seen = {"n": 0}
 
-    # The race, made deterministic: the first two gate checks both see the room as absent,
-    # which is exactly what two concurrent first-writers see. Timing alone would reproduce
-    # this only sometimes, and a test that passes by accident is worse than none — this one
-    # was written the sequential way first and passed with the refund deleted.
-    real = app_module._room_exists
-    seen = {"n": 0}
+        def racing(room: str) -> bool:
+            seen["n"] += 1
+            return False if seen["n"] <= 2 else real(room)
 
-    def racing(room: str) -> bool:
-        seen["n"] += 1
-        return False if seen["n"] <= 2 else real(room)
+        monkeypatch.setattr(app_module, "_room_exists", racing)
 
-    monkeypatch.setattr(app_module, "_room_exists", racing)
+        for _ in range(3):
+            assert client.get("/r/rendezvous/say/bot/hi").status_code == 200
 
-    for _ in range(3):
-        assert client.get("/r/rendezvous/say/bot/hi").status_code == 200
-
-    # One creation happened, so one token is spent: the loser appended to a room that
-    # already existed (seq 2) and got its token back. Two of three left = two more rooms.
-    assert client.get("/r/second-room/say/bot/hi").status_code == 200
-    assert client.get("/r/third-room/say/bot/hi").status_code == 200
-    assert client.get("/r/fourth-room/say/bot/hi").status_code == 429
+        # One creation happened, so one token is spent: the loser appended to a room that
+        # already existed (seq 2) and got its token back. Two of three left = two more
+        # rooms.
+        assert client.get("/r/second-room/say/bot/hi").status_code == 200
+        assert client.get("/r/third-room/say/bot/hi").status_code == 200
+        assert client.get("/r/fourth-room/say/bot/hi").status_code == 429
 
 
 def test_the_post_lanes_do_not_block_the_event_loop(client, monkeypatch):
@@ -397,16 +406,17 @@ def test_junk_query_params_never_500(client):
 def test_rate_limit_buckets_are_bounded(client, monkeypatch):
     """Every unseen IP adds entries; unbounded, a rotating-IP flood OOMs the container."""
     import app as app_module
+    import config
 
     monkeypatch.setattr(app_module, "MAX_BUCKETS", 8)
     # Opted in explicitly: no forwarded header is trusted by default, so without this the
     # whole loop is one client (the test socket) and nothing rotates.
-    monkeypatch.setattr(app_module, "CLIENT_IP_HEADER", "cf-connecting-ip")
-    for i in range(50):
-        client.get("/r/lobby", headers={"cf-connecting-ip": f"2001:db8::{i:x}"})
-    assert len(app_module._buckets) <= 8
-    # the survivors are the most recent callers, so an active client keeps its budget
-    assert ("2001:db8::31", "read") in app_module._buckets
+    with config.override(CLIENT_IP_HEADER="cf-connecting-ip"):
+        for i in range(50):
+            client.get("/r/lobby", headers={"cf-connecting-ip": f"2001:db8::{i:x}"})
+        assert len(app_module._buckets) <= 8
+        # the survivors are the most recent callers, so an active client keeps its budget
+        assert ("2001:db8::31", "read") in app_module._buckets
 
 
 def test_no_forwarded_header_is_trusted_by_default(client, monkeypatch):
@@ -425,9 +435,11 @@ def test_no_forwarded_header_is_trusted_by_default(client, monkeypatch):
     assert set(app_module._buckets) - before  # the peer's own bucket did get created
 
     # an operator whose origin really is locked to a proxy can still opt in
-    monkeypatch.setattr(app_module, "CLIENT_IP_HEADER", "cf-connecting-ip")
-    client.get("/r/lobby", headers=spoofed)
-    assert ("203.0.113.9", "read") in app_module._buckets
+    import config
+
+    with config.override(CLIENT_IP_HEADER="cf-connecting-ip"):
+        client.get("/r/lobby", headers=spoofed)
+        assert ("203.0.113.9", "read") in app_module._buckets
 
 
 def test_an_empty_trusted_proxy_header_falls_back_to_the_socket_peer(client, monkeypatch):
@@ -437,14 +449,15 @@ def test_an_empty_trusted_proxy_header_falls_back_to_the_socket_peer(client, mon
     the configured proxy owns the first hop, while anything after it may be caller input.
     """
     import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "CLIENT_IP_HEADER", "cf-connecting-ip")
-    app_module._buckets.clear()
-    client.get("/r/lobby", headers={"cf-connecting-ip": " , 198.51.100.7"})
+    with config.override(CLIENT_IP_HEADER="cf-connecting-ip"):
+        app_module._buckets.clear()
+        client.get("/r/lobby", headers={"cf-connecting-ip": " , 198.51.100.7"})
 
-    identities = {ip for ip, kind in app_module._buckets if kind == "read"}
-    assert identities == {"testclient"}
-    assert "" not in identities and "198.51.100.7" not in identities
+        identities = {ip for ip, kind in app_module._buckets if kind == "read"}
+        assert identities == {"testclient"}
+        assert "" not in identities and "198.51.100.7" not in identities
 
 
 def _dockerfile_cmd() -> list[str]:
@@ -477,19 +490,19 @@ def test_a_budget_warning_never_reaches_the_json_lane(client, monkeypatch):
     degrade, it would stop parsing — and only once a caller was near its limit, which is
     the worst moment to discover it. Pinned because the number of `note=` callers grew.
     """
-    import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "RATE_WRITE", 8)
-    for _ in range(6):
-        client.post("/r/lobby", json={"from": "a", "text": "x"})
+    with config.override(RATE_WRITE=8):
+        for _ in range(6):
+            client.post("/r/lobby", json={"from": "a", "text": "x"})
 
-    posted = client.post("/r/lobby?format=json", json={"from": "a", "text": "final"})
-    assert posted.headers["content-type"].startswith("application/json")
-    assert posted.json()["posted"]["text"] == "final"
-    assert "# budget:" not in posted.text
+        posted = client.post("/r/lobby?format=json", json={"from": "a", "text": "final"})
+        assert posted.headers["content-type"].startswith("application/json")
+        assert posted.json()["posted"]["text"] == "final"
+        assert "# budget:" not in posted.text
 
-    # The warning is not lost, it belongs to the lane that can carry it.
-    assert "# budget:" in client.post("/r/lobby", json={"from": "a", "text": "y"}).text
+        # The warning is not lost, it belongs to the lane that can carry it.
+        assert "# budget:" in client.post("/r/lobby", json={"from": "a", "text": "y"}).text
 
 
 def test_limit_is_clamped_to_the_response_budget(client):

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -30,12 +30,14 @@ def test_post_lane_reports_write_budget_like_get_writes(client, monkeypatch):
     """POST pays the same write bucket as GET /say, so it must carry the same in-body
     budget hint for clients whose harness does not expose response headers.
     """
-    import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "RATE_WRITE", 4)
-    responses = [client.post("/r/lobby", json={"from": "bot", "text": f"m{i}"}) for i in range(4)]
-    assert [response.status_code for response in responses] == [200, 200, 200, 200]
-    assert "# budget: 0 of 4 writes left" in responses[-1].text
+    with config.override(RATE_WRITE=4):
+        responses = [
+            client.post("/r/lobby", json={"from": "bot", "text": f"m{i}"}) for i in range(4)
+        ]
+        assert [response.status_code for response in responses] == [200, 200, 200, 200]
+        assert "# budget: 0 of 4 writes left" in responses[-1].text
 
 
 def test_a_lost_conditional_write_carries_the_value_after_the_first_line(client):
@@ -322,11 +324,11 @@ def test_an_unsigned_nick_can_never_look_verified(client):
 
 
 def test_signed_writes_pay_the_write_budget_like_any_other(client, monkeypatch):
-    import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "RATE_WRITE", 2)
-    did, sign = _keypair()
-    codes = [
-        _say_signed(client, "lobby", did, sign, f"m{i}", nonce=i).status_code for i in (1, 2, 3)
-    ]
-    assert codes == [200, 200, 429]
+    with config.override(RATE_WRITE=2):
+        did, sign = _keypair()
+        codes = [
+            _say_signed(client, "lobby", did, sign, f"m{i}", nonce=i).status_code for i in (1, 2, 3)
+        ]
+        assert codes == [200, 200, 429]

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -114,6 +114,7 @@ def test_rooms_cache_can_be_disabled_and_never_grows_past_its_bound(client, monk
     and a flood of distinct `limit` values cannot turn it into attacker-sized process state.
     """
     import app as app_module
+    import config
 
     real_stats = app_module.store.room_stats
     calls = []
@@ -123,17 +124,17 @@ def test_rooms_cache_can_be_disabled_and_never_grows_past_its_bound(client, monk
         return real_stats(*args, **kwargs)
 
     monkeypatch.setattr(app_module.store, "room_stats", counted)
-    monkeypatch.setattr(app_module, "ROOMS_CACHE_SECONDS", 0)
-    app_module._rooms_cache.clear()
-    client.get("/rooms?limit=7")
-    client.get("/rooms?limit=7")
-    assert calls == [7, 7] and app_module._rooms_cache == {}
+    with config.override(ROOMS_CACHE_SECONDS=0):
+        app_module._rooms_cache.clear()
+        client.get("/rooms?limit=7")
+        client.get("/rooms?limit=7")
+        assert calls == [7, 7] and app_module._rooms_cache == {}
 
-    monkeypatch.setattr(app_module, "ROOMS_CACHE_SECONDS", 60)
-    monkeypatch.setattr(app_module, "MAX_ROOMS_CACHE", 2)
-    for limit in (1, 2, 3):
-        client.get(f"/rooms?limit={limit}")
-    assert list(app_module._rooms_cache) == [2, 3]
+    with config.override(ROOMS_CACHE_SECONDS=60):
+        monkeypatch.setattr(app_module, "MAX_ROOMS_CACHE", 2)
+        for limit in (1, 2, 3):
+            client.get(f"/rooms?limit={limit}")
+        assert list(app_module._rooms_cache) == [2, 3]
 
 
 def test_rooms_overview_carries_stats_newest_first(client, tmp_path):

--- a/tests/http/test_stats.py
+++ b/tests/http/test_stats.py
@@ -15,16 +15,15 @@ def test_stats_says_whether_per_ip_limits_are_actually_per_ip(client, monkeypatc
     """Behind a CDN with no CHAT_CLIENT_IP_HEADER every caller shares one bucket, and the
     per-day room budget then bounds the whole world at once. Silent, and indistinguishable
     from an outage — so the evidence is published rather than left to be guessed at."""
-    import app as app_module
+    import config
 
-    monkeypatch.setattr(app_module, "STATS_TOKEN", "t")
-    monkeypatch.setattr(app_module, "STATS_CACHE_SECONDS", 0)
-    for i in range(3):
-        client.get("/r/lobby", headers={"CF-Connecting-IP": f"203.0.113.{i}"})
-    ident = client.get("/stats", headers={"X-Stats-Token": "t"}).json()["client_identity"]
-    assert ident["client_ip_header"] is None
-    assert ident["proxied_requests_ignored"] >= 3  # three real callers...
-    assert ident["distinct_identities"] == 1  # ...seen as one
+    with config.override(STATS_TOKEN="t", STATS_CACHE_SECONDS=0):
+        for i in range(3):
+            client.get("/r/lobby", headers={"CF-Connecting-IP": f"203.0.113.{i}"})
+        ident = client.get("/stats", headers={"X-Stats-Token": "t"}).json()["client_identity"]
+        assert ident["client_ip_header"] is None
+        assert ident["proxied_requests_ignored"] >= 3  # three real callers...
+        assert ident["distinct_identities"] == 1  # ...seen as one
 
 
 @pytest.fixture()
@@ -132,6 +131,7 @@ def test_stats_cache_avoids_repeating_the_expensive_store_walk(stats_client, mon
     stats walk still needs the short cache promised by the handler.
     """
     import app as app_module
+    import config
 
     real_view = app_module._stats_view
     calls = []
@@ -140,11 +140,11 @@ def test_stats_cache_avoids_repeating_the_expensive_store_walk(stats_client, mon
         calls.append(1)
         return real_view()
 
-    monkeypatch.setattr(app_module, "STATS_CACHE_SECONDS", 60)
-    monkeypatch.setattr(app_module, "_stats_view", counted)
-    app_module._stats_cache = (0.0, {})
-    headers = {"X-Stats-Token": "s3cret"}
-    first = stats_client.get("/stats", headers=headers)
-    second = stats_client.get("/stats", headers=headers)
-    assert first.status_code == second.status_code == 200
-    assert calls == [1]
+    with config.override(STATS_CACHE_SECONDS=60):
+        monkeypatch.setattr(app_module, "_stats_view", counted)
+        app_module._stats_cache = (0.0, {})
+        headers = {"X-Stats-Token": "s3cret"}
+        first = stats_client.get("/stats", headers=headers)
+        second = stats_client.get("/stats", headers=headers)
+        assert first.status_code == second.status_code == 200
+        assert calls == [1]


### PR DESCRIPTION
## What

Four closeout items, one commit each:

- **Alias removal (item 5):** every `monkeypatch.setattr(app_module, KNOB, ...)` that targeted a CHAT_* knob (28 setattr lines, 6 test files) migrates to `with config.override(KNOB=...)` wrapping the assertions that depended on it; the seven app-side aliases nothing needed any more are deleted and their use sites read `config.<name>` at call time. app.py 919 -> 916 code-lines.
- **CHAT_DEBUG (item 2):** a three-level stderr ladder on the write path — 1 = limiter take/refund verdicts with client identity, 2 = + store flock/compact/reap/CAS-conflict, 3 = + one line per room write (room, seq, chars). Zero cost when off, never message content, +20 core code-lines.
- **Three-lane differential check (item 3):** `tests/http/test_lane_parity.py` — one logical write via store.append, the HTTP GET lane, and the MCP wrapper, asserting field-identical JSONL records (modulo seq/ts, stated why) and byte-identical rendered lines; notes land the strictest form (byte-equal reads, nothing masked). Written as the seed of the §6.5 port gate.
- **sz caps (item 1):** per-file caps measured from the end state, enforced by `sz.py --check` (which now names the cap) and printable with `--caps`; AGENTS.md carries the numbers and the "new primitive or extra" rule, CONTRIBUTING.md points at `sz.py --caps`.

sz before -> after (code-lines): app 919 -> 919, config 39 -> 48, didkey 57 -> 57, limit 107 -> 110, store 709 -> 714, **total 1831 -> 1848**. The caps are exactly those end-state numbers; the baseline stays a ratchet that only moves down.

DEBUG ladder in one line: `CHAT_DEBUG=0|1|2|3` — limiter verdicts / +store locks & conflicts / +per-write room-seq-chars, stderr only, invalid -> 0 with one warning.

## Why

The split (PRs #52-#61) left each knob bound in three places — config, app's alias, limit's parameter plumbing — and tests were the thing holding the aliases alive. With every knob-shaped test on `config.override()`, the aliases are plain dead weight; deleting them is the last step of the move, not a new one. CHAT_DEBUG and the sz caps are the two adoptions the split was for: an operator-facing debug ladder that costs nothing off, and a numeric form of the line-tradeoff rule so "belongs in core" is checked, not argued. The lane-parity fixture exists because the three write lanes (store, HTTP, MCP) were only ever tested separately — if they disagreed about what a record is, no single-lane test could see it — and because §6.5 needs exactly this differential as a port gate.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 316 passed (313 at start + 3 parity tests)
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: AGENTS.md gains the cap line, CONTRIBUTING.md points at `sz.py --caps`; no served document changes (manual/agent.json publish per-deployment numbers only, and docs/manifest tests stayed green)
- [x] New surface on a world-writable service: **none — stderr only.** CHAT_DEBUG writes nothing to stdout, nothing into any room, adds no HTTP surface, and logs lengths/seqs/room names, never message content.
