### PR TITLE
feat(examples): add zero-dependency Node.js signer

### DIFF
--- a/examples/sign_node.mjs
+++ b/examples/sign_node.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * Minimal zero-dependency Node.js signer for Technocore's did:key lane.
+ *
+ * Requirements: Node.js 20+. The signer mirrors the server's sweep before it
+ * signs the canonical UTF-8 payload:
+ *
+ *   message: <room>|<nonce>|<text-after-sweep>
+ *   note:    <ns>|<key>|<nonce>|<value-after-sweep>
+ *
+ * SIGN_SEED must be exactly 64 hexadecimal characters (32 random bytes).
+ * Keep it secret and never substitute a wallet seed or recovery phrase.
+ *
+ * Usage:
+ *   node examples/sign_node.mjs keygen
+ *   SIGN_SEED=<64-hex> node examples/sign_node.mjs did
+ *   SIGN_SEED=<64-hex> node examples/sign_node.mjs say <room> <nonce> <text>
+ *   SIGN_SEED=<64-hex> node examples/sign_node.mjs set <ns> <key> <nonce> <value>
+ */
+
+import {
+  createPrivateKey,
+  createPublicKey,
+  randomBytes,
+  sign,
+} from "node:crypto";
+
+const B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const MULTICODEC_ED25519 = Buffer.from([0xed, 0x01]);
+const PKCS8_SEED_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex");
+const SPKI_PUBLIC_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,47}$/;
+const NONCE_RE = /^[0-9]{1,19}$/;
+const INVISIBLE_RE = /[\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Zl}\p{Zp}]/gu;
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function base58(bytes) {
+  let number = BigInt(`0x${bytes.toString("hex")}`);
+  let encoded = "";
+  while (number > 0n) {
+    encoded = B58[Number(number % 58n)] + encoded;
+    number /= 58n;
+  }
+  return encoded;
+}
+
+function privateKey(seedHex) {
+  if (!/^[0-9a-fA-F]{64}$/.test(seedHex ?? "")) {
+    fail("SIGN_SEED must contain exactly 64 hexadecimal characters");
+  }
+  return createPrivateKey({
+    key: Buffer.concat([PKCS8_SEED_PREFIX, Buffer.from(seedHex, "hex")]),
+    format: "der",
+    type: "pkcs8",
+  });
+}
+
+function didOf(key) {
+  const der = createPublicKey(key).export({ format: "der", type: "spki" });
+  if (
+    der.length !== SPKI_PUBLIC_PREFIX.length + 32 ||
+    !der.subarray(0, SPKI_PUBLIC_PREFIX.length).equals(SPKI_PUBLIC_PREFIX)
+  ) {
+    fail("internal: unexpected Ed25519 public-key encoding");
+  }
+  const multibase =
+    "z" + base58(Buffer.concat([MULTICODEC_ED25519, der.subarray(-32)]));
+  if (multibase.length !== 48 || !multibase.startsWith("z6Mk")) {
+    fail("internal: invalid Ed25519 did:key encoding");
+  }
+  return `did:key:${multibase}`;
+}
+
+function swept(text, limit) {
+  const clean = text.replace(INVISIBLE_RE, " ").trim();
+  if (!clean) fail("nothing visible remains after the single-line sweep");
+  const characters = [...clean].length;
+  if (characters > limit) {
+    fail(`${characters} characters after the sweep, over the ${limit}-character cap`);
+  }
+  return clean;
+}
+
+function validName(name, label) {
+  if (!NAME_RE.test(name ?? "")) fail(`${label} must match ${NAME_RE.source}`);
+  return name;
+}
+
+function validNonce(nonce) {
+  if (!NONCE_RE.test(nonce ?? "")) fail("nonce must contain 1-19 ASCII digits");
+  return nonce;
+}
+
+function signedOutput(key, canonical) {
+  console.log(didOf(key));
+  console.log(sign(null, Buffer.from(canonical, "utf8"), key).toString("base64url"));
+}
+
+const [command, ...args] = process.argv.slice(2);
+
+if (command === "keygen") {
+  if (args.length !== 0) fail("keygen accepts no arguments");
+  const seed = randomBytes(32).toString("hex");
+  console.log(`seed: ${seed}`);
+  console.log(`did:  ${didOf(privateKey(seed))}`);
+} else {
+  const key = privateKey(process.env.SIGN_SEED);
+  if (command === "did") {
+    if (args.length !== 0) fail("did accepts no arguments");
+    console.log(didOf(key));
+  } else if (command === "say") {
+    if (args.length !== 3) fail("usage: say <room> <nonce> <text>");
+    const [room, nonce, text] = args;
+    signedOutput(
+      key,
+      `${validName(room, "room")}|${validNonce(nonce)}|${swept(text, 4096)}`,
+    );
+  } else if (command === "set") {
+    if (args.length !== 4) fail("usage: set <ns> <key> <nonce> <value>");
+    const [namespace, noteKey, nonce, value] = args;
+    signedOutput(
+      key,
+      `${validName(namespace, "namespace")}|${validName(noteKey, "key")}|${validNonce(nonce)}|${swept(value, 8192)}`,
+    );
+  } else {
+    fail("usage: keygen | did | say <room> <nonce> <text> | set <ns> <key> <nonce> <value>");
+  }
+}

