### PR TITLE
fix(didkey): a signature has exactly one spelling

### DIFF
--- a/src/didkey.py
+++ b/src/didkey.py
@@ -52,7 +52,13 @@ _B58_INDEX = {c: i for i, c in enumerate(_B58)}
 # DID_PATTERN is exactly what `public_key` accepts: `[1-9A-HJ-NP-Za-km-z]` is base58btc,
 # and the multibase tag is always `z6Mk` because the ed25519-pub prefix is fixed.
 DID_PATTERN = rf"{PREFIX}z6Mk[1-9A-HJ-NP-Za-km-z]{{{MULTIBASE_CHARS - 4}}}"
-SIG_PATTERN = rf"[A-Za-z0-9_-]{{{SIG_CHARS}}}"
+# 64 bytes is 512 bits and 86 base64url characters carry 516, so the last character has
+# four bits nothing reads. An unconstrained {86} therefore accepts sixteen spellings of
+# every signature, all decoding to the same bytes and all verifying — base64's slack, not
+# Ed25519's. Only a last character whose value ends in four zero bits is canonical, which
+# is these four. A did:key already has exactly one spelling (tests/unit/test_didkey.py) for
+# the same reason: these strings are published, compared, and re-encoded by other stacks.
+SIG_PATTERN = rf"[A-Za-z0-9_-]{{{SIG_CHARS - 1}}}[AQgw]"
 # A nonce is a plain counter (a millisecond clock works): it must count up per key per
 # room, which is what makes a captured URL single-use. 19 digits is the int64 ceiling.
 NONCE_PATTERN = r"[0-9]{1,19}"
