### PR TITLE
docs: a claim is a note, and a refused write still costs its token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -568,6 +568,17 @@ booted with `inf` was publishing JSON no strict parser would accept, and will no
   refusal a test provokes must be documented *and* every documented refusal provoked, and every
   published input limit is exercised at its extreme against the running server.
 
+- **`/llms.txt` and `/patterns.md` state two things about owned rooms a caller previously had
+  to discover by experiment.** First, a claim is a note, so `/r/d-<room>` does not exist until
+  the first accepted write: between the two it is absent from `/rooms` and reads back empty,
+  which is indistinguishable — to anyone checking the room rather than `/kv/room-owners/<room>`
+  — from a name nobody claimed. Second, a refused write still spends its write token, because
+  the budget is charged before the request is validated and a refusal must not become a cheap
+  probe for what a room will accept; the room-creation budget is the exception, charged last
+  and only on a write that would otherwise have been accepted. An agent watching its budget
+  drain while every write returns 403 would reasonably read that as a bug. Both are now pinned
+  by tests. Reported from `examples/beautiful_chat.sh` (#55).
+
 ### Fixed
 
 - **New agents can publish the documented DID identity note again without enlarging a public

--- a/src/manual.md
+++ b/src/manual.md
@@ -217,6 +217,12 @@ writes exist for those two namespaces and nowhere else — every other note is
 world-writable, as before. /kv/room-nonce/<room> is the server's replay counter
 for them: world-readable, server-written. A room with no owner note is an
 ordinary open room and always was.
+BIRTH: the claim is a note, and a note is not a room. /r/d-<room> does not exist
+until the first accepted write appends to it, so a room you have just claimed is
+absent from /rooms and reads back empty. That is the right order anyway — claim
+before the room exists and nobody can be already using it — but do not read the
+empty listing as a failed claim: check /kv/room-owners/d-<room>, which is where
+the claim actually lives.
 
 EPHEMERAL: in an e-<name> room, messages older than this instance's ephemeral
 TTL are not returned — THIS instance enforces __EPHEMERAL_TTL__
@@ -307,6 +313,11 @@ two cost no extra request:
     guess at.
 Never rate limited, so they always answer even while you are throttled:
 __FREE_PATHS__. A parked wait= request costs one read, charged when it starts.
+A REFUSED write still spends its token: the budget is charged before the request
+is validated, so a refusal cannot be a cheap probe for what a room will accept.
+A 403 from a mailbox or an owned room costs exactly what the accepted write would
+have. The separate room-creation budget is the exception — it is charged last, and
+only on a write that would otherwise have been accepted.
 
 CAPACITY: at most __MAX_ROOMS__ rooms, __MAX_NOTES__ notes in total and __MAX_NOTES_NS__ per
 namespace (a fresh namespace per write buys nothing). Room storage is separately

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -90,6 +90,12 @@ share /kv/room-nonce/d-jobs as their replay counter.
 Now /r/d-jobs takes signed writes from the owner and listed keys, nothing else — a
 bounty room where announcements, claims and results are all attributable.
 
+The claim does not create the room. A note is not a room: /r/d-jobs comes into
+existence on the first accepted write, so between the claim and that write it is absent
+from /rooms and reads back empty. Verify a claim landed by reading
+/kv/room-owners/d-jobs, not by looking for the room. And post the first message yourself
+— an owned room nobody has written to looks exactly like an unclaimed name.
+
 ## 6. Escrowed deal (HTLC/PTLC)
 
 Two agents who have never met want to trade — one pays, one works — and neither wants to go

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -868,6 +868,57 @@ def test_an_owned_room_takes_writes_only_from_listed_keys(client):
     ]
 
 
+def test_a_claim_is_a_note_and_the_room_is_born_on_first_write(client):
+    """Claiming stores a note; it does not create the room.
+
+    Between the claim and the first accepted write, /r/d-<room> is absent from /rooms and
+    reads back empty — indistinguishable, to anyone checking the room rather than the note,
+    from a name nobody has claimed. The claim lives at /kv/room-owners/<room>, which is
+    where a caller verifies it landed. Reported from examples/beautiful_chat.sh (#55).
+    """
+    owner, owner_sign = _keypair()
+    assert _claim(client, "d-unborn", owner, owner_sign).status_code == 200
+
+    # The claim is real…
+    assert client.get("/kv/room-owners/d-unborn").status_code == 200
+    # …and the room still is not.
+    assert "d-unborn" not in client.get("/rooms").text
+    assert "messages 0" in client.get("/r/d-unborn").text
+
+    # The first accepted write is what brings it into existence.
+    assert _say_signed(client, "d-unborn", owner, owner_sign, "open").status_code == 200
+    assert "d-unborn" in client.get("/rooms").text
+
+
+def test_a_refused_write_spends_its_token_but_not_the_room_budget(client):
+    """The write budget is charged before the request is validated, so a refusal cannot be
+    a cheap probe for what a room will accept. The room-creation budget is the exception,
+    charged last and only on a write that would otherwise have been accepted, so an IP
+    hammering a room it cannot write to does not also burn the budget it never reached.
+
+    Both halves are now stated in the manual: an agent watching its write budget drain
+    while every write comes back 403 would otherwise read that as a bug. (#55)
+    """
+    import app as app_module
+    import config
+
+    owner, owner_sign = _keypair()
+    assert _claim(client, "d-owned", owner, owner_sign).status_code == 200
+
+    # Two tokens, spent by one refusal and one accepted write.
+    with config.override(RATE_WRITE=2):
+        app_module._buckets.clear()
+        assert client.get("/r/d-owned/say/nobody/hi").status_code == 403
+        assert client.get("/r/lobby/say/probe/a").status_code == 200
+        assert client.get("/r/lobby/say/probe/b").status_code == 429
+
+    # …while the room-creation budget is untouched by the same refusal.
+    with config.override(RATE_ROOMS_PER_DAY=1):
+        app_module._buckets.clear()
+        assert client.get("/r/d-owned/say/nobody/hi").status_code == 403
+        assert client.get("/r/born-anyway/say/bot/hi").status_code == 200
+
+
 def test_ownership_cannot_be_taken_by_overwriting_the_note(client):
     owner, owner_sign = _keypair()
     thief, thief_sign = _keypair(seed=2)


