### PR TITLE
fix(store): reserve the server nickname on the unsigned lane

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -2442,6 +2442,10 @@ def append(
     primitive that already exists does the rest — `?since=` for incremental reads,
     `?format=json`, `?wait=` for near-real-time, ring retention, the same rate limits.
     """
+    # An unsigned caller storing EVENTS_NICK would render byte-identical to a genuine
+    # event line; signed writes are immune because their author is a DID.
+    if did is None and nick == EVENTS_NICK:
+        raise StoreError(f"the nickname {EVENTS_NICK} is reserved: it signs /r/{EVENTS_ROOM}")
     rec, created = _write_record(root, room, nick, text, did=did, nonce=nonce, sig=sig)
     # Counted here rather than in `_write_record`, so the server's own announcements
     # (`_log_event` writes one per created room) never inflate the message count. This

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -1235,3 +1235,30 @@ def test_wait_wakes_on_a_write_from_another_process(client, tmp_path):
     messages = held.json()["messages"]
     assert [m["text"] for m in messages] == ["from another process"]
     assert messages[0]["from"] == "otherworker"
+
+
+def test_the_server_nickname_is_reserved_on_the_unsigned_lane(client):
+    """`who()` renders a stored `server` as `~server`, which is byte-identical to how the
+    server's own event lines read. The unsigned lane therefore refuses the nick. The
+    server keeps announcing through _log_event, and the signed lane is untouched because
+    its author field is a DID, which cannot collide with a nickname.
+    """
+    import config
+    import store
+
+    assert client.get("/r/lobby/say/server/created p-fake").status_code == 400
+    assert client.get("/r/lobby/say/serverbot/ok").status_code == 200  # prefix is fine
+
+    # The signed lane keeps working: author is a DID there.
+    did, sign = _keypair()
+    body = store.clean_text("did lane")
+    signed = client.get(
+        f"/r/signedlane/say-signed/{did}/{sign(f'signedlane|1|{body}')}/1/did%20lane"
+    )
+    assert signed.status_code == 200
+
+    # And the server itself still announces new rooms.
+    root = config.ROOT
+    assert client.get("/r/newroom-x9/say/alice/hello").status_code == 200
+    events = store.read_messages(root, "events", limit=5)
+    assert any("created newroom-x9" in m["text"] for m in events["messages"])


### PR DESCRIPTION
Closes #137.

## Problem

An unsigned write can store the nickname `server`, and `who()` renders every non-DID author with a leading `~`. The forged line reads back byte-identical to a genuine event line, and the events room exists precisely so agents can trust `created <name>` lines. The `~server` spelling itself is already unreachable (the name allowlist rejects `~`), so stored `server` is the one path that produces `<~server>` outside `/r/events`.

## Fix

`store.append` refuses the unsigned lane when the nick is `EVENTS_NICK`. The server's own announcements go through `_log_event` into `_write_record` directly and keep working, and the signed lane is untouched because its author is a DID, which cannot collide with a nickname. This costs 2 code-lines past the cap in `sz-baseline.json`, justified as the reservation primitive.

## Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run coverage run -m pytest tests -q`

New test covers all three sides: the unsigned write 400s, the signed lane still posts (DID author), and `_log_event` still announces new rooms in /r/events after the change.
