### PR TITLE
test(signer): gate the script's copy of the sweep against the server's

### DIFF
--- a/tests/http/test_signer.py
+++ b/tests/http/test_signer.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
+import unicodedata
 from pathlib import Path
+from urllib.parse import quote
 
 import _client  # noqa: F401 (imported for the fixture alias below)
 
@@ -77,3 +79,43 @@ def test_a_script_signature_is_accepted_by_the_real_server(client) -> None:
     assert r.status_code == 200, r.text
     assert text in r.text
     assert "<z6Mk" in r.text  # a verified writer renders as the key, not a nickname
+
+
+def test_the_scripts_sweep_still_matches_the_servers(client) -> None:
+    """The script's copy of the sweep is load-bearing, so gate it like the rest.
+
+    `scripts/sign.py` re-declares `INVISIBLE_CATEGORIES` instead of importing
+    `store`'s — deliberately, because it must run standalone with only
+    `cryptography` beside it. Nothing asserted the two agree, and every other
+    signer test signs plain ASCII, so a category added on one side and not the
+    other passes the whole suite while every swept character a real caller sends
+    starts returning 403.
+
+    One character from each swept category, signed by the script and submitted
+    raw: the server verifies against what it stores, so the copies agreeing is
+    the only reason this is a 200. `Cs` is absent because a lone surrogate has no
+    UTF-8 encoding and cannot survive an argv round-trip — the other five carry
+    the guard.
+    """
+    import store
+
+    raw = "a\x01b​cd e f"
+    covered = {unicodedata.category(c) for c in raw} & set(store.INVISIBLE_CATEGORIES)
+    assert covered == set(store.INVISIBLE_CATEGORIES) - {"Cs"}, (
+        "a category joined the server's sweep with no character here to exercise it"
+    )
+
+    out = run("say", "--seed", SEED, "sweeproom", "5", raw)
+    assert out.returncode == 0, out.stderr
+    did, sig = out.stdout.splitlines()
+
+    # percent-encoded, not raw: a C0 control is a legal path segment only escaped,
+    # and the HTTP client refuses to send one literally.
+    r = client.get(f"/r/sweeproom/say-signed/{did}/{sig}/5/{quote(raw, safe='')}")
+    assert r.status_code == 200, (
+        f"the script signed bytes the server did not store ({r.status_code}) — "
+        f"scripts/sign.py's INVISIBLE_CATEGORIES has drifted from store's"
+    )
+    assert client.get("/r/sweeproom?format=json").json()["messages"][0]["text"] == store.clean_text(
+        raw
+    )


### PR DESCRIPTION
## Summary

`scripts/sign.py` re-declares `INVISIBLE_CATEGORIES` rather than importing `store`'s — deliberately, so the script runs standalone with only `cryptography` beside it. Nothing asserted the two copies agree.

`tests/http/test_signer.py`'s own docstring says every claim the script's docstring makes is a promise a stranger relies on. The script promises its sweep is *"the single-line sweep every write passes through before storage (src/store.py clean_text)"*. That was the one promise with no gate behind it.

## Why it matters

Every existing signer test signs plain ASCII, so drift is invisible to the suite. Dropping `"Cf"` from the script's tuple on current `main`:

| | result |
|---|---|
| existing 321 tests | **all pass** |
| this test | fails — 403 |

A caller following the documented signer would get 403 on every message containing a zero-width space, a bidi override, or a ZWJ emoji — while CI stayed green.

Verified in both directions:

- script falls behind the server (drop `Cf`) → fails on the 403
- server gains a category (add `Zs`) → fails on the coverage assertion, rather than passing quietly with a category nothing exercises

## Approach

One character from each swept category, signed through the script and submitted raw. The server verifies against what it stores, so the two copies agreeing is the only reason the write is a 200 — an externally observable assertion rather than a comparison of private constants.

`Cs` is absent: a lone surrogate has no UTF-8 encoding and cannot survive an argv round-trip. The other five carry the guard, and the coverage assertion names the exclusion so it cannot rot silently.

The URL segment is percent-encoded because a C0 control is a legal path segment only when escaped — the HTTP client refuses to send one literally.

## Checks

`ruff check`, `ruff format --check`, `ty check` all pass. 322 passed, coverage 97.42%. Test-only: `sz.py --check` reports core code-lines unchanged at 1848.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qqppXhWQvPMg1pDBj9Bmw