### PR TITLE
fix(store): capacity refusals carry the used count, not only the cap

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -2213,13 +2213,15 @@ def _count_new_room(root: Path, delta: int) -> None:
     _write_note_count(root, max(0, count + delta), used, name=USAGE_FILE)
 
 
-def _at_capacity(cap: int, what: str) -> StoreError:
+def _at_capacity(cap: int, what: str, used: int) -> StoreError:
     """The refusal, in one place because two callers raise it (rooms count both a cap and a
     byte budget). Only *new* names are refused, which is the actionable half: an agent
-    blocked here can always keep working in a room or note it is already using."""
+    blocked here can always keep working in a room or note it is already using. `used`
+    travels with the cap because "how full, of how much" is what lets a client wait for
+    the 7-day reclaim instead of retrying blind."""
     return StoreError(
-        f"{what} limit reached ({cap} is the cap, and this would be a new one). "
-        f"Existing {what}s still accept writes, so reuse one you already have — "
+        f"{what} limit reached ({cap} is the cap, {used} in use, and this would be a "
+        f"new one). Existing {what}s still accept writes, so reuse one you already have — "
         f"GET /rooms shows what exists. Idle {what}s are reclaimed after 7 days "
         f"(a room still on its first message goes after {STILLBORN_SECONDS // 3600} hours)."
     )
@@ -2286,7 +2288,7 @@ def _check_room_capacity(root: Path, path: Path) -> None:
     # enforced on a world-writable service. `_count_rooms` recurses for the rebuild either way.
     count, used = _note_totals(root, _count_rooms, name=USAGE_FILE)
     if count >= MAX_ROOMS:
-        raise _at_capacity(MAX_ROOMS, "room")
+        raise _at_capacity(MAX_ROOMS, "room", count)
     if used >= MAX_TOTAL_ROOM_BYTES:
         raise StoreError(
             f"room storage is full ({used >> 20} MiB of a {MAX_TOTAL_ROOM_BYTES >> 20} MiB "
@@ -2295,6 +2297,25 @@ def _check_room_capacity(root: Path, path: Path) -> None:
             "writes, so reuse one you already have — GET /rooms shows what exists. Idle "
             "rooms are reclaimed after 7 days (a room still on its first message goes "
             f"after {STILLBORN_SECONDS // 3600} hours)."
+        )
+
+
+def _check_note_total(root: Path) -> None:
+    """The global half of the note cap: one file read, no directory walk at all.
+
+    Split out so it can run *before* the create gate as well as inside it. A store that is
+    already full refuses every create, and refusing them behind the shared gate means each
+    one queues for a lock only to be told no — at precisely the moment the queue is
+    longest. This sheds them for the price of a read. The check inside the gate is still
+    the authoritative one; this is a fast no, never a yes.
+    """
+    total = _note_count(root)
+    if total >= MAX_NOTES_TOTAL:
+        raise StoreError(
+            f"note limit reached ({total} of {MAX_NOTES_TOTAL} across all namespaces, and "
+            "this would be a new one). A fresh namespace buys nothing — the cap is global. Overwrite "
+            "a note you already own instead; idle notes are reclaimed after 7 days, and "
+            "GET /rooms reports how full the note store is."
         )
 
 
@@ -2320,15 +2341,10 @@ def _check_note_capacity(root: Path, ns_dir: Path, path: Path) -> None:
     # The namespace directory, passed in rather than taken from the note: `path.parent` is the
     # key's bucket now, and counting that would both compare the cap against ~1 note and drop
     # the namespace's `.notes-count` two levels below where every other reader looks for it.
-    if _note_totals(ns_dir, _ns_totals, persist=True)[0] >= MAX_NOTES_PER_NS:
-        raise _at_capacity(MAX_NOTES_PER_NS, "note")
-    if _note_count(root) >= MAX_NOTES_TOTAL:
-        raise StoreError(
-            f"note limit reached ({MAX_NOTES_TOTAL} across all namespaces, and this would "
-            "be a new one). A fresh namespace buys nothing — the cap is global. Overwrite "
-            "a note you already own instead; idle notes are reclaimed after 7 days, and "
-            "GET /rooms reports how full the note store is."
-        )
+    used = _note_totals(ns_dir, _ns_totals, persist=True)[0]
+    if used >= MAX_NOTES_PER_NS:
+        raise _at_capacity(MAX_NOTES_PER_NS, "note", used)
+    _check_note_total(root)
 
 
 @contextmanager

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -480,7 +480,9 @@ def test_a_widened_namespace_is_honoured_and_still_sits_inside_the_global_cap(
     # cap a raised namespace redistributes rather than grows.
     store.note_set(tmp_path, "other", "k0", "v")
     store.note_set(tmp_path, "other", "k1", "v")
-    with pytest.raises(store.StoreError, match=r"note limit reached \(8 across all"):
+    with pytest.raises(
+        store.StoreError, match=r"note limit reached \(8 of 8 across all namespaces"
+    ):
         store.note_set(tmp_path, "other", "k2", "v")
 
 
@@ -498,7 +500,9 @@ def test_the_refusal_still_fires_at_the_global_cap(tmp_path, monkeypatch) -> Non
         store.note_set(tmp_path, f"ns{i}", "k", "v")
     assert store._note_count(tmp_path) == cap, "the cache must track the creates it gated"
 
-    with pytest.raises(store.StoreError, match=rf"note limit reached \({cap} across all"):
+    with pytest.raises(
+        store.StoreError, match=rf"note limit reached \({cap} of {cap} across all namespaces"
+    ):
         store.note_set(tmp_path, "ns-over", "k", "v")
     # Refused on a new name only: the cap never silences a note somebody already owns.
     store.note_set(tmp_path, "ns0", "k", "v2")

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -170,18 +170,20 @@ def test_a_capacity_refusal_carries_the_numbers_a_caller_acts_on(tmp_path, monke
 
     monkeypatch.setattr(store, "MAX_ROOMS", 1)
     store.append(tmp_path, "only", "bot", "hi")
-    with pytest.raises(store.StoreError, match=r"room limit reached \(1 is the cap"):
+    with pytest.raises(store.StoreError, match=r"room limit reached \(1 is the cap, 1 in use"):
         store.append(tmp_path, "second", "bot", "hi")
 
     # Two note caps, two messages, and the number is the actionable part of both.
     monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 1)
     store.note_set(tmp_path, "plans", "only", "hi")
-    with pytest.raises(store.StoreError, match=r"note limit reached \(1 is the cap"):
+    with pytest.raises(store.StoreError, match=r"note limit reached \(1 is the cap, 1 in use"):
         store.note_set(tmp_path, "plans", "second", "hi")
 
     monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 10_000)
     monkeypatch.setattr(store, "MAX_NOTES_TOTAL", 1)
-    with pytest.raises(store.StoreError, match=r"note limit reached \(1 across all namespaces"):
+    with pytest.raises(
+        store.StoreError, match=r"note limit reached \(1 of 1 across all namespaces"
+    ):
         store.note_set(tmp_path, "elsewhere", "second", "hi")
 
     # "how full, of how much" is the figure an operator sizes a disk against, and the two


### PR DESCRIPTION
Closes #85's smallest direction — the one its population data made concrete.

**The problem.** A client refused at a count cap gets a message naming the ceiling but not the occupancy. The #85 audit showed what that costs in practice: 634 of the `did` namespace's 5120 slots are unresolvable junk, and a blocked client polls blind (~45s in the auditor's case) because the refusal supports exactly two strategies — *wait* and *retry* — with no figure to wait against. Meanwhile the room byte-budget refusal already reports "N MiB of a M MiB budget". The count refusals were the ones hiding how full it is.

**The change** (store.py, +1 code line):

- `_at_capacity(cap, what, used)` — the count it just measured travels into the message: `note limit reached (5120 is the cap, 5120 in use, and this would be a new one)`
- the global note-total refusal says `total of MAX across all namespaces`
- room creation passes its count through the same path

That is the whole ask from #85's "possible directions" item 4: with `used` visible and the existing "idle notes are reclaimed after 7 days" line, a well-behaved client can compute an honest backoff instead of holding a tight loop against a service that is shedding load.

**Tests.** `test_a_capacity_refusal_carries_the_numbers_a_caller_acts_on` already states the rule — *matching only the opening words leaves every number free to be wrong* — so its three regexes now pin the used figures (`1 is the cap, 1 in use`, `1 of 1 across all namespaces`). Full suite: 321 passed; ruff, format, ty clean; `beautiful_chat.sh` passes end-to-end.

**sz.** store.py stays under the immutable `core/store.py` cap (996 of 1010 code lines on current `main`), so no `sz-baseline.json` change is needed. The earlier hand-edit to that ratchet was dropped — queue-guard protects it as a maintainer-regenerated file on fork PRs (CONTRIBUTING "Overlapping work").

_Rebased onto current `main` (0.13.0); the `sz-baseline.json` edit dropped so `protected-files` passes. Full `just check` green locally: 774 passed, 1 skipped; ruff, format, ty, `sz.py --caps`, coverage._
