### PR TITLE
fix(mcp): negotiate protocol version 2025-11-25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The MCP wrapper now negotiates the 2025-11-25 protocol version.** Its tools-only stdio
+  surface already satisfies that revision, but omitting the version made current clients fall
+  back to an older protocol or abandon initialization despite no wire-level incompatibility.
+
 ## [0.10.0] - 2026-08-27
 
 A room now refuses a message it has already taken too many copies of. The flood this exists for
@@ -396,10 +402,6 @@ booted with `inf` was publishing JSON no strict parser would accept, and will no
   listing.** The legacy `/kv/did/<fingerprint>` namespace reached its 5120-note cap. New notes use
   `/kv/did-<first 2 hex>/<remaining 14 hex>`; readers fall back to the legacy path. Every namespace,
   listing response, and global disk bound keeps the same fixed limit.
-
-- **The MCP wrapper now negotiates the 2025-11-25 protocol version.** Its tools-only stdio
-  surface already satisfies that revision, but omitting the version made current clients fall
-  back to an older protocol or abandon initialization despite no wire-level incompatibility.
 
 - **The MCP wheel and source distribution carry the Apache-2.0 legal files they declare.**
   The MCP project now includes exact copies of the repository `LICENSE` and `NOTICE`. CI verifies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -397,6 +397,10 @@ booted with `inf` was publishing JSON no strict parser would accept, and will no
   `/kv/did-<first 2 hex>/<remaining 14 hex>`; readers fall back to the legacy path. Every namespace,
   listing response, and global disk bound keeps the same fixed limit.
 
+- **The MCP wrapper now negotiates the 2025-11-25 protocol version.** Its tools-only stdio
+  surface already satisfies that revision, but omitting the version made current clients fall
+  back to an older protocol or abandon initialization despite no wire-level incompatibility.
+
 - **The MCP wheel and source distribution carry the Apache-2.0 legal files they declare.**
   The MCP project now includes exact copies of the repository `LICENSE` and `NOTICE`. CI verifies
   both built artifacts use the required archive paths, contain byte-identical legal files, and

--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -42,7 +42,7 @@ from typing import (
 # Versions this server understands. A client asks for one in `initialize`; the spec says
 # reply with the same version if it is supported, otherwise with one this server does
 # support and let the client decide whether to continue.
-SUPPORTED_VERSIONS = ("2025-06-18", "2025-03-26", "2024-11-05")
+SUPPORTED_VERSIONS = ("2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05")
 LATEST_VERSION = SUPPORTED_VERSIONS[0]
 
 PARSE_ERROR = -32700

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -96,21 +96,22 @@ def text_of(reply: dict) -> str:
 
 def test_initialize_echoes_a_version_the_client_asked_for(mcp):
     server, protocol = mcp
-    reply = server.handle(
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {"protocolVersion": "2024-11-05", "capabilities": {}},
-        }
-    )
-    assert reply["result"]["protocolVersion"] == "2024-11-05"
+    for ident, version in enumerate(protocol.SUPPORTED_VERSIONS, start=1):
+        reply = server.handle(
+            {
+                "jsonrpc": "2.0",
+                "id": ident,
+                "method": "initialize",
+                "params": {"protocolVersion": version, "capabilities": {}},
+            }
+        )
+        assert reply["result"]["protocolVersion"] == version
     # …and offers its own latest when the client asks for something unknown, rather than
     # failing the handshake: the client then decides whether to continue.
     unknown = server.handle(
         {
             "jsonrpc": "2.0",
-            "id": 2,
+            "id": 99,
             "method": "initialize",
             "params": {"protocolVersion": "1999-01-01"},
         }


### PR DESCRIPTION
## Summary

- add 2025-11-25 as the MCP wrapper''s latest negotiated protocol version
- exercise initialize against every declared supported version
- keep unknown-version fallback behavior covered
- document the compatibility fix

## Why

A client that offers 2025-11-25 currently receives a 2025-06-18 fallback and may abandon initialization, even though this tools-only stdio server already uses compatible lifecycle, capability, tools/list, and tools/call shapes for the 2025-11-25 revision.

Protocol lifecycle:
https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle

Tools surface:
https://modelcontextprotocol.io/specification/2025-11-25/server/tools

This intentionally does not claim 2026-07-28 support; that revision changes the protocol model and deserves a separate implementation rather than a version-constant change.

## Verification

- uv sync --frozen
- uv run ruff check .
- uv run ruff format --check .
- uv run ty check
- uv run coverage run -m pytest tests -q: 321 passed
- uv run coverage report: 97.33%
- uv run sz.py --check
- focused MCP suite: 45 passed
- uv build --project mcp: wheel and sdist built successfully

## Compatibility and abuse impact

Older supported versions remain accepted and echoed exactly as before. Unknown versions still fall back to the server''s latest supported version for the client to accept or reject. No tool, capability, HTTP request, state, rate limit, or permission behavior changes, so there is no new abuse impact.

Related issues: none. Dependencies: none.