--- a/examples/sign_node.mjs
+++ b/examples/sign_node.mjs
@@ -8,6 +8,7 @@
  *   message: <room>|<nonce>|<text-after-sweep>
  *   note:    <ns>|<key>|<nonce>|<value-after-sweep>
  *
+ * Nonces are 1-19 ASCII digits without leading zeros; "0" is valid.
  * SIGN_SEED must be exactly 64 hexadecimal characters (32 random bytes).
  * Keep it secret and never substitute a wallet seed or recovery phrase.
  *
@@ -30,7 +31,9 @@ const MULTICODEC_ED25519 = Buffer.from([0xed, 0x01]);
 const PKCS8_SEED_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex");
 const SPKI_PUBLIC_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
 const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,47}$/;
-const NONCE_RE = /^[0-9]{1,19}$/;
+// Stored message nonces become integers: padding would change the signed bytes
+// on JSON/export reads. Match #356 without converting large counters to Number.
+const NONCE_RE = /^(?:0|[1-9][0-9]{0,18})$/;
 const INVISIBLE_RE = /[\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Zl}\p{Zp}]/gu;
 
 function fail(message) {
@@ -91,7 +94,9 @@ function validName(name, label) {
 }
 
 function validNonce(nonce) {
-  if (!NONCE_RE.test(nonce ?? "")) fail("nonce must contain 1-19 ASCII digits");
+  if (!NONCE_RE.test(nonce ?? "")) {
+    fail("nonce must contain 1-19 ASCII digits with no leading zero");
+  }
   return nonce;
 }
 

--- a/tests/http/test_node_signer.py
+++ b/tests/http/test_node_signer.py
@@ -1,0 +1,82 @@
+"""The Node example must remain wire-compatible with the Python/server contract."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import quote
+
+import _client  # noqa: F401 (imported for the fixture alias below)
+import pytest
+
+client = _client.client  # the shared TestClient fixture
+
+ROOT = Path(__file__).resolve().parents[2]
+NODE_SIGNER = ROOT / "examples" / "sign_node.mjs"
+PYTHON_SIGNER = ROOT / "scripts" / "sign.py"
+NODE = shutil.which("node")
+SEED = "aa" * 32
+
+
+def run_node(*args: str) -> subprocess.CompletedProcess[str]:
+    if NODE is None:
+        pytest.skip("Node.js is not installed")
+    return subprocess.run(
+        [NODE, str(NODE_SIGNER), *args],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        env={**os.environ, "SIGN_SEED": SEED},
+    )
+
+
+def run_python(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(PYTHON_SIGNER), args[0], "--seed", SEED, *args[1:]],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+
+
+def test_node_signer_matches_python_and_the_server(client) -> None:
+    # One reachable representative for every swept category in JavaScript, plus
+    # trimming at both ends and an interior Zs character that must survive.
+    raw = "\u0085a\u200bb\ue000c\u2028d\u2029e\u00a0f\u200b"
+    clean = "a b c d e\u00a0f"
+
+    node = run_node("say", "node-signer", "7", raw)
+    python = run_python("say", "node-signer", "7", raw)
+    assert node.returncode == 0, node.stderr
+    assert python.returncode == 0, python.stderr
+    assert node.stdout == python.stdout
+
+    did, signature = node.stdout.splitlines()
+    encoded = quote(raw, safe="")
+    response = client.get(f"/r/node-signer/say-signed/{did}/{signature}/7/{encoded}")
+    assert response.status_code == 200, response.text
+    assert clean in response.text
+
+
+def test_node_note_signer_matches_python_and_the_server(client) -> None:
+    identity = run_node("did")
+    assert identity.returncode == 0, identity.stderr
+    did = identity.stdout.strip()
+    namespace = "room-owners"
+    key = "d-node-signer"
+
+    node = run_node("set", namespace, key, "8", did)
+    python = run_python("set", namespace, key, "8", did)
+    assert node.returncode == 0, node.stderr
+    assert python.returncode == 0, python.stderr
+    assert node.stdout == python.stdout
+
+    signed_did, signature = node.stdout.splitlines()
+    assert signed_did == did
+    encoded = quote(did, safe="")
+    response = client.get(f"/kv/{namespace}/{key}/set-signed/{did}/{signature}/8/{encoded}")
+    assert response.status_code == 200, response.text
+    assert did in client.get(f"/kv/{namespace}/{key}").text

--- a/tests/http/test_node_signer.py
+++ b/tests/http/test_node_signer.py
@@ -1,4 +1,8 @@
-"""The Node example must remain wire-compatible with the Python/server contract."""
+"""The Node example must remain wire-compatible with the Python/server contract.
+
+Negative-input and parity coverage builds on Orshengnudor's PR #577 cases, while
+keeping this example's deliberately narrower hex-seed-only interface.
+"""
 
 from __future__ import annotations
 
@@ -21,15 +25,20 @@ NODE = shutil.which("node")
 SEED = "aa" * 32
 
 
-def run_node(*args: str) -> subprocess.CompletedProcess[str]:
+def run_node(*args: str, seed: str | None = SEED) -> subprocess.CompletedProcess[str]:
     if NODE is None:
         pytest.skip("Node.js is not installed")
+    env = {key: value for key, value in os.environ.items() if key != "SIGN_SEED"}
+    if seed is not None:
+        env["SIGN_SEED"] = seed
     return subprocess.run(
         [NODE, str(NODE_SIGNER), *args],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        timeout=10,
         cwd=ROOT,
-        env={**os.environ, "SIGN_SEED": SEED},
+        env=env,
     )
 
 
@@ -38,7 +47,10 @@ def run_python(*args: str) -> subprocess.CompletedProcess[str]:
         [sys.executable, str(PYTHON_SIGNER), args[0], "--seed", SEED, *args[1:]],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        timeout=10,
         cwd=ROOT,
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
     )
 
 
@@ -80,3 +92,98 @@ def test_node_note_signer_matches_python_and_the_server(client) -> None:
     response = client.get(f"/kv/{namespace}/{key}/set-signed/{did}/{signature}/8/{encoded}")
     assert response.status_code == 200, response.text
     assert did in client.get(f"/kv/{namespace}/{key}").text
+
+
+def test_node_note_signer_sweeps_unicode() -> None:
+    # Arbitrary Unicode values exercise canonical bytes offline. The service's
+    # signed namespaces accept DID payloads, covered by the ownership test above.
+    raw = "\u0085caf\u00e9\u200b\U0001f680\ue000a\u2028b\u2029c\u00a0d\u200b"
+    clean = "caf\u00e9 \U0001f680 a b c\u00a0d"
+    node = run_node("set", "coord", "node-unicode", "9", raw)
+    python = run_python("set", "coord", "node-unicode", "9", raw)
+    assert node.returncode == 0, node.stderr
+    assert python.returncode == 0, python.stderr
+    assert node.stdout == python.stdout
+    swept = run_python("set", "coord", "node-unicode", "9", clean)
+    assert swept.returncode == 0, swept.stderr
+    assert node.stdout == swept.stdout
+
+
+@pytest.mark.parametrize("seed", [None, "", "a" * 63, "a" * 65, "g" * 64, "a passphrase"])
+def test_node_signer_requires_an_explicit_hex_seed(seed: str | None) -> None:
+    result = run_node("did", seed=seed)
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "SIGN_SEED must contain exactly 64 hexadecimal characters" in result.stderr
+
+
+def test_node_signer_accepts_uppercase_hex_seed() -> None:
+    node = run_node("did", seed=SEED.upper())
+    python = run_python("did")
+    assert node.returncode == 0, node.stderr
+    assert python.returncode == 0, python.stderr
+    assert node.stdout == python.stdout
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("keygen", "extra"),
+        ("did", "extra"),
+        ("say", "room", "1", "hello", "extra"),
+        ("set", "coord", "key", "1", "hello", "extra"),
+    ],
+)
+def test_node_signer_rejects_extra_arguments(args: tuple[str, ...]) -> None:
+    result = run_node(*args)
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "accepts no arguments" in result.stderr or "usage:" in result.stderr
+
+
+@pytest.mark.parametrize("prefix", [("say", "room"), ("set", "coord", "key")])
+@pytest.mark.parametrize("nonce", ["", "1" * 20, "-1", "1.0", "\u0661", "1\n"])
+def test_node_signer_rejects_invalid_nonce(prefix: tuple[str, ...], nonce: str) -> None:
+    result = run_node(*prefix, nonce, "hello")
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "nonce must contain 1-19 ASCII digits" in result.stderr
+
+
+@pytest.mark.parametrize("prefix", [("say", "room"), ("set", "coord", "key")])
+@pytest.mark.parametrize("nonce", ["0", "0007", "9" * 19])
+def test_node_signer_preserves_nonce_bytes(prefix: tuple[str, ...], nonce: str) -> None:
+    node = run_node(*prefix, nonce, "hello")
+    python = run_python(*prefix, nonce, "hello")
+    assert node.returncode == 0, node.stderr
+    assert python.returncode == 0, python.stderr
+    assert node.stdout == python.stdout
+
+
+@pytest.mark.parametrize("prefix", [("say", "room"), ("set", "coord", "key")])
+def test_node_signer_refuses_empty_swept_payload(prefix: tuple[str, ...]) -> None:
+    result = run_node(*prefix, "1", "\u0085\u200b\ue000\u2028\u2029 ")
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert "nothing visible remains" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("prefix", "cap"), [(("say", "room"), 4096), (("set", "coord", "key"), 8192)]
+)
+def test_node_signer_caps_count_code_points_after_sweeping(
+    prefix: tuple[str, ...], cap: int
+) -> None:
+    # Astral characters distinguish code points from JS UTF-16 units; padding
+    # distinguishes the swept length from the raw argument length.
+    raw = "\u200b" + "\U0001f680" * cap + "\n"
+    node = run_node(*prefix, "1", raw)
+    python = run_python(*prefix, "1", raw)
+    assert node.returncode == 0, node.stderr
+    assert python.returncode == 0, python.stderr
+    assert node.stdout == python.stdout
+
+    rejected = run_node(*prefix, "1", "\U0001f680" * (cap + 1))
+    assert rejected.returncode != 0
+    assert rejected.stdout == ""
+    assert f"over the {cap}-character cap" in rejected.stderr

--- a/tests/http/test_node_signer.py
+++ b/tests/http/test_node_signer.py
@@ -6,6 +6,7 @@ keeping this example's deliberately narrower hex-seed-only interface.
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -142,8 +143,10 @@ def test_node_signer_rejects_extra_arguments(args: tuple[str, ...]) -> None:
 
 
 @pytest.mark.parametrize("prefix", [("say", "room"), ("set", "coord", "key")])
-@pytest.mark.parametrize("nonce", ["", "1" * 20, "-1", "1.0", "\u0661", "1\n"])
+@pytest.mark.parametrize("nonce", ["", "1" * 20, "-1", "1.0", "\u0661", "1\n", "0007", "00", "01"])
 def test_node_signer_rejects_invalid_nonce(prefix: tuple[str, ...], nonce: str) -> None:
+    # Padded counters lose their signed spelling when stored as integers. Reject
+    # them here even on servers/Python signers predating the matching fix in #356.
     result = run_node(*prefix, nonce, "hello")
     assert result.returncode != 0
     assert result.stdout == ""
@@ -151,13 +154,37 @@ def test_node_signer_rejects_invalid_nonce(prefix: tuple[str, ...], nonce: str) 
 
 
 @pytest.mark.parametrize("prefix", [("say", "room"), ("set", "coord", "key")])
-@pytest.mark.parametrize("nonce", ["0", "0007", "9" * 19])
+@pytest.mark.parametrize("nonce", ["0", "7", "10", "9" * 19])
 def test_node_signer_preserves_nonce_bytes(prefix: tuple[str, ...], nonce: str) -> None:
+    assert str(int(nonce)) == nonce
     node = run_node(*prefix, nonce, "hello")
     python = run_python(*prefix, nonce, "hello")
     assert node.returncode == 0, node.stderr
     assert python.returncode == 0, python.stderr
     assert node.stdout == python.stdout
+
+
+@pytest.mark.parametrize("nonce", ["0", "7", "9" * 19])
+def test_node_message_reverifies_from_json_and_export(client, nonce: str) -> None:
+    import didkey
+
+    # Check storage, not only agreement between two signers: both used to accept
+    # padded nonces. The upper boundary also catches lossy JS Number conversion.
+    room = "node-nonce"
+    node = run_node("say", room, nonce, "hello")
+    assert node.returncode == 0, node.stderr
+    did, signature = node.stdout.splitlines()
+    posted = client.get(f"/r/{room}/say-signed/{did}/{signature}/{nonce}/hello")
+    assert posted.status_code == 200, posted.text
+    served = client.get(f"/r/{room}?format=json").json()["messages"]
+    exported = [json.loads(line) for line in client.get(f"/r/{room}/export").content.splitlines()]
+    assert len(served) == len(exported) == 1
+    for record in (served[0], exported[0]):
+        assert record["from"] == did
+        assert record["sig"] == signature
+        assert str(record["nonce"]) == nonce
+        assert record["text"] == "hello"
+        didkey.verify(record["from"], record["sig"], f"{room}|{record['nonce']}|{record['text']}")
 
 
 @pytest.mark.parametrize("prefix", [("say", "room"), ("set", "coord", "key")])


### PR DESCRIPTION
## What

Adds a zero-dependency Node.js 20+ signer for messages and notes. Explicit hex seed only; no passphrase-derived identity, endpoint, server state or dependency.

## Why

Closes #75. Incorporates rejection/parity coverage from @Orshengnudor's closed #577, credited in the tests.

Addresses @yukkie3276's nonce review: both commands reject padded counters; `0` stays valid. Accepted strings are preserved without lossy numeric conversion. JSON/export tests re-verify stored records, including a 19-digit counter.

Server/Python enforcement remains in #356. This example rejects padded spellings before that separate fix lands; accepted-value Python parity remains covered.

## Checks

- Fresh main: `20a4457b89ba11254f4aa48217b066884a148d98`; head `670fc8a`.
- 47 focused cases: 42 native Windows CLI tests; 5 HTTP tests using local adapters excluded from this PR.
- Six padded-nonce rejection cases fail before the fix and pass afterward.
- [Exact-head Linux CI](https://github.com/zakazaka95/technocore-chat/actions/runs/34725121390/attempts/2): 817 passed, 1 skipped, 97.97% coverage. Retry followed an unchanged concurrent-note test failure.
- Core unchanged; lint, format, types, size and syntax pass.
- Usage updated beside the example. Proposed release note: add a tested Node-only signing example.
- Fork CI does not replace upstream required-check approval.