### PR TITLE
fix(limit): refund the room-creation token when the write is refused

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1520,6 +1520,14 @@ async def on_method_not_allowed(request: Request, exc: Exception) -> Response:
 
 
 async def on_bad_input(request: Request, exc: Exception) -> Response:
+    # A refused write to an absent room created nothing, so the creation token it was
+    # charged has to go back. The gate charges before the write by design, and the three
+    # success paths settle from the record they got; this is the same settlement for the
+    # outcome that has no record. `{}` carries no `seq`, which is the store's own answer to
+    # "did this call create the room" — no record, no creation, always a refund. A write to
+    # a room that already existed never reached the gate, so its scope flag is unset and
+    # this is a no-op.
+    limit._settle_room_budget(request, {}, RATE_ROOMS_PER_DAY, ip_header=CLIENT_IP_HEADER)
     return text(f"400 {exc}", 400)
 
 

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,18 +1,18 @@
 {
-  "core_total": 1848,
+  "core_total": 1849,
   "caps": {
-    "core/app.py": 919,
+    "core/app.py": 920,
     "core/config.py": 48,
     "core/didkey.py": 57,
     "core/limit.py": 110,
     "core/store.py": 714,
-    "core_total": 1848
+    "core_total": 1849
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1614,
-      "code_lines": 919,
-      "comment_lines": 216,
+      "raw_lines": 1622,
+      "code_lines": 920,
+      "comment_lines": 223,
       "tokens_per_line": 7.82
     },
     "core/config.py": {

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -322,6 +322,33 @@ def test_only_the_request_that_creates_a_room_pays_for_it(client, monkeypatch):
         assert client.get("/r/fourth-room/say/bot/hi").status_code == 429
 
 
+def test_a_refused_write_to_an_absent_room_gets_its_creation_token_back(client):
+    """The sibling of the race above, on the outcome that has no record to settle from.
+
+    The gate charges before the write, so an append the store refuses — a nick that is not
+    a name, text the sweep empties, a room past the capacity cap — unwinds past the
+    success-path settlement with the token spent and nothing created. A caller looping on
+    one bad nick would otherwise exhaust a whole day's room budget without opening a single
+    room, and be told by the 429 that it created rooms `/rooms` does not list.
+
+    Worse at the cap: `_check_room_capacity` refuses after the charge, so a full service
+    drains the caller's day budget and keeps it locked out long after room reaping frees
+    space — an outage lasting hours past its cause.
+    """
+    import config
+
+    with config.override(RATE_ROOMS_PER_DAY=3):
+        assert client.get("/r/never-a/say/BOB/hi").status_code == 400  # nick is not a name
+        assert client.get("/r/never-b/say/bot/%E2%80%8B").status_code == 400  # sweep empties it
+        assert client.get("/r/never-c/say/BOB/hi").status_code == 400
+        assert "/r/never-" not in client.get("/rooms").text  # not one of them exists
+
+        # So the day's budget is untouched: three real creations, and only then a 429.
+        for i in range(3):
+            assert client.get(f"/r/real-{i}/say/bot/hi").status_code == 200
+        assert client.get("/r/one-too-many/say/bot/hi").status_code == 429
+
+
 def test_the_post_lanes_do_not_block_the_event_loop(client, monkeypatch):
     """A POST must not stall every *other* request while it touches disk.
 


### PR DESCRIPTION
## What

`_room_create_gate` charges a room-creation token before the write, and the three success
paths settle it from the record `store.append` returned (`src/app.py:910`, `:938`, `:1032`).
An append that raises `StoreError` has no record — it unwinds straight to the 400 handler, so
the token stays spent even though no room was created.

Settled in `on_bad_input`, the one funnel every `StoreError` reaches. No behaviour change on
any path that already worked.

## Why

A nick that is not a valid name, text the sweep empties, or a body past the length cap is
enough to trigger it. Reproduced on `main` with `RATE_ROOMS_PER_DAY=3`:

```
GET /r/never-a/say/BOB/hi        400 bad name 'BOB'
GET /r/never-b/say/bot/%E2%80%8B 400 empty text: nothing visible was left after the sweep
GET /r/never-c/say/BOB/hi        400 bad name 'BOB'

GET /rooms                       (no rooms exist)

GET /r/realroom/say/bot/hello    429 room-creation budget spent: /r/realroom does not exist
                                     yet, and this IP has created its 3 rooms for the day.
                                     retry after: 28800s
```

Three typos, zero rooms, and an eight-hour lockout — with a 429 asserting the caller created
rooms `/rooms` does not list. An agent looping on one bad nick hits this immediately.

**It is worse while the service is full.** `_check_room_capacity` also raises after the
charge, so at `MAX_ROOMS` every refusal drains the caller's day budget. Reaping then frees
rooms but does not give tokens back, so the lockout outlives its cause by hours — which is the
opposite of what "capacity fails closed" is meant to buy.

This is the case `_settle_room_budget` exists for, on the one branch it never sees. Its
docstring already states the rule — "refund the room-creation token if this request turned out
not to create the room" — and `seq == 1` implements it for outcomes that have a record. A 400
has no record, so the one case where *provably* nothing was created is the one never refunded.
`/.well-known/agent.json` publishes the bucket as `limits.new_rooms_per_day_per_ip`, which a
refused write makes untrue.

## How

`{}` carries no `seq`, which is the store's own answer to "did this call create the room" — no
record, no creation, always a refund. `_settle_room_budget` needs no change. A write to a room
that already existed returned early from the gate, so its scope flag is unset and the call is
a no-op there; the note lanes never set it at all.

The regression test is the sibling of the existing
`test_only_the_request_that_creates_a_room_pays_for_it`: that one covers the loser of a
concurrent first-write, which *has* a record and settles from it. This one covers the outcome
that has none. It fails on `main` at the first valid creation, which answers 429 with zero
rooms in existence.

`core/app.py` grows by the single settlement line, so its cap and `core_total` each move by
one (919→920, 1848→1849). Flagging that explicitly rather than burying it: the gate has no
other single-statement place to settle from that sees both outcomes, and the alternative —
`try`/`finally` around three route bodies — costs more lines and more branches. Happy to take
a different shape if you would rather the cap held.

Does not touch #55 (the budget footer's literal `429`, and `d-` birth-on-first-write), though
this is friction found in the same gate.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 322 passed, 97.33%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — all clean
- [x] Docs that would now be wrong are updated: none. The published contract already says the
      bucket counts rooms created; this makes the code match it. No manual, `/skill.md`,
      `README.md`, `src/patterns.md` or `mcp/README.md` text changes meaning.
- [x] New surface on a world-writable service: **nothing new** — no new route, parameter or
      persistent state. The refund is strictly narrower than the charge: it fires only on a
      request the gate had already charged, and only when no room came into being, so it
      cannot be used to create rooms past the budget. `bash examples/beautiful_chat.sh` passes.
