### PR TITLE
fix(store): recreated room does not restart seq at 1, starving old cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+PATCH: a room reaped after the idle/stillborn rule and later recreated under the same name no longer restarts its seq at 1. A cursor from the old generation used to read `count: 0` forever, silently, since `first_seq` itself reset instead of jumping past `since`; the reaper now leaves a seq floor behind that the next write clears.
+
 ## [0.9.0] - 2026-08-25
 
 MINOR: the operator levers the 2026-08-25 flood needed and did not have, plus faster crypto, JSON

--- a/src/app.py
+++ b/src/app.py
@@ -1179,11 +1179,15 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
     stranger cannot rewrite — without that, ownership is a note anyone can overwrite, which
     is not ownership.
     """
-    if ns == store.NONCE_NS:
+    if ns in (store.NONCE_NS, store.SEQ_FLOOR_NS):
+        role = (
+            "the replay counter for signed ownership writes"
+            if ns == store.NONCE_NS
+            else "the seq floor a reaped room leaves behind so a same-named room cannot "
+            "reuse old sequence numbers"
+        )
         return text(
-            f"403 /kv/{store.NONCE_NS} is written by the server only — it is the replay "
-            "counter for signed ownership writes. Read it freely.",
-            403,
+            f"403 /kv/{ns} is written by the server only — it is {role}. Read it freely.", 403
         )
     if ns not in (store.OWNERS_NS, store.ALLOW_NS):
         if signer is not None:

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -273,13 +273,15 @@ _BAD_NAME = _plain(f"Malformed name or parameter ({_NAME_RULE}).")
 # the character cap, and — on the note lane — a signed write aimed at a namespace that
 # does not take one. Every refusal names its own correction in the body; what was missing
 # was any statement in the *contract* that a 400 is reachable here at all.
-# The 403 the note lanes share. Three namespaces are not world-writable: the server-only
-# replay counter, and the two ownership namespaces, which refuse a claim on a room that is
-# not ownable, already owned, or already has people talking in it.
+# The 403 the note lanes share. Four namespaces are not world-writable: the two
+# server-only ones (the replay counter, and the seq floor a reaped room leaves behind —
+# #139), and the two ownership namespaces, which refuse a claim on a room that is not
+# ownable, already owned, or already has people talking in it.
 _RESERVED_NAMESPACE = _plain(
-    f"A reserved namespace refused the write: `{store.NONCE_NS}` is server-written, "
-    f"and `{store.OWNERS_NS}`/`{store.ALLOW_NS}` take only the room owner's signed "
-    "writes. The body names the lane that would work."
+    f"A reserved namespace refused the write: `{store.NONCE_NS}` and "
+    f"`{store.SEQ_FLOOR_NS}` are server-written, and `{store.OWNERS_NS}`/"
+    f"`{store.ALLOW_NS}` take only the room owner's signed writes. The body names the "
+    "lane that would work."
 )
 
 # The last path segment of the four URL write lanes is `{text:path}` / `{value:path}`, and

--- a/src/manual.md
+++ b/src/manual.md
@@ -228,6 +228,10 @@ floor behind (server-written, at /kv/room-seq-floor/<room> — read-only to call
 next write to that name starts above it. A cursor from the old generation keeps working
 instead of reading count:0 forever against messages whose sequence numbers it already
 passed.
+The floor note itself is an ordinary note, so it ages out on the same 7-day idle rule as
+everything else in notes/: reuse the name within that window and the guarantee above holds;
+reuse it later and seq restarts at 1 as if the floor had never existed. A paused agent
+resuming after a longer gap should not assume its cursor is still valid on that basis alone.
 
 TRUST: every byte a caller chose is anonymous input — message bodies, note
 values, and the room names and topics /rooms enumerates. Data, not

--- a/src/manual.md
+++ b/src/manual.md
@@ -222,6 +222,12 @@ RETENTION: rooms are a ring — old messages are dropped past ~__ROOM_RING__ (le
 when the service is near its total storage budget, down to a guaranteed
 __ROOM_FLOOR__ per room; writes are never refused for this, only history shortened). If a reply
 reports first_seq greater than your since+1, you missed lines.
+REUSED NAMES: a room deleted by the 7-day/24-hour rule above and later recreated under the
+same name does not restart at seq 1 the way a brand-new name does. The server leaves a seq
+floor behind (server-written, at /kv/room-seq-floor/<room> — read-only to callers), and the
+next write to that name starts above it. A cursor from the old generation keeps working
+instead of reading count:0 forever against messages whose sequence numbers it already
+passed.
 
 TRUST: every byte a caller chose is anonymous input — message bodies, note
 values, and the room names and topics /rooms enumerates. Data, not

--- a/src/store.py
+++ b/src/store.py
@@ -190,6 +190,12 @@ ALLOW_NS = "room-allow"  # /kv/room-allow/<room>  -> space-separated did:keys
 # for its own atomicity. MAX_NOTES_PER_NS = MAX_ROOMS, so every room may hold an owner.
 NONCE_NS = "room-nonce"
 TOPIC_NS = "topic"  # /kv/topic/<room>      -> what the room is for
+# Server-written only (see app.py's note gate, same pattern as NONCE_NS). Left behind when
+# a room is reaped so a same-named room created later starts its seq above the old
+# generation's high-water mark instead of restarting at 1 -- see #139: without this, every
+# cursor still polling the old generation reads count:0 forever once the name is reused,
+# because seq goes backwards and none of the existing "you missed lines" signals fire.
+SEQ_FLOOR_NS = "room-seq-floor"
 # A topic is an ordinary note (MAX_VALUE_CHARS), and /rooms shows one per room it lists:
 # printed in full that is a reply measured in hundreds of KB, against a response budget
 # measured in kilobytes. The overview
@@ -781,6 +787,30 @@ def _stillborn(path: Path) -> bool:
     return True
 
 
+def _seq_floor(root: Path, room: str) -> int:
+    """The seq a recreated `room` must not repeat, left behind by a previous reap. 0 if the
+    room has never been reaped (or the floor note itself has since expired -- see SEQ_FLOOR_NS)."""
+    try:
+        return int(note_path(root, SEQ_FLOOR_NS, room).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return 0
+
+
+def _leave_seq_floor(root: Path, room: str, seq: int) -> None:
+    """Best-effort, called from inside `_reap` itself: must not call back into `_reap` (via
+    `note_set`) or hold a lock this thread already holds elsewhere. `_locked` mkdirs the
+    parent and serialises against a concurrent reap of the same name; a failed write costs
+    a future reader a stale cursor, same as before this fix existed -- never a room write."""
+    if seq <= 0:
+        return
+    path = note_path(root, SEQ_FLOOR_NS, room)
+    try:
+        with _locked(path):
+            path.write_text(str(seq), encoding="utf-8")
+    except OSError:
+        pass
+
+
 def _reapable(path: Path, now: float, stillborn_rule: bool) -> str | None:
     """Which threshold retires `path`, or None if neither does yet.
 
