### PR TITLE
fix(mcp): pin the stdio transport to UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ of the contract, not an implementation detail: agents parse it.
 
 ### Fixed
 
+- **The MCP stdio transport pins itself to UTF-8 instead of trusting the environment's.**
+  `sys.stdin`/`sys.stdout` follow the locale — PEP 686 only makes UTF-8 the default in 3.15 and
+  this wheel supports 3.11 — so under `PYTHONIOENCODING`, or on the code-page pipes a non-UTF-8
+  Windows console hands a child, the streams could not carry the service's own text. The
+  untrusted-content banner alone contains an em dash, so six of the nine tools raised
+  `UnicodeEncodeError` inside `_write` on every call, and a message holding one non-ASCII
+  character raised `UnicodeDecodeError` in the read loop. Both are outside every handler: the
+  session ended and later requests went unanswered, which is what the transport's framing
+  guarantees already rule out for a torn line.
+
 - **The MCP wheel and source distribution carry the Apache-2.0 legal files they declare.**
   The MCP project now includes exact copies of the repository `LICENSE` and `NOTICE`. CI verifies
   both built artifacts use the required archive paths, contain byte-identical legal files, and

--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -20,6 +20,7 @@ advertises and what `tools/call` enforces cannot disagree with what the handler 
 
 from __future__ import annotations
 
+import codecs
 import inspect
 import json
 import sys
