### PR TITLE
docs(openapi): publish the size warning on say-signed's {text} param

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -109,6 +109,24 @@ _SIG_SCHEMA = {
 _TEXT_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_TEXT_CHARS}
 _VALUE_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_VALUE_CHARS}
 
+# The `{text}` path param, hoisted because both URL write lanes carry it and only one
+# described it. The description is the size warning, and the signed lane is the lane that
+# needs it most: its DID, signature and nonce sit in the path ahead of the text, so it has
+# strictly less URL budget than the unsigned lane that used to carry the warning alone. A
+# `maxLength` that no non-Latin caller can reach is the only machine-readable thing it said
+# about size; one copy, published on both lanes, is the contract.
+_TEXT_PATH_PARAM = {
+    "in": "path",
+    "name": "text",
+    "required": True,
+    "schema": _TEXT_SCHEMA,
+    "description": (
+        "URL-encoded message body. The URL is the size limit in practice: "
+        f"{store.MAX_TEXT_CHARS} ASCII characters fit, one CJK character is 9 bytes "
+        "encoded — use POST for long non-Latin text."
+    ),
+}
+
 _NONCE_SCHEMA = {
     "type": "string",
     "pattern": f"^{didkey.NONCE_PATTERN}$",
@@ -448,17 +466,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     "parameters": [
                         {**_NAME_PARAM, "name": "room"},
                         {**_NAME_PARAM, "name": "nick"},
-                        {
-                            "in": "path",
-                            "name": "text",
-                            "required": True,
-                            "schema": _TEXT_SCHEMA,
-                            "description": (
-                                "URL-encoded message body. The URL is the size limit in "
-                                f"practice: {store.MAX_TEXT_CHARS} ASCII characters fit, one CJK character is "
-                                "9 bytes encoded — use POST for long non-Latin text."
-                            ),
-                        },
+                        _TEXT_PATH_PARAM,
                     ],
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),
@@ -489,12 +497,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         {"in": "path", "name": "did", "required": True, "schema": _DID_SCHEMA},
                         {"in": "path", "name": "sig", "required": True, "schema": _SIG_SCHEMA},
                         {"in": "path", "name": "nonce", "required": True, "schema": _NONCE_SCHEMA},
-                        {
-                            "in": "path",
-                            "name": "text",
-                            "required": True,
-                            "schema": _TEXT_SCHEMA,
-                        },
+                        _TEXT_PATH_PARAM,
                     ],
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -760,6 +760,15 @@ def test_openapi_limits_are_the_limits_the_server_enforces(client):
     assert body_limit in doc["paths"]["/kv/{ns}/{key}"]["post"]["responses"]["413"]["description"]
     room = next(p for p in say["parameters"] if p["name"] == "room")
     assert room["schema"]["pattern"] == store.NAME_RE.pattern
+    # Both URL write lanes carry `{text}`, and the signed lane has strictly less URL budget
+    # (its did/sig/nonce sit ahead of the text) — so it must publish the same size warning
+    # and maxLength, not a bare schema. One copy on both lanes, or the weaker one is the
+    # contract a client is built against.
+    signed = doc["paths"]["/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}"]["get"]
+    signed_text = next(p for p in signed["parameters"] if p["name"] == "text")
+    assert signed_text["schema"]["maxLength"] == store.MAX_TEXT_CHARS
+    assert signed_text.get("description") == text_param.get("description")
+    assert "use POST for long non-Latin text" in signed_text["description"]
     # …and the version comes from the file that declares it, not a second copy.
     pyproject = (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text()
     assert doc["info"]["version"] in pyproject


### PR DESCRIPTION
The two URL write lanes carry the same `{text}` path segment, but only one described it. `/r/{room}/say/{nick}/{text}` publishes the practical size budget — "the URL is the size limit in practice: 4096 ASCII characters fit, one CJK character is 9 bytes encoded — use POST for long non-Latin text" — while `/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}` published a bare schema with no description at all.

That is backwards. The signed lane has strictly *less* URL budget than the unsigned one: a 56-character DID, an 86-character signature and a nonce all sit in the path ahead of the text. It is the lane where a caller is most likely to build a URL that no proxy will carry, and it was the lane that said nothing about it. A code generator reads `maxLength: 4096` as a promise that 4096 characters of any script fit; on this lane that is further from true than anywhere else in the document.

The fix is the same one the `did`/`sig`/`nonce` schemas already got in this file: one definition, published everywhere the field appears. `_TEXT_PATH_PARAM` is hoisted next to `_TEXT_SCHEMA` and used by both lanes, so the two cannot drift into two different strengths again — which is how the weakest copy became the real contract last time.

No behaviour change; the served surface is unchanged apart from the added description.

## Verification

`test_openapi_limits_are_the_limits_the_server_enforces` is extended to assert the signed lane`s text param publishes the same `maxLength` **and** the same description as the unsigned lane, rather than checking the unsigned lane alone. It fails on `main`:

```
E       AssertionError: assert None == "URL-encoded message body. The URL is the size limit in practice: ..."
```

Full suite, `uv run --group dev python -m pytest tests`:

```
321 passed in 131.78s (0:02:11)
```

`ruff check src/manifest.py tests/http/test_docs.py` — All checks passed.