### PR TITLE
fix(store): keep note count exact across reap/create races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A reap no longer loses a concurrent note-count reservation.** The final cache rebuild now
+  shares the note-create gate, keeping the global note cap exact across reap/create races.
+
 ## [0.9.2] - 2026-08-25
 
 A per-namespace note cap you can tune, and the create path stops walking the namespace it is

--- a/src/store.py
+++ b/src/store.py
@@ -17,7 +17,7 @@ import time
 import unicodedata
 from collections import OrderedDict
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
@@ -950,12 +950,12 @@ def _reap(root: Path) -> None:
         os.replace(usage_tmp, root / USAGE_FILE)
     except OSError:
         pass  # a missing usage file reads as no pressure, which fails open, not closed
-    # Deletions are done and this is the only thing that deletes, so the walk below is
-    # exact as of now — which is what bounds the create path's drift to one reap interval.
-    try:
+    # Deletions are done and this is the only thing that deletes. Hold the create gate
+    # across the walk and rewrite so a new note cannot land after the walk and have its
+    # reserved increment replaced by the stale total.
+    # An unwritable count rebuilds by walking, which is what this replaced.
+    with suppress(OSError), _locked(root / ".notes-create"):
         _write_note_count(root, *_count_notes(root))
-    except OSError:
-        pass  # an unwritable count rebuilds by walking, which is what it replaced
     # Sidecar locks are deliberately *not* removed with their data file: unlinking one a
     # writer holds splits the lock domain (the next writer locks a fresh inode). Instead
     # sweep the orphans — a lock with no data file, idle as long as any reaped room — so

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from threading import Event, Thread
 
 import pytest
 
@@ -437,6 +438,54 @@ def test_the_cached_count_survives_reap_and_create_interleaving(tmp_path, monkey
         # must agree with the increments — a reap is not allowed to lose a concurrent create.
         assert store._note_count(tmp_path) == expected, f"after reap {round_}"
         assert store._count_notes(tmp_path)[0] == expected, "and it must match the disk"
+
+
+def test_a_create_cannot_land_between_the_reap_count_and_cache_rewrite(
+    tmp_path, monkeypatch
+) -> None:
+    """A reap must serialize its final count-and-rewrite with the complete create path.
+
+    Pause the reap after its disk walk has returned. On the broken path a create can finish
+    in that window, then the reap overwrites its increment with the stale walked count.
+    A shared create gate makes that creator wait; once the reap releases the gate, the note
+    and its increment land together and the cache still matches the disk.
+    """
+    import store
+
+    store.note_set(tmp_path, "seed", "one", "v")
+    (tmp_path / ".reaped").unlink()
+
+    walked = Event()
+    release_reap = Event()
+    create_done = Event()
+    real_count_notes = store._count_notes
+
+    def paused_count_notes(root):
+        totals = real_count_notes(root)
+        walked.set()
+        assert release_reap.wait(5), "test did not release the paused reap"
+        return totals
+
+    monkeypatch.setattr(store, "_count_notes", paused_count_notes)
+
+    reap = Thread(target=store._reap, args=(tmp_path,))
+    reap.start()
+    assert walked.wait(5), "reap never reached its final note walk"
+
+    def create() -> None:
+        store.note_set(tmp_path, "fresh", "two", "v")
+        create_done.set()
+
+    creator = Thread(target=create)
+    creator.start()
+    create_done.wait(1)
+    release_reap.set()
+    reap.join(5)
+    creator.join(5)
+
+    assert not reap.is_alive()
+    assert not creator.is_alive()
+    assert store._note_count(tmp_path) == real_count_notes(tmp_path)[0] == 2
 
 
 def test_a_stale_cache_over_admits_by_at_most_the_drift_a_reap_clears(


### PR DESCRIPTION
## What

Serializes the reaper's final note-count walk and cache rewrite with the existing `.notes-create` gate. A deterministic regression pauses the reap after its walk, starts a concurrent create, then verifies the cached global count matches disk.

## Why

On current 0.9.2 main, a create can complete between `_count_notes()` and `_write_note_count()`. Its reservation is then overwritten by the stale walked total, leaving `.notes-count` below the number of notes on disk. Because `MAX_NOTES_TOTAL` is enforced from that cache, the store can admit notes past the configured global cap.

The existing test alternates the operations but does not overlap this window.

## Checks

- [x] Regression fails on unmodified 0.9.2 (cache 1, disk 2) and passes with this change
- [x] Focused note-count suite: 17 passed; Unix multiprocess case deselected on Windows
- [x] Broad Windows suite: 372 passed; one Unix-only subprocess case cannot import `fcntl`
- [x] `ruff check`, `ruff format --check`, and `ty check --python-platform linux`
- [x] `python sz.py --check`: store 787/789; core 2010/2012
- [x] Changelog updated; protocol docs remain accurate
- [x] New world-writable surface: nothing new; this serializes internal maintenance