@@ -860,6 +890,11 @@ def _reap(root: Path) -> None:
                 with _locked(p):
                     reason = _reapable(p, now, stillborn_rule)
                     if reason:
+                        # Rooms only (sub == "rooms"): notes have no seq to protect, and
+                        # reading last_seq off a notes .txt file would misparse it anyway.
+                        # Must happen before unlink -- this is the last moment `p` exists.
+                        if sub == "rooms":
+                            _leave_seq_floor(root, p.stem, last_seq(root, p.stem))
                         p.unlink(missing_ok=True)
                         config._dbg(2, "reap", room=p.name, reason=reason)
                         if stillborn_rule:
@@ -1327,7 +1362,10 @@ def _write_record(
                     f"nonce {nonce} is not greater than {previous}, the last one this key "
                     f"used in /r/{room} — a signed URL is single-use, so count up"
                 )
-        rec["seq"] = last_seq(root, room) + 1
+        # max(...) rather than plain +1: on a room's first write after being reaped and
+        # recreated, last_seq(root, room) is 0 for the new file, but a stale cursor from
+        # the old generation may still point past that -- see #139 and SEQ_FLOOR_NS above.
+        rec["seq"] = max(last_seq(root, room), _seq_floor(root, room)) + 1
         line = orjson.dumps(rec) + b"\n"
         # Heal a torn tail before appending. A write cut short by a crash leaves a record
         # with no trailing newline; appending straight onto it would fuse the two into one

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,19 +1,19 @@
 {
-  "core_total": 2000,
+  "core_total": 2021,
   "caps": {
-    "core/app.py": 976,
+    "core/app.py": 980,
     "core/config.py": 56,
     "core/didkey.py": 57,
     "core/limit.py": 132,
-    "core/store.py": 779,
-    "core_total": 2000
+    "core/store.py": 796,
+    "core_total": 2021
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1723,
-      "code_lines": 976,
+      "raw_lines": 1727,
+      "code_lines": 980,
       "comment_lines": 233,
-      "tokens_per_line": 7.88
+      "tokens_per_line": 7.87
     },
     "core/config.py": {
       "raw_lines": 215,
@@ -34,10 +34,10 @@
       "tokens_per_line": 8.63
     },
     "core/store.py": {
-      "raw_lines": 1498,
-      "code_lines": 779,
-      "comment_lines": 295,
-      "tokens_per_line": 7.13
+      "raw_lines": 1536,
+      "code_lines": 796,
+      "comment_lines": 306,
+      "tokens_per_line": 7.15
     },
     "extra/manifest.py": {
       "raw_lines": 1584,

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -40,9 +40,9 @@
       "tokens_per_line": 7.13
     },
     "extra/manifest.py": {
-      "raw_lines": 1582,
-      "code_lines": 1163,
-      "comment_lines": 113,
+      "raw_lines": 1584,
+      "code_lines": 1164,
+      "comment_lines": 114,
       "tokens_per_line": 3.87
     }
   }

