### PR TITLE
Reject non-2.0 JSON-RPC MCP requests

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -307,6 +307,8 @@ class Server:
         ident = message["id"]
         if not _is_request_id(ident):
             return _error(None, INVALID_REQUEST, "request id must be a string or integer")
+        if "jsonrpc" in message and message["jsonrpc"] != "2.0":
+            return _error(ident, INVALID_REQUEST, "jsonrpc must be '2.0'")
         if not _is_request(message):
             return _error(ident, INVALID_REQUEST, "missing method")
         params = message.get("params", {})

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -198,6 +198,23 @@ def test_unknown_methods_get_an_error_not_a_crash(mcp):
     assert reply["id"] == 7
 
 
+def test_requests_must_use_jsonrpc_2(mcp):
+    """MCP rides on JSON-RPC 2.0; a request declaring another protocol version must not
+    be treated as a valid MCP frame and dispatched to a tool.
+    """
+    server, protocol = mcp
+    for bad in ("1.0", "2", "", None, 2):
+        reply = server.handle({"jsonrpc": bad, "id": 7, "method": "ping"})
+        assert reply == {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "error": {"code": protocol.INVALID_REQUEST, "message": "jsonrpc must be '2.0'"},
+        }
+
+    # Historical clients/tests that omitted the member entirely still work.
+    assert server.handle({"id": 8, "method": "ping"}) == {"jsonrpc": "2.0", "id": 8, "result": {}}
+
+
 # ------------------------------------------------------------------ the tools
 
 


### PR DESCRIPTION
## Summary

Reject MCP JSON-RPC requests that explicitly declare a protocol version other than `"2.0"` before they reach method dispatch.

## Why

MCP uses JSON-RPC 2.0 framing. Before this change, a request like:

```json
{"jsonrpc":"1.0","id":7,"method":"ping"}
```

was accepted and dispatched as a valid MCP request. That means a client, bridge, or agent sending an incompatible JSON-RPC version could still get successful tool responses instead of a protocol-shape error.

## Change

- Adds a guard in `Server.handle()` for explicit non-`"2.0"` `jsonrpc` members.
- Returns `-32600 Invalid Request` with `jsonrpc must be '2.0'`.
- Keeps historical omitted-`jsonrpc` frames working, matching the existing test style and compatibility behavior.
- Adds a regression test covering `"1.0"`, `"2"`, empty string, `null`, and numeric `2`.

## Verification

Ran the project checks listed in `AGENTS.md`:

```bash
UV_CACHE_DIR=$PWD/.uvcache uv run ruff check .
UV_CACHE_DIR=$PWD/.uvcache uv run ruff format --check .
UV_CACHE_DIR=$PWD/.uvcache uv run ty check
UV_CACHE_DIR=$PWD/.uvcache uv run coverage run -m pytest tests -q
UV_CACHE_DIR=$PWD/.uvcache uv run coverage report
UV_CACHE_DIR=$PWD/.uvcache uv run sz.py --check
```

Results:

- `ruff check`: passed
- `ruff format --check`: 48 files already formatted
- `ty check`: passed
- tests: 322 passed
- total coverage: 97.33%
- core size check: passed, core code-lines remain 1848
