### PR TITLE
fix: ask the name grammar before the class question (#109)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -829,8 +829,15 @@ def _allowed_keys(room: str) -> set[str]:
 
 def _room_write_gate(request: Request, room: str, signer: str | None) -> Response | None:
     """Every write to a room passes here, signed or not. Fail closed: a class that demands
-    a signature refuses the unsigned lane outright, and the reply says what to send."""
-    denied = _reject_if_events_room(room)
+    a signature refuses the unsigned lane outright, and the reply says what to send.
+
+    The grammar is asked FIRST. A class is a name prefix, so `room_classes` reads one off a
+    string this service will never store — and the gate then answered `mb-FOO` on class
+    grounds with a 403 whose named correction, the signed lane, reaches `store.append` and
+    answers 400. One write, two answers, and the 403 sent the caller to the lane that
+    contradicted it. `valid_name` raises StoreError, which is already mapped to the same
+    400 the storage layer produces, so this borrows the message rather than restating it."""
+    denied = _reject_if_events_room(store.valid_name(room))
     if denied:
         return denied
     if store.is_mailbox(room) and signer is None:
@@ -1121,6 +1128,10 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
     stranger cannot rewrite — without that, ownership is a note anyone can overwrite, which
     is not ownership.
     """
+    # Same order, same reason as `_room_write_gate`: `ownable` reads a class marker off a
+    # name the grammar refuses, so `D-FOO` was answered "cannot be owned" (403) while the
+    # allow-list lane, which validates on the way to the note, answered "bad name" (400).
+    ns, key = store.valid_name(ns), store.valid_name(key)
     if ns == store.NONCE_NS:
         return text(
             f"403 /kv/{store.NONCE_NS} is written by the server only — it is the replay "

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,19 +1,19 @@
 {
-  "core_total": 1902,
+  "core_total": 1903,
   "caps": {
-    "core/app.py": 941,
+    "core/app.py": 942,
     "core/config.py": 51,
     "core/didkey.py": 57,
     "core/limit.py": 110,
     "core/store.py": 743,
-    "core_total": 1902
+    "core_total": 1903
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1650,
-      "code_lines": 941,
-      "comment_lines": 218,
-      "tokens_per_line": 7.81
+      "raw_lines": 1661,
+      "code_lines": 942,
+      "comment_lines": 221,
+      "tokens_per_line": 7.83
     },
     "core/config.py": {
       "raw_lines": 170,

--- a/tests/http/test_lane_parity.py
+++ b/tests/http/test_lane_parity.py
@@ -30,6 +30,11 @@ from starlette.testclient import TestClient
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "src"))
 sys.path.insert(0, str(ROOT / "mcp" / "src"))
+sys.path.insert(0, str(ROOT / "tests"))
+
+# Reused, not re-implemented: a second copy of the signing construction in a parity test
+# would be a test that agrees with itself rather than with the service.
+from _client import _keypair, _say_signed  # noqa: E402
 
 
 @pytest.fixture()
@@ -196,6 +201,10 @@ def test_one_note_write_lands_identically_through_all_three_lanes(lanes):
 #
 # This lives here rather than beside the mailbox tests because that is exactly what this
 # file is for: a disagreement between lanes is invisible to every single-lane test.
+#
+# The signed lane is REALLY signed. `_signer` runs before the gate, so an unsigned probe
+# never reaches the name check at all — it is answered on the did:key, and a test that used
+# a placeholder DID would assert nothing about names while appearing to cover the lane.
 
 BAD_NAMES = ["mb-FOO", "d-FOO", "e-FOO", "p-FOO", "mb-p-FOO"]
 
@@ -203,32 +212,34 @@ BAD_NAMES = ["mb-FOO", "d-FOO", "e-FOO", "p-FOO", "mb-p-FOO"]
 @pytest.mark.parametrize("bad", BAD_NAMES)
 def test_bad_room_name_is_a_400_on_every_write_lane(lanes, bad):
     _root, client, _mcp = lanes
-    lanes = {
+    did, sign = _keypair()
+    answers = {
         "unsigned say": client.get(f"/r/{bad}/say/bot/hi"),
-        "signed say": client.get(f"/r/{bad}/say-signed/did:key:z6Mk/" + "A" * 86 + "/1/hi"),
+        "signed say": _say_signed(client, bad, did, sign, "hi"),
         "post": client.post(f"/r/{bad}", json={"from": "bot", "text": "hi"}),
         "read": client.get(f"/r/{bad}"),
     }
-    for lane, r in lanes.items():
-        assert r.status_code == 400, f"{lane} answered {r.status_code} for {bad!r}: {r.text[:120]}"
-        assert "bad name" in r.text, f"{lane} did not name the grammar: {r.text[:120]}"
+    for lane, r in answers.items():
+        assert r.status_code == 400, f"{lane} answered {r.status_code} for {bad!r}: {r.text[:140]}"
+        assert "bad name" in r.text, f"{lane} did not name the grammar: {r.text[:140]}"
 
 
 @pytest.mark.parametrize("bad", ["D-FOO", "d-FOO"])
 def test_bad_owner_key_is_a_400_on_both_ownership_lanes(lanes, bad):
-    _root, client, _mcp = lanes
     # `room-owners` asked `store.ownable` first and `room-allow` validated on the way to the
     # note, so the identical key got 403 from one and 400 from the other.
-    owners = client.get(f"/kv/room-owners/{bad}/set/did:key:z6Mk")
-    allow = client.get(f"/kv/room-allow/{bad}/set/did:key:z6Mk")
+    _root, client, _mcp = lanes
+    did, _sign = _keypair()
+    owners = client.get(f"/kv/room-owners/{bad}/set/{did}")
+    allow = client.get(f"/kv/room-allow/{bad}/set/{did}")
     assert owners.status_code == 400 and "bad name" in owners.text, owners.text[:160]
     assert allow.status_code == 400 and "bad name" in allow.text, allow.text[:160]
 
 
 def test_a_valid_class_name_still_gets_its_class_answer(lanes):
-    _root, client, _mcp = lanes
     # The mirror, and the reason this is an ordering fix rather than a new rejection: a name
-    # the grammar ACCEPTS must still be answered on class grounds. Without this the test
-    # above passes just as happily if the gate started refusing every mailbox.
+    # the grammar ACCEPTS must still be answered on class grounds. Without this the tests
+    # above pass just as happily if the gate started refusing every mailbox.
+    _root, client, _mcp = lanes
     r = client.get("/r/mb-real/say/bot/hi")
     assert r.status_code == 403 and "mailbox" in r.text, r.text[:160]

--- a/tests/http/test_lane_parity.py
+++ b/tests/http/test_lane_parity.py
@@ -183,3 +183,52 @@ def test_one_note_write_lands_identically_through_all_three_lanes(lanes):
         call(mcp_server.server, "read_note", {"namespace": "zz-parity", "key": "http"})
     )
     assert wrapped_read == http_read
+
+
+# --------------------------------------------------------------------------- name grammar
+#
+# One rejected name, asked through every write lane, asserting they all reject it the same
+# way. The class of bug: a room class is a name PREFIX, so `room_classes` reads a class off
+# a string the grammar refuses — and both write gates asked their class question before
+# anything read the grammar. `mb-FOO` was answered 403 "send a signature", and the signed
+# lane it named as the correction answered 400 "bad name". One write, two answers, and the
+# 403 pointed at the lane that contradicted it.
+#
+# This lives here rather than beside the mailbox tests because that is exactly what this
+# file is for: a disagreement between lanes is invisible to every single-lane test.
+
+BAD_NAMES = ["mb-FOO", "d-FOO", "e-FOO", "p-FOO", "mb-p-FOO"]
+
+
+@pytest.mark.parametrize("bad", BAD_NAMES)
+def test_bad_room_name_is_a_400_on_every_write_lane(lanes, bad):
+    _root, client, _mcp = lanes
+    lanes = {
+        "unsigned say": client.get(f"/r/{bad}/say/bot/hi"),
+        "signed say": client.get(f"/r/{bad}/say-signed/did:key:z6Mk/" + "A" * 86 + "/1/hi"),
+        "post": client.post(f"/r/{bad}", json={"from": "bot", "text": "hi"}),
+        "read": client.get(f"/r/{bad}"),
+    }
+    for lane, r in lanes.items():
+        assert r.status_code == 400, f"{lane} answered {r.status_code} for {bad!r}: {r.text[:120]}"
+        assert "bad name" in r.text, f"{lane} did not name the grammar: {r.text[:120]}"
+
+
+@pytest.mark.parametrize("bad", ["D-FOO", "d-FOO"])
+def test_bad_owner_key_is_a_400_on_both_ownership_lanes(lanes, bad):
+    _root, client, _mcp = lanes
+    # `room-owners` asked `store.ownable` first and `room-allow` validated on the way to the
+    # note, so the identical key got 403 from one and 400 from the other.
+    owners = client.get(f"/kv/room-owners/{bad}/set/did:key:z6Mk")
+    allow = client.get(f"/kv/room-allow/{bad}/set/did:key:z6Mk")
+    assert owners.status_code == 400 and "bad name" in owners.text, owners.text[:160]
+    assert allow.status_code == 400 and "bad name" in allow.text, allow.text[:160]
+
+
+def test_a_valid_class_name_still_gets_its_class_answer(lanes):
+    _root, client, _mcp = lanes
+    # The mirror, and the reason this is an ordering fix rather than a new rejection: a name
+    # the grammar ACCEPTS must still be answered on class grounds. Without this the test
+    # above passes just as happily if the gate started refusing every mailbox.
+    r = client.get("/r/mb-real/say/bot/hi")
+    assert r.status_code == 403 and "mailbox" in r.text, r.text[:160]


### PR DESCRIPTION
Closes #109.

## The change

A room class is a name **prefix**, so `room_classes` reads a class marker off a string this service will never store. Both write gates asked their class question before anything read the grammar, so the correction the answer named then contradicted it:

```
GET /r/mb-FOO/say/bot/hi        403 … it takes signed writes only,
                                    send: GET /r/mb-FOO/say-signed/…
GET /r/mb-FOO/say-signed/…      400 bad name 'mb-FOO'
```

The ownership lane split the same way on the identical key: `room-owners` asks `store.ownable` first (403 "cannot be owned"), while `room-allow` reaches `note_get`, which validates (400 "bad name").

Both gates now validate first. `valid_name` raises `StoreError`, which is already mapped to the same 400 the storage layer produces, so this **borrows that message rather than restating it** — no new error text, and the signed lane's answer becomes every lane's answer.

## Two things worth flagging rather than burying

**The core cap moves by one.** Folding the calls into existing statements kept it to a single added code line, which puts `core/app.py` at 942 and the core total at 1903. I did not golf it further: `ns, key = store.valid_name(ns), store.valid_name(key)` is deliberately not the shorter `and` form, because `and` short-circuits and the key would then only be validated when `ns` happened to be the nonce namespace — a validation that does not run, which is the bug being fixed. Happy to take a different shape if you would rather the cap held.

**The tests go in `tests/http/test_lane_parity.py`**, because that is precisely what this bug is: one logical write, several lanes, disagreeing — invisible to any single-lane test. They reuse `_client`'s `_keypair` / `_say_signed` rather than re-implementing the signing construction.

The signed lane is really signed, and that mattered: `_signer` runs before the gate, so a placeholder `did:key` is answered on the DID and never reaches the name check. My first version did exactly that and CI caught it — the test would have asserted nothing about names while appearing to cover the lane.

There is also a mirror test: a name the grammar **accepts** must still get its class answer, or the whole thing would pass just as happily if the gate started refusing every mailbox.

## Verification

`ruff check`, `ruff format --check`, `sz.py --check` and `sz.py --caps` pass. The pytest suite needs POSIX `fcntl`, which the machine I wrote this on does not have, so it was verified in CI rather than claimed here:

- **with the fix:** all green — <https://github.com/VendettaGamesHQ/technocore-chat/actions/runs/32808277867>
- **the same tests against unfixed `app.py`:** red, with exactly the reported symptoms — `mb-FOO` and `mb-p-FOO` answering 403 on the unsigned lane and `D-FOO` answering 403 on `room-owners` — <https://github.com/VendettaGamesHQ/technocore-chat/actions/runs/32808378645>

The `d-`, `e-` and `p-` parameters do not reproduce the bug (no gate fires on those classes); they are there for the consistency the file exists to assert.