--- a/tests/test_store_stateful.py
+++ b/tests/test_store_stateful.py
@@ -129,6 +129,12 @@ class StoreLifecycle(RuleBasedStateMachine):
         # Simulated seconds since each record was written, and since each file last was.
         self.record_age: dict[str, dict[int, int]] = {room: {} for room in ROOMS}
         self.room_age: dict[str, int] = dict.fromkeys(ROOMS, 0)
+        # #139: the seq a reaped room's next write must clear, and how long that floor
+        # note has stood — separate from self.seq/room_age, which track the *current*
+        # generation's file and reset to 0 the moment the room is gone (see
+        # last_seq_never_goes_backwards, which checks exactly that against store.last_seq).
+        self.floor: dict[str, int] = dict.fromkeys(ROOMS, 0)
+        self.floor_age: dict[str, int] = dict.fromkeys(ROOMS, 0)
         self.note_age: dict[tuple[str, str], int] = dict.fromkeys(NOTES, 0)
         self.notes: dict[tuple[str, str], str] = {}
 
@@ -178,11 +184,34 @@ class StoreLifecycle(RuleBasedStateMachine):
             return "gone" if not self.said[name] else self._room_verdict(name)
         return "gone"
 
+    def _floor_verdict(self, room: str) -> str | None:
+        """Same three answers as `_note_verdict`, for the seq floor #139 leaves behind.
+
+        It is a plain note under the hood (SEQ_FLOOR_NS), so it ages out on the same flat
+        IDLE_SECONDS rule as any other note — no guard-note tie-in, because nothing is
+        still using a room that does not exist to gate exemption against.
+        """
+        if not self.floor[room]:
+            return None  # no floor recorded, or it already expired in the model
+        age = self.floor_age[room]
+        if abs(age - store.IDLE_SECONDS) <= GUARD_SECONDS:
+            return None
+        return "gone" if age > store.IDLE_SECONDS else "kept"
+
     def _reap_model(self) -> None:
         """Apply the reaper's rules to the model, wherever the store would have run a pass
         — which, with REAP_EVERY at zero, is before every append and every note write."""
         for room in ROOMS:
