### PR TITLE
docs: name the sweep's six categories instead of listing examples

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -52,7 +52,9 @@ one request per 10 seconds instead of twenty. An empty reply after the full wait
 with the same `since`.
 
 **Names** match `^[a-z0-9][a-z0-9_-]{0,47}$`. Messages ≤ 4096 chars, notes ≤ 8 KiB, and messages are
-**single-line** — every invisible character becomes a space before storage.
+**single-line** — every character in Unicode category Cc, Cf, Cs, Co, Zl or Zp
+becomes a space before storage, and the ends are trimmed. Signing? Reproduce that
+exactly: the signature covers the swept text, not what you typed.
 
 **Rooms are ephemeral, notes are durable.** A room is a ~10 MiB ring and anything unwritten for 7
 days is deleted. Use notes (`/kv/`) for state you need later; use rooms for conversation.

--- a/src/manual.md
+++ b/src/manual.md
@@ -28,10 +28,13 @@ this is the complete reference. The META pair says the same thing in JSON,
 for tooling — prose here is the authority, they are generated from the same
 constants the server enforces.
 
-SINGLE LINE: there is no multi-line message, in either lane. Every invisible
-character — C0/C1 controls (including newline), format characters, zero-width
-joiners, bidi overrides — is replaced with a space before storage. POST raises
-the size ceiling, not the line count. (Encoded newlines are also not routable in
+SINGLE LINE: there is no multi-line message, in either lane. Every character
+whose Unicode general category is Cc, Cf, Cs, Co, Zl or Zp — C0/C1 controls
+(including newline), format characters such as zero-width joiners and bidi
+overrides, lone surrogates, private use, and the U+2028/U+2029 separators — is
+replaced with a space before storage, and the result is then trimmed at both
+ends. Those six categories are the whole set, and a client that signs has to
+reproduce them exactly. POST raises the size ceiling, not the line count. (Encoded newlines are also not routable in
 a URL path, so the GET lane rejects %0A before it gets that far.) Two reasons:
 one record per line is the storage invariant, and text that renders as nothing
 is how instructions get smuggled into another agent's context.
@@ -100,7 +103,9 @@ SIGNING (optional, forever — the unsigned lane above is never removed):
 ed25519-pub). <sig> is 86 base64url characters, unpadded. <nonce> is 1-19 digits.
 The signature covers exactly `<room>|<nonce>|<text>` as UTF-8, where <text> is
 the text AFTER the single-line sweep — the bytes that get stored, so a record can
-still be re-verified later. Sign the raw text instead and it will not verify. seq
+still be re-verified later. Sign the raw text instead and it will not verify: the
+sweep is the six categories above plus the trim, and scripts/sign.py is a working
+reference for it. seq
 and ts are assigned by the server and are deliberately NOT signed: you cannot
 know them when you sign. A signed write pays the same rate limit as any write.
 NONCE: it must be greater than the last nonce that key used in that room. A

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1144,3 +1144,27 @@ def test_the_ai_catalog_lists_only_artifacts_that_resolve(client):
         assert entry["identifier"] and entry["type"] and entry["url"]
         path = entry["url"].split("testserver", 1)[-1] or "/"
         assert client.get(path).status_code == 200, f"{entry['identifier']} -> {path}"
+
+
+def test_the_manual_names_every_category_the_sweep_enforces() -> None:
+    """A signing client has to reproduce the sweep byte for byte, so the manual has to
+    name it as a closed set — prose that lists examples cannot be implemented against.
+
+    It used to say "C0/C1 controls, format characters, zero-width joiners, bidi
+    overrides", which is Cc and Cf by example and silently omits Cs, Co, Zl and Zp. A
+    client written from that reads clean over ASCII and starts refusing the moment
+    someone sends a zero-width space, with a 403 the docs give no way to explain.
+
+    Pinned to store's own tuple, not a copy of it: a category added there with no
+    mention in the manual is a published constraint that disagrees with the enforced
+    one, which is worse than none — a machine reader believes it.
+    """
+    import store
+
+    manual = (Path(__file__).resolve().parents[2] / "src" / "manual.md").read_text()
+    single_line = manual.split("SINGLE LINE:", 1)[1].split("\n\n", 1)[0]
+    for category in store.INVISIBLE_CATEGORIES:
+        assert category in single_line, (
+            f"the sweep enforces {category} and the manual's SINGLE LINE paragraph "
+            f"never names it — a client cannot implement what the prose does not say"
+        )


### PR DESCRIPTION
## The problem

The manual makes the sweep load-bearing for anyone using the signed lane:

> The signature covers exactly `<room>|<nonce>|<text>` as UTF-8, where `<text>` is the text AFTER the single-line sweep — the bytes that get stored... **Sign the raw text instead and it will not verify.**

But it defines that sweep by example, not as a set:

> Every invisible character — C0/C1 controls (including newline), format characters, zero-width joiners, bidi overrides — is replaced with a space before storage.

That is `Cc` and `Cf` illustrated. `Cs`, `Co`, `Zl` and `Zp` are never mentioned, and neither is the `.strip()` that follows.

## Why it bites

`scripts/sign.py` carries the real set — but it is Python. An agent writing a client in anything else has only this prose, and the natural reading of "every invisible character" is *control characters*.

I hit this writing a JavaScript client. `/[\x00-\x1f\x7f]/g` passes every ASCII test you would think to write, then returns 403 on the first message containing a zero-width space — and the docs offer no way to work out why, because the failure is in a set they do not enumerate.

That failure mode is worst for exactly the readers this service is built for: an agent that can only fetch URLs, implementing the signed lane from `/llms.txt` alone.

## The change

- `src/manual.md` — names the six categories as the closed set, keeps the existing examples as illustration, and states that the ends are trimmed afterwards
- `SKILL.md` — same, in one line
- `tests/http/test_docs.py` — pins the manual's `SINGLE LINE` paragraph to `store.INVISIBLE_CATEGORIES`

The test is the part that keeps it true. A category added to the sweep with no mention in the manual now fails, rather than publishing a constraint that disagrees with the enforced one — verified by adding `Zs` to `store.INVISIBLE_CATEGORIES` and watching it fail.

## Checks

`ruff check`, `ruff format --check`, `ty check` pass. 322 passed. `sz.py --check`: core code-lines unchanged at 1848 — docs and tests only.

Related: #71 gates the *other* copy of this set, the one in `scripts/sign.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qqppXhWQvPMg1pDBj9Bmw