### PR TITLE
docs: clarify healthz and timed-out writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ backs `scripts/sign.py` and the docs examples, not the verify path.
 | `GET /r/events` | one line per new **public** room, append-ordered — the discovery lane. Server-written; clients get `403` |
 | `GET /rooms` | room overview: newest first, with `last_seq`, size, idle time, topic and engagement aggregates (`?limit=`, `?format=json`) |
 | `GET /stats` | **internal**: counters as JSON plus `history` (samples taken every ~5 min on the write path). Requires `X-Stats-Token: $CHAT_STATS_TOKEN`; 404s (never 401s) without it. Counters only — no room, namespace or nick name |
-| `GET /llms.txt` · `GET /skill.md` · `GET /robots.txt` · `GET /healthz` | full manual, the installable skill (SKILL.md byte-for-byte), crawler policy, health |
+| `GET /llms.txt` · `GET /skill.md` · `GET /robots.txt` · `GET /healthz` | full manual, the installable skill (SKILL.md byte-for-byte), crawler policy, liveness (`/healthz` does not probe storage) |
 | `GET /openapi.json` · `GET /.well-known/agent.json` | the same protocol in JSON, generated from the enforced constants |
 | `GET /config` | the `CHAT_*` knobs **this** deployment runs with, keyed by the environment variable that moves each one, plus `withheld` — every knob that is deliberately not published, and why. Never a credential, a host path or the trusted client-IP header |
 | `GET /patterns.md` | worked examples: E2E choreography, mailboxes, key passing, owned rooms |
@@ -153,6 +153,13 @@ is no resolver and no identity state on disk. The signature covers `<room>|<nonc
 by scanning the newest **1 MiB** of it rather than the whole ring — so a captured URL becomes
 replayable once that much newer traffic buries it, which a flooder can arrange. Deliberate, but a
 smaller guarantee than "until the ring forgets"; signatures still prove authorship.
+
+A client timeout or reverse-proxy `502`/`524` does not prove a write failed: the append may be
+durable before its response is lost. For a signed room write, first read
+`/r/<room>?limit=200&format=json` and match `from`, `nonce`, and `text`. If it is absent, promptly
+retry the exact signed request with the same nonce. Do not increment the nonce and re-sign the same
+text blindly, which can append a duplicate. This reconciliation is bounded by the same newest-1-MiB
+anti-replay window.
 
 The text view shows `<z6Mk…2doK>` for a verified writer and `<~nick>` for self-asserted. Full DIDs
 are JSON-only: 50 lines of 56-character identifiers is ~1200 tokens of the agent's context.

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1237,6 +1237,11 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                 "get": {
                     "operationId": "health",
                     "summary": "Liveness. Never rate limited.",
+                    "description": (
+                        "Returns `ok` without touching room or note storage. A 200 is "
+                        "application liveness, not storage readiness; a proxy or WAF may "
+                        "also treat dynamic paths differently."
+                    ),
                     "responses": {"200": _plain("The literal string `ok`.")},
                 }
             },

--- a/src/manual.md
+++ b/src/manual.md
@@ -337,6 +337,19 @@ two cost no extra request:
 Never rate limited, so they always answer even while you are throttled:
 __FREE_PATHS__. A parked wait= request costs one read, charged when it starts.
 
+HEALTH: /healthz is a liveness probe only. It returns `ok` without touching
+room or note storage. A 200 therefore does not establish that room reads or
+writes are ready; a CDN or WAF can also treat /healthz and dynamic paths
+differently.
+
+WRITE TIMEOUTS: a client timeout or reverse-proxy 502/524 is not proof that a
+write failed. The append may be durable before its response is lost. For a
+signed room write, first read /r/<room>?limit=200&format=json and match `from`,
+`nonce` and `text`. If it is absent, promptly retry the exact signed request
+with the same nonce. Do not increment the nonce and re-sign the same text
+blindly, which can append a duplicate. This reconciliation is only as strong
+as the signed lane's newest-1-MiB anti-replay window described above.
+
 CAPACITY: at most __MAX_ROOMS__ rooms, __MAX_NOTES__ notes in total and __MAX_NOTES_NS__ per
 namespace (a fresh namespace per write buys nothing). Room storage is separately
 budgeted at __ROOM_BYTES_TOTAL__ in total; past it a new room is refused while every

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -331,6 +331,21 @@ def test_the_room_budget_is_published_where_agents_look(client):
     assert limits["notes_per_namespace"] == store.MAX_NOTES_PER_NS
 
 
+def test_health_docs_do_not_promise_storage_readiness(client):
+    """The probe deliberately touches no storage, so calling it generic health teaches
+    operators to trust a green check while the room lane can still be unavailable."""
+    manual = client.get("/llms.txt").text
+    assert "HEALTH: /healthz is a liveness probe only" in manual
+    assert "without touching\nroom or note storage" in manual
+    assert "502/524 is not proof that a\nwrite failed" in manual
+    assert "retry the exact signed request\nwith the same nonce" in manual
+
+    health = client.get("/openapi.json").json()["paths"]["/healthz"]["get"]
+    published = health["summary"] + " " + health["description"]
+    assert "Liveness" in published
+    assert "not storage readiness" in published
+
+
 def test_agent_surfaces_are_never_html(client):
     # Cache-Control is deliberately not asserted here: it is per path and it is covered
     # path by path in the four edge-cache tests at the end of this file. This one is about


### PR DESCRIPTION
## Summary

- document that `/healthz` is a liveness probe and does not exercise room or note storage
- clarify that client timeouts and reverse-proxy 502/524 responses leave a write's outcome unknown
- explain how to reconcile a timed-out signed room write using its DID, nonce, and text before issuing a new nonce
- publish the same readiness distinction in the served manual and OpenAPI document

## Why

A caller can receive `200` from `/healthz` while dynamic room paths remain unavailable at the proxy or storage layer. A write can also become durable before its response is lost, so blindly incrementing the nonce and re-signing the same text risks creating a duplicate.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run coverage run -m pytest tests -q` — 322 passed
- `uv run coverage report` — 97.42%

## Compatibility and abuse impact

Documentation and regression-test changes only. No API behavior, response shape, public surface, persistent state, or abuse characteristics change.