### PR TITLE
feat(signer): add private seed-file workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bundle.log
 # `wrangler secret`. It holds a signing key and a bearer token in plaintext; it is never
 # part of a deploy and must never be part of a commit.
 .dev.vars
+/identity.seed
 data/
 dist/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -157,6 +157,20 @@ smaller guarantee than "until the ring forgets"; signatures still prove authorsh
 The text view shows `<z6Mk…2doK>` for a verified writer and `<~nick>` for self-asserted. Full DIDs
 are JSON-only: 50 lines of 56-character identifiers is ~1200 tokens of the agent's context.
 
+The standalone reference signer in `scripts/sign.py` can keep a long-lived seed out of shell
+history and exported environment variables. `keygen --seed-file` creates the file exclusively and
+prints only its path and public DID; later commands read it directly. On POSIX the signer refuses a
+file with group or world permissions:
+
+```bash
+uv run scripts/sign.py keygen --seed-file identity.seed
+uv run scripts/sign.py did --seed-file identity.seed
+```
+
+Protect the file as a private key and back it up securely; on Windows, restrict it with your
+account's file ACLs. The original `--seed` and `SIGN_SEED` inputs remain available for ephemeral and
+externally managed secret workflows.
+
 ## Room classes
 
 A room name is `<class>-…-<body>`, and classes compose by prefix: `mb-p-<random>` is a private

--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -34,20 +34,26 @@ Cc, Cf, Cs, Co, Zl or Zp becomes a space, then the ends are trimmed. Sign the
 raw text and the server answers 403 — by design, so that a stored record can
 be re-verified later against the bytes on disk.
 
-Key material comes from --seed or $SIGN_SEED:
+Key material comes from --seed-file, --seed or $SIGN_SEED:
+  * --seed-file PATH   -> one seed/passphrase line read directly from a private
+                          file, without putting it in argv or the environment
   * 64 hex characters   -> used directly as the 32-byte Ed25519 seed
   * anything else       -> SHA-256 of it (so a passphrase works; weaker than
                            randomness, fine for a demo, not for a identity you
                            care about)
   * neither given       for 'keygen': 32 random bytes, printed so you can reuse
 
+On keygen, --seed-file PATH creates PATH exclusively with a fresh random seed
+and prints only the path and DID. On POSIX, an input seed file must have no
+group or world permissions; `chmod 600 identity.seed` is the normal setting.
+
 Usage:
-  uv run scripts/sign.py keygen
-  uv run scripts/sign.py did      [--seed HEX|PASSPHRASE]
-  uv run scripts/sign.py say      [--seed ...] <room> <nonce> <text>
-  uv run scripts/sign.py set      [--seed ...] <ns> <key> <nonce> <value>
+  uv run scripts/sign.py keygen   [--seed-file PATH]
+  uv run scripts/sign.py did      [--seed-file PATH|--seed HEX|PASSPHRASE]
+  uv run scripts/sign.py say      [--seed-file PATH|--seed ...] <room> <nonce> <text>
+  uv run scripts/sign.py set      [--seed-file PATH|--seed ...] <ns> <key> <nonce> <value>
   uv run scripts/sign.py note     <did:key>
-  uv run scripts/sign.py delegate [--seed ...] <agent-did> <scope> <days> [nonce]
+  uv run scripts/sign.py delegate [--seed-file PATH|--seed ...] <agent-did> <scope> <days> [nonce]
   uv run scripts/sign.py check    <root-did> [file]
 
 'keygen' prints the seed and the did:key. 'did' prints the did:key. 'say' and
@@ -89,6 +95,7 @@ import hashlib
 import os
 import re
 import secrets
+import stat
 import sys
 import time
 import unicodedata
@@ -108,6 +115,7 @@ INVISIBLE_CATEGORIES = ("Cc", "Cf", "Cs", "Co", "Zl", "Zp")
 
 MAX_TEXT_CHARS = 4096  # messages
 MAX_VALUE_CHARS = 8192  # notes
+MAX_SEED_FILE_CHARS = 4096
 
 # A delegation's scope. Deliberately three shapes and no grammar to speak of: this file
 # issues and checks delegations, it does not enforce them, and a scope language richer than
@@ -164,18 +172,60 @@ def multibase(raw: bytes) -> str:
     return out
 
 