@@ -370,6 +371,8 @@ class Server:
         """
         stdin = stdin or sys.stdin
         stdout = stdout or sys.stdout
+        _as_utf8(stdin)
+        _as_utf8(stdout)
         for line in stdin:
             line = line.strip()
             if not line:
@@ -418,6 +421,38 @@ def _ok(ident: RequestId | None, result: dict[str, Any]) -> Success:
 
 def _error(ident: RequestId | None, code: int, message: str) -> Failure:
     return {"jsonrpc": "2.0", "id": ident, "error": {"code": code, "message": message}}
+
+
+def _as_utf8(stream: TextIO) -> None:
+    """Pin a stdio stream to UTF-8, when it is a real one that is not already.
+
+    MCP's stdio transport is UTF-8 by definition; `sys.stdin` and `sys.stdout` are whatever
+    the environment made them. PEP 686 only makes UTF-8 the default in 3.15 and this wheel
+    supports 3.11, so a client that exports PYTHONIOENCODING — or hands this process the
+    code-page pipes a non-UTF-8 Windows console gives a child — gets streams that cannot
+    carry the service's own content. A room holding one emoji then raises UnicodeEncodeError
+    inside `_write`, and a message carrying one raises UnicodeDecodeError inside the read
+    loop. Both are outside every handler, so the loop is gone and every later request goes
+    unanswered — the failure `test_malformed_json_does_not_kill_the_session` already rules
+    out for a torn line, arriving instead through ordinary content.
+
+    `errors="replace"` is for the read half: bytes that are not UTF-8 are a client framing
+    bug, and U+FFFD reaching `json.loads` answers it with the PARSE_ERROR that says so
+    rather than taking the session down. Nothing can trigger it on the write half, where
+    every `str` encodes.
+
+    A stream already UTF-8 is left alone. reconfigure() refuses to run once a stream has
+    been read from, and the common case must not be the one that raises.
+    """
+    reconfigure = getattr(stream, "reconfigure", None)
+    encoding = getattr(stream, "encoding", None)
+    if reconfigure is None or encoding is None:
+        return  # the StringIO the tests inject: no encoding to correct
+    try:
+        if codecs.lookup(encoding).name != "utf-8":
+            reconfigure(encoding="utf-8", errors="replace")
+    except (LookupError, ValueError):
+        pass  # an unknown encoding name, or a stream already read from: no worse off
 
 
 def _write(stdout: TextIO, message: Reply | list[Reply]) -> None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -600,6 +600,105 @@ def test_malformed_json_does_not_kill_the_session(mcp):
     assert replies[1] == {"jsonrpc": "2.0", "id": 9, "result": {}}
 
 
+def _ascii_stdio(payload: str = "") -> tuple[io.TextIOWrapper, io.TextIOWrapper, io.BytesIO]:
+    """The stdio pair a client on a non-UTF-8 locale hands this process.
+
+    `PYTHONIOENCODING=ascii` produces exactly this, and so does a Windows console whose code
+    page is not UTF-8: the pipes a child gets are decoded and encoded with it. Real
+    TextIOWrappers rather than StringIO, because the encoding is the whole subject and
+    StringIO has none.
+    """
+    written = io.BytesIO()
+    stdin = io.TextIOWrapper(io.BytesIO(payload.encode("utf-8")), encoding="ascii")
+    stdout = io.TextIOWrapper(written, encoding="ascii", write_through=True)
+    return stdin, stdout, written
+
+
+def test_a_room_that_is_not_ascii_does_not_kill_the_session(mcp):
+    """Reading a room with an emoji in it must not take the transport down.
+
+    `_write` serialises with `ensure_ascii=False`, so a message body reaches `stdout.write`
+    as the characters it holds. On a stdout that cannot encode them that raises outside
+    every handler, and the session is gone — the same loss
+    `test_malformed_json_does_not_kill_the_session` rules out for a torn line, reached here
+    through ordinary content that any stranger can put in a public room.
+    """
+    server, _ = mcp
+    assert "1" in text_of(call(server, "say", {"room": "lobby", "text": "café 🐱 猫", "nick": "a"}))
+
+    stdin, stdout, written = _ascii_stdio(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "read_room", "arguments": {"room": "lobby"}},
+            }
+        )
+        + "\n"
+        + json.dumps({"jsonrpc": "2.0", "id": 2, "method": "ping"})
+        + "\n"
+    )
+    server.serve(stdin, stdout)
+
+    replies = [json.loads(line) for line in written.getvalue().decode("utf-8").splitlines()]
+    assert [reply["id"] for reply in replies] == [1, 2]  # the ping proves the loop survived
+    assert "café 🐱 猫" in replies[0]["result"]["content"][0]["text"]
+
+
+def test_a_message_that_is_not_ascii_does_not_kill_the_session(mcp):
+    """The read half of the same defect: the emoji is in the request, not the reply.
+
+    A stdin that cannot decode it raises in the `for line in stdin` that drives the loop,
+    before any framing check can answer, so the client loses the session for sending a
+    message the service accepts and stores.
+    """
+    server, _ = mcp
+    stdin, stdout, written = _ascii_stdio(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "say",
+                    "arguments": {"room": "lobby", "text": "café 🐱 猫", "nick": "a"},
+                },
+            }
+        )
+        + "\n"
+        + json.dumps({"jsonrpc": "2.0", "id": 2, "method": "ping"})
+        + "\n"
+    )
+    server.serve(stdin, stdout)
+
+    replies = [json.loads(line) for line in written.getvalue().decode("utf-8").splitlines()]
+    assert [reply["id"] for reply in replies] == [1, 2]
+    assert replies[0]["result"]["isError"] is False
+    # stored as sent, not as mojibake: the fix pins the encoding, it does not drop characters
+    assert "café 🐱 猫" in text_of(call(server, "read_room", {"room": "lobby"}, ident=3))
+
+
+def test_pinning_the_encoding_never_raises_on_its_own(mcp):
+    """The repair must not become the failure. reconfigure() refuses to run once a stream has
+    been read from, so a stream already UTF-8 is left untouched rather than re-set, and one
+    that cannot be corrected is left as it was — no worse off than before the attempt."""
+    _, protocol = mcp
+
+    def read_from(encoding: str) -> io.TextIOWrapper:
+        stream = io.TextIOWrapper(io.BytesIO(b"{}\n{}\n"), encoding=encoding)
+        stream.readline()  # a caller that peeked; reconfigure would now raise
+        return stream
+
+    already = read_from("utf-8")
+    protocol._as_utf8(already)  # skipped before reconfigure is reached
+    assert already.encoding == "utf-8"
+
+    uncorrectable = read_from("ascii")
+    protocol._as_utf8(uncorrectable)  # reconfigure raises here and is swallowed
+    assert uncorrectable.encoding == "ascii"
+
+
 # ------------------------------------------------------------------ packaging
 
 


### PR DESCRIPTION
## What

`serve()` pins stdin and stdout to UTF-8 before its first read or write. The wire format is
unchanged.

For a caller: the wrapper now works on a runtime whose stdio is not UTF-8. Before this it raised
on the first tool call and the session ended.

## Why

`sys.stdin`/`sys.stdout` carry whatever encoding the environment gave them. PEP 686 only makes
UTF-8 the default in 3.15 and `mcp/pyproject.toml` supports 3.11, so `PYTHONIOENCODING=ascii`
produces streams that cannot carry this service's own text.

This is not a rare-content problem. `_write` serialises with `ensure_ascii=False`, and the
untrusted-content banner contains an em dash, so six of the nine tools emit non-ASCII on *every*
call — `read_room`, `wait_for_message`, `list_rooms`, `discover_rooms`, `read_docs`, and the reply
to `say`. Each raised `UnicodeEncodeError` inside `_write`. The read half fails the same way from
one non-ASCII character in an inbound message, as `UnicodeDecodeError` in the `for line in stdin`
that drives the loop.

Both raise outside every handler, so the loop ends and every later request goes unanswered — the
loss `test_malformed_json_does_not_kill_the_session` already rules out for a torn line, arriving
here through ordinary content instead.

Against the entry point, before the change:

```
$ printf '%s\n' \
    '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_room","arguments":{"room":"lobby"}}}' \
    '{"jsonrpc":"2.0","id":2,"method":"ping"}' \
  | PYTHONIOENCODING=ascii TECHNOCORE_URL=http://localhost:8099 python -m technocore_mcp.server

UnicodeEncodeError: 'ascii' codec can't encode character '—' in position 136
```

`—` is the banner's em dash, not the room's content, and `id: 2` is never answered. After the
change both replies land and the text round-trips intact.

Two things the repair is careful not to become the failure, both covered by
`test_pinning_the_encoding_never_raises_on_its_own`: a stream already UTF-8 is left alone, because
`reconfigure()` refuses to run once a stream has been read from and the common case must not be the
one that raises; and a stream that cannot be corrected is left as it was. `errors="replace"` is for
the read half only — bytes that are not UTF-8 are a client framing bug, and U+FFFD reaching
`json.loads` answers with `PARSE_ERROR` rather than ending the session. Nothing can trigger it on
the write half, where every `str` encodes.

The two behavioural tests fail without the change and pass with it.

No dependency on, or conflict with, any open pull request: this touches `serve()` and adds a
module-level helper, where #90 and #92 change `_CHECKS` and `_validate`.

One claim I could not verify myself, flagged rather than buried: I reproduced the
`PYTHONIOENCODING` path directly, but I have no Windows machine, so the changelog's mention of the
code-page pipes a non-UTF-8 Windows console hands a child is inference from documented behaviour,
not something I ran. Glad to narrow that sentence to what is proven if you would prefer.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 324 passed, 97.44% total
      against the 96% floor, with the new code fully covered
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — clean
- [x] Docs that would now be wrong are updated: none of the generated documents describe the
      transport's encoding, so `CHANGELOG.md` is the only one. No HTTP surface changes, so the
      manual, `/skill.md`, `README.md`, `src/patterns.md` and `mcp/README.md` are untouched.
- [x] New surface on a world-writable service: **nothing new.** No route, parameter or persistent
      state is added and the service itself is not touched — the change is confined to the MCP
      wrapper's own stdio.

Also run locally: `uv run sz.py --check` (ok), `uv build --project mcp` with
`tests/verify_mcp_dist.py` (ok), `bash examples/beautiful_chat.sh` (ok), and the contract job at
`--max-examples 500` (6092 cases, all passed). The Docker image build I did not run — no Docker on
this machine — but nothing in the change reaches the image.
