### PR TITLE
fix(http): reject non-finite JSON constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ of the contract, not an implementation detail: agents parse it.
 
 ### Fixed
 
+- **POST bodies now use strict RFC 8259 JSON.** Python's decoder accepts the bare constants
+  `NaN`, `Infinity`, and `-Infinity` by default; the room and note POST lanes now reject them with
+  the same actionable 400 as other malformed JSON instead of coercing them into stored text.
+
 - **The MCP wheel and source distribution carry the Apache-2.0 legal files they declare.**
   The MCP project now includes exact copies of the repository `LICENSE` and `NOTICE`. CI verifies
   both built artifacts use the required archive paths, contain byte-identical legal files, and

--- a/src/app.py
+++ b/src/app.py
@@ -948,10 +948,6 @@ def _payload_credentials(payload: dict) -> tuple[str, str, str] | None:
     return did, str(payload.get("sig", "")).strip(), str(payload.get("nonce", "")).strip()
 
 
-def _reject_json_constant(value: str) -> None:
-    raise ValueError(f"{value} is not valid JSON")
-
-
 async def read_json(request: Request) -> dict | Response:
     """Refuse on Content-Length, then cap the stream.
 
@@ -979,7 +975,7 @@ async def read_json(request: Request) -> dict | Response:
     try:
         # Python accepts NaN and Infinity by default; RFC 8259 JSON does not. Reject them
         # at the parser boundary so neither POST lane can turn non-JSON into stored text.
-        payload = json.loads(bytes(raw) if raw else b"{}", parse_constant=_reject_json_constant)
+        payload = json.loads(bytes(raw) if raw else b"{}", parse_constant=int)
     except ValueError as exc:
         return text(
             f"400 body must be JSON, and this did not parse: {exc}.\n"

--- a/src/app.py
+++ b/src/app.py
@@ -948,6 +948,10 @@ def _payload_credentials(payload: dict) -> tuple[str, str, str] | None:
     return did, str(payload.get("sig", "")).strip(), str(payload.get("nonce", "")).strip()
 
 
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"{value} is not valid JSON")
+
+
 async def read_json(request: Request) -> dict | Response:
     """Refuse on Content-Length, then cap the stream.
 
@@ -973,7 +977,9 @@ async def read_json(request: Request) -> dict | Response:
         if len(raw) > MAX_BODY:
             return text(f"{too_large}\nthe stream passed it before it ended.", 413)
     try:
-        payload = json.loads(bytes(raw) if raw else b"{}")
+        # Python accepts NaN and Infinity by default; RFC 8259 JSON does not. Reject them
+        # at the parser boundary so neither POST lane can turn non-JSON into stored text.
+        payload = json.loads(bytes(raw) if raw else b"{}", parse_constant=_reject_json_constant)
     except ValueError as exc:
         return text(
             f"400 body must be JSON, and this did not parse: {exc}.\n"

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,19 +1,19 @@
 {
-  "core_total": 1848,
+  "core_total": 1850,
   "caps": {
-    "core/app.py": 919,
+    "core/app.py": 921,
     "core/config.py": 48,
     "core/didkey.py": 57,
     "core/limit.py": 110,
     "core/store.py": 714,
-    "core_total": 1848
+    "core_total": 1850
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1614,
-      "code_lines": 919,
-      "comment_lines": 216,
-      "tokens_per_line": 7.82
+      "raw_lines": 1620,
+      "code_lines": 921,
+      "comment_lines": 218,
+      "tokens_per_line": 7.83
     },
     "core/config.py": {
       "raw_lines": 158,

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,19 +1,19 @@
 {
-  "core_total": 1850,
+  "core_total": 1848,
   "caps": {
-    "core/app.py": 921,
+    "core/app.py": 919,
     "core/config.py": 48,
     "core/didkey.py": 57,
     "core/limit.py": 110,
     "core/store.py": 714,
-    "core_total": 1850
+    "core_total": 1848
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1620,
-      "code_lines": 921,
-      "comment_lines": 218,
-      "tokens_per_line": 7.83
+      "raw_lines": 1614,
+      "code_lines": 919,
+      "comment_lines": 216,
+      "tokens_per_line": 7.82
     },
     "core/config.py": {
       "raw_lines": 158,

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 
 import _client
+import pytest
 from starlette.testclient import TestClient
 
 client = _client.client  # the shared TestClient fixture
@@ -593,6 +594,28 @@ def test_malformed_payload_shapes_are_400_not_500(client):
         assert r.status_code == 400, body
     assert client.post("/r/lobby", content=b"{not json").status_code == 400
     assert client.post("/r/lobby", json={}).status_code == 400  # empty from/text
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+def test_non_finite_constants_are_not_accepted_as_json(client, constant):
+    """Python's decoder accepts these extensions by default, but RFC 8259 does not.
+
+    The two POST lanes publish application/json, so accepting a different language here
+    makes a payload this Python service accepts fail in a strict implementation of the same
+    protocol. It also used to persist NaN as the ordinary text ``nan`` after coercion.
+    """
+    room = client.post(
+        "/r/lobby",
+        content=f'{{"from":"bot","text":{constant}}}'.encode(),
+        headers={"content-type": "application/json"},
+    )
+    note = client.post(
+        "/kv/plans/next",
+        content=f'{{"value":{constant}}}'.encode(),
+        headers={"content-type": "application/json"},
+    )
+    assert room.status_code == note.status_code == 400
+    assert constant in room.text and constant in note.text
 
 
 def test_a_malformed_note_post_names_the_note_shape_to_send_next(client):


### PR DESCRIPTION
## Summary

- make the shared HTTP body parser reject bare NaN, Infinity, and -Infinity
- cover both room-message and note POST lanes with regression tests
- document the stricter parser boundary and update the core size budget

## Why

Python''s json.loads accepts these implementation extensions by default even though RFC 8259 does not permit them. The service consequently accepted an application/json body that interoperable clients cannot produce or consume consistently, then coerced a room NaN value into the stored text nan.

Open PR #90 fixes the same standards gap at the separate MCP stdio boundary. This PR is complementary and changes only the HTTP parser shared by /r and /kv POST routes.

## Verification

- uv sync --frozen
- uv run ruff check .
- uv run ruff format --check .
- uv run ty check
- uv run coverage run -m pytest tests -q: 324 passed
- uv run coverage report: 97.33%
- uv run sz.py --check
- focused HTTP limits suite: 52 passed

## Compatibility and abuse impact

Valid JSON payloads are unchanged. Only non-standard numeric constants now receive the existing actionable 400 parse response. Rate limits, storage caps, signatures, and persistent formats are unchanged. Rejecting these values also prevents ambiguous cross-language representations from entering public room or note state.

Related issues: none. Dependencies: none.