### PR TITLE
docs: warn that a timed-out/5xx signed write may have already landed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+PATCH: the manual now warns that a timed-out or 5xx signed write may have already landed server-side (the nonce is consumed before the client hears back), and that a retried URL against room-owners/room-allow is refused forever rather than eventually re-accepted, since their replay counter never expires.
+
 ### Changed
 
 - **`/rooms` no longer re-walks every room on every message.** Its cache was validated against a
@@ -130,6 +132,7 @@ clients depend on tightens.
 - **A note create scans its namespace once, not twice.** The capacity check ran before the
   create gate and again inside it. The pre-gate call now checks only the global cap, which is
   a file read, so a full store still refuses without queueing for the gate.
+
 
 ## [0.9.0] - 2026-08-25
 

--- a/src/manual.md
+++ b/src/manual.md
@@ -144,6 +144,16 @@ writes exist for those two namespaces and nowhere else — every other note is
 world-writable, as before. /kv/room-nonce/<room> is the server's replay counter
 for them: world-readable, server-written. A room with no owner note is an
 ordinary open room and always was.
+TIMEOUT / 5xx ON A SIGNED WRITE: the nonce is consumed server-side before your
+client hears back, so a request that times out or answers 5xx may have already
+landed. Never resend the identical signed URL to check — a second attempt is
+read as a replay and refused, and that refusal means the first one worked, not
+that it failed. Read the state instead (the room with `?since=`, or
+/kv/room-owners/<room> for a claim) to see what actually happened, then sign a
+fresh, greater nonce only if the write still needs to happen. This bites hardest
+in room-owners/room-allow: their replay counter is persistent, so unlike a room
+message the single-use guarantee here never expires and a stale retry is
+refused forever, not just until it ages out of the scanned tail.
 
 EPHEMERAL: in an e-<name> room, messages older than this instance's ephemeral
 TTL are not returned — 15 minutes by default (CHAT_EPHEMERAL_TTL_SECONDS), and


### PR DESCRIPTION
Closes #141. The nonce for a signed write is consumed server-side before the client gets a response, so a timeout or 5xx doesn't mean the write failed — and for room-owners/room-allow specifically, the replay counter is persistent, so a retried URL is refused forever rather than eventually re-accepted. Adds a note near OWNED ROOMS telling callers to re-read state instead of resending the same signed URL.

## Abuse impact

None. This PR only adds a warning paragraph to `src/manual.md`; it introduces no new route, parameter, or persistent state, and changes no enforced behavior.