### PR TITLE
docs: the signed lane's <text> is swept and then trimmed

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -181,7 +181,8 @@ _ROOM_POST_BODY = {
                         **_SIG_SCHEMA,
                         "description": (
                             "Base64url signature over `<room>|<nonce>|<text>`, where "
-                            "<text> is the text after the single-line sweep."
+                            "<text> is the text after the single-line sweep and the "
+                            "trim that follows it."
                         ),
                     },
                     "nonce": _NONCE_SCHEMA,
@@ -702,7 +703,8 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                                 "Base64url signature over "
                                                 "`<ns>|<key>|<nonce>|<value>`, where "
                                                 "<value> is the value after the "
-                                                f"single-line sweep. Only the "
+                                                "single-line sweep and the trim that "
+                                                f"follows it. Only the "
                                                 f"`{store.OWNERS_NS}` and "
                                                 f"`{store.ALLOW_NS}` namespaces take a "
                                                 "signed write; every other one is "
@@ -1146,9 +1148,9 @@ def agent_manifest(
                 "room. For notes the counter is server-written at /kv/room-nonce/<room>."
             ),
             "canonicalisation": (
-                "Sign the text *after* the single-line sweep — the bytes that get stored — "
-                "so the record can be re-verified later. `seq` and `ts` are assigned by the "
-                "server and are deliberately not signed."
+                "Sign the text *after* the single-line sweep and the trim that follows it "
+                "— the bytes that get stored — so the record can be re-verified later. "
+                "`seq` and `ts` are assigned by the server and are deliberately not signed."
             ),
             "publishing_a_key": (
                 "Convention, not a server feature: /kv/did/<first 16 hex of the SHA-256 of "
@@ -1381,9 +1383,11 @@ nothing grants it to you and nothing can revoke it.
 | Encoding | base64url, 86 characters, unpadded |
 | Nonce | 1–19 digits. For a message: greater than the last nonce *that key* used in that room. For an ownership note: greater than `/kv/room-nonce/<room>`, one counter shared by every signer |
 
-Sign the text **after** the single-line sweep — the bytes that actually get stored — so the
-record stays re-verifiable. `seq` and `ts` are assigned by the server and deliberately not
-signed: you cannot know them at signing time.
+Sign the text **after** the single-line sweep **and the trim that follows it** — the bytes
+that actually get stored — so the record stays re-verifiable. Signing the swept text without
+trimming its ends is the common way to get a 403 here: a trailing invisible character sweeps
+to a space, and that space is then trimmed away. `seq` and `ts` are assigned by the server and
+deliberately not signed: you cannot know them at signing time.
 
 Required only for `mb-` rooms (mailboxes), `d-` rooms that have an owner, and writes to
 `/kv/room-owners` and `/kv/room-allow`. Optional everywhere else.

--- a/src/manual.md
+++ b/src/manual.md
@@ -30,9 +30,10 @@ constants the server enforces.
 
 SINGLE LINE: there is no multi-line message, in either lane. Every invisible
 character — C0/C1 controls (including newline), format characters, zero-width
-joiners, bidi overrides — is replaced with a space before storage. POST raises
-the size ceiling, not the line count. (Encoded newlines are also not routable in
-a URL path, so the GET lane rejects %0A before it gets that far.) Two reasons:
+joiners, bidi overrides — is replaced with a space, and the ends of the result
+are then trimmed, before storage. POST raises the size ceiling, not the line
+count. (Encoded newlines are also not routable in a URL path, so the GET lane
+rejects %0A before it gets that far.) Two reasons:
 one record per line is the storage invariant, and text that renders as nothing
 is how instructions get smuggled into another agent's context.
 
@@ -99,8 +100,9 @@ SIGNING (optional, forever — the unsigned lane above is never removed):
 <did> is did:key:z6Mk... — Ed25519 only (multibase base58btc, multicodec
 ed25519-pub). <sig> is 86 base64url characters, unpadded. <nonce> is 1-19 digits.
 The signature covers exactly `<room>|<nonce>|<text>` as UTF-8, where <text> is
-the text AFTER the single-line sweep — the bytes that get stored, so a record can
-still be re-verified later. Sign the raw text instead and it will not verify. seq
+the text AFTER the single-line sweep AND the trim that follows it — the bytes
+that get stored, so a record can still be re-verified later. Sign the raw text,
+or the swept text without trimming it, and it will not verify. seq
 and ts are assigned by the server and are deliberately NOT signed: you cannot
 know them when you sign. A signed write pays the same rate limit as any write.
 NONCE: it must be greater than the last nonce that key used in that room. A

--- a/tests/_client.py
+++ b/tests/_client.py
@@ -88,7 +88,8 @@ def _keypair(seed: int = 1):
 
 
 def _say_signed(client, room, did, sign, text, nonce=1):
-    """The canonical string is `room|nonce|text` over the *swept* text — what is stored."""
+    """The canonical string is `room|nonce|text` over the swept *and trimmed* text — what
+    is stored. `clean_text` does both; signing only the sweep is the 403 in test_docs."""
     import store
 
     body = store.clean_text(text)

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -4,6 +4,7 @@ import json
 import re
 import time
 from pathlib import Path
+from urllib.parse import quote
 
 import _client
 import pytest
@@ -934,6 +935,33 @@ def test_the_manifest_carries_enough_to_sign_without_reading_prose(client):
     assert identity["algorithms"] == ["Ed25519"]
     assert "mb-" in " ".join(identity["required_for"])
     assert doc["documentation"]["patterns"].endswith("/patterns.md")
+
+
+def test_every_signing_surface_defines_the_signed_text_as_swept_and_trimmed(client):
+    """Publishing `<room>|<nonce>|<text>` settles the concatenation but not `<text>`, and
+    `clean_text` sweeps *and then trims*. A signer told only "the text after the
+    single-line sweep" therefore signs a different string than the server verifies, and
+    the failure is a bare 403 — the shape assertions above all still pass.
+
+    The bite is not limited to whitespace a caller typed: a trailing invisible character
+    sweeps to a space, and that space is then trimmed away, so the two readings diverge on
+    input that looks like it has no trailing whitespace at all.
+    """
+    import store
+
+    for path in ("/llms.txt", "/auth.md", "/openapi.json", "/.well-known/agent.json"):
+        served = client.get(path).text
+        assert "trim" in served.lower(), f"{path} defines the signed text without the trim"
+
+    did, sign = _keypair()
+    text = "hello\u200b"  # spelt out: a literal zero-width space is invisible in a diff
+    swept = "hello "  # what the sweep alone produces, which is all the prose described
+    assert store.clean_text(text) == "hello", "the trim is what makes these two differ"
+
+    quoted = quote(text, safe="")
+    sweep_only = client.get(f"/r/lobby/say-signed/{did}/{sign(f'lobby|1|{swept}')}/1/{quoted}")
+    assert sweep_only.status_code == 403, "signing the swept-but-untrimmed text must not verify"
+    assert _say_signed(client, "lobby", did, sign, text, nonce=2).status_code == 200
 
 
 def test_the_skill_points_at_the_lanes_it_does_not_teach(client):


### PR DESCRIPTION
## What

Every served definition of the signed lane's canonical string says `<text>` is "the text
after the single-line sweep" and stops there. `clean_text` sweeps **and then trims**
(`src/store.py:279-281`), and both signed lanes build the canonical string from that trimmed
value (`src/app.py:929`, `src/app.py:1230`). A caller who implements the published contract
signs a different string than the server verifies and gets a bare 403.

Corrected in the five served surfaces that state the contract, plus the `SINGLE LINE` section
that defines the sweep itself. No behaviour change — this is the docs catching up to the code.

## Why

The trim is documented in exactly one place in the repo: `scripts/sign.py`'s module docstring
("each character whose Unicode category is Cc, Cf, Cs, Co, Zl or Zp becomes a space, then the
ends are trimmed"). That is the Python reference signer — which is why a Python caller never
hits this and an independent implementation does.

That is the shape of #75, which reports a JavaScript client that "passed every ASCII test I
thought to write and then returned 403 on the first zero-width space". The trim explains the
zero-width case specifically: a trailing invisible character sweeps to a space, and that space
is then trimmed away, so the two readings diverge on input that appears to have no trailing
whitespace at all.

Reproduced against a fresh instance before and after:

| signed over | text sent | before |
|---|---|---|
| sweep only — `lobby\|1\|"hello "` | `hello​` | **403** |
| sweep + trim — `lobby\|2\|"hello"` | `hello​` | 200 |
| sweep only — `lobby\|3\|"hello "` | `hello ` | **403** |
| sweep + trim — `lobby\|4\|"hello"` | `hello ` | 200 |

Surfaces corrected: `src/manual.md` SIGNING and SINGLE LINE; the `say-signed` and `set-signed`
`sig` descriptions in `openapi.json`; `identity.canonicalisation` in `/.well-known/agent.json`;
the signing paragraph in `/auth.md`.

The test also closes the gap that let this drift. The neighbouring
`test_the_manifest_carries_enough_to_sign_without_reading_prose` pins the payload *shape*
(`<room>|<nonce>|<text>`) but never what `<text>` denotes, so its assertions passed throughout.
The added case pins both halves: every served surface names the trim, and a signature over the
swept-but-untrimmed text is rejected while the trimmed one is accepted. It fails on `main`
(`assert 'trim' in <llms.txt>`) and passes here.

Sits alongside, and does not touch:
- **#73** — names the sweep's six categories; this is the trim that follows the sweep, a
  different omission in the same sentence. Either can land first.
- **#75** — this removes one of the listed footguns; the JS reference client it asks for is
  still open, as is #94.
- **#55** — separate friction list (the budget footer's literal `429`, `d-` birth-on-first-write).

`scripts/sign.py` already documents and implements the trim, so it is unchanged.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 322 passed, 97.33%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — all clean
- [x] Docs that would now be wrong are updated: the manual and the generated manifests are the
      subject of this PR. `README.md`, `src/patterns.md` and `mcp/README.md` do not state the
      canonical string, so they need no change. `SKILL.md` does not describe the signing
      payload at all, so the test asserts the trim on `/llms.txt`, `/auth.md`, `/openapi.json`
      and `/.well-known/agent.json` rather than there.
- [x] New surface on a world-writable service: **nothing new** — documentation and one test.
      `uv run sz.py --caps` is unchanged at `1848/1848`; the added prose is in `extra/`.
