### PR TITLE
fix(http): a deeply nested JSON body is a 400, not a 500

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1010,7 +1010,11 @@ async def read_json(request: Request) -> dict | Response:
             return text(f"{too_large}\nthe stream passed it before it ended.", 413)
     try:
         payload = json.loads(bytes(raw) if raw else b"{}")
-    except ValueError as exc:
+    # RecursionError beside ValueError: loads recurses per nesting level, and a deeply
+    # nested array raises it rather than ValueError. Uncaught, that escaped as a 500 —
+    # an undocumented status on a lane the contract says answers 400 for malformed
+    # bodies. Same refusal either way: the body is not a usable object.
+    except (ValueError, RecursionError) as exc:
         return text(
             f"400 body must be JSON, and this did not parse: {exc}.\n"
             'send an object like {"from":"bot","text":"hello"} for a room, or '

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -902,3 +902,13 @@ def test_polled_reads_are_edge_cacheable_and_held_or_write_replies_never_are(cli
     with config.override(EDGE_CACHE_SECONDS=0):
         assert client.get("/rooms").headers["cache-control"] == "no-store"
         assert client.get("/r/lobby").headers["cache-control"] == "no-store"
+
+
+def test_a_deeply_nested_body_is_a_400_not_a_500(client):
+    """json.loads recurses per nesting level, so a deeply nested array raises
+    RecursionError — which is not a ValueError, and escaped read_json's handler as a 500.
+    The contract documents 400 for malformed bodies on this lane; the refusal now matches
+    at every depth.
+    """
+    deep = b"[" * 20_000 + b"]" * 20_000
+    assert client.post("/r/nested", content=deep).status_code == 400


### PR DESCRIPTION
Closes #130.

## Problem

POST a body of ~20k nested arrays (about 40 KB, well under the 256 KiB cap) to `/r/{room}` or `/kv/{ns}/{key}` and the server answers 500. json.loads recurses per nesting level and raises RecursionError, which is not a ValueError, so read_json's handler misses it and Starlette's default 500 goes out. That status is documented nowhere on these lanes: the contract promises 400/413/429.

## Fix

Catch RecursionError beside ValueError in read_json. Callers get the ordinary malformed-body refusal either way. No new branch and no new status; core code-lines unchanged (`uv run sz.py --check` stays at 1848).

Abuse impact: none. This removes an undocumented status, it adds no surface.

## Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run coverage run -m pytest tests -q` — 322 passed

New regression test posts a depth-20_000 array and asserts 400. Fails with a 500 without the fix.

One judgment call: folded RecursionError into the existing except rather than giving the deep case its own message, so bad bodies keep one refusal path. Happy to split it out if you'd rather it say so explicitly.
