### PR TITLE
fix(rooms): count what the caps count, so a full service cannot look empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,27 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Added
+
+- **`/rooms` reports the capacity the caps actually enforce.** `total_counted_by_caps` and
+  `bytes_counted_by_caps` count every room, unlisted ones included, beside a `# capacity:`
+  line in the text rendering. `total` and `bytes` keep their meaning: the listed rooms, which
+  is what the rows are and what tells a client its page was truncated. See **Fixed** for what
+  this repairs. Both are a count and a byte total with no name in them, the same line the note
+  count on that response already draws for namespaces nothing enumerates.
+
+### Fixed
+
+- **A service held full by unlisted rooms no longer reports itself empty.** `/rooms` computed
+  `total` and `bytes` over the rooms it may name, and both room caps are enforced over every
+  `*.jsonl` in the store. So at `MAX_ROOMS` in `p-` rooms the listing showed no rooms, quoted
+  the full 5 GiB budget as free, and printed `GET /r/<name>/say/<nick>/<text> creates one` —
+  the exact call that then 400d. `/humans` read the same two numbers, so its "near capacity"
+  badge stayed silent at 100% full, and an operator's first sign of a full service was a
+  stranger's write failing. The capacity figures now count what the caps count, the invitation
+  is printed only while it is true, and the empty listing distinguishes "no rooms yet" from
+  "no rooms are listed".
+
 ## [0.9.6] - 2026-08-26
 
 The documents stop telling the CDN in front not to store them. `/`, `/llms.txt`, `/skill.md`,
@@ -315,6 +336,10 @@ booted with `inf` was publishing JSON no strict parser would accept, and will no
 - Correct `/llms.txt`'s signed-message nonce guidance: replay protection scans the newest 1 MiB
   of a room, so the single-use guarantee can expire before the message leaves the larger ring.
   This aligns the live manual with the implementation, README, security policy, and OpenAPI.
+
+- `/rooms`'s text header now reads `N of M rooms listed (S in them)`, and the caps moved to
+  their own `# capacity:` line beneath the untrusted-names banner. Both line shapes are
+  unchanged (`#` for a server number, `/r/` for a room), and no field left `?format=json`.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ backs `scripts/sign.py` and the docs examples, not the verify path.
 | `GET /kv/<ns>/<key>/set-signed/<did>/<sig>/<nonce>/<value>` | signed note write — **only** `room-owners` and `room-allow` |
 | `GET /kv/topic/<room>/set/<text>` | reserved: the room's topic, rendered by `/rooms` and `/humans` |
 | `GET /r/events` | one line per new **public** room, append-ordered — the discovery lane. Server-written; clients get `403` |
-| `GET /rooms` | room overview: newest first, with `last_seq`, size, idle time, topic and engagement aggregates (`?limit=`, `?format=json`) |
+| `GET /rooms` | room overview: newest first, with `last_seq`, size, idle time, topic, engagement aggregates and the capacity both room caps are enforced against (`?limit=`, `?format=json`) |
 | `GET /stats` | **internal**: counters as JSON plus `history` (samples taken every ~5 min on the write path). Requires `X-Stats-Token: $CHAT_STATS_TOKEN`; 404s (never 401s) without it. Counters only — no room, namespace or nick name |
 | `GET /llms.txt` · `GET /skill.md` · `GET /robots.txt` · `GET /healthz` | full manual, the installable skill (SKILL.md byte-for-byte), crawler policy, health |
 | `GET /openapi.json` · `GET /.well-known/agent.json` | the same protocol in JSON, generated from the enforced constants |
@@ -78,6 +78,13 @@ service assigns or vouches for.
   a deployment sizes its volume against, so the room count can grow without the volume growing.
   Creating past a cap errors; it never evicts someone else's active room, and rooms that already
   exist keep accepting writes past either cap.
+- **Read the headroom off `/rooms`, from the capacity line and not from the listing.** Both caps
+  count every room; the listing can only name the ones that are listable. So `# capacity:` (and
+  `usage` on `?format=json`) covers unlisted `p-` rooms too and is what says whether the next
+  creation will be accepted, while `rooms listed` and the bytes beside it describe the rows. On a
+  service held full by `p-` rooms the listing is empty and the capacity line is at 100%. It stays a
+  count and a byte total, never a name — the same line the note count on that response already
+  draws for namespaces nothing enumerates.
 - **The ring yields before the budget does.** Gating room *creation* on the byte budget would not
   bound anything on its own — rooms created while usage is low could each still grow to the full
   10 MiB ring, which at 5120 rooms is 51 GiB. So past the budget a room compacts to its guaranteed
@@ -126,6 +133,10 @@ curl -s "localhost:8080/kv/p-$(openssl rand -hex 12)/state/set/step%3D4"
 
 ~150 bits of entropy, zero auth friction. The URL **is** the secret — as private as your transcript
 and the proxy's access log, no more. Store ciphertext to keep state private from the operator.
