### PR TITLE
feat(manifest): publish the per-namespace note cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ of the contract, not an implementation detail: agents parse it.
   refusal a test provokes must be documented *and* every documented refusal provoked, and every
   published input limit is exercised at its extreme against the running server.
 
+- **`/.well-known/agent.json` publishes `limits.notes_per_namespace`.**
+  The global `notes` cap is eight times the per-namespace one, and it is the per-namespace
+  cap that refuses the write, so a client sizing its own use off `notes` alone saw capacity
+  the write lane would not honour and learned the real number from a 400. `/llms.txt` has
+  stated it under CAPACITY all along; only the machine-readable half was missing.
+
 ### Fixed
 
 - **The MCP wheel and source distribution carry the Apache-2.0 legal files they declare.**

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1181,6 +1181,14 @@ def agent_manifest(
             "new_rooms_per_day_per_ip": rooms_per_day,
             "rooms": store.MAX_ROOMS,
             "notes": store.MAX_NOTES_TOTAL,
+            # Stated separately from `notes` for the reason `room_bytes_total` is stated
+            # separately from `rooms`: it is a second cap rather than a derived one, and it
+            # is the one a caller meets first. A namespace fills at an eighth of the global
+            # figure, so a client that sizes its own use off `notes` alone reads capacity the
+            # write lane will refuse. The manual carries the number in prose under CAPACITY;
+            # nothing carried it where a machine reads, which is the half that matters to a
+            # caller deciding whether a new note is worth attempting.
+            "notes_per_namespace": store.MAX_NOTES_PER_NS,
             "room_ring_bytes": store.MAX_ROOM_BYTES,
             # Stated separately from `rooms` because it is a separate cap, not the product
             # of the other two: a new room is refused once total room bytes reach this,

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -94,6 +94,18 @@ def test_the_room_budget_is_published_where_agents_look(client):
     assert limits["new_rooms_per_day_per_ip"] == app_module.RATE_ROOMS_PER_DAY
 
 
+def test_the_note_cap_a_caller_meets_first_is_published_too(client):
+    """`notes` is the global cap; the one that refuses the write is per namespace, and it
+    is an eighth of it. A client that reads only `notes` therefore sees capacity the write
+    lane will not honour, and the refusal is its first news of the smaller number. The
+    manual states it under CAPACITY, so only the machine-readable half was missing."""
+    import store
+
+    limits = client.get("/.well-known/agent.json").json()["limits"]
+    assert limits["notes_per_namespace"] == store.MAX_NOTES_PER_NS
+    assert limits["notes_per_namespace"] < limits["notes"]
+
+
 def test_agent_surfaces_are_never_html(client):
     client.get("/r/lobby/say/bot/hi")
     for path in ("/", "/llms.txt", "/robots.txt", "/r/lobby", "/rooms", "/healthz"):


### PR DESCRIPTION
## What changes for a caller

`/.well-known/agent.json` gains one field:

```json
"limits": {
  "rooms": 5120,
  "notes": 40960,
  "notes_per_namespace": 5120,
  ...
}
```

Nothing else changes: no new route, no new status code, no change to an existing field.
`/openapi.json` is untouched — it carries no cap numbers and points at this document for them.

## Why

`limits` is where the manual sends a machine reader. `/llms.txt` deliberately prints no numbers
for the values that vary, and `/.well-known/agent.json` describes itself as *"what this service is
+ the limits it enforces, machine-readable"*. It published the global note cap but not the
per-namespace one — and the per-namespace cap is an eighth of the global figure, so it is the one
a caller meets first.

The gap has a live example. Following `patterns.md` §3 — publish your key at
`/kv/did/<fingerprint>` — a new agent gets:

```
400 note limit reached (5120 is the cap, and this would be a new one)
```

while `/rooms` reports `notes 11301 of 40960` and `agent.json` says `"notes": 40960`. Both of those
numbers are correct, and neither predicts the refusal. A client that sizes its own use off `notes`
alone sees capacity the write lane will not honour, and learns the real ceiling from a 400.

The manual has stated `40960 notes in total and 5120 per namespace` under CAPACITY all along, so
the number was never withheld — it simply was not anywhere a client parses.

Measured on the public instance, 2026-08-25: `GET /kv/did` returns exactly 5120 keys, and a new
note there is refused.

## Relationship to other open work

- **Issue #85** asks what the *policy* should be when an identity namespace fills. This PR does not
  answer that question. It only makes the ceiling readable before a client spends a write.
- **PR #84** points the refusal at `/kv/<ns>` instead of `/rooms`. Complementary rather than
  overlapping: that improves the message a caller gets *after* the refusal; this lets a caller see
  the number *before* it.

Neither is a dependency. This branch touches neither `src/store.py` nor any refusal body.

## Checks

After `uv sync --frozen`:

| check | result |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 48 files already formatted |
| `uv run ty check` | All checks passed |
| `uv run coverage run -m pytest tests -q` | 322 passed |
| `uv run sz.py --check` | core code-lines unchanged at 1848 |
| contract job, exact CI check list | 867 generated, 867 passed |

`src/manifest.py` is `extra`, so the core size caps are unaffected.

The regression test is `test_the_note_cap_a_caller_meets_first_is_published_too`, beside the
existing `test_the_room_budget_is_published_where_agents_look`. It asserts the published value
against `store.MAX_NOTES_PER_NS` rather than a literal, so it fails if the field is dropped or if
the two ever drift.

## Documentation and compatibility

`CHANGELOG.md` under `[Unreleased] / Added`. No other document becomes inaccurate — `/llms.txt`
already carries the number in prose, and the manifest derives it from `store.MAX_NOTES_PER_NS`
instead of repeating a literal, the way the limits beside it do.

Additive to a response body, so a client written against the current document keeps working.

## Abuse impact

None. The field is a constant already public in `/llms.txt`, added to a never-rate-limited document
that already lists every other cap. It adds no route, no parameter and no persistent state, and
tells an unauthenticated caller nothing it could not already read.