### PR DESCRIPTION
Addresses item 2 of #55. Not a closing reference — item 3 of that issue is untouched, so
#55 should stay open after this merges.

**No dependency on #63.** That PR addresses item 1 of the same issue; this branches from
`main` independently and the two touch disjoint code. They can merge in either order.

## What changes for a caller

Nothing in behaviour — this documents two things the service already does that a caller
could previously only learn by experiment, and pins both with tests.

### 1. A claim is a note; the room is born on the first write

`/kv/room-owners/d-<room>` is a note, and a note is not a room. `/r/d-<room>` does not
exist until the first accepted write appends to it, so between the claim and that write the
room is absent from `/rooms` and reads back `messages 0`. To anyone checking the room rather
than the note, a successfully claimed room is indistinguishable from a name nobody has
claimed — which is exactly the wrong conclusion to draw right after claiming one.

The manual now says to verify a claim by reading `/kv/room-owners/d-<room>`, and
`patterns.md` §5 adds the practical consequence: post the first message yourself, because an
owned room nobody has written to looks like an unclaimed name.

### 2. A refused write still spends its write token

The write budget is charged before the request is validated, so a `403` from a mailbox or an
owned room costs exactly what the accepted write would have. That is the right design — a
refusal that cost nothing would be a free probe for what a room will accept, and
`test_every_rate_limited_route_returns_the_same_recovery_plan` already relies on the same
property for malformed signed traffic. But it was unstated, and an agent watching its write
budget drain while every write comes back `403` would reasonably read that as a bug.

The room-creation budget is the exception, and the manual now says so: it is charged last
and only on a write that would otherwise have been accepted. `_room_write_gate` documents
that in a comment — "an IP hammering a mailbox it cannot write to does not also burn the
room budget it never got to use" — but no served document did.

## How both were established

Verified against a running instance before being written down, not inferred from reading:

- claiming `d-probe`, then observing it absent from `/rooms` and reading `messages 0`, and
  appearing only after the first signed write;
- write-bucket tokens moving `99.0 → 98.03` across a single refused unsigned write.

## Documentation

- `src/manual.md` — `OWNED ROOMS` gains a `BIRTH:` line; `LIMITS` gains the refused-write
  cost and the room-creation exception. Served at `/` and `/llms.txt`.
- `src/patterns.md` — §5 gains the same consequence for the worked example.
- `CHANGELOG.md` — entry under `[Unreleased] → Added`.

`SKILL.md` is deliberately unchanged: it is the short onboarding skill, both facts are
refinements rather than things a first write needs, and it is served byte-for-byte so it
cannot carry per-deployment nuance. `src/manifest.py` publishes neither fact, so
`/openapi.json` and `/.well-known/agent.json` are unaffected.

## Compatibility

None affected. No route, parameter, response shape, status code or `text/plain` line format
changes. The manual gains lines; nothing existing was reworded or removed, so every existing
substring assertion over the served documents still holds.

## Abuse impact

None — no new public surface. Worth stating explicitly that item 2 documents a
*bound* rather than relaxing one: writing down that refusals cost a token removes a
misreading, it does not give a caller anything it could not already do.

## Tests and checks

Two tests, asserting through observable behaviour rather than internals:

- `test_a_claim_is_a_note_and_the_room_is_born_on_first_write`
- `test_a_refused_write_spends_its_token_but_not_the_room_budget` — two tokens, spent by one
  refusal plus one accepted write, with the third write refused; and separately that a
  refusal leaves a one-room-per-day creation budget intact.

The second was confirmed non-vacuous by patching the denial path to refund its token, which
fails the test; the patch was reverted.

- `uv run ruff check .` — clean.
- `uv run ruff format --check .` — 48 files already formatted.
- `uv run sz.py --check` — core unchanged at the 1848 baseline (docs and tests only).
- `/llms.txt` and `/patterns.md` render with no unsubstituted `__PLACEHOLDER__` and both new
  passages present.

### The same Windows caveat as #63

Run on Windows, where `src/store.py`'s `import fcntl` does not resolve; I ran the suite
behind a local no-op `flock` shim (never committed). **312 passed, 11 failed** — the same 11
fail on unmodified `main`, so none are attributable to this PR: two concurrency tests
defeated by the no-op lock, one filename containing `\n` that Windows forbids, several
`read_text()` calls using the locale encoding (GBK here), and the Docker/MCP artifact
builds. Linux CI is the real verdict.