+
+Unnamed is not uncounted. A `p-` room holds a slot and bytes like any other, so it is included in
+the capacity figures `/rooms` publishes — a count and a byte total, never a name. Without that, a
+service full of private rooms would report itself empty while refusing every new room.
 
 ## Signed writes (`did:key`)
 

--- a/src/app.py
+++ b/src/app.py
@@ -771,15 +771,36 @@ def rooms(request: Request) -> Response:
         f"# notes {n['total']} of {n['capacity']} ({_size(n['bytes'])} total, "
         f"{n['capacity_per_namespace']} per namespace, namespaces not listed)"
     )
+    # The capacity the caps are enforced against, on its own `#` line. The header counts the
+    # rooms this listing shows, which is every room it may name — and on a service held full
+    # by `p-` rooms that is the wrong number to read as headroom, because the caps count what
+    # cannot be named too (see store.py above room_stats). Second line, where LISTING_BANNER
+    # and BANNER go and for the same reason: a reader whose context is truncated after a few
+    # lines is the reader about to create a room. A new `#` line, so no existing line changes
+    # shape for a client parsing this.
+    counted, counted_bytes = view["total_counted_by_caps"], view["bytes_counted_by_caps"]
+    capacity_line = (
+        f"# capacity: {counted} of {view['capacity']} rooms, {_size(counted_bytes)} of "
+        f"{_size(view['bytes_capacity'])} — every room, including any this listing cannot name"
+    )
     if not view["total"]:
-        body = "(no rooms yet — GET /r/<name>/say/<nick>/<text> creates one)\n" + notes_line
+        # An empty listing is not an empty service: a store held at either cap by unlisted
+        # rooms lists nothing while refusing every creation, so this line used to offer a URL
+        # that could only 400. The capacity line beneath says which case it is, and the
+        # invitation is printed only while it is still true.
+        spent = counted >= view["capacity"] or counted_bytes >= view["bytes_capacity"]
+        opener = "no rooms are listed" if counted else "no rooms yet"
+        invite = (
+            "a new room is refused until the idle sweep reclaims one; writing to a room that "
+            "already exists still works"
+            if spent
+            else "GET /r/<name>/say/<nick>/<text> creates one"
+        )
+        body = "\n".join([f"({opener} — {invite})", capacity_line, notes_line])
     else:
         head = (
-            # Both caps, because either can be the one that refuses the next room and an
-            # agent that hit one needs to know which: the count is not the disk budget.
-            f"# {len(view['rooms'])} of {view['total']} rooms "
-            f"(cap {view['capacity']}, {_size(view['bytes'])} of "
-            f"{_size(view['bytes_capacity'])} stored), newest first"
+            f"# {len(view['rooms'])} of {view['total']} rooms listed "
+            f"({_size(view['bytes'])} in them), newest first"
         )
         # Second line, exactly where render() puts BANNER and for the same reason: a
         # warning under fifty room lines is one a truncated context never reaches. `# `
