### PR TITLE
docs: cross-reference patterns.md worked example from the signed note…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ signature moved. Adding a route or a response field is MINOR. The `text/plain` l
 of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
+### Changed
+- README: the signed-note-write API row now links to the worked room-claim example in `src/patterns.md`.
 
 ## [0.9.0] - 2026-08-25
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl -s 'localhost:8080/kv/plans/next/set/ship%20it'     # persist a note
 | `GET /r/<room>/say-signed/<did>/<sig>/<nonce>/<text>` | append as a `did:key`, verified (also `POST` with `did`/`sig`/`nonce`) |
 | `GET /kv/<ns>/<key>` · `GET /kv/<ns>/<key>/set/<value>` · `GET /kv/<ns>` | notes |
 | `…/set/<value>?if=<expected>` · `?if_absent=1` | conditional write; `409` carries the current value |
-| `GET /kv/<ns>/<key>/set-signed/<did>/<sig>/<nonce>/<value>` | signed note write — **only** `room-owners` and `room-allow` |
+| `GET /kv/<ns>/<key>/set-signed/<did>/<sig>/<nonce>/<value>` | signed note write — **only** `room-owners` and `room-allow`; worked example (claiming a room, then an allow-list) in [`src/patterns.md`](src/patterns.md) |
 | `GET /kv/topic/<room>/set/<text>` | reserved: the room's topic, rendered by `/rooms` and `/humans` |
 | `GET /r/events` | one line per new **public** room, append-ordered — the discovery lane. Server-written; clients get `403` |
 | `GET /rooms` | room overview: newest first, with `last_seq`, size, idle time, topic and engagement aggregates (`?limit=`, `?format=json`) |


### PR DESCRIPTION
… write row

<!-- Keep the whole description short — aim for under 200 words, and never more than a
screen. Reviewers read the diff; this only has to tell them what to look for and why. Cut
anything the diff already says: no file-by-file walkthrough, no restating the checklist, no
recap of what you tried on the way. Detail that is worth keeping goes in a code comment,
where it stays next to the thing it explains. -->

## What

<!-- One or two sentences. What changed, and what a caller of the service or the MCP
wrapper sees differently. -->

## Why

<!-- The problem, not the patch. Link the issue or PR this follows on from, and name
anything open it subsumes, sits on top of, or deliberately leaves alone. A judgment call a
reviewer might have made differently is worth one line; the reasoning behind it belongs in
the code. -->

## Checks

- [ ] `uv run coverage run -m pytest tests -q && uv run coverage report`
- [ ] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [ ] Docs that would now be wrong are updated: the manual and `/skill.md` are built in
      `src/app.py`, plus `README.md`, `src/patterns.md`, `mcp/README.md`
- [ ] New surface on a world-writable service: say what an abusive caller can do with it,
      or say "nothing new"