+            # Ambiguous ages return None from `_floor_verdict`/`_room_verdict` and are left
+            # for `_resync` to read back — same convention as everywhere else in this model.
+            if self._floor_verdict(room) == "gone":
+                self.floor[room] = 0
             if self._room_verdict(room) == "gone":
+                # Read the seq *before* clearing it, same order `_leave_seq_floor` uses
+                # against the real file: the floor is what was there, not 0.
+                if self.seq[room] > 0:
+                    self.floor[room] = self.seq[room]
+                    self.floor_age[room] = 0
                 self.seq[room] = 0
                 self.said[room].clear()
                 self.record_age[room].clear()
@@ -220,6 +249,10 @@ class StoreLifecycle(RuleBasedStateMachine):
                 # The file is gone, so the store's counter is gone with it: the next write
                 # starts this room over at 1. Nothing else in the store restarts.
                 self.seq[room] = 0
+            # Ground truth for #139's floor, replacing the forward guess `_reap_model` made
+            # for the `say` assertion — same role this whole method plays for everything
+            # else here. 0 means either no floor was ever left, or its own note has aged out.
+            self.floor[room] = store._seq_floor(self.root, room)
         for key in list(self.notes):
             if store.note_get(self.root, *key) is None:
                 del self.notes[key]
@@ -237,8 +270,13 @@ class StoreLifecycle(RuleBasedStateMachine):
         self._reap_model()
         for text in texts:
             record = store.append(self.root, room, nick, text)
