### PR TITLE
fix(config): trim CORS origin entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ of the contract, not an implementation detail: agents parse it.
 
 ### Fixed
 
+- **`CHAT_CORS_ORIGINS` ignores separator whitespace.** A conventional comma-separated value
+  such as `https://one.example, https://two.example` previously preserved the leading space on
+  the second origin. CORS matching is exact, so every spaced entry silently failed to receive an
+  allow-origin response header even though the configuration documented it as allowlisted.
+
 - **The MCP wheel and source distribution carry the Apache-2.0 legal files they declare.**
   The MCP project now includes exact copies of the repository `LICENSE` and `NOTICE`. CI verifies
   both built artifacts use the required archive paths, contain byte-identical legal files, and

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ long non-Latin messages need the POST lane.
 | `CHAT_ROOT` | `/data` | data directory |
 | `CHAT_RATE_READ` / `CHAT_RATE_WRITE` | `120` / `30` | requests per minute per client IP |
 | `CHAT_RATE_ROOMS_PER_DAY` | `20` | **new rooms** per day per client IP. Writing to a room that already exists is unaffected and never spends from it. A refilling bucket, not a midnight quota, so a blocked caller is served as it refills rather than at a reset |
-| `CHAT_CORS_ORIGINS` | *(empty)* | comma-separated allowlist; empty = no browser origin trusted |
+| `CHAT_CORS_ORIGINS` | *(empty)* | comma-separated allowlist (surrounding whitespace is ignored); empty = no browser origin trusted |
 | `CHAT_CLIENT_IP_HEADER` | *(empty)* | header the rate limiter keys on. Empty means the socket peer — **only set this once the origin is unreachable except through your proxy**. Behind Cloudflare that is `cf-connecting-ip`. This is not optional bookkeeping: unset, every caller shares one bucket, and `CHAT_RATE_ROOMS_PER_DAY` then bounds room creation for the whole internet at once rather than per caller. `/stats` reports `client_identity` so the mistake is visible rather than silent |
 | `CHAT_SECURITY_CONTACT` | `security@flop.finance` | the mailbox `/.well-known/security.txt` names. **Change it if you run your own instance** — the default is the upstream project's channel, which is right for a bug in the software and wrong for one in your deployment |
 | `CHAT_ROOMS_CACHE_SECONDS` | `3` | how long the `/rooms` directory walk is reused across callers. Writes invalidate it immediately, so a caller always sees its own writes; `0` disables it |

--- a/src/config.py
+++ b/src/config.py
@@ -33,7 +33,7 @@ RATE_WRITE = max(1, int(os.environ.get("CHAT_RATE_WRITE", "30")))
 # next caller, whoever they are, gets the fail-closed refusal. This is what makes MAX_ROOMS
 # a cap on the service rather than a race won by whoever creates rooms fastest.
 RATE_ROOMS_PER_DAY = max(1, int(os.environ.get("CHAT_RATE_ROOMS_PER_DAY", "20")))
-CORS_ORIGINS = [o for o in os.environ.get("CHAT_CORS_ORIGINS", "").split(",") if o]
+CORS_ORIGINS = [o.strip() for o in os.environ.get("CHAT_CORS_ORIGINS", "").split(",") if o.strip()]
 # /stats is the one internal surface. Growth numbers are not published — the design doc's
 # §I.2.3 caution against count-based marketing is exactly why they stay off the public
 # service — so the endpoint exists only when a token is configured, and answers 404 rather

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -378,6 +378,43 @@ def test_a_published_ceiling_is_a_number_json_can_carry(client, monkeypatch):
         json_module.loads(raw)  # parses under Python's lenient reader too
 
 
+def test_cors_allowlist_ignores_separator_whitespace(tmp_path):
+    """A documented comma-separated list is commonly written with a space after each
+    comma. CORS matches origins exactly, so preserving that separator whitespace silently
+    made every origin after the first fail to receive an allow-origin response header.
+
+    Boot the real middleware chain in a fresh interpreter: checking the parsed list alone
+    would miss a future wiring error between config and CORSMiddleware.
+    """
+    import os
+    import subprocess
+    import sys
+
+    src = repr(str(Path(__file__).resolve().parents[2] / "src"))
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                f"import sys; sys.path.insert(0, {src}); "
+                "from starlette.testclient import TestClient; import app; "
+                "r = TestClient(app.app).get('/healthz', "
+                "headers={'Origin': 'https://two.example'}); "
+                "print(r.headers.get('access-control-allow-origin', ''))"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "CHAT_ROOT": str(tmp_path),
+            "CHAT_CORS_ORIGINS": "https://one.example, https://two.example ",
+        },
+    )
+    assert probe.returncode == 0, probe.stderr
+    assert probe.stdout.strip() == "https://two.example"
+
+
 def test_an_integral_ceiling_publishes_as_an_integer(client):
     """`10.0` and `10` are the same number to a validator and different bytes to a reader,
     and this was an integer literal until the ceiling became configurable. A fractional


### PR DESCRIPTION
## What changes

`CHAT_CORS_ORIGINS` now strips surrounding whitespace from each comma-separated entry and drops entries that become empty.

A conventional value such as `https://one.example, https://two.example` previously preserved the leading space on the second entry. Starlette matches CORS origins exactly, so that origin was configured but never received `Access-Control-Allow-Origin`.

## Verification

The regression test boots the real app and middleware in a fresh interpreter, configures two origins with separator whitespace, and verifies a request from the second receives the expected response header.

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run coverage run -m pytest tests -q` — 322 passed
- `uv run coverage report` — 97.42%
- `uv run sz.py --check` — core remains at the 1848-line baseline

## Compatibility and abuse impact

No default changes: the empty default still trusts no browser origin. This only makes explicitly configured comma-separated values behave as documented. URL origins cannot contain surrounding whitespace, so trimming does not change a valid origin. No route, response shape, storage, rate limit, or authentication behavior changes.

Related context: #42 discusses the deployment-level CORS choice; this PR does not change that policy or enable CORS by default.