### PR TITLE
fix(store): assign timestamps in append order

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -2520,7 +2520,7 @@ def _write_record(
     # treat as provenance, and the allowlist that protects it does not apply to a DID (it
     # rejects ':'). One place decides the shape, for both write lanes.
     if did is None:
-        rec = {"seq": 0, "from": valid_name(nick), "text": clean_text(text)}
+        rec = {"seq": 0, "ts": "", "from": valid_name(nick), "text": clean_text(text)}
     else:
         didkey.public_key(did)
         if not isinstance(nonce, int) or nonce < 0:
@@ -2529,7 +2529,7 @@ def _write_record(
                 "digits, greater than the last one this key used in this room. A counter "
                 "or a millisecond clock both work"
             )
-        rec = {"seq": 0, "from": did, "text": clean_text(text), "nonce": nonce}
+        rec = {"seq": 0, "ts": "", "from": did, "text": clean_text(text), "nonce": nonce}
         # The signature the caller was accepted on, kept so the record can be checked
         # again later by anyone holding the room JSON. `room|nonce|text` is rebuildable
         # from the record itself, and the text here is the swept text that was signed,
@@ -2566,7 +2566,8 @@ def _write_record(
                     f"nonce {nonce} is not greater than {previous}, the last one this key "
                     f"used in /r/{room} — a signed URL is single-use, so count up"
                 )
-        rec.update(seq=last_seq(root, room) + 1, ts=_now())
+        rec["seq"] = last_seq(root, room) + 1
+        rec["ts"] = _now()
         line = orjson.dumps(rec) + b"\n"
         # Heal a torn tail before appending. A write cut short by a crash leaves a record
         # with no trailing newline; appending straight onto it would fuse the two into one

--- a/src/store.py
+++ b/src/store.py
@@ -2566,8 +2566,7 @@ def _write_record(
                     f"nonce {nonce} is not greater than {previous}, the last one this key "
                     f"used in /r/{room} — a signed URL is single-use, so count up"
                 )
-        rec["seq"] = last_seq(root, room) + 1
-        rec["ts"] = _now()
+        rec.update(seq=last_seq(root, room) + 1, ts=_now())
         line = orjson.dumps(rec) + b"\n"
         # Heal a torn tail before appending. A write cut short by a crash leaves a record
         # with no trailing newline; appending straight onto it would fuse the two into one

--- a/src/store.py
+++ b/src/store.py
@@ -2520,7 +2520,7 @@ def _write_record(
     # treat as provenance, and the allowlist that protects it does not apply to a DID (it
     # rejects ':'). One place decides the shape, for both write lanes.
     if did is None:
-        rec = {"seq": 0, "ts": _now(), "from": valid_name(nick), "text": clean_text(text)}
+        rec = {"seq": 0, "from": valid_name(nick), "text": clean_text(text)}
     else:
         didkey.public_key(did)
         if not isinstance(nonce, int) or nonce < 0:
@@ -2529,7 +2529,7 @@ def _write_record(
                 "digits, greater than the last one this key used in this room. A counter "
                 "or a millisecond clock both work"
             )
-        rec = {"seq": 0, "ts": _now(), "from": did, "text": clean_text(text), "nonce": nonce}
+        rec = {"seq": 0, "from": did, "text": clean_text(text), "nonce": nonce}
         # The signature the caller was accepted on, kept so the record can be checked
         # again later by anyone holding the room JSON. `room|nonce|text` is rebuildable
         # from the record itself, and the text here is the swept text that was signed,
@@ -2566,7 +2566,7 @@ def _write_record(
                     f"nonce {nonce} is not greater than {previous}, the last one this key "
                     f"used in /r/{room} — a signed URL is single-use, so count up"
                 )
-        rec["seq"] = last_seq(root, room) + 1
+        rec.update(seq=last_seq(root, room) + 1, ts=_now())
         line = orjson.dumps(rec) + b"\n"
         # Heal a torn tail before appending. A write cut short by a crash leaves a record
         # with no trailing newline; appending straight onto it would fuse the two into one

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -952,6 +952,11 @@ def test_concurrent_writers_cannot_put_an_expired_record_after_a_fresh_one(tmp_p
     stamps = iter((stamp(expired), stamp(now)))
     monkeypatch.setattr(store, "_now", lambda: next(stamps))
     monkeypatch.setattr(store.time, "time", lambda: now)
+    # Match the reaper's filesystem clock to the frozen clock. Otherwise the nested
+    # append reaps while the outer create holds the shared create-span lock.
+    marker = tmp_path / ".reaped"
+    marker.touch()
+    os.utime(marker, (now, now))
     room = "e-p-order"
     path = store.room_path(tmp_path, room)
     fired = _race_before_lock(

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -932,6 +932,45 @@ def test_ephemeral_expiry_is_lazy_but_rotation_reclaims_the_disk(tmp_path, monke
     assert store.room_path(tmp_path, "e-chat").stat().st_size <= 4096
 
 
+def test_concurrent_writers_cannot_put_an_expired_record_after_a_fresh_one(tmp_path, monkeypatch):
+    """A timestamp taken before the room lock can disagree with append order.
+
+    Ephemeral reads walk newest-first and stop at the first expired record, relying on every
+    older seq having an older timestamp. Make the first caller pause before the lock while a
+    later caller appends, and advance the clock between its two reads.
+    """
+    from datetime import UTC, datetime
+
+    import store
+
+    now = 2_000_000_000.0
+    expired = now - store.EPHEMERAL_TTL_SECONDS - 1
+
+    def stamp(epoch):
+        return datetime.fromtimestamp(epoch, UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    stamps = iter((stamp(expired), stamp(now)))
+    monkeypatch.setattr(store, "_now", lambda: next(stamps))
+    monkeypatch.setattr(store.time, "time", lambda: now)
+    room = "e-p-order"
+    path = store.room_path(tmp_path, room)
+    fired = _race_before_lock(
+        monkeypatch,
+        store,
+        path,
+        lambda: store.append(tmp_path, room, "later", "committed-first"),
+    )
+
+    store.append(tmp_path, room, "first", "committed-second")
+
+    assert fired
+    records = [json.loads(line) for line in path.read_text().splitlines()]
+    assert [record["text"] for record in records] == ["committed-first", "committed-second"]
+    assert [record["ts"] for record in records] == [stamp(expired), stamp(now)]
+    view = store.read_messages(tmp_path, room)
+    assert [message["text"] for message in view["messages"]] == ["committed-second"]
+
+
 @pytest.mark.parametrize("stamp", ["whenever", None, 0, {}, []])
 def test_an_unparseable_timestamp_counts_as_expired(tmp_path, stamp):
     """Fail closed for malformed JSON types as well as malformed timestamp strings.


### PR DESCRIPTION
## What

Assign room timestamps under the same lock as sequence numbers, for both signed and unsigned writes. Preserve serialized record key order.

Rebased onto `main` `45921c3`; current head: `eb51658`.

## Why

Concurrent callers can take timestamps in one order and append in the opposite order. Newest-first expiry reads can then hide a fresh record behind an expired one.

The deterministic regression also aligns the reaper marker's filesystem time with its frozen clock, fixing the test hang reported in review without disabling locks.

## Checks

- [x] Native Linux [fork CI](https://github.com/zakazaka95/technocore-chat/actions/runs/34106704678): **771 passed, 1 skipped; 97.90% coverage**, including the ordering regression.
- [x] Repository lint, format, types, size caps and baseline ratchet; example, MCP packaging/Worker bundle, Docker build/smoke, and OpenAPI contract.
- [x] Regression fails on reversed timestamps when run with the unmodified `45921c3` write function.
- [x] Documentation compatibility reviewed; no protocol or response-shape changes.
- [x] New world-writable surface: nothing new.
- [ ] Upstream required CI, regression guard and browser workflow still need maintainer approval. Fork CI does not replace them.