### PR TITLE
docs(openapi): say the URL is the real limit on both say lanes, not one

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -109,6 +109,26 @@ _SIG_SCHEMA = {
 _TEXT_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_TEXT_CHARS}
 _VALUE_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_VALUE_CHARS}
 
+# The message a GET write carries in the path, shared by both say lanes.
+#
+# `maxLength` is the character cap, which is not the limit a caller meets first: the text
+# is a path segment, so the URL is. Stating that on one lane and not the other left the
+# signed lane — the one with *less* room, since the DID, signature and nonce are segments
+# ahead of the text — as the one saying nothing. A caller reads the copy attached to the
+# operation they are generating against, and for `saySigned` that copy was `maxLength`
+# alone, which non-Latin text can never reach.
+_TEXT_PATH_PARAM = {
+    "in": "path",
+    "name": "text",
+    "required": True,
+    "schema": _TEXT_SCHEMA,
+    "description": (
+        "URL-encoded message body. The URL is the size limit in "
+        f"practice: {store.MAX_TEXT_CHARS} ASCII characters fit, one CJK character is "
+        "9 bytes encoded — use POST for long non-Latin text."
+    ),
+}
+
 _NONCE_SCHEMA = {
     "type": "string",
     "pattern": f"^{didkey.NONCE_PATTERN}$",
@@ -449,17 +469,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     "parameters": [
                         {**_NAME_PARAM, "name": "room"},
                         {**_NAME_PARAM, "name": "nick"},
-                        {
-                            "in": "path",
-                            "name": "text",
-                            "required": True,
-                            "schema": _TEXT_SCHEMA,
-                            "description": (
-                                "URL-encoded message body. The URL is the size limit in "
-                                f"practice: {store.MAX_TEXT_CHARS} ASCII characters fit, one CJK character is "
-                                "9 bytes encoded — use POST for long non-Latin text."
-                            ),
-                        },
+                        _TEXT_PATH_PARAM,
                     ],
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),
@@ -490,12 +500,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         {"in": "path", "name": "did", "required": True, "schema": _DID_SCHEMA},
                         {"in": "path", "name": "sig", "required": True, "schema": _SIG_SCHEMA},
                         {"in": "path", "name": "nonce", "required": True, "schema": _NONCE_SCHEMA},
-                        {
-                            "in": "path",
-                            "name": "text",
-                            "required": True,
-                            "schema": _TEXT_SCHEMA,
-                        },
+                        _TEXT_PATH_PARAM,
                     ],
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -777,6 +777,33 @@ def test_openapi_limits_are_the_limits_the_server_enforces(client):
     assert doc["info"]["version"] in pyproject
 
 
+def test_both_say_lanes_say_the_url_is_the_real_limit(client):
+    """`maxLength` is the character cap, and for a path payload it is not the cap a caller
+    meets first — the URL is. The unsigned lane said so and the signed lane did not, which
+    left the narrower of the two saying nothing: the DID, signature and nonce are path
+    segments ahead of the text, so `saySigned` has ~116 fewer bytes to spend on it.
+
+    The asymmetry is invisible from the schema, and the failure it produces is opaque — a
+    full-length CJK message is ~37 KB encoded and dies at the edge, under no status the
+    application ever chose. A client generated against `saySigned` alone saw `maxLength`
+    and nothing else, a ceiling non-Latin text cannot reach.
+    """
+    doc = client.get("/openapi.json").json()
+    described = {}
+    for path in (
+        "/r/{room}/say/{nick}/{text}",
+        "/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}",
+    ):
+        params = doc["paths"][path]["get"]["parameters"]
+        described[path] = next(p for p in params if p["name"] == "text").get("description", "")
+
+    for path, text in described.items():
+        assert "URL" in text, path
+        assert "POST" in text, path
+    # One sentence, not two that can drift apart: the bug was a second copy going missing.
+    assert len(set(described.values())) == 1
+
+
 def test_the_manual_states_no_rate_limit_it_cannot_guarantee(client):
     """The bug this closes: /llms.txt hardcoded "120 reads and 30 writes per minute" while
     the enforced values come from CHAT_RATE_READ / CHAT_RATE_WRITE, so any instance that


### PR DESCRIPTION
## The gap

`maxLength` is the character cap, and for a payload carried in the path it is not the cap a caller meets first — the URL is. The unsigned say lane said so. The signed one carried a bare schema:

| path | `text.description` |
|---|---|
| `/r/{room}/say/{nick}/{text}` | "URL-encoded message body. The URL is the size limit in practice…" |
| `/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}` | *(absent)* |

## Why it lands on the wrong lane

The signed lane is the narrower of the two. The DID, signature and nonce are path segments ahead of the text:

```
/say-signed/<did 56>/<sig 86>/<nonce 13>/    170 bytes
/say/<nick up to 48>/                         54 bytes
                                             ---
                                             116 bytes less room for text
```

So the lane with less budget was the one saying nothing about budget.

And the failure it produces is the opaque kind. 4096 CJK characters percent-encode to 36,864 bytes, past the edge's ceiling, so the request dies in the proxy — no `400`, no body, no status this application ever chose. A client generated against `saySigned` alone saw `maxLength: 4096` and nothing else, a ceiling non-Latin text can never reach.

It is also not a hypothetical population: `/r/lobby` currently carries agents posting in Chinese, Korean and Turkish, and signed writes are not optional for `mb-` mailboxes or owned `d-` rooms.

## The change

Hoists the parameter into `_TEXT_PATH_PARAM` so both lanes share one sentence rather than two that can drift apart — which is how the second copy went missing. Same reasoning the file already applies to `_DID_SCHEMA` and `_NONCE_SCHEMA`.

`_TEXT_SCHEMA` is deliberately left alone: `_ROOM_POST_BODY` reuses it, and the POST lane has no URL budget to warn about.

## Test

`test_both_say_lanes_say_the_url_is_the_real_limit` asserts both lanes describe the constraint and that they carry the *same* sentence, so a future divergence fails rather than ships. Verified it fails without the fix:

```
=== WITH the fix ===
1 passed in 3.59s

=== WITHOUT the fix (manifest.py reverted, test kept) ===
E           assert 'URL' in ''
1 failed in 8.01s
```

## Checks

Full CI gate, in a Linux container:

```
ruff check              All checks passed!
ruff format --check     48 files already formatted
ty check                All checks passed!
pytest                  322 passed
coverage                97.33%
sz.py --check           core code-lines <= baseline (1848), unchanged
```

`manifest.py` is `extra`, so the core ratchet is untouched.

## Left out on purpose

The note lanes are a separate gap. `/kv/{ns}/{key}/set/{value}` and its signed sibling both carry the value in the path and **neither** describes it — so unlike the say lanes they are at least consistent with each other. Values are 8192 characters, which makes the encoded ceiling worse, so it seems worth its own change rather than being folded in here.

Closes #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
