### PR TITLE
fix(mcp): reject malformed no-id request objects

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -305,6 +305,8 @@ class Server:
         if "id" not in message:
             if not _is_request(message):
                 return _error(None, INVALID_REQUEST, "missing method")
+            if "params" in message and not isinstance(message["params"], (dict, list)):
+                return _error(None, INVALID_REQUEST, "params must be an object or array")
             return None
         ident = message["id"]
         if not _is_request_id(ident):

--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -303,6 +303,8 @@ class Server:
         it is a request whose id this server refuses, and it gets told so.
         """
         if "id" not in message:
+            if not _is_request(message):
+                return _error(None, INVALID_REQUEST, "missing method")
             return None
         ident = message["id"]
         if not _is_request_id(ident):

--- a/tests/test_mcp_invalid_request_shape.py
+++ b/tests/test_mcp_invalid_request_shape.py
@@ -26,6 +26,25 @@ def test_malformed_no_id_objects_are_invalid_requests(message):
     }
 
 
+def test_malformed_no_id_params_are_invalid_request():
+    server = protocol.Server("test", "test")
+
+    assert server.handle({"jsonrpc": "2.0", "method": "ping", "params": 1}) == {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {
+            "code": protocol.INVALID_REQUEST,
+            "message": "params must be an object or array",
+        },
+    }
+
+
+def test_valid_by_position_notification_remains_silent():
+    server = protocol.Server("test", "test")
+
+    assert server.handle({"jsonrpc": "2.0", "method": "ping", "params": []}) is None
+
+
 def test_malformed_no_id_batch_member_is_not_silently_dropped():
     server = protocol.Server("test", "test")
 
@@ -33,7 +52,7 @@ def test_malformed_no_id_batch_member_is_not_silently_dropped():
         server,
         [
             {"jsonrpc": "2.0", "id": 1, "method": "ping"},
-            {"jsonrpc": "2.0", "method": 1},
+            {"jsonrpc": "2.0", "method": "ping", "params": 1},
             {"jsonrpc": "2.0", "method": "ping"},
         ],
     ) == [
@@ -41,6 +60,9 @@ def test_malformed_no_id_batch_member_is_not_silently_dropped():
         {
             "jsonrpc": "2.0",
             "id": None,
-            "error": {"code": protocol.INVALID_REQUEST, "message": "missing method"},
+            "error": {
+                "code": protocol.INVALID_REQUEST,
+                "message": "params must be an object or array",
+            },
         },
     ]

--- a/tests/test_mcp_invalid_request_shape.py
+++ b/tests/test_mcp_invalid_request_shape.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "mcp" / "src"))
+
+from technocore_mcp import protocol  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        {"jsonrpc": "2.0"},
+        {"jsonrpc": "2.0", "method": 1},
+    ],
+)
+def test_malformed_no_id_objects_are_invalid_requests(message):
+    server = protocol.Server("test", "test")
+
+    assert server.handle(message) == {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {"code": protocol.INVALID_REQUEST, "message": "missing method"},
+    }
+
+
+def test_malformed_no_id_batch_member_is_not_silently_dropped():
+    server = protocol.Server("test", "test")
+
+    assert protocol._response(
+        server,
+        [
+            {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            {"jsonrpc": "2.0", "method": 1},
+            {"jsonrpc": "2.0", "method": "ping"},
+        ],
+    ) == [
+        {"jsonrpc": "2.0", "id": 1, "result": {}},
+        {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": protocol.INVALID_REQUEST, "message": "missing method"},
+        },
+    ]


### PR DESCRIPTION
## What

Reject malformed no-`id` MCP JSON-RPC objects instead of silently classifying them as notifications. Valid notifications remain silent, including unknown methods and legal by-position (`array`) params.

Examples that now return `-32600 Invalid Request` with `id: null`:

```json
{"jsonrpc":"2.0"}
{"jsonrpc":"2.0","method":1}
{"jsonrpc":"2.0","method":"ping","params":1}
```

A malformed member inside a batch now contributes its own error entry instead of disappearing.

## Why

A JSON-RPC notification is a valid Request object without an `id`, not an arbitrary object without `id`. Before suppressing a reply, the no-`id` path now verifies both the string `method` and that an explicitly supplied `params` value is structured (`object` or `array`). Scalar `params` therefore cannot disappear silently.

## Checks

- focused regressions cover missing/non-string `method` and scalar `params`;
- mixed-batch regression confirms malformed no-`id` members produce `-32600`;
- valid notifications remain silent, including legal by-position params;
- id-bearing by-position behavior is unchanged;
- rebased onto current `main` (`9c7df0e`);
- no HTTP, tool-schema, persistence, auth, rate-limit, or world-writable surface change.