### PR TITLE
fix(store): tolerate concurrent reaping in readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -397,6 +397,10 @@ booted with `inf` was publishing JSON no strict parser would accept, and will no
   `/kv/did-<first 2 hex>/<remaining 14 hex>`; readers fall back to the legacy path. Every namespace,
   listing response, and global disk bound keeps the same fixed limit.
 
+- **Room and note reads tolerate concurrent idle reaping.** A reaper can unlink an idle file
+  after a reader resolves its path but before it opens it; every read path now treats that race as
+  the same ordinary empty result it returns when the file was already gone, instead of a 500.
+
 - **The MCP wheel and source distribution carry the Apache-2.0 legal files they declare.**
   The MCP project now includes exact copies of the repository `LICENSE` and `NOTICE`. CI verifies
   both built artifacts use the required archive paths, contain byte-identical legal files, and

--- a/src/store.py
+++ b/src/store.py
@@ -19,7 +19,7 @@ import time
 import unicodedata
 from collections import OrderedDict
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
@@ -746,19 +746,18 @@ def read_messages(root: Path, room: str, limit: int = 50, since: int | None = No
     # advancing past records nobody can read any more, or an expired room would reuse seqs.
     cutoff = _cutoff(room)
     out: list[dict] = []
-    if path.exists():
-        with path.open("rb") as f:
-            for raw in reverse_lines(f):
-                rec = _parse(raw)
-                if rec is None:
-                    continue
-                if since is not None and rec["seq"] <= since:
-                    break
-                if cutoff is not None and _expired(rec, cutoff):
-                    break
-                out.append(rec)
-                if len(out) >= limit:
-                    break
+    with suppress(FileNotFoundError), path.open("rb") as f:
+        for raw in reverse_lines(f):
+            rec = _parse(raw)
+            if rec is None:
+                continue
+            if since is not None and rec["seq"] <= since:
+                break
+            if cutoff is not None and _expired(rec, cutoff):
+                break
+            out.append(rec)
+            if len(out) >= limit:
+                break
     out.reverse()
     return {
         "room": room,
@@ -771,9 +770,7 @@ def read_messages(root: Path, room: str, limit: int = 50, since: int | None = No
 
 def last_seq(root: Path, room: str) -> int:
     path = room_path(root, room)
-    if not path.exists():
-        return 0
-    with path.open("rb") as f:
+    with suppress(FileNotFoundError), path.open("rb") as f:
         for raw in reverse_lines(f, max_bytes=65536):
             rec = _parse(raw)
             if rec is not None:
@@ -803,17 +800,16 @@ def room_window(root: Path, room: str) -> tuple[int, list[str]]:
     nicks: list[str] = []
     top = 0
     path = room_path(root, room)
-    if path.exists():
-        with path.open("rb") as f:
-            for raw in reverse_lines(f, max_bytes=WINDOW_BYTES):
-                rec = _parse(raw)
-                if rec is None:
-                    continue
-                if not nicks:
-                    top = rec["seq"]
-                nicks.append(str(rec.get("from", "")))
-                if len(nicks) >= WINDOW_MESSAGES:
-                    break
+    with suppress(FileNotFoundError), path.open("rb") as f:
+        for raw in reverse_lines(f, max_bytes=WINDOW_BYTES):
+            rec = _parse(raw)
+            if rec is None:
+                continue
+            if not nicks:
+                top = rec["seq"]
+            nicks.append(str(rec.get("from", "")))
+            if len(nicks) >= WINDOW_MESSAGES:
+                break
     return top, nicks
 
 
@@ -1953,8 +1949,9 @@ def note_set(
 
 
 def note_get(root: Path, ns: str, key: str) -> str | None:
-    path = note_path(root, ns, key)
-    return path.read_text(encoding="utf-8") if path.exists() else None
+    with suppress(FileNotFoundError):
+        return note_path(root, ns, key).read_text(encoding="utf-8")
+    return None
 
 
 def topic(root: Path, room: str) -> str | None:

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -662,6 +662,43 @@ def test_torn_final_line_costs_only_that_record(tmp_path):
     assert store.read_messages(tmp_path, "crash", limit=1)["messages"][0]["text"] == "after"
 
 
+@pytest.mark.parametrize(
+    ("kind", "reader", "empty"),
+    (
+        ("room", lambda store, root: store.read_messages(root, "gone")["messages"], []),
+        ("room", lambda store, root: store.last_seq(root, "gone"), 0),
+        ("room", lambda store, root: store.room_window(root, "gone"), (0, [])),
+        ("note", lambda store, root: store.note_get(root, "plans", "gone"), None),
+    ),
+)
+def test_readers_tolerate_a_reap_between_path_resolution_and_open(
+    tmp_path, monkeypatch, kind, reader, empty
+):
+    """A concurrent reaper may unlink after a reader chose the path but before open().
+
+    That state is externally indistinguishable from an already-absent room or note, so it
+    must return the ordinary empty result instead of turning an idle cleanup into a 500.
+    """
+    import store
+
+    if kind == "room":
+        store.append(tmp_path, "gone", "bot", "hi")
+        target = store.room_path(tmp_path, "gone")
+    else:
+        store.note_set(tmp_path, "plans", "gone", "hi")
+        target = store.note_path(tmp_path, "plans", "gone")
+    path_type = type(target)
+    real_open = path_type.open
+
+    def open_after_reap(self, *args, **kwargs):
+        if self == target:
+            target.unlink(missing_ok=True)
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(path_type, "open", open_after_reap)
+    assert reader(store, tmp_path) == empty
+
+
 def test_concurrent_appends_never_duplicate_a_seq(tmp_path):
     import threading
 


### PR DESCRIPTION
## What

Room and note readers tolerate a file being reaped just before it is opened, instead of returning an HTTP 500. `last_seq` still falls back to the retained sequence floor; permission errors still propagate.

## Why

Checking whether a file exists does not prevent the idle reaper from removing it before `open()`. This updates the original fix for current main (`e4c4f73`), including its sharded storage and retained sequence state. Successful reads, exports, and write behavior are unchanged.

Thanks to @almondous for the [forward-port and additional regression tests](https://gist.github.com/almondous/2cb564dc069e17cc7dee71a9f8fc15fe). The original regressions are retained, with an additional state-machine rule for a `last_seq` read interrupted by reaping. No dependencies on other open PRs.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report`
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] No existing documentation becomes inaccurate; public responses are unchanged.
- [x] New abuse surface: nothing new.

Linux regression: 6 failures before the fix, all 13 supplemental cases pass afterward. Size caps, Chromium checks, and HTTP contract checks pass. Changelog and size baselines are unchanged.