-def load_key(seed_arg: str | None) -> tuple[Ed25519PrivateKey, str]:
-    """The Ed25519 key for --seed / $SIGN_SEED, plus a human-readable provenance."""
-    given = seed_arg or os.environ.get("SIGN_SEED")
+def read_seed_file(path: Path) -> str:
+    """Read one private seed/passphrase line without exporting it to child processes."""
+    try:
+        # Opening a FIFO normally blocks before fstat can reject it. Nonblocking open
+        # leaves regular files unchanged and lets the type check refuse special files.
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NONBLOCK", 0))
+        with os.fdopen(descriptor, encoding="utf-8") as source:
+            mode = os.fstat(source.fileno()).st_mode
+            if not stat.S_ISREG(mode):
+                raise SystemExit(f"seed file is not a regular file: {path}")
+            if os.name != "nt" and stat.S_IMODE(mode) & 0o077:
+                raise SystemExit(f"seed file is readable by others; run: chmod 600 {path}")
+            raw = source.read(MAX_SEED_FILE_CHARS + 1)
+    except (OSError, UnicodeError) as exc:
+        raise SystemExit(f"cannot read seed file {path}: {exc}") from exc
+    if len(raw) > MAX_SEED_FILE_CHARS:
+        raise SystemExit(f"seed file is over {MAX_SEED_FILE_CHARS} characters: {path}")
+    given = raw.removesuffix("\n").removesuffix("\r")
+    if not given or "\n" in given or "\r" in given:
+        raise SystemExit(f"seed file must contain exactly one non-empty line: {path}")
+    return given
+
+
+def write_seed_file(path: Path, seed: str) -> None:
+    """Create a private seed file without following or replacing an existing path."""
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except OSError as exc:
+        raise SystemExit(f"cannot create seed file {path}: {exc}") from exc
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as destination:
+            destination.write(seed + "\n")
+            destination.flush()
+            os.fsync(destination.fileno())
+    except OSError as exc:
+        raise SystemExit(f"cannot write seed file {path}: {exc}") from exc
+
+
+def load_key(seed_arg: str | None, seed_file: Path | None = None) -> tuple[Ed25519PrivateKey, str]:
+    """The Ed25519 key for --seed-file / --seed / $SIGN_SEED, plus its provenance."""
+    given = read_seed_file(seed_file) if seed_file is not None else seed_arg
+    given = given or os.environ.get("SIGN_SEED")
     if given is None:
-        raise SystemExit("no key: pass --seed <hex|passphrase> or set $SIGN_SEED")
+        raise SystemExit(
+            "no key: pass --seed-file <path>, --seed <hex|passphrase>, or set $SIGN_SEED"
+        )
+    provenance = f"file:{seed_file}" if seed_file is not None else given
     if len(given) == 64:
         try:
-            return Ed25519PrivateKey.from_private_bytes(bytes.fromhex(given)), given
+            return Ed25519PrivateKey.from_private_bytes(bytes.fromhex(given)), provenance
         except ValueError:
             pass  # 64 chars but not hex — fall through and hash it like any passphrase
     digest = hashlib.sha256(given.encode()).hexdigest()
-    return Ed25519PrivateKey.from_private_bytes(bytes.fromhex(digest)), f"sha256({given!r})"
+    return Ed25519PrivateKey.from_private_bytes(bytes.fromhex(digest)), f"sha256({provenance!r})"
 
 
 def did_of(key: Ed25519PrivateKey) -> str:
@@ -338,10 +388,17 @@ def main() -> None:
     # copy of the option re-defaults the attribute to None AFTER the top-level parse
     # already stored X, silently discarding it (review: PR #54).
     seeded = argparse.ArgumentParser(add_help=False)
-    seeded.add_argument(
+    source = seeded.add_mutually_exclusive_group()
+    source.add_argument(
         "--seed",
         default=argparse.SUPPRESS,
         help="64-hex-char seed, or any string (hashed with SHA-256)",
+    )
+    source.add_argument(
+        "--seed-file",
+        type=Path,
+        default=argparse.SUPPRESS,
+        help="private file containing one seed/passphrase line; keygen creates it",
     )
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0], parents=[seeded])
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -367,11 +424,18 @@ def main() -> None:
     audit.add_argument("root", help="the root did:key the note belongs to")
     audit.add_argument("file", nargs="?", help="note text; reads stdin when absent")
     args = parser.parse_args()
+    if hasattr(args, "seed") and hasattr(args, "seed_file"):
+        parser.error("--seed and --seed-file are mutually exclusive")
 
     if args.cmd == "keygen":
         seed = secrets.token_hex(32)
         key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(seed))
-        print(f"seed: {seed}")
+        seed_file = getattr(args, "seed_file", None)
+        if seed_file is None:
+            print(f"seed: {seed}")
+        else:
+            write_seed_file(seed_file, seed)
+            print(f"seed file: {seed_file}")
         print(f"did:  {did_of(key)}")
         return
 
@@ -391,8 +455,9 @@ def main() -> None:
         raise SystemExit(0 if live else 1)
 
     seed = getattr(args, "seed", None)  # unset when --seed was passed nowhere (SUPPRESS)
+    seed_file = getattr(args, "seed_file", None)
     if args.cmd == "did":
-        key, _ = load_key(seed)
+        key, _ = load_key(seed, seed_file)
         print(did_of(key))
         return
 
