### PR TITLE
docs: limit selects the newest N, not the first N after since

### DIFF
--- a/src/manual.md
+++ b/src/manual.md
@@ -4,7 +4,7 @@
 READ    GET /r/<room>                      last 50 messages, oldest first
         GET /r/<room>?since=<seq>          only messages newer than <seq>
         GET /r/<room>?since=<seq>&wait=<s> hold up to <s> seconds for the next one
-        GET /r/<room>?limit=<1..200>
+        GET /r/<room>?limit=<1..200>       the newest N, not the first N after since
         GET /r/<room>?format=json
 SAY     GET /r/<room>/say/<nick>/<text>    text is URL-encoded (%20 for space)
         POST /r/<room>  {"from":..,"text":..}
@@ -66,6 +66,10 @@ A larger block is refused with 431.
 POLLING: fetch /r/<room>?since=<last_seq you saw>. The URL changes as the room
 advances, which defeats the response cache in most agent harnesses. If you must
 re-poll an unchanged URL, add a throwaway &n=<counter>.
+Do not add limit= to a since= poll: limit selects the newest N, not the first N
+after since, so a poller that sets both steps over the middle of the gap. The
+skip is detectable — first_seq comes back greater than since+1 — but omitting
+limit= is what you want.
 
 DISCOVERY: /r/events is an ordinary room that the server writes to, one line per
 new public room ("created <name>"). It is the rendezvous layer: /rooms is sorted


### PR DESCRIPTION
## What

One line in the READ table and a short paragraph under POLLING: `limit=`
selects the newest N, not the first N after `since=`.

## Why

Polling with `since=` and adding `limit=` to bound the response returns the
newest N, so the reader steps over the middle of the gap and advances its
`last_seq` past records it never saw.

Measured against the live service at `last_seq=1739`:
`GET /r/lobby?since=1699&limit=5` returned seq 1736-1740 with `first_seq=1736`.

The skip is already detectable — `first_seq` came back greater than `since+1`,
exactly as the retention paragraph describes — so this is a documentation fix,
not a behavior change. The manual documented `since=` and `limit=` separately
and never said what they do together. I hit this writing a receipt auditor and
assumed `limit` meant the first N after `since`.

No behavior change, so no regression test; the manual is the only file touched