### PR TITLE
fix(humans): align the message input limit with the server

### DIFF
--- a/src/humans.html
+++ b/src/humans.html
@@ -381,7 +381,7 @@
 
   <div class="row">
     <input id="nick" value="human" maxlength="48" aria-label="Your nickname" spellcheck="false">
-    <input id="text" placeholder="Say something…" maxlength="2000" aria-label="Message">
+    <input id="text" placeholder="Say something…" maxlength="4096" aria-label="Message">
     <button id="send" class="btn-primary">Send</button>
   </div>
 

--- a/tests/test_humans_name_input_limit.py
+++ b/tests/test_humans_name_input_limit.py
@@ -30,3 +30,21 @@ def test_humans_name_inputs_match_the_server_name_limit(field: str):
 
     with pytest.raises(store.StoreError):
         store.valid_name("a" * (limit + 1))
+
+
+def test_humans_message_input_matches_the_server_text_limit():
+    import app as app_module
+    import store
+
+    # The page states this limit twice: once for the human typing into #text, and once in
+    # the maxLength its own WebMCP `say` tool publishes. Both drive the same POST /r/<room>
+    # lane, so a smaller box is a silent truncation at the one place there is a person to
+    # notice it — maxlength gives no feedback, it just stops accepting characters.
+    html = TestClient(app_module.app).get("/humans").text
+    limit = _maxlength(html, "text")
+
+    accepted = "a" * limit
+    assert store.clean_text(accepted) == accepted
+
+    with pytest.raises(store.StoreError):
+        store.clean_text("a" * (limit + 1))


### PR DESCRIPTION
The message box on `/humans` stops accepting input at 2000 characters. The server takes 4096.

What made me file this rather than shrug at it is that the page disagrees with itself. The WebMCP `say` tool that same page publishes declares `maxLength: 4096` for `text`, and both it and the input box post to `POST /r/<room>`. One page, one operation, two limits, and the smaller one is the one a person hits.

`maxlength` is also silent when it bites. There is no message and no counter. The input just stops taking characters, so someone pasting a long message loses the tail without being told it happened or how much went missing.

### Checked against a running instance

```
CHAT_ROOT=./data uv run uvicorn --app-dir src app:app --port 8080

POST /r/probe  {"text": 4096 chars}   200, stored 4096, nothing truncated
POST /r/probe  {"text": 4097 chars}   400 text too long: 4097 characters, and the limit is 4096
```

So 4096 is real on the lane the page actually uses, not just the number in `store.MAX_TEXT_CHARS`.

### The change

One attribute, 2000 to 4096.

The test reads `maxlength` off the page as served and checks it against `store.clean_text`, which is the validator that lane reaches. That mirrors `test_humans_name_inputs_match_the_server_name_limit` directly above it, which does the same thing for `#room` and `#nick` against `valid_name`. Putting it in the same file keeps one place that answers "do the boxes on this page agree with the server".

It fails without the fix: at 2000, `clean_text("a" * 2001)` raises nothing, so the `pytest.raises` block reports `DID NOT RAISE StoreError`.

### Gates

`ruff check`, `ruff format --check`, `ty check` all clean. `coverage report` 97.40%. `sz.py --check` ok, and the core baseline does not move since `humans.html` is not core and the test is not either.

One note in the interest of not overclaiming: on one full-suite run I saw `test_the_post_lanes_do_not_block_the_event_loop` fail. It did not reproduce in three further full runs or six isolated ones, and `main` was clean across five runs on the same machine. It asserts a 0.2s ceiling on event loop scheduling gaps, and I was running under Docker on Windows with coverage on, so I believe it was host noise rather than anything here. Mentioning it because 1 in 4 is not 0 in 4.

---

I used Claude to help investigate this. The verification against the running service, and the writing, are mine.
