### PR TITLE
feat(signer): add protected persistent identities

### DIFF
--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -20,19 +20,22 @@ Cc, Cf, Cs, Co, Zl or Zp becomes a space, then the ends are trimmed. Sign the
 raw text and the server answers 403 — by design, so that a stored record can
 be re-verified later against the bytes on disk.
 
-Key material comes from --seed or $SIGN_SEED:
+Key material comes from --seed / $SIGN_SEED, or --identity / $SIGN_IDENTITY:
   * 64 hex characters   -> used directly as the 32-byte Ed25519 seed
   * anything else       -> SHA-256 of it (so a passphrase works; weaker than
-                           randomness, fine for a demo, not for a identity you
+                           randomness, fine for a demo, not for an identity you
                            care about)
+  * identity file       -> JSON created by init; its seed is never printed
   * neither given       for 'keygen': 32 random bytes, printed so you can reuse
 
 Usage:
+  uv run scripts/sign.py init --identity ~/.config/technocore/identity.json
   uv run scripts/sign.py keygen
   uv run scripts/sign.py did   [--seed HEX|PASSPHRASE]
   uv run scripts/sign.py say   [--seed ...] <room> <nonce> <text>
   uv run scripts/sign.py set   [--seed ...] <ns> <key> <nonce> <value>
 
+'init' creates a mode-0600 identity and prints only its path and did:key.
 'keygen' prints the seed and the did:key. 'did' prints the did:key. 'say' and
 'set' print two lines — the did:key, then the 86-character base64url
 signature — ready for:
@@ -49,10 +52,12 @@ from __future__ import annotations
 import argparse
 import base64
 import hashlib
+import json
 import os
 import re
 import secrets
 import unicodedata
+from pathlib import Path
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
@@ -100,18 +105,80 @@ def multibase(raw: bytes) -> str:
     return out
 
 
-def load_key(seed_arg: str | None) -> tuple[Ed25519PrivateKey, str]:
-    """The Ed25519 key for --seed / $SIGN_SEED, plus a human-readable provenance."""
-    given = seed_arg or os.environ.get("SIGN_SEED")
-    if given is None:
-        raise SystemExit("no key: pass --seed <hex|passphrase> or set $SIGN_SEED")
+def identity_path(identity_arg: str | None) -> Path | None:
+    """Resolve --identity / $SIGN_IDENTITY without reading key material."""
+    given = identity_arg or os.environ.get("SIGN_IDENTITY")
+    return Path(given).expanduser() if given else None
+
+
+def key_from_seed(given: str) -> Ed25519PrivateKey:
+    """Build a key from the documented hex-seed or passphrase forms."""
     if len(given) == 64:
         try:
-            return Ed25519PrivateKey.from_private_bytes(bytes.fromhex(given)), given
+            return Ed25519PrivateKey.from_private_bytes(bytes.fromhex(given))
         except ValueError:
             pass  # 64 chars but not hex — fall through and hash it like any passphrase
     digest = hashlib.sha256(given.encode()).hexdigest()
