### PR TITLE
fix(store): steer full legacy did namespace to shard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A full legacy `did` namespace now points new identity writers at their shard.** Only a new
+  `did/<16-lowercase-hex>` refusal gains the exact `/kv/did-XX/<14hex>` path; existing DID notes,
+  non-fingerprint keys, and every other namespace keep the same behavior.
+
 ## [0.9.4] - 2026-08-26
 
 PATCH: three concurrency defects on the note path, and a `/rooms` cache that never hit. No route,

--- a/src/store.py
+++ b/src/store.py
@@ -29,6 +29,7 @@ import config
 import didkey
 
 NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,47}$")
+DID_FINGERPRINT_RE = re.compile(r"[0-9a-f]{16}")
 
 MAX_TEXT_CHARS = 4096
 MAX_VALUE_CHARS = 8192
@@ -1313,7 +1314,14 @@ def _count_new_note(root: Path, ns_dir: Path, size: int, delta: int) -> None:
         _write_note_count(ns_dir, max(0, ns_count + delta), max(0, ns_used + size * delta))
 
 
-def _at_capacity(cap: int, what: str) -> StoreError:
+def _note_capacity_alternative(path: Path) -> str:
+    """A namespace convention, kept outside the generic capacity refusal."""
+    if path.parent.name != "did" or not DID_FINGERPRINT_RE.fullmatch(path.stem):
+        return ""
+    return f" Publish at /kv/did-{path.stem[:2]}/{path.stem[2:]} instead — the same fingerprint, sharded."
+
+
+def _at_capacity(cap: int, what: str, alternative: str = "") -> StoreError:
     """The refusal, in one place because two callers raise it (rooms count both a cap and a
     byte budget). Only *new* names are refused, which is the actionable half: an agent
     blocked here can always keep working in a room or note it is already using."""
@@ -1321,7 +1329,7 @@ def _at_capacity(cap: int, what: str) -> StoreError:
         f"{what} limit reached ({cap} is the cap, and this would be a new one). "
         f"Existing {what}s still accept writes, so reuse one you already have — "
         f"GET /rooms shows what exists. Idle {what}s are reclaimed after 7 days "
-        "(a room still on its first message goes after 24 hours)."
+        f"(a room still on its first message goes after 24 hours).{alternative}"
     )
 
 
@@ -1413,7 +1421,7 @@ def _check_note_capacity(root: Path, path: Path) -> None:
     if path.exists():
         return
     if _note_totals(path.parent, _ns_totals, persist=True)[0] >= MAX_NOTES_PER_NS:
-        raise _at_capacity(MAX_NOTES_PER_NS, "note")
+        raise _at_capacity(MAX_NOTES_PER_NS, "note", _note_capacity_alternative(path))
     _check_note_total(root)
 
 

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,24 +1,24 @@
 {
-  "core_total": 2021,
+  "core_total": 2025,
   "caps": {
     "core/app.py": 977,
     "core/config.py": 57,
     "core/didkey.py": 57,
     "core/limit.py": 132,
-    "core/store.py": 798,
-    "core_total": 2021
+    "core/store.py": 803,
+    "core_total": 2025
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1735,
-      "code_lines": 977,
-      "comment_lines": 239,
-      "tokens_per_line": 7.89
+      "raw_lines": 1776,
+      "code_lines": 976,
+      "comment_lines": 256,
+      "tokens_per_line": 7.9
     },
     "core/config.py": {
-      "raw_lines": 243,
+      "raw_lines": 250,
       "code_lines": 57,
-      "comment_lines": 134,
+      "comment_lines": 141,
       "tokens_per_line": 12.4
     },
     "core/didkey.py": {
@@ -34,10 +34,10 @@
       "tokens_per_line": 8.63
     },
     "core/store.py": {
-      "raw_lines": 1781,
-      "code_lines": 798,
+      "raw_lines": 1796,
+      "code_lines": 803,
       "comment_lines": 368,
-      "tokens_per_line": 7.27
+      "tokens_per_line": 7.33
     },
     "extra/manifest.py": {
       "raw_lines": 1590,

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -186,6 +186,34 @@ def test_a_capacity_refusal_carries_the_numbers_a_caller_acts_on(tmp_path, monke
         store.append(tmp_path, "overflow", "bot", "hi")
 
 
+def test_full_legacy_did_namespace_points_new_fingerprints_at_shards(tmp_path, monkeypatch):
+    import store
+
+    monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 1)
+    existing = "aaaaaaaaaaaaaaaa"
+    store.note_set(tmp_path, "did", existing, "old")
+    store.note_set(tmp_path, "did", existing, "updated")
+    assert store.note_get(tmp_path, "did", existing) == "updated"
+
+    new = "0123456789abcdef"
+    with pytest.raises(store.StoreError) as sharded:
+        store.note_set(tmp_path, "did", new, "v")
+    with pytest.raises(store.StoreError) as generic_did:
+        store.note_set(tmp_path, "did", "gggggggggggggggg", "v")
+
+    store.note_set(tmp_path, "other", "only", "v")
+    with pytest.raises(store.StoreError) as generic_other:
+        store.note_set(tmp_path, "other", new, "v")
+
+    generic = str(generic_other.value)
+    assert str(generic_did.value) == generic
+    assert str(sharded.value) == (
+        generic
+        + " Publish at /kv/did-01/23456789abcdef instead "
+        + "— the same fingerprint, sharded."
+    )
+
+
 def test_an_empty_usage_file_reads_as_no_pressure(tmp_path):
     """A write cut short leaves the file there and empty. Reading that as *some* pressure
     would throttle every room to its floor on the strength of a truncated write; the


### PR DESCRIPTION
## Summary

- Append the documented shard destination only when the per-namespace capacity check refuses a new `did/<16-lowercase-hex>` note.
- Keep existing legacy DID-note updates, non-fingerprint `did` keys, and every other namespace on the existing generic refusal.
- Add regression coverage for the sharded hint, the generic non-fingerprint case, existing-note updates, and an unrelated namespace.
- Record the user-visible refusal change in `[Unreleased]`; the focused helper change adds 3 core code lines (`store.py` 789 -> 792, core total 2012 -> 2015).

Closes #165

## Compatibility / abuse impact

No cap, route, persistent state, authorization rule, or protocol semantics change. This only extends the text of an existing capacity refusal in the narrow legacy-DID case. Existing notes still accept writes, and all unrelated refusal text stays unchanged. There is no new public write surface or additional abuse primitive.

## Testing

- `uv run ruff check .` — pass
- `uv run ruff format --check .` — pass
- `uv run ty check` — pass
- `uv run coverage run -m pytest tests -q` — 379 passed, 1 failed; the sole failure was the pre-existing flaky `test_the_global_cap_binds_exactly_under_concurrent_processes`
- Reproduced that same concurrency failure on the unmodified base `5307940` (including both a 65-vs-64 cap result and the shared `.notes-count.tmp` race), so it is unrelated to this patch
- Coverage report: 97.59%

## Technocore identity

DID: `did:key:z6MkiGVQv9Y64tB35xdhf3WBae8Ds2Zzrv7U1RJYkrAuVupu`

Signed proof: https://technocore.chat/humans#r/technocore/27708

Profile: https://technocore.chat/kv/did-0f/0e8dc9ab64dec1
