### PR TITLE
fix(docs): document the signed lane's real text budget in openapi.json

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -494,6 +494,17 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "name": "text",
                             "required": True,
                             "schema": _TEXT_SCHEMA,
+                            "description": (
+                                "URL-encoded message body, same single-line sweep as the "
+                                "unsigned lane. This lane has far less real budget before "
+                                "the URL length limit bites: "
+                                f"{_DID_LENGTH + didkey.SIG_CHARS + 19 + 3} bytes go to "
+                                "did/sig/nonce and their path separators before text even "
+                                "starts, against roughly 49 for the unsigned lane's nick. "
+                                f"{store.MAX_TEXT_CHARS} is the declared cap either way, but "
+                                "a long non-Latin message that fits the unsigned lane's URL "
+                                "may not fit this one -- use POST for those."
+                            ),
                         },
                     ],
                     "responses": {

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1149,3 +1149,17 @@ def test_the_ai_catalog_lists_only_artifacts_that_resolve(client):
         assert entry["identifier"] and entry["type"] and entry["url"]
         path = entry["url"].split("testserver", 1)[-1] or "/"
         assert client.get(path).status_code == 200, f"{entry['identifier']} -> {path}"
+
+
+def test_the_signed_says_text_param_documents_its_real_budget(client):
+    """Issue #76: the signed lane's text param had no description at all, while the
+    unsigned lane's explained the URL-length budget in practice. Since did/sig/nonce
+    eat real budget before text starts, this lane needs its own number, not a copy of
+    the unsigned lane's -- so this checks it exists and says something concrete, not
+    that it matches the unsigned lane's text verbatim."""
+    doc = client.get("/openapi.json").json()
+    say_signed = doc["paths"]["/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}"]["get"]
+    text_param = next(p for p in say_signed["parameters"] if p["name"] == "text")
+    description = text_param.get("description", "")
+    assert description, "signed lane's text param has no description"
+    assert "budget" in description.lower() or "url" in description.lower()


### PR DESCRIPTION
Fixes #76

## What

Adds a `description` to the signed `say` lane's `text` parameter in
`/openapi.json` — it had none, while the unsigned lane's already explained
the real URL-length budget in practice.

## Why

`did`/`sig`/`nonce` eat real budget before `text` even starts on the signed
lane -- 164 bytes (56 + 86 + 19 + 3 separators) against roughly 49 for the
unsigned lane's `nick`. Copying the unsigned lane's description verbatim
would have been wrong, since the signed lane's actual usable budget is
smaller. The number is derived from the same constants the server already
enforces (`_DID_LENGTH`, `didkey.SIG_CHARS`, the nonce's max digits) rather
than hardcoded, so it can't drift out of sync if those change.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report`
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run ty check`
- [x] Docs that would now be wrong are updated: this *is* the doc fix
- [x] New surface on a world-writable service: nothing new — this only adds
      a description string to an existing, already-enforced schema field