### PR TITLE
docs: one trailing %0A does route, and the sweep is what stops the forgery

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -285,15 +285,20 @@ _RESERVED_NAMESPACE = _plain(
 # The last path segment of the four URL write lanes is `{text:path}` / `{value:path}`, and
 # Starlette's path convertor is `.*` without DOTALL — so a segment carrying a raw newline
 # (a caller that sent `%0A` in its message) matches no route at all and lands on the 404
-# handler, before any of this service's own validation runs. That is deliberate: the say
-# route's regex never matching a newline is what makes it impossible to forge a second
-# JSONL record out of one message. It was simply never written down, so the contract said
-# a `text` the router silently drops was a 200.
+# handler, before any of this service's own validation runs — with one exception that
+# belongs to the regex, not to this service: Python's `$` also matches immediately before a
+# final newline, so a segment ending in exactly one `%0A` *does* match, and `.*` hands the
+# route a `text` with that newline already stripped off. Two of them, or one anywhere else,
+# still 404. So the router narrows what reaches a write; what actually makes a second JSONL
+# record impossible to forge is `clean_text`, which sweeps every Cc character — the newline
+# among them — on every write in both lanes.
 _UNROUTABLE_PATH = _plain(
-    "No route matched. The free-form final segment cannot contain a raw newline "
+    "No route matched. The free-form final segment cannot carry a raw newline "
     "(`%0A`): the router does not match one, so the request never reaches this "
-    "operation. Send the message through the POST lane, which accepts newlines and "
-    "flattens them, or strip it first. The body lists every route this service has."
+    "operation. The single exception is one trailing `%0A`, which routes with the "
+    "newline already dropped. Send the message through the POST lane, which accepts "
+    "newlines and flattens them, or strip it first. The body lists every route this "
+    "service has."
 )
 
 _BAD_BODY = _plain(

--- a/src/manual.md
+++ b/src/manual.md
@@ -31,8 +31,9 @@ constants the server enforces.
 SINGLE LINE: there is no multi-line message, in either lane. Every invisible
 character — C0/C1 controls (including newline), format characters, zero-width
 joiners, bidi overrides — is replaced with a space before storage. POST raises
-the size ceiling, not the line count. (Encoded newlines are also not routable in
-a URL path, so the GET lane rejects %0A before it gets that far.) Two reasons:
+the size ceiling, not the line count. (A %0A inside the final path segment is not
+routable, so the GET lane 404s before it gets that far; exactly one at the very
+end does route, and the router drops it.) Two reasons:
 one record per line is the storage invariant, and text that renders as nothing
 is how instructions get smuggled into another agent's context.
 

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -433,8 +433,9 @@ def test_every_refusal_is_provoked_and_every_provoked_refusal_is_documented(clie
             404,
             lambda: client.get("/sitemap.xml", headers={"host": "not a host"}),
         ),
-        # The URL write lanes. `%0A` matches no route at all — deliberate, and the reason a
-        # message cannot forge a second JSONL record.
+        # The URL write lanes. A `%0A` inside the segment matches no route; exactly one at
+        # the very end does route, with the newline dropped, so what actually stops a
+        # message forging a second JSONL record is the sweep — see test_rooms.py.
         ("/r/{room}/say/{nick}/{text}", "get", 400, lambda: client.get("/r/UPPER/say/bot/hi")),
         ("/r/{room}/say/{nick}/{text}", "get", 403, lambda: client.get("/r/mb-box/say/bot/hi")),
         ("/r/{room}/say/{nick}/{text}", "get", 404, lambda: client.get("/r/lobby/say/bot/a%0Ab")),

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -78,6 +78,34 @@ def test_control_chars_cannot_forge_records(client):
     assert view["messages"][0]["seq"] == 1 and view["messages"][0]["from"] == "mallory"
 
 
+def test_one_trailing_newline_routes_and_the_sweep_is_what_stops_the_forgery(client):
+    """The router's guarantee is narrower than the documents claimed, and the invariant
+    above does not rest on it.
+
+    `{text:path}` compiles to `.*` with no DOTALL, but Python's `$` also matches
+    immediately before a final newline — so a segment ending in exactly one `%0A` does
+    match, and the regex hands the route a `text` with the newline already gone. Two of
+    them, or one anywhere else, 404 as published.
+
+    So the forgery above is stopped by `clean_text` sweeping every Cc character on both
+    lanes, not by the route regex. Moving the same payload to the end of the segment gets
+    it past the router and no further.
+    """
+    assert client.get("/r/nl/say/bot/hi%0A").status_code == 200  # published as a 404
+    assert client.get("/r/nl/say/bot/hi%0A%0A").status_code == 404
+    assert client.get("/r/nl/say/bot/h%0Ai").status_code == 404
+
+    assert client.get("/r/nl/say/mallory/%7B%22seq%22%3A99%7D%0A").status_code == 200
+    view = client.get("/r/nl?format=json").json()
+    assert [m["seq"] for m in view["messages"]] == [1, 2]  # two writes, two records
+    assert view["messages"][1]["from"] == "mallory"  # not the 99/admin it asked for
+
+    # And the exception is published, so a client is not told to expect a 404 it will
+    # never get.
+    assert "trailing" in client.get("/openapi.json").text
+    assert "%0A" in client.get("/llms.txt").text
+
+
 def test_private_names_are_reachable_but_never_enumerated(client):
     client.get("/r/p-7f3a9c/say/bot/secret%20journal")
     client.get("/kv/p-7f3a9c/state/set/step%3D4")


### PR DESCRIPTION
## What

Three documents say a `%0A` in the free-form final segment is unroutable, and
`_UNROUTABLE_PATH` is published as a 404 response on `say`, `saySigned`, `writeNote` and
`writeNoteSigned`. That holds for a newline *inside* the segment. It does not hold at the end
of one.

`{text:path}` compiles to `.*` with no `DOTALL`, but Python's `$` also matches immediately
before a final newline — so a segment ending in exactly one `%0A` matches, and the regex hands
the route a `text` with the newline already removed. Two of them, or one anywhere else, still
404.

```
rx.match('/r/lobby/say/bob/hello\n')    -> {'room':'lobby','nick':'bob','text':'hello'}
rx.match('/r/lobby/say/bob/hello\n\n')  -> None
rx.match('/r/lobby/say/bob/hel\nlo')    -> None

GET /r/lobby/say/bob/hi%0A   -> 200, stored as "hi"     (published as 404)
GET /r/lobby/say/bob/hi%0A%0A -> 404
GET /r/lobby/say/bob/h%0Ai   -> 404
```

## Why this is not only a wording fix

The comment above `_UNROUTABLE_PATH` draws a safety conclusion from the same premise:

> That is deliberate: the say route's regex never matching a newline is what makes it
> impossible to forge a second JSONL record out of one message.

The premise is false, so the attribution is too. **The invariant itself is not in question** —
`clean_text` sweeps every `Cc` character, the newline among them, on both write lanes, and it
is holding that line on its own. `test_control_chars_cannot_forge_records` still passes, and
the new test moves that test's own forged payload to the end of the segment, where it gets
past the router and no further: two writes, two records, `from` still `mallory`.

I am flagging this rather than quietly rewording it, because "the regex *and* the sweep" and
"the sweep" are different amounts of defence, and only one of them was ever real. A reader of
the current comment would reasonably believe the route regex is load-bearing here. It is not.

## Two ways to close it — your call

1. **What this PR does.** Correct the documents to the router's actual boundary. Cheap, no
   behaviour change, and the published 404 stops promising something a caller will not get.
2. **Tighten the router** so the published contract becomes true, restoring the second layer
   instead of only describing its absence. That changes behaviour for callers whose trailing
   `%0A` currently succeeds, which is why I have not assumed it.

If you would rather have (2), say so and I will send that shape instead — including whether a
trailing newline should 404 or be swept like any other invisible character. I went with (1)
because the safety property is intact either way, and because silently making an accidental
success into a refusal seemed like yours to decide, not mine.

## Notes

Every existing `%0A` assertion in the suite uses `a%0Ab` — mid-segment — so the trailing form
was never exercised. That is why this survived: the tests agreed with the docs, and both were
describing the same half of the behaviour. The stale claim in `tests/http/test_docs.py`'s
refusal table is corrected in the same commit.

`src/manual.md`: this rewrites the parenthetical in the `SINGLE LINE` paragraph. #98 rewrites
the sentence immediately before it, in the same paragraph. They conflict textually, not
semantically — I will rebase whichever lands second.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 322 passed, 97.33%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — all clean
- [x] Docs that would now be wrong are updated: `src/manual.md`, the `_UNROUTABLE_PATH`
      response published on four operations in `openapi.json`, and the comment stating its
      rationale. `README.md`, `src/patterns.md`, `mcp/README.md` and `SKILL.md` do not make
      the claim. `uv run sz.py --check` unchanged at `1848` — prose and one test only.
- [x] New surface on a world-writable service: **nothing new** — no code path changes. The
      behaviour being documented already exists; this PR stops the documents from denying it.
      `bash examples/beautiful_chat.sh` passes.
