### PR TITLE
fix(manifest): reject out-of-range ports

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -36,7 +36,7 @@ SOURCE_URL = "https://github.com/flop-labs/technocore-chat"
 # dropped and the documents fall back to relative URLs, which are legal in both formats
 # and still correct for whoever fetched them. Operators who want absolute URLs guaranteed
 # set CHAT_PUBLIC_URL.
-_HOST_RE = re.compile(r"^[a-z0-9]([a-z0-9.-]{0,253}[a-z0-9])?(:[0-9]{1,5})?$")
+_HOST_RE = re.compile(r"^[a-z0-9](?:[a-z0-9.-]{0,253}[a-z0-9])?(?::([0-9]{1,5}))?$")
 
 SUMMARY = (
     "HTTP-native rendezvous, chat and notes for LLM agents. Every operation — including "
@@ -56,8 +56,12 @@ def public_base(scheme: str, host: str, configured: str = "") -> str:
     """
     if configured:
         return configured.rstrip("/")
-    if host and _HOST_RE.match(host.lower()) and scheme in ("http", "https"):
-        return f"{scheme}://{host.lower()}"
+    normalized = host.lower()
+    match = _HOST_RE.fullmatch(normalized) if host else None
+    if match and scheme in ("http", "https"):
+        port = match.group(1)
+        if port is None or int(port) <= 65535:
+            return f"{scheme}://{normalized}"
     return ""
 
 

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1149,3 +1149,11 @@ def test_the_ai_catalog_lists_only_artifacts_that_resolve(client):
         assert entry["identifier"] and entry["type"] and entry["url"]
         path = entry["url"].split("testserver", 1)[-1] or "/"
         assert client.get(path).status_code == 200, f"{entry['identifier']} -> {path}"
+
+
+def test_public_base_rejects_out_of_range_ports():
+    import manifest
+
+    assert manifest.public_base("https", "example.com:65535") == "https://example.com:65535"
+    assert manifest.public_base("https", "example.com:65536") == ""
+    assert manifest.public_base("https", "example.com:99999") == ""


### PR DESCRIPTION
`public_base()` accepted five-digit ports without checking whether they were in the valid port range, so values such as `:65536` and `:99999` could end up in generated absolute URLs.

This keeps `:65535` valid and rejects out-of-range ports.

Tests:
- `uv run pytest -q` — 322 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
