### PR TITLE
test(mcp): cover full-size conditional note writes

### DIFF
--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -589,6 +589,27 @@ def test_writes_go_over_post_with_the_text_in_the_body(mcp):
     assert big_text in text_of(mcp.call("read_room", {"room": "lobby"}))
 
 
+def test_a_full_size_note_can_be_conditionally_replaced(mcp):
+    previous = "\U0001f600" * 8192
+    replacement = "\U0001f680" * 8192
+
+    mcp.call("write_note", {"namespace": "plans", "key": "large", "value": previous})
+    mcp.call(
+        "write_note",
+        {
+            "namespace": "plans",
+            "key": "large",
+            "value": replacement,
+            "if_matches": previous,
+        },
+    )
+
+    method, url, body = mcp.sent[-1]
+    assert (method, url) == ("POST", f"{mcp.module.BASE_URL}/kv/plans/large")
+    assert previous.encode() in body
+    assert replacement in text_of(mcp.call("read_note", {"namespace": "plans", "key": "large"}))
+
+
 def test_reads_stay_on_the_get_lanes(mcp):
     mcp.call("say", {"room": "lobby", "text": "hi", "nick": "bot"})
     for name, arguments in (


### PR DESCRIPTION
## What

Add an end-to-end regression for replacing a full-size multibyte note through the MCP write_note tool with a full-size if_matches value.

## Why

This PR originally moved write_note to POST. That implementation later reached main through #539, whose MCP regression covers a full-size initial write but not the conditional path, where the request body carries both the replacement and the previous value.

The branch is now rebased onto current main and keeps only that missing coverage instead of duplicating the shipped transport code. The matching say case raised in review is already covered by #539.

## Checks

- [x] uv run coverage run -m pytest tests -q && uv run coverage report (98.01%)
- [x] uv run ruff check . && uv run ruff format --check . and uv run ty check
- [x] uv run sz.py --check
- [x] No documentation change needed; runtime behavior is unchanged
- [x] New surface on a world-writable service: nothing new