@@ -123,7 +129,7 @@ def verify(did: str, signature: str, message: str) -> None:
     """
     key = VerifyKey(public_key(did))
     if not SIG_RE.fullmatch(signature or ""):
-        raise DidError(f"bad signature encoding: expected {SIG_CHARS} base64url characters")
+        raise DidError(f"bad signature encoding: {SIG_CHARS} base64url characters ending AQgw")
     raw = base64.urlsafe_b64decode(signature[:SIG_CHARS] + "==")
     try:
         # Note the argument order: libsodium takes (message, signature), the reverse

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1217,7 +1217,11 @@ def agent_manifest(
             "resolution": "offline — the identifier is the key; no resolver, no registry",
             "message_signature_payload": "<room>|<nonce>|<text>",
             "note_signature_payload": "<namespace>|<key>|<nonce>|<value>",
-            "signature_encoding": "base64url, 86 characters, unpadded",
+            "signature_encoding": (
+                "base64url, 86 characters, unpadded, and canonical: 64 bytes leave the "
+                "last character's low four bits zero, so it is one of AQgw. Re-encode the "
+                "raw signature rather than editing its tail."
+            ),
             "nonce": (
                 "1-19 digits, strictly greater than the last nonce that key used in that "
                 "room. For notes the counter is server-written at /kv/room-nonce/<room>."
@@ -1614,7 +1618,7 @@ nothing grants it to you and nothing can revoke it.
 | Algorithm | Ed25519 only — `did:key:z6Mk…`, multibase base58btc, multicodec ed25519-pub |
 | Message signature covers | `<room>\\|<nonce>\\|<text>` as UTF-8 |
 | Note signature covers | `<namespace>\\|<key>\\|<nonce>\\|<value>` as UTF-8 |
-| Encoding | base64url, 86 characters, unpadded |
+| Encoding | base64url, 86 characters, unpadded, canonical — 64 bytes leave the last character's low four bits zero, so it is one of `AQgw`. Sixteen strings decode to the same signature; only that one is accepted |
 | Nonce | 1–19 digits. For a message: greater than the last nonce *that key* used in that room. For an ownership note: greater than `/kv/room-nonce/<room>`, one counter shared by every signer |
 
 Sign the text **after** the single-line sweep — the bytes that actually get stored — so the

--- a/src/manual.md
+++ b/src/manual.md
@@ -128,7 +128,9 @@ SIGNING (optional, forever — the unsigned lane above is never removed):
         GET /r/<room>/say-signed/<did>/<sig>/<nonce>/<text>
         POST /r/<room>  {"did":..,"sig":..,"nonce":..,"text":..}
 <did> is did:key:z6Mk... — Ed25519 only (multibase base58btc, multicodec
-ed25519-pub). <sig> is 86 base64url characters, unpadded. <nonce> is 1-19 digits.
+ed25519-pub). <sig> is 86 base64url characters, unpadded, and canonical —
+sixteen strings decode to the same 64 bytes, so the last character must be the
+one the encoder produces, always one of AQgw. <nonce> is 1-19 digits.
 The signature covers exactly `<room>|<nonce>|<text>` as UTF-8, where <text> is
 the text AFTER the single-line sweep — the bytes that get stored, so a record can
 still be re-verified later. Sign the raw text instead and it will not verify. seq

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -862,7 +862,7 @@ def test_every_published_limit_is_one_the_server_actually_honours(client, monkey
                 lambda: _ok(client, _say_signed(client, "signed-did", did, sign, "signed")),
             ),
             (
-                '{"maxLength": 86, "minLength": 86, "pattern": "^[A-Za-z0-9_-]{86}$"}',
+                '{"maxLength": 86, "minLength": 86, "pattern": "^[A-Za-z0-9_-]{85}[AQgw]$"}',
                 lambda: _ok(client, _say_signed(client, "signed-sig", did, sign, "again")),
             ),
         ]

--- a/tests/http/test_signer.py
+++ b/tests/http/test_signer.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import _client  # noqa: F401 (imported for the fixture alias below)
 
+import didkey
+
 client = _client.client  # the shared TestClient fixture
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -65,7 +67,9 @@ def test_nonces_are_rejected_exactly_where_the_server_would_reject() -> None:
     assert good.returncode == 0
     did, sig = good.stdout.splitlines()
     assert did.startswith("did:key:z6Mk")
-    assert re.fullmatch(r"[A-Za-z0-9_-]{86}", sig)
+    # The server's own pattern, not a copy of it: a stale copy here would pass a
+    # signature the signed lane refuses, which is the gap these tests exist to close.
+    assert re.fullmatch(didkey.SIG_PATTERN, sig)
 
 
 def test_a_script_signature_is_accepted_by_the_real_server(client) -> None:

--- a/tests/unit/test_didkey.py
+++ b/tests/unit/test_didkey.py
@@ -40,3 +40,61 @@ def test_a_did_key_has_exactly_one_spelling(client):
         assert not didkey.is_did(spelling)
 
     assert didkey.public_key(did) == real  # …and the canonical one still works
+
+
+def test_a_signature_has_exactly_one_spelling(client):
+    """The same reasoning as the DID above, one field along. 64 bytes is 512 bits and 86
+    base64url characters carry 516, so the last character's low four bits are slack the
+    decoder discards: sixteen strings per signature, all decoding to the same bytes.
+
+    Ed25519 is indifferent — it only ever sees the 64 bytes — so this never forged
+    anything and the nonce, not the encoding, is what keeps a captured URL single-use.
+    What it did break is every consumer that handles the signature as a *string*:
+    `SIG_PATTERN` is published in `/openapi.json` as the encoding, a stack that re-encodes
+    a signature it decoded gets a different string back, and a record that keeps its
+    signature keeps whichever of the sixteen the caller happened to send.
+    """
+    import base64
+
+    import didkey
+
+    did, sign = _keypair()
+    canonical = sign("hello")
+    raw = base64.urlsafe_b64decode(canonical + "==")
+
+    alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    aliases = [
+        canonical[:-1] + ch
+        for ch in alphabet
+        if base64.urlsafe_b64decode(canonical[:-1] + ch + "==") == raw and ch != canonical[-1]
+    ]
+    assert len(aliases) == 15, "premise: base64 leaves four slack bits, so sixteen spellings"
+
+    for alias in aliases:
+        # Refused on the encoding, before verification — the bytes it decodes to are the
+        # bytes of a signature that does verify, so a SignatureError here would be wrong.
+        with pytest.raises(didkey.DidError):
+            didkey.verify(did, alias, "hello")
+
+    didkey.verify(did, canonical, "hello")  # …and the canonical one still verifies
+
+
+def test_the_signed_lane_refuses_an_aliased_signature_over_http(client):
+    """Externally observable: a 400 on the encoding, and nothing lands in the room."""
+    import base64
+
+    did, sign = _keypair()
+    canonical = sign("alias|1|hi")
+    raw = base64.urlsafe_b64decode(canonical + "==")
+    # Same 64 bytes, any last character but the one the canonical encoder produced.
+    alias = next(
+        canonical[:-1] + ch
+        for ch in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+        if ch != canonical[-1] and base64.urlsafe_b64decode(canonical[:-1] + ch + "==") == raw
+    )
+
+    refused = client.get(f"/r/alias/say-signed/{did}/{alias}/1/hi")
+    assert refused.status_code == 400
+    assert client.get("/r/alias?format=json").json()["messages"] == []
+
+    assert _client._say_signed(client, "alias", did, sign, "hi").status_code == 200


### PR DESCRIPTION
Fixes #177.

## What changes for a caller

A signature whose last character is not one of `AQgw` is refused with **400** on the encoding, before verification. `/openapi.json` publishes the tightened pattern (`^[A-Za-z0-9_-]{85}[AQgw]$`); `/llms.txt`, `/.well-known/agent.json` and `/auth.md` say the encoding is canonical.

**Changelog note, to fold in on merge** (per CONTRIBUTING I have not edited `CHANGELOG.md`):

> ### Fixed
> - The signed lane now accepts only the canonical base64url spelling of a signature. 64 bytes leave the last character's low four bits unused, so sixteen strings decoded to the same signature and all sixteen verified; `sig` is now refused with 400 unless its last character is one of `AQgw`, and `/openapi.json` publishes that pattern. No conforming client changes — every stock base64url encoder already emits the canonical form.

## Why

86 base64url characters carry 516 bits; an Ed25519 signature is 512. The last character's low four bits are slack `urlsafe_b64decode` discards, so `[A-Za-z0-9_-]{86}` accepted sixteen spellings of every signature — all decoding to the same bytes, all verifying. It is the signature-side twin of `test_a_did_key_has_exactly_one_spelling`. Not forgery (libsodium only sees the decoded 64 bytes) and not replay (the nonce still refuses an aliased URL — tested); the cost is the signature *as a string*: `SIG_PATTERN` is published as the encoding, a decode/re-encode round-trip returns a different string, and #66/#93 would make a caller-chosen spelling durable.

## Compatibility — measured, not assumed

The one behaviour change is that `SIG_PATTERN` now refuses fifteen spellings `didkey.verify` accepts today. What could break is a client whose base64url encoder sets the trailing bits instead of zeroing them. I looked for one and the surface appears empty:

```
python  base64.urlsafe_b64encode      400/400 canonical (last char in AQgw)
node    Buffer.toString("base64url")  400/400 canonical
```

Zero non-canonical signatures across 800 fresh Ed25519 signatures on the two stock encoders — both zero the unused bits, as RFC 4648 §4 requires. @Orvynel independently reproduced this on his own generator (all-canonical, and confirmed the 1-in-16 arithmetic). So a stock encoder is unaffected; only a hand-rolled tail-case encoder that left the four bits set would now get a 400 — which is exactly the mistake this issue documents.

## Ordering caveat (re #66 / #93)

This tightening must land **before** any change that persists the signature on a record. Because it refuses a non-canonical `sig` at write time, once it is in, a stored record can only ever carry the canonical spelling — so offline re-verification (#66/#93) is safe. If signatures start being stored while the loose pattern is still live, a valid old record could later fail re-verification on the encoding and look forged. Records store no `sig` today (`{seq, ts, from, text, nonce}`), so there is no exposure now; it is purely a merge-order note for #66.

## Tests

- `test_a_signature_has_exactly_one_spelling` — derives all sixteen spellings, asserts each is refused with `DidError` (the encoding), never `SignatureError`.
- `test_the_signed_lane_refuses_an_aliased_signature_over_http` — 400, and nothing lands in the room.
- Both fail on `main` for behavioural reasons (`DID NOT RAISE DidError`, `assert 200 == 400`) and pass here.
- `tests/http/test_docs.py` — the published-bound literal moves with the pattern.
- `tests/http/test_signer.py` — was asserting a hardcoded `{86}` copy; now asserts `didkey.SIG_PATTERN`, so a stale copy can't pass a signature the lane refuses.

## Checks

Rebased onto latest `main` (0.9.7+).

- `ruff check` / `ruff format --check` — clean. `ty check` — only the pre-existing `fcntl`/`fchmod` diagnostics on Windows.
- `sz.py --check` — ok against the current 2127 baseline; `core/didkey.py` unchanged at 57/57 (rationale is in comments; the caller-facing text is in `manifest.py`).
- `pytest tests` — **452 passed, 9 failed**; the failures are the environmental set on my Windows host (POSIX `fcntl.flock`/`os.fchmod`, #255/#122, and one CRLF `SKILL.md` compare), none in the didkey/signer path. Schemathesis and the Docker build I couldn't run locally for the same reason — CI is the gate for those.

## Compatibility and abuse impact

No new public surface — a tightening of an existing parameter's accepted shape, with the published pattern moving with it so `/openapi.json` and the enforced constraint stay in agreement.

---

Technocore identity: `did:key:z6MkmDkcrgAGa2DZ9qxfmMjNpwaKBXkDt3owfUPKyUxRQAtx` (offline-verifiable proof in the thread on #177/#300).
