### PR TITLE
fix(mcp): accept None for optional non-required arguments in _validate and clamp wait seconds

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -237,6 +237,9 @@ def _validate(arguments: dict[str, Any], schema: dict[str, Any]) -> dict[str, An
         raise _BadParamsError(f"missing arguments: {', '.join(sorted(missing))}")
     checked: dict[str, Any] = {}
     for name, value in arguments.items():
+        if value is None and name not in schema.get("required", ()):
+            checked[name] = None
+            continue
         expected = properties[name]
         kind = expected["type"]
         if kind == "integer" and isinstance(value, float) and value.is_integer():

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -128,7 +128,7 @@ def wait_for_message(
         float, f"How long to hold, 0-{WAIT_CEILING:g}. Default {WAIT_CEILING:g}."
     ] = WAIT_CEILING,
 ) -> str:
-    return _fetch(f"/r/{_segment(room)}", {"since": since, "wait": min(seconds, WAIT_CEILING)})
+    return _fetch(f"/r/{_segment(room)}", {"since": since, "wait": max(0.0, min(float(seconds), WAIT_CEILING))})
 
 
 @server.tool(

--- a/tests/test_mcp_falsey_params.py
+++ b/tests/test_mcp_falsey_params.py
@@ -22,3 +22,31 @@ def test_falsey_non_object_params_are_rejected(params):
             "message": "params must be an object",
         },
     }
+
+
+def test_null_optional_params_are_accepted():
+    """Optional arguments passed explicitly as null/None must be accepted."""
+    from technocore_mcp import protocol
+
+    server = protocol.Server("test", "0")
+
+    @server.tool("test_tool", "A test tool")
+    def test_tool(room: str, since: int | None = None) -> str:
+        return f"room={room} since={since}"
+
+    reply = server.handle(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "test_tool", "arguments": {"room": "general", "since": None}},
+        }
+    )
+    assert reply == {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "result": {
+            "content": [{"type": "text", "text": "room=general since=None"}],
+            "isError": False,
+        },
+    }


### PR DESCRIPTION
In mcp/src/technocore_mcp/protocol.py, updated _validate() to permit explicit None/null values for arguments not listed in the schema's required list (e.g. since: None, limit: None from clients sending default object keys). In mcp/src/technocore_mcp/server.py, clamped wait seconds to [0.0, WAIT_CEILING]. Added unit tests.