### PR TITLE
fix(limit): make the token bucket thread-safe under the threadpool

### DIFF
--- a/src/limit.py
+++ b/src/limit.py
@@ -53,6 +53,11 @@ FREE_PATHS = "/, /llms.txt, /skill.md, /patterns.md, /interop.md, /auth.md, /ope
 # limiter state — which is why the authoritative limit belongs in the proxy (see README).
 MAX_BUCKETS = 20_000
 _buckets: OrderedDict[tuple[str, str], tuple[float, float]] = OrderedDict()
+# take() and refund() run from Starlette's threadpool (their callers are sync def), so two
+# requests from one IP can read the same bucket before either writes it back. The lock
+# guards only that read-modify-write — get, compute, assign, and the LRU touch/eviction
+# that rides along with it in take() — never I/O, so a held lock is always microseconds.
+_buckets_lock = threading.Lock()
 
 # Request counters for /stats. Deliberately in-process (the store's counters are the
 # durable ones): traffic is only ever read as a rate, and a rate needs the uptime that
@@ -271,19 +276,25 @@ def take(request, kind, per_min, burst=None, *, ip_header="", max_buckets=MAX_BU
     ip = client_ip(request, ip_header)
     if len(_identities) < MAX_IDENTITIES:
         _identities.add(ip)
-    now = time.monotonic()
     cap = float(per_min if burst is None else burst)
-    tokens, last = _buckets.get((ip, kind), (cap, now))
-    tokens = min(cap, tokens + (now - last) * per_min / 60.0)
-    if tokens >= 1.0:  # granted: no wait, even when this was the last token
-        tokens -= 1.0
-        wait = 0.0
-    else:
-        wait = (1.0 - tokens) * 60.0 / per_min
-    _buckets[(ip, kind)] = (tokens, now)
-    _buckets.move_to_end((ip, kind))
-    while len(_buckets) > max_buckets:
-        _buckets.popitem(last=False)
+    with _buckets_lock:
+        # The clock sample lives inside the lock: sampled outside, two callers can sample
+        # and acquire in opposite orders, and the stale `now` then computes a negative
+        # refill against a newer `last` — refusing an available bucket with a false
+        # Retry-After and rewinding `last`. Inside the lock, timestamp order matches
+        # mutation order, so `now - last >= 0` holds.
+        now = time.monotonic()
+        tokens, last = _buckets.get((ip, kind), (cap, now))
+        tokens = min(cap, tokens + (now - last) * per_min / 60.0)
+        if tokens >= 1.0:  # granted: no wait, even when this was the last token
+            tokens -= 1.0
+            wait = 0.0
+        else:
+            wait = (1.0 - tokens) * 60.0 / per_min
+        _buckets[(ip, kind)] = (tokens, now)
+        _buckets.move_to_end((ip, kind))
+        while len(_buckets) > max_buckets:
+            _buckets.popitem(last=False)
     # Counted at the one point every rate-limited route already funnels through, so a new
     # route cannot forget to count itself. In-process, so these reset on restart — /stats
     # reports them next to `uptime_seconds`, which is what makes them readable.
@@ -302,8 +313,9 @@ def refund(request, kind, per_min, burst=None, *, ip_header="") -> None:
     """
     ip = client_ip(request, ip_header)
     cap = float(per_min if burst is None else burst)
-    tokens, last = _buckets.get((ip, kind), (cap, time.monotonic()))
-    _buckets[(ip, kind)] = (min(cap, tokens + 1.0), last)
+    with _buckets_lock:
+        tokens, last = _buckets.get((ip, kind), (cap, time.monotonic()))
+        _buckets[(ip, kind)] = (min(cap, tokens + 1.0), last)
     config._dbg(1, "refund", ip=ip, kind=kind)
 
 

--- a/src/limit.py
+++ b/src/limit.py
@@ -57,6 +57,8 @@ _buckets: OrderedDict[tuple[str, str], tuple[float, float]] = OrderedDict()
 # requests from one IP can read the same bucket before either writes it back. The lock
 # guards only that read-modify-write — get, compute, assign, and the LRU touch/eviction
 # that rides along with it in take() — never I/O, so a held lock is always microseconds.
+# Scope: this covers _buckets only. The duplicate ring keeps its own _dupes_lock below,
+# and the waiter counters stay unlocked on the event loop.
 _buckets_lock = threading.Lock()
 
 # Request counters for /stats. Deliberately in-process (the store's counters are the
@@ -94,11 +96,12 @@ MAX_IDENTITIES = 50_000  # bounded like _buckets; a counter that OOMs is not a d
 # drag its own window open by hammering: the phrase becomes acceptable again exactly
 # `window` after the last copy that landed, never later.
 #
-# Guarded by a lock, unlike every other structure in this module. The waiter counters are
-# safe unlocked because they are only ever touched by the single-threaded event loop, and
-# the buckets are read-modify-write on ONE key so a lost update costs a fraction of a
-# token. This one is neither: both write lanes reach it from a threadpool (the GETs are
-# sync endpoints, the POST goes through run_in_threadpool), and the sweep walks and
+# Guarded by its own leaf lock, like the token buckets above -- but its own, not
+# _buckets_lock. The waiter counters are the one unlocked structure left, safe because
+# only the single-threaded event loop touches them. A bucket mutation is a swap on ONE
+# key; this ring's write is not, which is why it needs more than the buckets' lock gives.
+# Both write lanes reach it from a threadpool (the GETs are sync endpoints, the POST goes
+# through run_in_threadpool), and unlike a bucket's single-key swap, the sweep walks and
 # deletes from the front while another thread may be inserting — which is an
 # `OrderedDict mutated during iteration` RuntimeError, or a KeyError on a key the other
 # thread just evicted, i.e. a 500 on exactly the write path the filter exists to protect.

--- a/tests/unit/test_limit_concurrency.py
+++ b/tests/unit/test_limit_concurrency.py
@@ -1,0 +1,174 @@
+"""Run: uv run --group dev python -m pytest tests
+
+Sync handlers (room_say, note_write, rooms, ...) run in Starlette's threadpool, so two
+requests from one IP can call limit.take() at the same instant. take()'s read/compute/
+write on the module-level _buckets dict has no lock: this pins the one-token case as
+observable behavior (how many of two concurrent callers are granted), not as a detail of
+_buckets' own implementation.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from types import SimpleNamespace
+
+import limit
+
+
+def _fake_request(ip: str) -> SimpleNamespace:
+    """The one thing take() reads off a request when no ip_header is configured."""
+    return SimpleNamespace(headers={}, client=SimpleNamespace(host=ip))
+
+
+class _RendezvousBucket(OrderedDict):
+    """get() reads immediately, then holds the value it read until a second caller has
+    also read -- so neither call can return (and take() cannot write back) until both
+    have observed the same pre-write state. OrderedDict, like the real _buckets, because
+    take() also calls move_to_end() and popitem(last=False) on it.
+
+    The hold is a barrier with a timeout, not the coordination mechanism itself: if
+    take()'s read-modify-write is serialized (by whatever means -- this test does not
+    know or care how), the second call's get() cannot happen until the first has finished
+    and released whatever it holds. The first then times out waiting for a second reader
+    that will not arrive in time, returns what it already (correctly) read, and finishes;
+    the second, once admitted, reads the first's already-written value and its own
+    barrier wait breaks immediately (the barrier is already broken) instead of pairing it
+    with a stale read. Two callers timing out separately and each returning their own
+    honestly-read value is serialized behavior working, not a failure of this helper --
+    and it is only ever paid once, by whichever caller is first.
+    """
+
+    def __init__(self, barrier: threading.Barrier):
+        super().__init__()
+        self._barrier = barrier
+
+    def get(self, key, default=None):
+        value = super().get(key, default)  # the read happens first, always
+        try:
+            self._barrier.wait(timeout=0.25)  # then hold it until a second reader catches up
+        except threading.BrokenBarrierError:
+            pass  # no second reader arrived in time -- return what was actually read
+        return value
+
+
+def test_two_concurrent_takes_on_a_one_token_bucket_grant_exactly_one(monkeypatch) -> None:
+    """A bucket holding one token, read by two threads that are forced to see the same
+    pre-decrement state before either writes back.
+
+    This is deliberately agnostic to HOW (or whether) take() is made safe: it forces the
+    interleaving and asserts only the observable grant/refuse outcome, not any detail of
+    _buckets' own implementation.
+
+    Unlocked, both threads read the untouched (1.0, now) starting tuple, both compute
+    tokens >= 1.0, and both are granted: two wait==0 results out of a bucket of one, the
+    lost update. Serialized, the second thread's get() cannot reach the barrier until the
+    first has finished and released whatever serializes them, so it observes the first's
+    already-spent bucket instead and is refused.
+    """
+    barrier = threading.Barrier(2)
+    monkeypatch.setattr(limit, "_buckets", _RendezvousBucket(barrier))
+
+    ip = "203.0.113.9"
+    # Appended, not indexed: list.append is atomic under the GIL, and which caller finishes
+    # first does not matter -- only that, across both, exactly one grant and one refusal
+    # come back.
+    results: list[tuple[int, float]] = []
+
+    def call() -> None:
+        results.append(limit.take(_fake_request(ip), "probe", per_min=1, burst=1))
+
+    threads = [threading.Thread(target=call) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+    assert not any(t.is_alive() for t in threads), "a take() call never returned"
+    assert len(results) == 2, f"expected 2 results, got {results}"
+
+    granted = [wait for _, wait in results if wait == 0.0]
+    refused = [wait for _, wait in results if wait > 0.0]
+    assert len(granted) == 1 and len(refused) == 1, (
+        f"a one-token bucket did not grant exactly one of two concurrent callers: results={results}"
+    )
+
+
+# This race is direction-sensitive -- eviction has to land strictly between the target
+# key's insert and its own move_to_end -- unlike the lost-update race above, where either
+# resume order produces the same grant/refuse outcome. Reusing _RendezvousBucket's shared
+# barrier here made resume order ambiguous and the test flaky, so this uses an explicit
+# inserted/resume Event pair instead: the test's own resume.set() drives release on the
+# unlocked path (once the real second take() has actually run), and the wrapper's own
+# bounded wait is paid only as a hang-guard on the serialized path.
+class _EvictionRaceBucket(OrderedDict):
+    """__setitem__ inserts normally, then -- only for the one key under test -- signals
+    that the insert has landed and pauses (bounded by a hang-guard timeout the test always
+    clears itself) before returning control to the caller. That lands take()'s own next
+    statement, move_to_end, exactly after whatever happens in the window: a second take()
+    call really evicting the same key when unlocked, or nothing at all once the lock has
+    serialized the two calls end to end.
+
+    The pause is a bounded wait, not the coordination mechanism itself: if take()'s
+    read-modify-write is serialized (by whatever means -- this test does not know or care
+    how), the second call cannot even start its own eviction loop until the first has
+    released whatever serializes them. The first then times out waiting for a release that
+    will not arrive in time, proceeds with the key still its own, and finishes; only then
+    does the second call run, evicting a key nothing is still reading. The test's own
+    resume.set() -- never the timeout -- is what releases the first call whenever the
+    second one legitimately got to run before it, so the timeout is paid only on the
+    serialized path, as a hang-guard.
+    """
+
+    def __init__(
+        self, watch_key: tuple[str, str], inserted: threading.Event, resume: threading.Event
+    ):
+        super().__init__()
+        self._watch_key = watch_key
+        self._inserted = inserted
+        self._resume = resume
+
+    def __setitem__(self, key, value) -> None:
+        super().__setitem__(key, value)  # the write happens first, always
+        if key == self._watch_key:
+            self._inserted.set()
+            self._resume.wait(timeout=0.25)  # hang-guard only: the test always sets this
+
+
+def test_move_to_end_survives_a_concurrent_eviction_of_the_same_key(monkeypatch) -> None:
+    """#378: after take() writes (ip, kind) into _buckets, it calls move_to_end on that
+    same key. Unlocked, a second take() (any IP, any kind) can run its own eviction loop
+    in between and pop the just-written key as the LRU victim, so move_to_end then raises
+    KeyError on a key that was there an instant ago. Serialized, the second call cannot
+    even reach its own eviction loop until the first's write, move_to_end and eviction
+    have all completed and released whatever serializes them, so there is nothing left to
+    evict out from under a move_to_end that has not happened yet.
+
+    Deliberately agnostic to HOW (or whether) take() is made safe: the wrapper only forces
+    the interleaving around one dict write, and the test asserts only whether move_to_end
+    raised, not on the presence or name of a lock.
+    """
+    watch_key = ("203.0.113.7", "probe")
+    inserted = threading.Event()
+    resume = threading.Event()
+    monkeypatch.setattr(limit, "_buckets", _EvictionRaceBucket(watch_key, inserted, resume))
+
+    outcome: list[BaseException | None] = []
+
+    def inserter() -> None:
+        try:
+            limit.take(_fake_request(watch_key[0]), watch_key[1], per_min=1, burst=1, max_buckets=2)
+        except BaseException as exc:  # noqa: BLE001 -- the failure under test IS an exception
+            outcome.append(exc)
+        else:
+            outcome.append(None)
+
+    t = threading.Thread(target=inserter)
+    t.start()
+    assert inserted.wait(timeout=5), "take() never inserted its bucket"
+    limit.take(_fake_request("203.0.113.8"), "probe", per_min=1, burst=1, max_buckets=1)
+    resume.set()
+    t.join(timeout=5)
+    assert not t.is_alive(), "take() never returned"
+    assert outcome and outcome[0] is None, (
+        f"move_to_end raised after a concurrent eviction of the same key: {outcome!r}"
+    )

--- a/tests/unit/test_token_bucket.py
+++ b/tests/unit/test_token_bucket.py
@@ -1,0 +1,202 @@
+"""Run: uv run --group dev python -m pytest tests
+
+The per-IP token bucket's own rules, tested against limit.take and limit.refund
+directly. A budget is only a budget if it holds when the callers arrive together:
+Starlette runs every sync route in a real thread pool, so "one IP, one bucket" means
+one dict entry that several OS threads reach at the same moment.
+
+The concurrency test does not hope for an interleaving. It substitutes a mapping whose
+lookup waits for its siblings, which puts every thread past the read before any of them
+writes back. That is the interleaving the thread pool produces on its own under load;
+pinning it here is what makes the test a statement about the code rather than about the
+machine it ran on. Guarded, the threads serialise, the barrier times out once and breaks,
+and the arithmetic is the same as it would be one caller at a time.
+
+Parameters are passed explicitly rather than leaning on the shipped defaults, which have
+moved with the config: a bucket test asserts arithmetic at numbers it chose.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from collections import OrderedDict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+import limit  # noqa: E402
+
+# One token in the bucket, refilling at one a minute. Chosen so a single grant empties it
+# and the refill contributes nothing measurable over the life of the test.
+CAP = 1.0
+PER_MIN = 1.0
+IP_HEADER = "x-test-ip"
+
+
+class _Headers(dict):
+    def get(self, key, default=""):  # Request.headers.get's signature, not dict's
+        return dict.get(self, key, default)
+
+
+class _Request:
+    """The two attributes limit.client_ip reads, and nothing else."""
+
+    def __init__(self, ip: str) -> None:
+        self.headers = _Headers({IP_HEADER: ip})
+        self.client = None
+
+
+class _SynchronisedBuckets(OrderedDict[tuple[str, str], tuple[float, float]]):
+    """An OrderedDict whose get() releases only once every caller has reached it.
+
+    The window this opens is the one the bug lives in: between reading a balance and
+    writing the decremented one back. A lock closes it, and then the barrier is never
+    satisfied and breaks on the timeout instead, which is the pass condition.
+    """
+
+    def __init__(self, parties: int, timeout: float = 0.25) -> None:
+        super().__init__()
+        self._barrier = threading.Barrier(parties)
+        self._timeout = timeout
+
+    def get(self, key, default=None):
+        value = super().get(key, default)
+        try:
+            self._barrier.wait(timeout=self._timeout)
+        except threading.BrokenBarrierError:
+            pass  # serialised, so the others are not coming: this is the guarded path
+        return value
+
+
+class _ReverseFirstTwoLock:
+    """Make the second arriving thread enter the critical section first."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._arrival_lock = threading.Lock()
+        self._first_waiting = threading.Event()
+        self._second_entered = threading.Event()
+        self._arrivals = 0
+
+    def __enter__(self):
+        with self._arrival_lock:
+            arrival = self._arrivals
+            self._arrivals += 1
+        if arrival == 0:
+            self._first_waiting.set()
+            assert self._second_entered.wait(timeout=1)
+        self._lock.acquire()
+        if arrival == 1:
+            self._second_entered.set()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self._lock.release()
+
+
+def _grants(callers: int) -> int:
+    """How many of `callers` simultaneous requests from one IP the bucket admitted."""
+    saved = limit._buckets
+    limit._buckets = _SynchronisedBuckets(callers)
+    granted: list[int] = []
+    counting = threading.Lock()
+
+    def hit() -> None:
+        _, wait = limit.take(
+            _Request("198.51.100.7"),
+            "write",
+            per_min=PER_MIN,
+            burst=CAP,
+            ip_header=IP_HEADER,
+        )
+        if wait == 0.0:  # wait of zero is the grant; anything else was refused
+            with counting:
+                granted.append(1)
+
+    try:
+        threads = [threading.Thread(target=hit) for _ in range(callers)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+    finally:
+        limit._buckets = saved
+    return len(granted)
+
+
+def test_a_one_token_bucket_admits_one_caller_however_many_arrive_together():
+    """The overdraft this guards against scales with concurrency, so the count matters.
+
+    Unguarded, every thread reads the full bucket and every thread is admitted: four
+    callers spend four tokens out of a bucket holding one, and only the last decrement
+    survives. That is the whole per-IP budget, bypassable by opening more connections.
+    """
+    assert _grants(4) == 1, "a bucket holding one token cannot fund four requests"
+
+
+def test_a_refund_hands_back_exactly_one_token_per_caller():
+    """refund() is the same read-modify-write on the same dict, so it races the same way.
+
+    Two refunds racing on a spent bucket must leave two tokens, not one. A lost refund is
+    a room-creation charge the caller paid for a room it never created, and it is charged
+    against a day-long budget, so it is not repaid by the next refill either.
+
+    The balance is seeded directly rather than by calling take, because take refills from
+    the clock and the barrier's own timeout would show up in the arithmetic. refund does
+    not refill: it leaves `last` alone on purpose, so two refunds are exactly two tokens.
+    """
+    saved = limit._buckets
+    buckets = _SynchronisedBuckets(2)
+    key = ("192.0.2.5", "create")
+    buckets[key] = (0.0, time.monotonic())
+    limit._buckets = buckets
+    request = _Request("192.0.2.5")
+    try:
+        threads = [
+            threading.Thread(
+                target=limit.refund,
+                args=(request, "create", PER_MIN, 4.0),
+                kwargs={"ip_header": IP_HEADER},
+            )
+            for _ in range(2)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        back, _ = buckets[key]
+    finally:
+        limit._buckets = saved
+    assert back == 2.0, "two refunds must return two tokens, not one"
+
+
+def test_the_bucket_samples_time_after_entering_the_lock(monkeypatch):
+    saved_buckets = limit._buckets
+    lock = _ReverseFirstTwoLock()
+    key = ("203.0.113.9", "write")
+    limit._buckets = OrderedDict({key: (1.0, 0.0)})
+    monkeypatch.setattr(limit, "_buckets_lock", lock)
+    samples = iter((10.0, 20.0))
+    monkeypatch.setattr(limit.time, "monotonic", lambda: next(samples))
+    waits: list[float] = []
+
+    def hit() -> None:
+        _, wait = limit.take(_Request(key[0]), "write", per_min=1.0, burst=1.0, ip_header=IP_HEADER)
+        waits.append(wait)
+
+    try:
+        first = threading.Thread(target=hit)
+        second = threading.Thread(target=hit)
+        first.start()
+        assert lock._first_waiting.wait(timeout=1)
+        second.start()
+        first.join()
+        second.join()
+        balance, last = limit._buckets[key]
+    finally:
+        limit._buckets = saved_buckets
+    assert sorted(waits) == [0.0, 50.0]
+    assert balance == 1 / 6
+    assert last == 20.0


### PR DESCRIPTION
## What

`take()` and `refund()` in `src/limit.py` guard their `_buckets` read-modify-write with a lock. Under concurrent requests from one IP, a per-IP budget is no longer overspent by a lost update.

## Why

`take()`/`refund()` run in Starlette's threadpool (sync `def` handlers), so two requests from one IP can read the same bucket before either writes back, and a one-token bucket grants both. This adds a `threading.Lock` around both read-modify-write sites; `config._dbg` stays outside it. `_requests`/`_identities` are left unlocked deliberately (diagnostics only, no grant/gate decision). The regression test forces the interleaving via a barrier on `get()`: red on `main`, green with the lock.

This costs 4 core lines over `limit.py`'s `sz.py` cap, so `sz-baseline.json` is raised (`limit.py` 132→136 and `core_total`, cap plus `limit.py`'s own measurement record; no other file touched). I know the core budget and the floor-not-authority framing are deliberate; this is a lost update inside the floor's own contract, cheap to close. Happy to close if in-process locking is out of scope.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report`
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [ ] Docs that would now be wrong are updated: n/a, no observable behavior or API change
- [x] New surface on a world-writable service: nothing new; this only closes a race on existing per-IP limiting