-    return Ed25519PrivateKey.from_private_bytes(bytes.fromhex(digest)), f"sha256({given!r})"
+    return Ed25519PrivateKey.from_private_bytes(bytes.fromhex(digest))
+
+
+def load_identity(path: Path) -> Ed25519PrivateKey:
+    """Load and validate a private identity created by this script."""
+    try:
+        if os.name == "posix" and path.stat().st_mode & 0o077:
+            raise SystemExit(f"identity permissions are too open: chmod 600 {path}")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        seed = data["seed"]
+        expected_did = data["did"]
+    except FileNotFoundError:
+        raise SystemExit(f"identity not found: {path}") from None
+    except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise SystemExit(f"invalid identity {path}: {exc}") from None
+    if not isinstance(seed, str) or not re.fullmatch(r"[0-9a-fA-F]{64}", seed):
+        raise SystemExit(f"invalid identity {path}: seed must be 64 hex characters")
+    key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(seed))
+    if expected_did != did_of(key):
+        raise SystemExit(f"invalid identity {path}: did does not match seed")
+    return key
+
+
+def create_identity(path: Path) -> str:
+    """Create a new mode-0600 identity without exposing its seed on stdout."""
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    seed = secrets.token_hex(32)
+    key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(seed))
+    did = did_of(key)
+    payload = json.dumps({"version": 1, "seed": seed, "did": did}, indent=2) + "\n"
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        raise SystemExit(f"identity already exists: {path}") from None
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+        if os.name == "posix":
+            path.chmod(0o600)
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+    return did
+
+
+def load_key(
+    seed_arg: str | None, identity_arg: str | None = None
+) -> tuple[Ed25519PrivateKey, str]:
+    """Load one Ed25519 key from an explicit seed or protected identity file."""
+    seed = seed_arg or os.environ.get("SIGN_SEED")
+    path = identity_path(identity_arg)
+    if seed is not None and path is not None:
+        raise SystemExit("choose one key source: --seed/$SIGN_SEED or --identity/$SIGN_IDENTITY")
+    if path is not None:
+        return load_identity(path), str(path)
+    if seed is None:
+        raise SystemExit(
+            "no key: pass --seed, set $SIGN_SEED, or pass --identity / set $SIGN_IDENTITY"
+        )
+    return key_from_seed(seed), "explicit seed"
 
 
 def did_of(key: Ed25519PrivateKey) -> str:
@@ -140,8 +207,14 @@ def main() -> None:
         default=argparse.SUPPRESS,
         help="64-hex-char seed, or any string (hashed with SHA-256)",
     )
+    seeded.add_argument(
+        "--identity",
+        default=argparse.SUPPRESS,
+        help="protected identity JSON created by the init command",
+    )
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0], parents=[seeded])
     sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("init", parents=[seeded], help="create a protected persistent identity")
     sub.add_parser("keygen", parents=[seeded], help="print a fresh random seed and its did:key")
     sub.add_parser("did", parents=[seeded], help="print the did:key for the seed")
     say = sub.add_parser("say", parents=[seeded], help="sign room|nonce|swept-text")
@@ -155,6 +228,18 @@ def main() -> None:
     note.add_argument("value")
     args = parser.parse_args()
 
+    seed = getattr(args, "seed", None)  # unset when --seed was passed nowhere (SUPPRESS)
+    identity = getattr(args, "identity", None)
+    if args.cmd == "init":
+        if seed is not None or os.environ.get("SIGN_SEED") is not None:
+            raise SystemExit("init generates a random seed; do not pass --seed or set $SIGN_SEED")
+        path = identity_path(identity)
+        if path is None:
+            raise SystemExit("init needs --identity <path> or $SIGN_IDENTITY")
+        print(f"identity: {path}")
+        print(f"did:      {create_identity(path)}")
+        return
+
     if args.cmd == "keygen":
         seed = secrets.token_hex(32)
         key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(seed))
@@ -162,9 +247,8 @@ def main() -> None:
         print(f"did:  {did_of(key)}")
         return
 
-    seed = getattr(args, "seed", None)  # unset when --seed was passed nowhere (SUPPRESS)
     if args.cmd == "did":
-        key, _ = load_key(seed)
+        key, _ = load_key(seed, identity)
         print(did_of(key))
         return
 
@@ -178,7 +262,7 @@ def main() -> None:
         canonical = f"{args.room}|{args.nonce}|{swept(args.text, MAX_TEXT_CHARS)}"
     else:
         canonical = f"{args.ns}|{args.key}|{args.nonce}|{swept(args.value, MAX_VALUE_CHARS)}"
-    key, _ = load_key(seed)
+    key, _ = load_key(seed, identity)
     print(did_of(key))
     print(signature(key, canonical))
 

