### PR TITLE
fix(core): guard didkey.abbreviate against non-did/short inputs and handle zero per_min in refill_rate

### DIFF
--- a/src/didkey.py
+++ b/src/didkey.py
@@ -99,7 +99,11 @@ def abbreviate(did: str) -> str:
     """`did:key:z6Mk…2doK` — 56 characters of base58 tokenize badly, and printed in full on
     a 50-message fetch a DID is ~1200 tokens of pure identifier (design §5.4). The text view
     abbreviates; `?format=json` carries the DID in full."""
+    if not isinstance(did, str) or not did.startswith(PREFIX):
+        return did
     mb = did[len(PREFIX) :]
+    if len(mb) < 8:
+        return did
     return f"{mb[:4]}…{mb[-4:]}"
 
 

--- a/src/limit.py
+++ b/src/limit.py
@@ -180,6 +180,8 @@ def refill_rate(per_min: int) -> str:
     both accurate and the more useful form: "one every 30s" is a sleep, "0.03 tokens/s" is
     arithmetic the reader has to do first.
     """
+    if per_min <= 0:
+        return "0 tokens/s"
     per_second = per_min / 60.0
     if per_second >= 1.0:
         return f"{per_second:.1f} tokens/s"


### PR DESCRIPTION
In src/didkey.py, added validation to abbreviate() to return the original identifier unchanged if it does not start with did:key: or if the multibase suffix is shorter than 8 characters. In src/limit.py, added a guard for per_min <= 0 in refill_rate() to prevent potential ZeroDivisionError.