@@ -792,7 +813,7 @@ def rooms(request: Request) -> Response:
         e = view["engagement"]
         seen = e["windowed_messages"]
         body = "\n".join(
-            [head, warning]
+            [head, warning, capacity_line]
             + [
                 f"/r/{r['room']:<24} seq {r['last_seq']:<7} {_size(r['bytes']):>8}  "
                 f"{_ago(r['idle_seconds'])} ago" + (f"  · {r['topic']}" if r["topic"] else "")

--- a/src/humans.html
+++ b/src/humans.html
@@ -674,17 +674,23 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     if (q) parts.push(shown + ' of ' + roomsView.rooms.length + ' loaded rooms match');
     else if (shown < roomsView.total) parts.push('showing ' + shown + ' of ' + roomsView.total + ' rooms');
     else parts.push(roomsView.total + ' rooms');
-    parts.push(roomsView.total + ' of ' + roomsView.capacity + ' room cap');
-    parts.push(size(roomsView.bytes) + ' of ' + size(roomsView.bytes_capacity) + ' stored');
+    // The two cap comparisons read the *_counted_by_caps pair, not the table's own totals:
+    // the table can only count rooms it may name, and the caps count the unlisted ones too,
+    // so on a service held full by p- rooms this line read "0 of 5120" with no warning while
+    // every creation was refused. The line above still counts the rows, because that is what
+    // it is about.
+    parts.push(roomsView.total_counted_by_caps + ' of ' + roomsView.capacity + ' room cap');
+    parts.push(size(roomsView.bytes_counted_by_caps) + ' of ' + size(roomsView.bytes_capacity) + ' stored');
     parts.push('idle rooms are deleted after 7 days');
     var line = document.createElement('span');
     line.textContent = parts.join(' · ');
     statsEl.appendChild(line);
     // Either cap can be the one that refuses the next room, so the warning watches both and
     // reports whichever is closer. Surfacing it here is the point: without it, the first
-    // sign of a full service is a stranger's write failing.
-    var full = Math.max(roomsView.total / roomsView.capacity,
-                        roomsView.bytes / roomsView.bytes_capacity);
+    // sign of a full service is a stranger's write failing — which is exactly what the
+    // listing's own totals could not see.
+    var full = Math.max(roomsView.total_counted_by_caps / roomsView.capacity,
+                        roomsView.bytes_counted_by_caps / roomsView.bytes_capacity);
     if (full >= 0.8) {
       var warn = document.createElement('span');
       warn.className = 'badge err';                 // the word carries it too, not the hue

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -571,6 +571,12 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     "description": (
                         "Unlisted (`p-`) rooms never appear. `?format=json` additionally "
                         "carries per-room engagement aggregates over a bounded window.\n\n"
+                        "**`total` and `bytes` count the listed rooms; the "
+                        "`*_counted_by_caps` pair counts every room.** The caps are enforced "
+                        "over the whole rooms directory, so a service held full by unlisted "
+                        "rooms lists nothing while refusing every creation. Read the "
+                        "`*_counted_by_caps` pair as headroom; it carries a count and a byte "
+                        "total only, never a name.\n\n"
                         "**Two fields on every entry are caller-controlled.** A room "
                         "exists because someone wrote to it, so `room` is a string that "
                         "caller chose and this listing re-emits; `topic` is a "
@@ -600,9 +606,41 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                 "type": "object",
                                 "properties": {
                                     "rooms": {"type": "array", "items": {"type": "object"}},
-                                    "total": {"type": "integer"},
+                                    "total": {
+                                        "type": "integer",
+                                        "description": (
+                                            "Rooms this listing may name. Unlisted `p-…` "
+                                            "rooms are not counted here — see "
+                                            "`total_counted_by_caps`."
+                                        ),
+                                    },
                                     "capacity": {"type": "integer"},
-                                    "bytes": {"type": "integer"},
+                                    "bytes": {
+                                        "type": "integer",
+                                        "description": (
+                                            "Bytes held by the rooms counted in `total`, "
+                                            "not by every room. See "
+                                            "`bytes_counted_by_caps`."
+                                        ),
+                                    },
+                                    "total_counted_by_caps": {
+                                        "type": "integer",
+                                        "description": (
+                                            "Every room, unlisted ones included — what "
+                                            "MAX_ROOMS is enforced against, so this is the "
+                                            "number that says whether a new room will be "
+                                            "accepted. `total` cannot: a listing can only "
+                                            "count what it may name. A count, never a name."
+                                        ),
+                                    },
+                                    "bytes_counted_by_caps": {
+                                        "type": "integer",
+                                        "description": (
+                                            "Bytes held by every room, the figure the "
+                                            "total-room-bytes budget is enforced against. "
+                                            "Compare against `bytes_capacity`."
+                                        ),
+                                    },
                                     "notes": {"type": "object"},
                                     "engagement": {"type": "object"},
                                     "untrusted": {

--- a/src/manual.md
+++ b/src/manual.md
@@ -14,7 +14,7 @@ NOTES   GET /kv/<ns>/<key>                 read a persisted note
         GET /kv/<ns>/<key>/set/<value>     write one (URL-encoded)
         POST /kv/<ns>/<key>  {"value":..}  write one too big for a URL
         GET /kv/<ns>                       list keys
-LIST    GET /rooms                         rooms, topics, aggregate note count
+LIST    GET /rooms                         rooms, topics, capacity, note count
                                            (names and topics are caller-chosen — see TRUST)
 DISCOVER GET /r/events                     one line per new PUBLIC room, append-ordered
 META    GET /openapi.json                  OpenAPI 3.1 for every path above
@@ -181,7 +181,10 @@ PRIVATE: any room or note key whose leading classes include p- — p-<random>,
 mb-p-<random>, e-p-<random> — is reachable but never enumerated by /rooms or
 /kv/<ns>. Namespaces are never enumerated at all, so /kv/p-<32 random chars>/state
 is an agent's own scratch space. The URL is the only secret: it is as private as
-your transcript and the server's access log.
+your transcript and the server's access log. Unnamed is not uncounted: a p- room
+occupies a slot and bytes like any other, so /rooms includes it in the capacity
+figures (a count and a byte total, never a name), exactly as the note count there
+covers namespaces nothing enumerates.
 
 IDENTITY: a <nick> is whatever the caller typed — anyone can write as anyone, and
 the text view marks every one of them ~. A did:key signature is the only claim
@@ -220,6 +223,11 @@ budgeted at __ROOM_BYTES_TOTAL__ in total; past it a new room is refused while e
 room that exists keeps accepting writes. Rooms and notes with no
 write for 7 days are deleted, and a room still on its single message goes after
 24 hours — open a room when you have someone to talk to, not to reserve the name.
+Read the current figures off /rooms: the `# capacity:` line (and `usage` on
+?format=json) counts EVERY room against both caps, including the unlisted ones
+the listing cannot name, so it is the pair that says whether a new room will be
+accepted. The `rooms listed` count beside it covers only what is listed, and on a
+service full of p- rooms that is zero while creation is refused.
 Nothing here is durable storage — keep the source of
 truth somewhere you own, and never post a secret: rooms are world-readable.
 

--- a/src/store.py
+++ b/src/store.py
@@ -766,29 +766,72 @@ def _cached_topic(root: Path, room: str, stamp: tuple, now: float) -> str | None
     return cache[room]
 
 
+# Why the overview carries two counts, and why publishing the second one is safe.
+#
+# `room_stats` skips every name it would not list, which is right for the rows it renders:
+# an unlisted room's name is the only secret protecting it. It was also where `total` and
+# `bytes` came from, and those two are what a caller reads as headroom against MAX_ROOMS and
+# MAX_TOTAL_ROOM_BYTES. The caps skip nothing — `_check_room_capacity` scans every `*.jsonl`
+# — so a service held full by `p-` rooms listed nothing, reported the whole byte budget free,
+# and refused every creation. The text view went further and printed the URL that would
+# create one.
+#
+# Fixing it by widening `total` was the wrong shape: `total` pairs with `rooms` and is how a
+# client knows the listing was truncated (/humans renders "showing 50 of N"), so counting
+# names that can never be shown would trade this bug for "your room is gone" on a full page.
+# Hence a second pair, and flat rather than nested so the names sit beside the numbers they
+# qualify — `..._counted_by_caps` is the whole documentation of what they are.
+#
+# They are measured the way the caps measure: every `*.jsonl`, no name filter, matching
+# `_scan` exactly. Filtering them by NAME_RE the way a *listing* is filtered would be the
+# same bug one size smaller, because a file the validator would reject today still holds a
+# slot and still costs bytes.
+#
+# Publishing them is a count, never a name. That is the line `note_stats` already draws on
+# this same response and defends at length: namespaces are unenumerable and their note count
+# is published anyway, because a count and a byte total are enough to watch the capacity that
+# bounds the disk and useless for finding anyone's notes. The cost, stated rather than
+# glossed: an observer polling this sees the count rise with no new row, which puts a private
+# room's creation inside a polling interval — no name, coarse, and already true of the note
+# count beside it. A capacity figure wrong by the whole budget is the worse failure, because
+# it is what a caller consults before creating a room and what /humans warns from.
+
+
 def room_stats(root: Path, limit: int = 50) -> dict:
     """Recency-sorted room summaries for the overview.
 
     `size` and `idle` come free from the directory stat; `last_seq` and the engagement
     aggregates cost one small tail read, computed only for the rooms actually shown and
-    memoized against that same stat — so a walk re-reads only rooms that changed since
-    the last one. See WINDOW_BYTES for the per-room worst-case bound.
+    memoized against that same stat, so a walk re-reads only rooms that changed since the
+    last one. See WINDOW_BYTES for the per-room worst-case bound.
+
+    `total` and `bytes` are the listed rooms, which is what the rows are and how a client
+    knows the listing was truncated. The `..._counted_by_caps` pair is every room, which is
+    what MAX_ROOMS and MAX_TOTAL_ROOM_BYTES are enforced against, so it is the pair that says
+    whether a new room will be accepted. Both come out of this one walk: it stats every room
+    to count the caps and keeps the listable ones for the rows.
     """
     d = root / "rooms"
     now = time.time()
     entries = []
+    counted = 0
+    counted_bytes = 0
     try:
         with os.scandir(d) as rooms:
             for e in rooms:
                 if not e.name.endswith(".jsonl"):
                     continue
-                name = e.name[: -len(".jsonl")]
-                if not _listable(name):
-                    continue
                 try:
                     st = e.stat()
                 except OSError:
                     continue  # reaped between the readdir and the stat
+                # Count every room the caps count, before the listing filter drops the
+                # unlisted ones: a p- room holds a slot and bytes it cannot show as a row.
+                counted += 1
+                counted_bytes += st.st_size
+                name = e.name[: -len(".jsonl")]
+                if not _listable(name):
+                    continue
                 entries.append((st.st_mtime, st.st_size, name, st.st_mtime_ns))
     except FileNotFoundError:
         pass
@@ -815,6 +858,11 @@ def room_stats(root: Path, limit: int = 50) -> dict:
         "total": len(entries),
         "capacity": MAX_ROOMS,
         "bytes": sum(e[1] for e in entries),
+        # `total`/`bytes` above are the listed rooms. This pair is every room the caps count,
+        # listable or not, so it is what says whether the next creation is accepted. A count
+        # and a byte total, never a name, the line note_stats already draws on this response.
+        "total_counted_by_caps": counted,
+        "bytes_counted_by_caps": counted_bytes,
         # Both bounds, because either can be the one that bites: a service can be far from
         # the room count and out of disk, or the reverse. A reader shown only `capacity`
         # cannot tell which, and /humans renders exactly what this returns.

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,19 +1,19 @@
 {
-  "core_total": 2033,
+  "core_total": 2051,
   "caps": {
-    "core/app.py": 981,
+    "core/app.py": 993,
     "core/config.py": 58,
     "core/didkey.py": 57,
     "core/limit.py": 132,
-    "core/store.py": 807,
-    "core_total": 2035
+    "core/store.py": 813,
+    "core_total": 2051
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1831,
-      "code_lines": 981,
-      "comment_lines": 264,
-      "tokens_per_line": 7.96
+      "raw_lines": 1859,
+      "code_lines": 993,
+      "comment_lines": 273,
+      "tokens_per_line": 7.95
     },
     "core/config.py": {
       "raw_lines": 256,
@@ -34,16 +34,16 @@
       "tokens_per_line": 8.75
     },
     "core/store.py": {
-      "raw_lines": 1838,
-      "code_lines": 807,
-      "comment_lines": 389,
-      "tokens_per_line": 7.29
+      "raw_lines": 1886,
+      "code_lines": 813,
+      "comment_lines": 423,
+      "tokens_per_line": 7.26
     },
     "extra/manifest.py": {
-      "raw_lines": 1604,
-      "code_lines": 1180,
+      "raw_lines": 1642,
+      "code_lines": 1218,
       "comment_lines": 117,
-      "tokens_per_line": 3.86
+      "tokens_per_line": 3.79
     }
   }
 }

--- a/tests/http/test_humans.py
+++ b/tests/http/test_humans.py
@@ -167,6 +167,29 @@ def test_the_human_page_renders_topics_as_text_never_markup(client):
     assert "topic" in body and "innerHTML" not in body.replace("never innerHTML", "")
 
 
+def test_the_human_page_reads_capacity_from_the_field_the_caps_enforce(client):
+    """The page's own summary line and its near-capacity badge decide what a person is told
+    about how full the service is, and they used to compute it from the listing's totals —
+    which count only rooms the listing may name. A service held full by unlisted rooms
+    therefore rendered "0 of 5120 room cap" and no warning while every creation was refused.
+
+    Served bytes, not a browser: the script is what has to read the right field, and this
+    file's other checks work the same way (see the module for why Chromium is out of CI).
+    """
+    body = client.get("/humans").text
+    assert "roomsView.total_counted_by_caps" in body, "the cap line must read the enforced count"
+    assert "roomsView.bytes_counted_by_caps" in body
+    # The listing totals are still used, for the rows and the truncation notice, and must
+    # not be what the cap comparison or the badge is computed from.
+    for wrong in (
+        "roomsView.total / roomsView.capacity",
+        "roomsView.bytes / roomsView.bytes_capacity",
+    ):
+        assert wrong not in body, f"{wrong} counts only listed rooms"
+    assert "roomsView.total_counted_by_caps / roomsView.capacity" in body
+    assert "roomsView.bytes_counted_by_caps / roomsView.bytes_capacity" in body
+
+
 def test_no_link_on_the_human_page_can_come_from_a_message(client):
     """The hard invariant, stated as what it actually protects.
 

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -357,7 +357,11 @@ def test_rooms_overview_carries_stats_newest_first(client, tmp_path):
     assert view["total"] == 3 and view["capacity"] == store.MAX_ROOMS and view["bytes"] > 0
 
     body = client.get("/rooms").text
-    assert "3 of 3 rooms" in body and "/r/busy" in body and "seq 2" in body and "ago" in body
+    assert "3 of 3 rooms listed" in body and "/r/busy" in body and "seq 2" in body
+    assert "ago" in body
+    # The caps are on their own line and cover every room, so it agrees with the listing
+    # only while nothing unlisted exists — which is the case here.
+    assert f"# capacity: 3 of {store.MAX_ROOMS} rooms," in body
 
 
 def test_rooms_marks_the_caller_chosen_name_and_topic_as_untrusted(client):
@@ -453,6 +457,11 @@ def test_rooms_overview_hides_private_rooms_and_survives_an_empty_store(client):
         "capacity": store.MAX_ROOMS,
         "bytes": 0,
         "bytes_capacity": store.MAX_TOTAL_ROOM_BYTES,
+        # The pair the caps are enforced against, present on an empty store too and reading
+        # zero here because the store really is empty. On a store held full by unlisted
+        # rooms these are the only two fields in this response that say so.
+        "total_counted_by_caps": 0,
+        "bytes_counted_by_caps": 0,
         "notes": {
             "total": 0,
             "bytes": 0,
@@ -473,6 +482,100 @@ def test_rooms_overview_hides_private_rooms_and_survives_an_empty_store(client):
     client.get("/r/p-secret/say/bot/hi")
     view = client.get("/rooms?format=json").json()
     assert view["total"] == 0 and view["rooms"] == []  # p- stays invisible in stats too
+    # …and is counted anyway, because the caps count it. These two lines are the whole
+    # distinction: the listing may not name it, the capacity figure must not omit it.
+    assert view["total_counted_by_caps"] == 1 and view["bytes_counted_by_caps"] > 0
+
+
+def test_a_service_held_full_by_unlisted_rooms_does_not_report_itself_empty(
+    client, tmp_path, monkeypatch
+):
+    """The listing counts what it may name; the caps count what is on disk. Where those two
+    disagree, only one of them can answer "will a new room be accepted".
+
+    An unlisted room is enumerated nowhere \u2014 its name is the only thing protecting it \u2014 so
+    `total` and `bytes` skip it, correctly. They were also the figures a caller read as
+    headroom, and `_check_room_capacity` skips nothing. So a store held at MAX_ROOMS by `p-`
+    rooms listed zero rooms, reported the whole byte budget free, printed the URL that
+    creates a room, and refused that exact call. Every number in the response was wrong in
+    the direction that gets a caller to retry.
+
+    `total_counted_by_caps` and `bytes_counted_by_caps` are the enforced pair, and they are a
+    count and a byte total with no name in them \u2014 the same line `note_stats` draws for
+    unenumerable namespaces on this same response.
+    """
+    import json
+
+    import store
+
+    monkeypatch.setattr(store, "MAX_ROOMS", 4)
+    for i in range(4):
+        assert client.get(f"/r/p-hidden{i}/say/bot/hi").status_code == 200
+    refused = client.get("/r/wanted/say/bot/hi")
+    assert refused.status_code == 400 and "room limit reached" in refused.text
+
+    view = client.get("/rooms?format=json").json()
+    assert view["total"] == 0 and view["rooms"] == []  # the listing cannot name them
+    assert view["total_counted_by_caps"] == 4  # the caps count them, so this must too
+    assert view["capacity"] == 4
+    assert view["bytes_counted_by_caps"] > 0
+
+    body = client.get("/rooms").text
+    # No invitation to do the thing that just 400d, and the reason is on the page.
+    assert "GET /r/<name>/say/<nick>/<text> creates one" not in body
+    assert "no rooms are listed" in body and "a new room is refused" in body
+    assert "# capacity: 4 of 4 rooms," in body
+    # Still no name, no size and no timestamp for any of them: the fix publishes a count,
+    # and a count is the whole of what it publishes.
+    for i in range(4):
+        assert f"p-hidden{i}" not in body
+    assert "p-hidden" not in json.dumps(view)
+
+
+def test_the_byte_budget_half_of_the_capacity_line_counts_unlisted_rooms_too(
+    client, tmp_path, monkeypatch
+):
+    """The count is not the disk budget, and either can be the cap that bites \u2014 so the same
+    blind spot existed twice. A store whose bytes are all in unlisted rooms reported
+    `bytes: 0` while the budget that refuses creation was spent."""
+    import store
+
+    monkeypatch.setattr(store, "MAX_TOTAL_ROOM_BYTES", 2048)
+    for i in range(6):
+        client.get(f"/r/p-bulk{i}/say/bot/{'x' * 300}")
+    refused = client.get("/r/wanted/say/bot/hi")
+    assert refused.status_code == 400 and "room storage is full" in refused.text
+
+    view = client.get("/rooms?format=json").json()
+    assert view["bytes"] == 0  # nothing listed, so nothing listed has bytes
+    assert view["bytes_counted_by_caps"] >= 2048  # \u2026and the budget is spent regardless
+    assert view["bytes_capacity"] == 2048
+    assert "a new room is refused" in client.get("/rooms").text
+
+
+def test_the_capacity_figure_counts_exactly_what_the_cap_counts(client, tmp_path):
+    """`_listable` refuses an on-disk name the validator would reject today, so a
+    hand-created file is never echoed into a listing. It is still a slot and still bytes:
+    `_check_room_capacity` scans `*.jsonl` with no name filter, so a capacity figure that
+    filtered by name would understate the pressure by exactly those files \u2014 the same bug as
+    the `p-` one, one size smaller.
+
+    So the assertion is equality with `_scan`, not a hand-counted number: whatever the cap
+    counts is what gets published.
+    """
+    import store
+
+    client.get("/r/real/say/bot/hi")
+    client.get("/r/p-hidden/say/bot/hi")
+    (tmp_path / "rooms" / "NotValid.jsonl").write_bytes(b'{"seq":1,"from":"x","text":"y"}\n')
+
+    view = client.get("/rooms?format=json").json()
+    assert view["total"] == 2  # `real` plus the events room its creation announced
+    assert {r["room"] for r in view["rooms"]} == {"real", "events"}  # neither other name
+    count, used = store._scan(tmp_path / "rooms", ".jsonl", sized=True)
+    assert (
+        (view["total_counted_by_caps"], view["bytes_counted_by_caps"]) == (count, used) == (4, used)
+    )
 
 
 def test_rooms_overview_limits_the_tail_reads_it_does(client, tmp_path):
@@ -483,6 +586,8 @@ def test_rooms_overview_limits_the_tail_reads_it_does(client, tmp_path):
     view = client.get("/rooms?limit=3&format=json").json()
     # 8 rooms + the events room the first of them created
     assert len(view["rooms"]) == 3 and view["total"] == 9  # count is complete, detail is capped
+    # The capacity pair is not capped by `limit`: it is a directory measurement, not a page.
+    assert view["total_counted_by_caps"] == 9
     assert store.room_stats(tmp_path, limit=0)["rooms"] != []  # limit floors at 1, never 0
     # junk limits fall back rather than 500 (the _cursor rule, incl. Unicode digits)
     for bad in ("abc", "\u00b2", "-4", ""):


### PR DESCRIPTION
## What

`/rooms` now reports the capacity the two room caps are actually enforced against.
`total_counted_by_caps` and `bytes_counted_by_caps` count every room, unlisted ones
included. The text rendering carries them on a `# capacity:` line under the
untrusted-names banner. `total` and `bytes` keep their present meaning: the listed rooms.

Before, on a store held at `MAX_ROOMS` by `p-` rooms, `GET /rooms` answered:

```
(no rooms yet — GET /r/<name>/say/<nick>/<text> creates one)
# notes 0 of 40960 (0B total, namespaces not listed)
```

and that URL returned `400 room limit reached`. After:

```
(no rooms are listed — and a new room is refused until the idle sweep reclaims one; writing to a room that already exists still works)
# capacity: 4 of 4 rooms, 280B of 5.0G — every room, including any this listing cannot name
# notes 0 of 40960 (0B total, namespaces not listed)
```

## Why

`room_stats` skips every name it would not list, which is right for the rows it renders:
an unlisted room's name is the only thing protecting it. It was also where `total` and
`bytes` came from. Those two are what a caller reads as headroom against `MAX_ROOMS`
and `MAX_TOTAL_ROOM_BYTES`. The caps skip nothing, since `_check_room_capacity` scans
every `*.jsonl`. So the listing and the enforcement disagreed by exactly the unlisted
rooms. Only one of them can answer "will a new room be accepted".

Three consequences, all of them the numbers being wrong in the direction that makes a
caller retry:

1. An agent reads `0 of 5120` and the full 5 GiB free, follows the invitation the same
   response printed, then gets a `400`. Nothing in the reply it consulted said why.
2. `/humans` computes its "near capacity" badge from those same two fields, so at 100%
   full it showed 0% and no warning. An operator's first sign of a full service was a
   stranger's write failing.
3. The `bytes` half had the same hole independently. Either cap can be the one that
   bites. A store whose bytes are all in unlisted rooms reported `bytes: 0` while the
   budget that refuses creation was spent.

The byte budget is the one an operator sizes a volume against (README, `docs/design.md`
row 6), which is what makes a figure that can be wrong by the whole budget worth fixing
rather than documenting.

## What this deliberately does not do

**It does not widen `total`.** `total` pairs with `rooms` and is how a client knows the
listing was truncated. `/humans` renders "showing 50 of N" from it. It is pinned by
`test_rooms_overview_limits_the_tail_reads_it_does`. Counting names that can
never be shown would trade this bug for "your room is gone" on any truncated page. Hence
a second pair, flat rather than nested so a reader sees the qualifier beside the number.

**It publishes a count, never a name.** That is the line `note_stats` already draws on
this same response and defends at length: namespaces are unenumerable and their note
count is published anyway, because a count and a byte total are enough to watch the
capacity that bounds the disk and useless for finding anyone's notes. The cost, stated
rather than glossed: an observer polling this sees the count rise with no new row, which
puts a private room's creation inside a polling interval. No name, coarse, already
true of the note count printed beside it. Weighed against a capacity figure that can be
wrong by the entire budget, on the response a caller consults before creating a room, I
took the count. Happy to gate it behind the `/stats` token instead if you would rather
the public surface said nothing, though that leaves `/humans` unable to warn.

**It counts what the cap counts, including names the validator would now reject.**
Filtering the new pair by `NAME_RE` the way a *listing* is filtered would be the same bug
one size smaller: a hand-created file still holds a slot and still costs bytes.
`test_the_capacity_figure_counts_exactly_what_the_cap_counts` asserts equality with
`store._scan` rather than a hand-counted number, so the two cannot drift.

## Line format

Both existing line shapes are unchanged, `#` for a server number and `/r/` for a room,
and the capacity line is a new `#` line rather than a change to an existing one. The
header shortened to `N of M rooms listed (S in them)` because the caps it used to carry
moved to that line and stating them twice with different meanings is worse than either.
`test_rooms_text_stays_parseable_for_a_client_that_split_on_the_old_shapes` still passes.
No field left `?format=json`.

## Cost

The walk now stats a room before deciding whether it may be listed rather than after.
Measured at `MAX_ROOMS=5120` on the original branch, the listable-skip walk against this one
over the same tree (the merged walk also keeps `main`'s per-room window memoization, which
does not touch this stat cost):

| store | before | after |
|---|---|---|
| every room listed | 16.5 ms | 16.2 ms |
| half unlisted | 11.8 ms | 16.4 ms |
| every room unlisted | 7.7 ms | 17.7 ms |

Flat ~16 ms whatever the mix, so the worst case is bounded by what an all-listed store
already cost, which is the figure this overview was sized against
(`WINDOW_BYTES`). On the same response `note_stats` walks up to `MAX_NOTES_TOTAL` note
files at ~12 ms per 4096. The whole view is served from the
`CHAT_ROOMS_CACHE_SECONDS` cache.

## Core size

`app 981 -> 993`, `store 807 -> 813`, `core_total 2035 -> 2051`: +18 core code-lines for a
second measurement in the walk, the `# capacity:` line with its empty-listing branch, plus the
counted-by-caps read the text view renders. This is growth past a cap, so it is a deliberate
ask rather than a silent baseline bump (#62 is the precedent). The cap numbers live in
`sz-baseline.json` now, so they move there; the branch's old `AGENTS.md` cap-number edit is
dropped, because 0.9.x moved those figures out of `AGENTS.md`. If you would rather the caps
not move, the variant that fits under them drops the empty-listing refusal wording and prints
the capacity line unconditionally; say so and I will send that instead.

## Tests

Three new cases in `tests/http/test_rooms.py`, each failing on `main`:

- `test_a_service_held_full_by_unlisted_rooms_does_not_report_itself_empty` fills to
  `MAX_ROOMS` with `p-` rooms and asserts the refusal, then asserts three things: the
  listing still names none of them while the capacity figures count all four, no name,
  size or timestamp appears in either rendering, the invitation to create a room is gone.
- `test_the_byte_budget_half_of_the_capacity_line_counts_unlisted_rooms_too` does the
  same against `MAX_TOTAL_ROOM_BYTES`, since the count is not the disk budget.
- `test_the_capacity_figure_counts_exactly_what_the_cap_counts` pins the pair to
  `store._scan`.

Plus one in `tests/http/test_humans.py` asserting the page's cap comparison and its badge
read the new fields, against the served bytes the way that file's other checks do, plus
extensions to the two existing `/rooms` tests. Verified they fail without the source
change: reverting `src/` leaves 6 failures across those five tests.

## Checks

Rebased onto `main` (`c5cc02f`, 0.9.6) and re-verified:

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report`: 402 passed, 97.57%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] `uv run sz.py --check` and `uv run sz.py --caps`, with the caps above
- [x] `bash examples/beautiful_chat.sh`, plus a live check: three writes to one listable room
      and two `p-` rooms make `/rooms` read `total` 2 and `total_counted_by_caps` 4, with the
      text `# capacity:` line counting all four while naming none of the `p-` rooms
- [x] the contract job: `schemathesis run` against the instance's own `/openapi.json`,
      no issues. Both new fields are in `src/manifest.py`; an earlier draft
      carried a field the response did not always have and the check caught it.
- [x] `uv build --project mcp` + `tests/verify_mcp_dist.py` and `docker build` + the CI smoke:
      not re-run on this rebase, since it changes no `mcp/` or `docker/` file; the capacity
      rendering is exercised by the suite, `beautiful_chat.sh` and the live check above
- [x] Docs that would now be wrong are updated: the manual (`CAPACITY`, `PRIVATE`, the
      `LIST` row), `README.md`, `src/manifest.py`'s `/rooms` schema and description,
      `CHANGELOG.md`. `docs/store.md` regenerated with `scripts/gen_store_doc.py`. The old
      `AGENTS.md` cap-number edit is dropped: 0.9.x keeps those figures in `sz-baseline.json`.
- [x] New surface on a world-writable service: two integers and one rendered line, no new
      route, parameter or persistent state. The disclosure is a room count and a byte
      total with no name in either, discussed above; nothing new is writable, no
      refusal changed.

---

AI assistance (Claude, Anthropic) was used in developing this change. The design, review
and verification were done by the author. Verified locally before submitting: the full
suite at 402 passing with 97.57% branch coverage, ruff check and format, `ty check`, the
core-size gate at the caps stated above, `examples/beautiful_chat.sh`, a live capacity
check, plus the schemathesis contract run against the running service. The MCP and Docker
gates were green on the pre-rebase revision; this rebase changes neither. The benchmark
numbers above were measured on the original branch at `MAX_ROOMS=5120` over one tree.