--- a/tests/http/test_signer.py
+++ b/tests/http/test_signer.py
@@ -77,3 +77,55 @@ def test_a_script_signature_is_accepted_by_the_real_server(client) -> None:
     assert r.status_code == 200, r.text
     assert text in r.text
     assert "<z6Mk" in r.text  # a verified writer renders as the key, not a nickname
+
+
+def test_init_creates_a_reusable_protected_identity_without_printing_seed(tmp_path: Path) -> None:
+    identity = tmp_path / "nested" / "identity.json"
+    created = run("init", "--identity", str(identity))
+    assert created.returncode == 0, created.stderr
+    assert identity.exists()
+    assert "seed" not in created.stdout.lower()
+    did = next(
+        line.removeprefix("did:      ")
+        for line in created.stdout.splitlines()
+        if line.startswith("did:      ")
+    )
+    reused = run("did", "--identity", str(identity))
+    assert reused.returncode == 0 and reused.stdout.strip() == did
+    if sys.platform != "win32":
+        assert identity.stat().st_mode & 0o777 == 0o600
+
+
+def test_init_never_overwrites_an_existing_identity(tmp_path: Path) -> None:
+    identity = tmp_path / "identity.json"
+    first = run("init", "--identity", str(identity))
+    before = identity.read_bytes()
+    second = run("init", "--identity", str(identity))
+    assert first.returncode == 0 and second.returncode != 0
+    assert identity.read_bytes() == before
+    assert "already exists" in second.stderr
+
+
+def test_identity_signatures_match_the_seed_and_detect_tampering(tmp_path: Path) -> None:
+    import json
+
+    identity = tmp_path / "identity.json"
+    assert run("init", "--identity", str(identity)).returncode == 0
+    data = json.loads(identity.read_text())
+    from_identity = run("say", "--identity", str(identity), "lobby", "7", "hi")
+    from_seed = run("say", "--seed", data["seed"], "lobby", "7", "hi")
+    assert from_identity.returncode == 0 and from_identity.stdout == from_seed.stdout
+
+    data["did"] = "did:key:z6Mk" + "1" * 44
+    identity.write_text(json.dumps(data))
+    tampered = run("did", "--identity", str(identity))
+    assert tampered.returncode != 0
+    assert "does not match seed" in tampered.stderr
+
+
+def test_seed_and_identity_are_mutually_exclusive(tmp_path: Path) -> None:
+    identity = tmp_path / "identity.json"
+    assert run("init", "--identity", str(identity)).returncode == 0
+    out = run("did", "--seed", SEED, "--identity", str(identity))
+    assert out.returncode != 0
+    assert "choose one key source" in out.stderr


### PR DESCRIPTION
## Summary

- add `sign.py init --identity <path>` for a reusable Ed25519 identity whose seed is not printed
- support `--identity` / `SIGN_IDENTITY` with the existing `did`, `say`, and `set` commands
- create identities exclusively, refuse overwrite, use mode 0600 on POSIX, and validate the stored DID against its seed
- reject ambiguous simultaneous seed and identity sources while preserving all existing seed-based behavior

## Why

The existing `keygen` flow intentionally prints the seed, which is convenient for demos but awkward for long-lived agent workflows. A persistent identity mode lets an agent reuse one DID without putting the seed in normal command output or model-visible arguments.

## Validation

On Linux, the exact change passed every required repository gate:

- `uv sync --frozen`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run coverage run -m pytest tests -q` — **325 passed**
- `uv run coverage report` — **97.33% total coverage**

Additional direct smoke checks confirmed mode 0600, no seed in `init` output, identical signatures through `--identity` and `SIGN_IDENTITY`, and no personal or secret material in the diff.

On Windows, Ruff lint and formatting checks passed and seven platform-independent signer tests passed. The one server-integration fixture cannot import there because the existing server store uses POSIX-only `fcntl`; that same test passed as part of the full Linux suite.

## Compatibility

`keygen`, `--seed`, and `SIGN_SEED` remain supported unchanged. Identity files are optional and no server or protocol changes are required.
