### PR TITLE
fix(http): a failed room write no longer spends the creation token

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1689,6 +1689,10 @@ async def on_method_not_allowed(request: Request, exc: Exception) -> Response:
 
 
 async def on_bad_input(request: Request, exc: Exception) -> Response:
+    # A 400 from a room write means the create gate charged a token for a write that did
+    # not happen (bad nick, text that sweeps to empty). Settling against an empty record
+    # carries no seq, so the charge refunds and only real creations spend the budget.
+    limit._settle_room_budget(request, {}, RATE_ROOMS_PER_DAY, ip_header=CLIENT_IP_HEADER)
     return text(f"400 {exc}", 400)
 
 

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,7 +1,7 @@
 {
   "core_total": 2028,
   "caps": {
-    "core/app.py": 979,
+    "core/app.py": 980,
     "core/config.py": 57,
     "core/didkey.py": 57,
     "core/limit.py": 132,
@@ -10,9 +10,9 @@
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1796,
-      "code_lines": 979,
-      "comment_lines": 264,
+      "raw_lines": 1800,
+      "code_lines": 980,
+      "comment_lines": 267,
       "tokens_per_line": 7.89
     },
     "core/config.py": {

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -909,3 +909,18 @@ def test_waiter_slots_are_bounded_per_ip(client):
                 assert other is True  # a different IP is unaffected
     assert app._waiters_total == 0  # every slot released
     assert app._waiters_by_ip == {}  # and the table does not grow per distinct IP
+
+
+def test_a_failed_room_write_does_not_spend_the_creation_budget(client, monkeypatch):
+    """The gate charges before the store validates the text, and a caller-input StoreError
+    unwinds past _settle_room_budget. Three whitespace-only writes burned a whole day's
+    budget and refused the fourth, perfectly valid one; the 400 handler settles the charge
+    now, so only writes that bring a room into existence keep a token spent.
+    """
+    import config
+
+    with config.override(RATE_ROOMS_PER_DAY=2):
+        for name in ("waste1", "waste2"):
+            assert client.get(f"/r/{name}/say/bot/%20%20%20").status_code == 400
+        # Both charges refunded: a valid third room still fits the budget of 2.
+        assert client.get("/r/legitroom/say/bot/hello").status_code == 200


### PR DESCRIPTION
Closes #131.

## Problem

The room-creation gate charges a token before the write runs, and on the happy path `_settle_room_budget` refunds it unless this request actually created the room. But when `store.append` raises `StoreError` (a nickname that fails `valid_name`, or text that sweeps to empty in `clean_text`), the exception unwinds past the settle call and the charge stays spent. With the default budget that means three malformed writes lock an IP out of creating rooms until tokens refill, which reads to the caller like the service is broken rather than like it sent junk. The comment on `_room_write_gate` already states the intended rule: a token is only ever spent on a write that would otherwise have been accepted. A caller-input 400 is not such a write.

## Fix

Settle the creation charge in the `StoreError` handler (`on_bad_input`) against an empty record: an empty dict carries no `seq`, so `_settle_room_budget` treats the write as not-a-creation and refunds. One line plus its reasoning comment; every room-write lane is covered because they all funnel through the same handler, and note writes are untouched since their gate never sets the charged flag.

This grows core by one line, so `sz-baseline.json` bumps `core/app.py` to 920 with the new pattern as the justification.

## Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run coverage run -m pytest tests -q`

New test in `tests/http/test_limits.py`: two whitespace-only writes (both 400) followed by a valid third room write must be 200 under `RATE_ROOMS_PER_DAY=2`. Before the fix the third write 429s.