@@ -406,7 +471,7 @@ def main() -> None:
         if not DIGITS_RE.fullmatch(nonce):
             raise SystemExit(f"nonce must be 1-19 ASCII digits, got {nonce!r}")
         expires = str(int(time.time()) + int(args.days) * 86400)
-        key, _ = load_key(seed)
+        key, _ = load_key(seed, seed_file)
         root = did_of(key)
         if root == args.agent:
             raise SystemExit("a key cannot delegate to itself — it already acts for itself")
@@ -426,7 +491,7 @@ def main() -> None:
         canonical = f"{args.room}|{args.nonce}|{swept(args.text, MAX_TEXT_CHARS)}"
     else:
         canonical = f"{args.ns}|{args.key}|{args.nonce}|{swept(args.value, MAX_VALUE_CHARS)}"
-    key, _ = load_key(seed)
+    key, _ = load_key(seed, seed_file)
     print(did_of(key))
     print(signature(key, canonical))
 

--- a/tests/http/test_signer.py
+++ b/tests/http/test_signer.py
@@ -9,12 +9,14 @@ those promises and anything a gate ran; these tests are the gate (issue #56).
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
 from pathlib import Path
 
 import _client  # noqa: F401 (imported for the fixture alias below)
+import pytest
 
 import didkey
 
@@ -52,6 +54,143 @@ def test_a_keygen_seed_reproduces_the_did() -> None:
     )
     again = run("did", "--seed", seed)
     assert again.returncode == 0 and again.stdout.strip() == did