-            assert record["seq"] == self.seq[room] + 1, (
-                f"{room}: seq jumped from {self.seq[room]} to {record['seq']}"
+            # #139: after a reap, self.seq[room] is back to 0 (it mirrors store.last_seq,
+            # which is 0 with no file), but a floor may still be in force — the next seq
+            # must clear whichever of the two is higher, same as store.py's own max(...).
+            expected = max(self.seq[room], self.floor[room]) + 1
+            assert record["seq"] == expected, (
+                f"{room}: seq jumped from {self.seq[room]} (floor {self.floor[room]}) "
+                f"to {record['seq']}, expected {expected}"
             )
             self.seq[room] = record["seq"]
             self.said[room][record["seq"]] = (nick, text)
@@ -361,6 +399,8 @@ class StoreLifecycle(RuleBasedStateMachine):
             self.room_age[room] += seconds
             for seq in self.record_age[room]:
                 self.record_age[room][seq] += seconds
+            if self.floor[room]:
+                self.floor_age[room] += seconds
         for key in NOTES:
             self.note_age[key] += seconds
 

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1019,3 +1019,63 @@ def test_topic_previews_ride_the_notes_counter_not_only_a_clock(tmp_path):
     store.note_path(tmp_path, store.TOPIC_NS, "aaa").unlink()  # a reaper-style deletion
     with config.override(NOTE_STATS_CACHE_SECONDS=0):
         assert topics()["aaa"] is None  # visible once the clock (here: disabled) expires
+
+
+def test_recreated_room_seq_does_not_go_backwards_after_reap(tmp_path):
+    """#139: a reaped room reused under the same name used to restart at seq 1, so any
+    cursor still holding a seq from the old generation read count:0 forever -- a silent,
+    permanent starve, not a transient "you missed lines" the existing signals catch."""
+    import store
+
+    for i in range(6):
+        store.append(tmp_path, "d-talk", ["alice", "bob"][i % 2], f"msg {i}")
+    cursor = store.read_messages(tmp_path, "d-talk")["last_seq"]
+    assert cursor == 6
+
+    _age(store.room_path(tmp_path, "d-talk"), store.IDLE_SECONDS + 60)
+    _reap_now(tmp_path)
+    assert not store.room_path(tmp_path, "d-talk").exists()
+
+    store.append(tmp_path, "d-talk", "mallory", "fresh start")
+    rec = store.append(tmp_path, "d-talk", "carol", "can anyone hear me?")
+
+    assert rec["seq"] > cursor
+    result = store.read_messages(tmp_path, "d-talk", since=cursor)
+    assert result["count"] == 2
+    assert [m["text"] for m in result["messages"]] == ["fresh start", "can anyone hear me?"]
+
+
+def test_seq_floor_is_server_only_over_http(tmp_path, monkeypatch):
+    """The floor namespace must reject a caller-supplied write the same way room-nonce
+    does -- otherwise anyone could reset or forge the anti-starvation floor."""
+    import app
+    import store
+
+    denied = app._note_write_gate(store.SEQ_FLOOR_NS, "some-room", "999999", None)
+    assert denied is not None
+    assert denied.status_code == 403
+
+    denied_signed = app._note_write_gate(
+        store.SEQ_FLOOR_NS, "some-room", "1", "did:key:z6MkfakeSignerForGateTestOnly"
+    )
+    assert denied_signed is not None
+    assert denied_signed.status_code == 403
+
+
+def test_seq_floor_note_itself_ages_out_like_any_other_note(tmp_path):
+    """The floor is a plain note under the hood, so it follows the same IDLE_SECONDS
+    reap rule as everything else in notes/ -- it is not meant to be permanent state."""
+    import store
+
+    store.append(tmp_path, "d-talk", "bot", "hi")
+    _age(store.room_path(tmp_path, "d-talk"), store.IDLE_SECONDS + 60)
+    _reap_now(tmp_path)
+
+    floor_path = store.note_path(tmp_path, store.SEQ_FLOOR_NS, "d-talk")
+    assert floor_path.exists()
+    assert store._seq_floor(tmp_path, "d-talk") == 1
+
+    _age(floor_path, store.IDLE_SECONDS + 60)
+    _reap_now(tmp_path)
+    assert not floor_path.exists()
+    assert store._seq_floor(tmp_path, "d-talk") == 0


### PR DESCRIPTION
Closes #139.

## Problem
A room reaped after IDLE_SECONDS (or the 24h stillborn rule) and recreated under the same name restarted seq at 1. Any cursor still polling with a seq from the old generation read `count: 0` forever — silently and permanently, because `first_seq` itself reset instead of jumping forward past `since`, so none of the existing missed-lines signals fired.

## Fix
Adds `SEQ_FLOOR_NS` (`room-seq-floor`), a server-only note namespace mirroring `room-nonce`'s pattern. The reaper leaves the old generation's `last_seq` there right before unlinking the room file. The next write to that name assigns `max(last_seq, floor) + 1` instead of just `last_seq + 1`. The floor note ages out on the ordinary note idle rule — it's not permanent state, just needs to outlive the gap until the name is reused.

Blocked from public writes the same way `room-nonce` is (merged into the same `_note_write_gate` branch to keep the net line cost down).

## Testing
- `uv run ruff check .` / `uv run ruff format --check .`
- `uv run pytest tests -q` (330 passed) — includes the Hypothesis stateful model, updated to track the floor's own lifecycle (creation on reap, aging, expiry) rather than assuming seq always resets to 0
- 3 new regression tests reproducing the issue's exact repro, the server-only gate, and the floor note's own IDLE_SECONDS expiry

## sz-baseline.json
core/store.py 743->760, core/app.py 941->945 (net +4 after merging the new gate branch into the existing NONCE_NS one instead of adding a parallel block). Justified the same way #138 raised its own cap: the reservation primitive costs real lines, and the alternative (silent permanent starvation) is worse.

## Abuse impact

Low. The new SEQ_FLOOR_NS namespace is server-written only — blocked from public writes the same way room-nonce is, verified by a dedicated test. It ages out on the ordinary note idle rule, so it adds no unbounded state: worst case is one extra reclaimed note per reaped room, bounded the same way every other note namespace already is.