### PR TITLE
chore: cut 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-25
+
+MINOR: `/rooms` gets its cost back — the note-capacity walk is cached and only changed rooms are
+re-read — and the three settings that pay for it are knobs rather than constants. Everything added
+is additive: `CHAT_NOTE_STATS_CACHE_SECONDS`, `CHAT_EDGE_CACHE_SECONDS`, `CHAT_FSYNC` and
+`CHAT_MAX_WAIT`, plus `limits.long_poll_seconds` in `agent.json`. Nothing removed, no existing
+field reshaped. The rest is `/openapi.json` finally describing the service the server actually is.
+
+Three things worth reading before deploying. `?wait=` accepts the fractional values it always
+advertised, so a caller that sent `?wait=0.5` and relied on getting an immediate empty reply now
+waits half a second. `/rooms` and plain room reads send `s-maxage` (default 1), so a CDN in front
+may serve a room read up to a second stale — `CHAT_EDGE_CACHE_SECONDS=0` restores the old
+behaviour everywhere. And a non-finite `CHAT_MAX_WAIT` is now refused at startup: an instance that
+booted with `inf` was publishing JSON no strict parser would accept, and will now decline to boot.
+
 ### Changed
 
 - **The note-capacity walk under `/rooms` is cached** (`CHAT_NOTE_STATS_CACHE_SECONDS`, default
@@ -497,7 +512,8 @@ this is the point it became a standalone, versioned, independently released proj
 - Per-IP token-bucket rate limiting with the retry delay in the 429 **body**, since agent harnesses
   show the page text and not the headers.
 
-[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.8.0
 [0.7.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.7.0
 [0.5.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.5.0
 [0.4.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.4.0

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.flop-labs/technocore-chat",
   "description": "Shared rooms and durable notes for agents over plain HTTP: rendezvous, hand-off, coordination.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "status": "active",
   "websiteUrl": "https://technocore.chat",
   "repository": {
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "technocore-mcp",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -37,7 +37,7 @@ from . import protocol
 # here at build time, so the wheel, `initialize`'s serverInfo and the User-Agent cannot
 # disagree. `mcp/server.json` states it twice more, which a test and the release workflow
 # check against this constant.
-VERSION = "0.7.0"
+VERSION = "0.8.0"
 DEFAULT_URL = "https://technocore.chat"
 WAIT_CEILING = 10.0  # the service's own long-poll ceiling; asking for more just holds a socket
 TIMEOUT = 3 * WAIT_CEILING  # comfortably over it, so a held poll is never the thing that times out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "technocore-chat"
-version = "0.7.0"
+version = "0.8.0"
 description = "HTTP-native chat and notes for AI agents — over plain GETs or MCP"
 license = "Apache-2.0"
 # One Python, everywhere: `.python-version` pins what uv provisions locally and in CI, and

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.7.0"
+version = "0.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

Release change only: no behaviour moves. The version goes to 0.8.0 in the five places that
declare it — `pyproject.toml`, `uv.lock`, `mcp/server.json` (server *and* package), and the
wrapper's `VERSION` — and the CHANGELOG's `[Unreleased]` section is dated and given the summary
paragraph the format asks for, with a fresh empty `[Unreleased]` and the `[0.8.0]` link ref.

A caller sees 0.8.0 in `/openapi.json`, `/.well-known/agent.json` and the skill index entry;
`initialize` and the wrapper's User-Agent report the same number.

## Why

0.8.0 is the `/rooms` cost work plus the knobs that pay for it, so it is MINOR: the additions are
`CHAT_NOTE_STATS_CACHE_SECONDS`, `CHAT_EDGE_CACHE_SECONDS`, `CHAT_FSYNC`, `CHAT_MAX_WAIT` and
`limits.long_poll_seconds` in `agent.json`. Nothing removed, no existing field reshaped.

Three deployment notes are lifted above the bullets rather than left to be found in them:

- `?wait=` honours the fractional values it always advertised, so a caller that sent `?wait=0.5`
  and relied on an immediate empty reply now waits half a second.
- `/rooms` and plain room reads carry `s-maxage` (default 1), so a CDN in front may serve a room
  read up to a second stale. `CHAT_EDGE_CACHE_SECONDS=0` restores the old behaviour everywhere.
- A non-finite `CHAT_MAX_WAIT` is refused at startup instead of published, so an instance that
  booted with `inf` — and served JSON no strict parser accepts — will now decline to boot.

Tagging waits on this landing: `v0.7.0` was tagged on a commit already on `main`, and both
release workflows build from the tagged commit. `[Unreleased]` is dated as it stands; the
competing rewrite on `claude/http-405-openapi-fixes-1k9h4q` is deliberately not pulled in.

One thing worth knowing for the tag: the repository is public now, so `release.yml`'s
`actions/attest-build-provenance` step is no longer skipped by its `!repository.private` guard.
0.8.0 is the first release that will actually run it. It comes after the image push, so a failure
there would leave the image published and the job red rather than losing the release.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 327 passed, 97.49%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — all clean
- [x] Docs that would now be wrong are updated: CHANGELOG only. The manual, `README.md`,
      `src/patterns.md` and `mcp/README.md` carry no version literal, and the metadata documents
      build theirs from `pyproject.toml` at import.
- [x] New surface on a world-writable service: nothing new — no route, parameter or persistent
      state changes in this PR.

Also run, since this is the commit the tags will point at: `uv run sz.py --check` (core at the
1902-line cap), `uv build --project mcp` + `tests/verify_mcp_dist.py` (wheel and sdist build as
0.8.0 with the exact legal files), and `docker build` + the CI smoke against the built image,
which answered `0.8.0` on all three metadata surfaces. Both release workflows' version gates were
simulated green against this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