+
+
+def test_a_keygen_seed_file_hides_the_seed_and_reproduces_the_did(tmp_path) -> None:
+    seed_file = tmp_path / "identity.seed"
+    out = run("keygen", "--seed-file", str(seed_file))
+    assert out.returncode == 0
+    assert not any(line.startswith("seed: ") for line in out.stdout.splitlines())
+    did = next(
+        line.removeprefix("did:  ") for line in out.stdout.splitlines() if line.startswith("did:  ")
+    )
+
+    before = run("--seed-file", str(seed_file), "did")
+    after = run("did", "--seed-file", str(seed_file))
+    assert before.returncode == 0 and after.returncode == 0
+    assert before.stdout.strip() == after.stdout.strip() == did
+    if os.name != "nt":
+        assert seed_file.stat().st_mode & 0o777 == 0o600
+
+
+def test_keygen_refuses_to_replace_a_seed_file(tmp_path) -> None:
+    seed_file = tmp_path / "identity.seed"
+    first = run("keygen", "--seed-file", str(seed_file))
+    original = seed_file.read_bytes()
+    second = run("keygen", "--seed-file", str(seed_file))
+    assert first.returncode == 0 and second.returncode != 0
+    assert seed_file.read_bytes() == original
+    assert "cannot create seed file" in (second.stdout + second.stderr)
+
+
+def test_a_posix_seed_file_must_be_private(tmp_path) -> None:
+    if os.name == "nt":
+        return
+    seed_file = tmp_path / "identity.seed"
+    seed_file.write_text(SEED + "\n", encoding="utf-8")
+    seed_file.chmod(0o644)
+    out = run("did", "--seed-file", str(seed_file))
+    assert out.returncode != 0
+    assert "chmod 600" in (out.stdout + out.stderr)
+
+
+def test_seed_and_seed_file_are_mutually_exclusive_across_option_orders(tmp_path) -> None:
+    seed_file = tmp_path / "identity.seed"
+    seed_file.write_text(SEED + "\n", encoding="utf-8")
+    out = run("--seed-file", str(seed_file), "did", "--seed", SEED)
+    assert out.returncode != 0
+    assert "mutually exclusive" in (out.stdout + out.stderr)
+
+
+def test_seed_file_signatures_match_the_existing_seed_input(tmp_path) -> None:
+    seed_file = tmp_path / "identity.seed"
+    seed_file.write_text(SEED + "\n", encoding="utf-8")
+    if os.name != "nt":
+        seed_file.chmod(0o600)
+    from_file = run("say", "--seed-file", str(seed_file), "lobby", "7", "hello")
+    from_argument = run("say", "--seed", SEED, "lobby", "7", "hello")
+    assert from_file.returncode == 0 and from_argument.returncode == 0
+    assert from_file.stdout == from_argument.stdout
+
+
+@pytest.mark.parametrize("ending", [b"", b"\n", b"\r\n"])
+def test_seed_file_overrides_environment_and_accepts_line_endings(tmp_path, monkeypatch, ending):
+    seed_file = tmp_path / "identity.seed"
+    seed_file.write_bytes(SEED.encode() + ending)
+    seed_file.chmod(0o600)
+    monkeypatch.setenv("SIGN_SEED", "bb" * 32)
+    out = run("did", "--seed-file", str(seed_file))
+    expected = run("did", "--seed", SEED)
+    assert out.returncode == expected.returncode == 0
+    assert out.stdout == expected.stdout
+    assert SEED not in out.stdout + out.stderr
+
+
+@pytest.mark.parametrize("contents", [b"", b"\n", b"aa\nbb", b"aa\rbb", b"x" * 4097, b"\xff"])
+def test_invalid_seed_file_is_refused_without_environment_fallback(tmp_path, monkeypatch, contents):
+    seed_file = tmp_path / "identity.seed"
+    seed_file.write_bytes(contents)
+    seed_file.chmod(0o600)
+    monkeypatch.setenv("SIGN_SEED", SEED)
+    out = run("did", "--seed-file", str(seed_file))
+    assert out.returncode != 0
+    assert out.stdout == ""
+    assert "seed file" in out.stderr
+    assert SEED not in out.stderr
+
+
+def test_missing_seed_file_is_refused_without_environment_fallback(tmp_path, monkeypatch):
+    monkeypatch.setenv("SIGN_SEED", SEED)
+    out = run("did", "--seed-file", str(tmp_path / "missing.seed"))
+    assert out.returncode != 0
+    assert out.stdout == ""
+    assert "cannot read seed file" in out.stderr
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX FIFO and device semantics")
+def test_nonregular_seed_files_are_refused_without_blocking(tmp_path):
+    fifo = tmp_path / "seed.fifo"
+    os.mkfifo(fifo, 0o600)
+    for path in (str(fifo), os.devnull):
+        out = subprocess.run(
+            [sys.executable, str(SIGNER), "did", "--seed-file", path],
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+            timeout=5,
+        )
+        assert out.returncode != 0
+        assert "not a regular file" in out.stderr
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_keygen_never_replaces_a_symlink_target(tmp_path):
+    target = tmp_path / "existing.seed"
+    target.write_text("keep this key", encoding="utf-8")
+    link = tmp_path / "identity.seed"
+    link.symlink_to(target)
+    out = run("keygen", "--seed-file", str(link))
+    assert out.returncode != 0
+    assert target.read_text(encoding="utf-8") == "keep this key"
+    assert link.is_symlink()
+
+
+def test_seed_file_can_sign_notes_and_delegations(tmp_path):
+    seed_file = tmp_path / "identity.seed"
+    seed_file.write_text(SEED + "\n", encoding="utf-8")
+    seed_file.chmod(0o600)
+    note = run("set", "--seed-file", str(seed_file), "room-owners", "example", "9", "owner")
+    assert note.returncode == 0, note.stderr
+    root, sig = note.stdout.splitlines()
+    didkey.verify(root, sig, "room-owners|example|9|owner")
+
+    agent = run("did", "--seed", "bb" * 32).stdout.strip()
+    out = run("delegate", "--seed-file", str(seed_file), agent, "r:example", "1", "10")
+    assert out.returncode == 0, out.stderr
+    record = next(line for line in out.stdout.splitlines() if line.startswith("delegate:"))
+    _, actual_agent, scope, expires, nonce, signature = record.split()
+    assert actual_agent == agent and scope == "r:example" and nonce == "10"
+    didkey.verify(root, signature, f"delegate|{root}|{agent}|{scope}|{expires}|{nonce}")
 
 
 def test_nonces_are_rejected_exactly_where_the_server_would_reject() -> None:


### PR DESCRIPTION
## What

Adds `--seed-file PATH` to the standalone signer. `keygen` creates a private seed and prints only its path and DID; `did`, `say`, `set`, and `delegate` read it directly. Existing seed inputs remain supported.

## Why

Long-lived seeds otherwise appear in arguments, environment variables, or terminal output. Reads enforce POSIX permissions, bounded input, and regular files.

Creation syncs a private staging file before create-only publication. POSIX syncs the parent directory before success; Windows requests a write-through move. Existing identities are preserved. Post-publication storage failures retain the complete key and report uncertain durability. Windows users must restrict the parent directory's ACLs first.

Continues #81, retained over #79/#89. Head: `d2408a46cc95cf0680411e677735695674cc17b4`; base: `20a4457b89ba11254f4aa48217b066884a148d98`.

## Checks

- [x] Linux `uv sync --frozen` / `uv run just check`: 800 passed, 3 skipped; 97.90% repository coverage. Lint, formatting, types, caps passed.
- [x] Windows signer: 29 passed, 6 POSIX skips, 3 Linux server cases excluded.
- [x] Four regressions fail before the fix and pass afterward.
- [x] Documentation updated; generated files untouched.
- [x] New world-writable surface: nothing new; local CLI only.

[Hosted CI](https://github.com/flop-labs/technocore-chat/actions/runs/34754523189) requires maintainer action; queue-guard passed. Local results are separate from hosted CI.
