### PR TITLE
fix(mcp): reject non-finite JSON numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ of the contract, not an implementation detail: agents parse it.
 
 ### Fixed
 
+- **The MCP stdio transport now rejects `NaN` and infinite numbers as invalid JSON.** Python's
+  decoder accepts those tokens by default, which let non-finite tool arguments pass an advertised
+  `number` schema and reach a handler. Direct calls receive `INVALID_PARAMS` as a second guard.
+
 - **The MCP wheel and source distribution carry the Apache-2.0 legal files they declare.**
   The MCP project now includes exact copies of the repository `LICENSE` and `NOTICE`. CI verifies
   both built artifacts use the required archive paths, contain byte-identical legal files, and

--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import math
 import sys
 import types
 from collections.abc import Callable
@@ -147,8 +148,12 @@ _CHECKS: dict[str, Callable[[Any], bool]] = {
     "boolean": lambda value: isinstance(value, bool),
     "integer": lambda value: isinstance(value, int) and not isinstance(value, bool),
     # JSON has one number type, so an integer is a number and `seconds: 0` is valid. A bool
-    # is not a number here for the same reason it is not an id.
-    "number": lambda value: isinstance(value, (int, float)) and not isinstance(value, bool),
+    # is not a number here for the same reason it is not an id. JSON also has no spelling
+    # for non-finite floats, even though Python's decoder accepts them by default.
+    "number": lambda value: (
+        (isinstance(value, int) and not isinstance(value, bool))
+        or (isinstance(value, float) and math.isfinite(value))
+    ),
 }
 
 
@@ -362,6 +367,11 @@ class Server:
 
     # ------------------------------------------------------------------ transport
 
+    @staticmethod
+    def _reject_json_constant(value: str) -> None:
+        """Keep Python's permissive decoder inside JSON's actual number grammar."""
+        raise json.JSONDecodeError(f"{value} is not permitted in JSON", value, 0)
+
     def serve(self, stdin: TextIO | None = None, stdout: TextIO | None = None) -> None:
         """Newline-delimited JSON-RPC on stdio, the transport every MCP client supports.
 
@@ -375,7 +385,7 @@ class Server:
             if not line:
                 continue
             try:
-                message = json.loads(line)
+                message = json.loads(line, parse_constant=self._reject_json_constant)
             except json.JSONDecodeError as exc:
                 _write(stdout, _error(None, PARSE_ERROR, f"invalid JSON: {exc}"))
                 continue

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -443,6 +443,19 @@ def test_an_integer_is_an_acceptable_number(mcp):
         assert "no new messages" in text_of(reply)
 
 
+@pytest.mark.parametrize("seconds", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_numbers_are_rejected_before_the_tool_runs(mcp, monkeypatch, seconds):
+    server, protocol = mcp
+
+    def never(request, timeout=None):
+        pytest.fail("invalid tool arguments reached the network")
+
+    monkeypatch.setattr(urllib.request, "urlopen", never)
+    reply = call(server, "wait_for_message", {"room": "lobby", "since": 0, "seconds": seconds})
+    assert reply["error"]["code"] == protocol.INVALID_PARAMS
+    assert "seconds" in reply["error"]["message"]
+
+
 def test_an_integral_float_is_an_acceptable_integer(mcp, monkeypatch):
     """JSON Schema reads `integer` by value, not by spelling, so `1.0` satisfies the schema
     this server advertised and a client that validated locally against it must not then be
@@ -598,6 +611,23 @@ def test_malformed_json_does_not_kill_the_session(mcp):
     replies = [json.loads(line) for line in stdout.getvalue().splitlines()]
     assert replies[0]["error"]["code"] == protocol.PARSE_ERROR
     assert replies[1] == {"jsonrpc": "2.0", "id": 9, "result": {}}
+
+
+def test_non_finite_number_tokens_are_invalid_json_and_do_not_kill_the_session(mcp):
+    server, protocol = mcp
+    bad = ["NaN", "Infinity", "-Infinity"]
+    template = (
+        '{"jsonrpc":"2.0","id":1,"method":"tools/call",'
+        '"params":{"name":"wait_for_message","arguments":{"seconds":VALUE}}}'
+    )
+    lines = [template.replace("VALUE", value) for value in bad]
+    lines.append('{"jsonrpc":"2.0","id":9,"method":"ping"}')
+    stdout = io.StringIO()
+    server.serve(io.StringIO("\n".join(lines) + "\n"), stdout)
+
+    replies = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert [reply["error"]["code"] for reply in replies[:3]] == [protocol.PARSE_ERROR] * 3
+    assert replies[3] == {"jsonrpc": "2.0", "id": 9, "result": {}}
 
 
 # ------------------------------------------------------------------ packaging


### PR DESCRIPTION
## Summary

- reject NaN, Infinity, and -Infinity at the MCP stdio JSON boundary
- reject non-finite floats passed directly to number-typed tool arguments before handlers or network calls
- keep the stdio session alive after returning a JSON-RPC parse error
- add regression coverage for both raw wire input and direct tool calls

## Why

Python's JSON decoder accepts non-standard numeric constants by default. That allowed an MCP request containing seconds: NaN to satisfy the advertised number schema and reach a handler, even though RFC 8259 does not permit those tokens.

The parser is now strict at the wire boundary, while schema validation provides a second guard for callers that invoke Server.handle directly.

## Verification

- uv sync --frozen
- uv run ruff check .
- uv run ruff format --check .
- uv run ty check
- uv run coverage run -m pytest tests -q: 325 passed
- uv run coverage report: 97.33% branch coverage
- uv run sz.py --check
- uv build --project mcp

## Compatibility and abuse impact

Ordinary integer and finite floating-point arguments are unchanged. Invalid wire tokens now receive PARSE_ERROR; direct non-finite arguments receive INVALID_PARAMS. No HTTP route, persistent state, rate-limit behavior, or other public service surface changes, so there is no new abuse impact.

Related issues: none. Dependencies: none. Open PR #78 also handles NaN, but only in HTTP Accept q-values; this change is limited to the MCP JSON transport and tool-schema validator.