### PR TITLE
fix(limit): keep the advisory budget footer out of the 429 search space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -575,6 +575,15 @@ booted with `inf` was publishing JSON no strict parser would accept, and will no
   `/kv/did-<first 2 hex>/<remaining 14 hex>`; readers fall back to the legacy path. Every namespace,
   listing response, and global disk bound keeps the same fixed limit.
 
+- **The advisory budget footer no longer contains the string `429`.** Every refusal body
+  *begins* with `429 ` — deliberately, because harnesses show the body and drop the headers —
+  which makes `429` the string a caller searches a body for. The footer rides on a 200 and
+  means "slow down", but it mentioned one ("a 429 states the wait"), so any such search
+  matched it and read the pacing hint as the wall. It now reads "the refusal states the
+  wait", and `/llms.txt` states the rule the two lanes keep: a refusal starts `429 `, the
+  advisory starts `# budget:`, and neither string appears inside the other. Reported from
+  `examples/beautiful_chat.sh` (#55).
+
 - **The MCP wheel and source distribution carry the Apache-2.0 legal files they declare.**
   The MCP project now includes exact copies of the repository `LICENSE` and `NOTICE`. CI verifies
   both built artifacts use the required archive paths, contain byte-identical legal files, and

--- a/src/limit.py
+++ b/src/limit.py
@@ -377,13 +377,20 @@ def limited(kind: str, per_min: int, retry_after: float, *, text, max_wait: floa
 
 
 def budget_note(kind: str, left: int, per_min: int) -> str:
-    """Warn before the wall, not at it — only once the budget is nearly gone."""
+    """Warn before the wall, not at it — only once the budget is nearly gone.
+
+    This rides on a 200, so it deliberately does not contain the string "429".
+    Every refusal body *begins* with it, which makes "429" the obvious thing for a
+    caller to search a body for — and a pacing hint that matched would read as the
+    wall itself, turning "slow down" into "stop". The two lanes stay tellable
+    apart by their first characters: "429 " refused, "# budget:" advisory.
+    """
     if left * 4 > per_min:
         return ""
     return (
         f"\n# budget: {left} of {per_min} {kind}s left this minute "
-        f"(refills {refill_rate(per_min)}; a 429 states the wait, and the full limits are "
-        f"in /.well-known/agent.json)"
+        f"(refills {refill_rate(per_min)}; the refusal states the wait, and the full limits "
+        f"are in /.well-known/agent.json)"
     )
 
 

--- a/src/manual.md
+++ b/src/manual.md
@@ -305,6 +305,10 @@ two cost no extra request:
     cross-sender (see DUPLICATES above). Credentials and host details are never
     in it, and it names the ones it leaves out, so there is nothing there to
     guess at.
+Tell the first two apart by what the body STARTS with, never by searching it: a
+refusal begins "429 ", the advisory footer begins "# budget:", and neither string
+appears inside the other. A search for "429" over a whole body is the trap —
+the footer rides on a 200 and means slow down, not stop.
 Never rate limited, so they always answer even while you are throttled:
 __FREE_PATHS__. A parked wait= request costs one read, charged when it starts.
 

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -248,6 +248,37 @@ def test_budget_warning_appears_before_the_wall(client, monkeypatch):
         assert "# budget: 1 of 8 reads left" in client.get("/r/lobby").text
 
 
+def test_the_advisory_footer_cannot_be_mistaken_for_the_wall(client):
+    """Pacing advice on a 200 and a refusal must not answer the same substring search.
+
+    Every refusal body *begins* "429 " — deliberately, because harnesses show the body and
+    drop the headers — which makes "429" the string a caller reaches for. The footer used
+    to carry one ("a 429 states the wait"), so anything grepping a body for it
+    false-positived on every pacing hint, turning "slow down" into "stop" at the moment
+    the difference matters most. A rule rather than a wording check: however either string
+    is phrased, the two stay tellable apart by what the body starts with. Found by the
+    author of examples/beautiful_chat.sh while making the demo deterministic (#55).
+    """
+    import app as app_module
+    import config
+
+    with config.override(RATE_READ=8):
+        for _ in range(6):
+            client.get("/r/lobby")
+        advisory = client.get("/r/lobby")
+        assert advisory.status_code == 200
+        assert "# budget:" in advisory.text
+        assert "429" not in advisory.text
+
+    app_module._buckets.clear()
+    with config.override(RATE_READ=1):
+        client.get("/r/lobby")
+        refused = client.get("/r/lobby")
+        assert refused.status_code == 429
+        assert refused.text.startswith("429 ")
+        assert "# budget:" not in refused.text
+
+
 def test_new_rooms_are_budgeted_per_ip_and_say_when_to_retry(client, monkeypatch):
     """The room cap bounds the service; this bounds how much of it one caller can take.
 


### PR DESCRIPTION
Addresses item 1 of #55. Deliberately not a closing reference — items 2 and 3 of that
issue are untouched here, so #55 should stay open after this merges.

## What changes for a caller

A caller detecting rate limiting by looking at the response **body** — which is what agent
harnesses surface, as this project's own refusals assume — can no longer confuse the
advisory footer for the wall.

Before, a healthy `200` could contain:

```
# budget: 1 of 8 reads left this minute (refills 0.1 tokens/s; a 429 states the wait, …)
```

Every real refusal body *begins* `429 ` (`limit.py:201`, `app.py:857`). That convention is
deliberate and documented — the body repeats what `Retry-After` says because harnesses show
bodies and drop headers. But it also makes `429` the obvious string to search a body for,
and the footer above matched it. The caller then read *"slow down"* as *"stop"*, at the one
moment the difference matters: the footer exists precisely so a caller can pace **instead
of** hitting the wall.

After, the footer reads `the refusal states the wait`, and the two lanes are separated by a
rule stated in the manual:

> a refusal begins `429 `, the advisory footer begins `# budget:`, and neither string
> appears inside the other.

## Why this rather than only a documentation note

#55 offered two options: reword the footer, or document "grep for `# budget:`, never for
`429`". This does both, in that order, because the collision is the kind this project
already treats as a defect elsewhere — a published surface that disagrees with what a
reader will reasonably do with it. Telling every caller to work around a string we control
is weaker than not emitting it. The manual line then makes the guarantee explicit rather
than incidental, so a future edit knows it is load-bearing.

## Documentation

- `src/manual.md` — the LIMITS section states the rule. Served at `/` and `/llms.txt`.
- `CHANGELOG.md` — entry under `[Unreleased] → Fixed`.
- `SKILL.md` mentions `429` only when describing an actual refusal, which stays correct;
  no change needed. `src/manifest.py` publishes no footer string, so `/openapi.json` and
  `/.well-known/agent.json` are unaffected.

## Compatibility

The footer's parseable prefix — `# budget: <left> of <max> <kind>s left this minute` — is
unchanged; only the parenthetical prose after `refills …` differs. `test_humans.py` relies
on the `# budget:` prefix and `test_budget_warning_appears_before_the_wall` on the leading
clause; both still pass unmodified. A caller keying on the documented prefix sees no
change. A caller that was string-matching `429` on a `200` was already reading a bug.

## Abuse impact

None. No new route, parameter, persistent state or unauthenticated surface; the change is
one f-string's wording plus documentation and a test. The refusal path, the token buckets
and the thresholds are untouched.

## Tests and checks

Added `test_the_advisory_footer_cannot_be_mistaken_for_the_wall`, which asserts the **rule**
rather than the wording — a `200` carrying `# budget:` contains no `429`, and a refusal
starts `429 ` and carries no `# budget:`. Rephrasing either string cannot silently
reintroduce the collision.

- Fails without the `limit.py` change, passes with it (verified by reverting the footer).
- `uv run ruff check .` — clean.
- `uv run ruff format --check .` — 48 files already formatted.
- `uv run sz.py --check` — core code-lines at the 1848 baseline; `limit.py` remains at its
  110 cap. The added explanation is docstring, not code.

### One honest caveat about the local run

The suite was run on **Windows**, where `src/store.py`'s `import fcntl` does not resolve. I
ran it behind a local no-op `flock` shim (never committed) to exercise the HTTP layer. On
that setup: **311 passed, 11 failed** — and the same 11 fail on an unmodified `main` with
the changes stashed, so none are attributable to this PR. They are:

- two concurrency tests defeated by the no-op lock shim,
- one test writing a filename containing `\n`, which Windows forbids,
- one reading a file without an explicit encoding (Windows defaults to GBK),
- and the Docker / MCP-artifact checks, which need a build not run locally.

`uv run ty check` reports 4 diagnostics, all `fcntl.flock` / `fcntl.LOCK_*` unresolved on
win32; it is clean on a POSIX checkout. Linux CI is the real verdict on all of the above —
none of these paths are touched by this change.

## Follow-up

#55 items 2 and 3 are untouched here to keep this focused. Item 2 (a `d-` claim does not
create the room; a denied unsigned write to an owned-but-unborn room still spends a write
token) looks like a clean separate documentation PR, which I am happy to open.
