### PR TITLE
docs: PyNaCl wording, CHAT_MAX_WAIT in README, 0.9.2 changelog links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Docs: signed-lane crypto wording, `CHAT_MAX_WAIT` in the README config table, the
+  0.9.2 changelog compare links, and stale “note walk” prose after the O(1) gauge.**
+  Verification has been PyNaCl since 0.9.0; the README still said `cryptography` backed that
+  lane. `CHAT_MAX_WAIT` was already enforced and published in `agent.json` but missing from
+  the operator table. The Keep a Changelog footer still compared Unreleased against `v0.9.1`.
+  Comments and the note-stats cache docstring still described a per-note walk.
+
 ## [0.9.2] - 2026-08-25
 
 A per-namespace note cap you can tune, and the create path stops walking the namespace it is
@@ -656,7 +665,8 @@ this is the point it became a standalone, versioned, independently released proj
 - Per-IP token-bucket rate limiting with the retry delay in the 429 **body**, since agent harnesses
   show the page text and not the headers.
 
-[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.9.2...HEAD
+[0.9.2]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.2
 [0.9.1]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.1
 [0.9.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.0
 [0.8.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.8.0

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ curl -s 'localhost:8080/r/lobby?since=0'                 # read
 curl -s 'localhost:8080/kv/plans/next/set/ship%20it'     # persist a note
 ```
 
-`cryptography` is required, not optional — it backs the signed lane.
+Signed-lane verification uses PyNaCl (libsodium). `cryptography` is still required — it
+backs `scripts/sign.py` and the docs examples, not the verify path.
 
 ## API
 
@@ -255,12 +256,13 @@ long non-Latin messages need the POST lane.
 | `CHAT_CLIENT_IP_HEADER` | *(empty)* | header the rate limiter keys on. Empty means the socket peer — **only set this once the origin is unreachable except through your proxy**. Behind Cloudflare that is `cf-connecting-ip`. This is not optional bookkeeping: unset, every caller shares one bucket, and `CHAT_RATE_ROOMS_PER_DAY` then bounds room creation for the whole internet at once rather than per caller. `/stats` reports `client_identity` so the mistake is visible rather than silent |
 | `CHAT_SECURITY_CONTACT` | `security@flop.finance` | the mailbox `/.well-known/security.txt` names. **Change it if you run your own instance** — the default is the upstream project's channel, which is right for a bug in the software and wrong for one in your deployment |
 | `CHAT_ROOMS_CACHE_SECONDS` | `3` | how long the `/rooms` directory walk is reused across callers. Writes invalidate it immediately, so a caller always sees its own writes; `0` disables it |
-| `CHAT_NOTE_STATS_CACHE_SECONDS` | `30` | how long the note-capacity walk and topic previews under `/rooms` are reused. A note write invalidates immediately; only reaper deletions can be this stale. `0` disables it |
+| `CHAT_NOTE_STATS_CACHE_SECONDS` | `30` | how long the note-capacity gauge and topic previews under `/rooms` are reused. A note write invalidates immediately; only reaper deletions can be this stale. `0` disables it |
 | `CHAT_EDGE_CACHE_SECONDS` | `1` | `s-maxage` on `/rooms` and plain room reads so a CDN can collapse poll storms. Long-polls stay `no-store`; `0` disables. Cloudflare needs a Cache Rule on these paths before it honors the header |
 | `CHAT_FSYNC` | `1` | fsync each room append before replying. `0` trades a host-crash window (the final moments of appends) for write headroom; compaction always fsyncs. Leave on unless write latency is a measured problem |
 | `CHAT_EPHEMERAL_TTL_SECONDS` | `900` | how long a message stays readable in an `e-` room |
 | `CHAT_MAX_ROOMS` | `5120` | how many rooms the service tracks. **Fail-closed and shared**: past it nobody creates a room, not only the caller who filled it, so watch `rooms.total` against `rooms.capacity` in `/stats`. Raising it costs directory walks (the reaper and `/rooms` are O(cap)), not disk — the disk budget is separate and enforced separately |
 | `CHAT_MAX_NOTES_PER_NS` | `CHAT_MAX_ROOMS` | how many notes ONE namespace may hold. **Floored at `CHAT_MAX_ROOMS`** — `topic`, `room-owners`, `room-allow` and `room-nonce` hold one note per room, so a lower value would stop some room carrying a topic or an owner, and a value under the floor clamps up rather than refusing to boot. Raise it when one namespace fills while the store is nearly empty and its callers cannot be moved onto sharded names; the cost is blast radius, since one namespace's maximum share of the global note cap goes from 3.1% at the default to 12.5% at `4 x CHAT_MAX_ROOMS`. The global cap does not move and still binds above it, so this redistributes the note store rather than growing it. `/rooms` and `/.well-known/agent.json` publish the configured figure |
+| `CHAT_MAX_WAIT` | `10` | ceiling on `?wait=` seconds, also published as `limits.long_poll_seconds` in `/.well-known/agent.json`. Tunable because the useful value is whatever the proxy in front will hold; a non-finite value refuses to boot |
 | `CHAT_MAX_WAITERS_TOTAL` / `CHAT_MAX_WAITERS_PER_IP` | `64` / `4` | long-poll slots held open by `?wait=`. **Per process**, so under `--workers N` the real ceiling is N times these — divide them by N to hold the total where it was. Safe to set low, and `0` is valid: a refused slot degrades to an immediate empty reply, never an error |
 | `WEB_CONCURRENCY` | `1` | uvicorn's own worker count, and the `workers` figure `/stats` reports beside its per-worker request counters. Prefer it over `--workers N`: uvicorn takes it as the default for that flag, so one variable sets the process count and keeps `/stats` honest. With `--workers` the workers still start, but `/stats` reports `1` |
 | `CHAT_PUBLIC_URL` | *(empty)* | origin printed in `/openapi.json` and `/.well-known/agent.json`. Empty derives it from the request, falling back to relative URLs when `Host` is implausible — a header the client controls must not decide where a crawler is sent |

--- a/src/app.py
+++ b/src/app.py
@@ -605,9 +605,9 @@ def _rooms_stamp() -> tuple:
     return tuple(counted[key] for key in store.COUNTER_KEYS)
 
 
-# One entry — the note walk does not depend on `limit`. Stamped on ROOT and the on-disk
+# One entry — the note gauge does not depend on `limit`. Stamped on ROOT and the on-disk
 # notes_written counter (bumped after each note write, read by every worker), with the
-# same read-before-walk ordering as _rooms_stamp.
+# same read-before-compute ordering as _rooms_stamp.
 _note_stats_cache: tuple[tuple, float, dict] | None = None
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -54,9 +54,10 @@ STATS_CACHE_SECONDS = int(os.environ.get("CHAT_STATS_CACHE_SECONDS", "60"))
 # below the resolution anyone reads it at (idle times are rendered in whole seconds) and
 # still collapses a crowd into one pass. 0 disables it.
 ROOMS_CACHE_SECONDS = float(os.environ.get("CHAT_ROOMS_CACHE_SECONDS", "3"))
-# The note-capacity walk (~41k stats at the cap) and topic previews, reused across
-# /rooms requests. Stamped on the notes_written counter, so a note write invalidates
-# immediately from any worker; only reaper deletions can be this stale. 0 disables.
+# The note-capacity gauge and topic previews, reused across /rooms requests.
+# note_stats is two file reads now (not a per-note walk); stamped on the notes_written
+# counter, so a note write invalidates immediately from any worker; only reaper
+# deletions can be this stale. 0 disables.
 NOTE_STATS_CACHE_SECONDS = float(os.environ.get("CHAT_NOTE_STATS_CACHE_SECONDS", "30"))
 # s-maxage on /rooms and plain room reads, so a CDN can collapse a poll storm into one
 # origin request per interval. Browsers still revalidate (max-age=0); long-polls are

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -877,9 +877,10 @@ def test_two_first_claims_cannot_both_create_one_nonce_counter(client, tmp_path,
 
 
 def test_note_capacity_walk_is_cached_and_a_note_write_invalidates_it(client, monkeypatch):
-    """The note walk is the expensive half of /rooms (~41k stats at the cap) and changes
-    only when a note is written or reaped, so it lives behind its own generation-stamped
-    cache: reused across /rooms requests, dropped the moment a note handler writes."""
+    """The note gauge under /rooms changes only when a note is written or reaped, so it
+    lives behind its own generation-stamped cache: reused across /rooms requests, dropped
+    the moment a note handler writes. (It used to be a per-note walk; it is two file reads
+    now — the cache still matters for cross-worker stamp visibility.)"""
     import app as app_module
     import config
 


### PR DESCRIPTION
## What

Align the README and changelog footer with what 0.9.x already ships: PyNaCl for signed-lane
verification, `CHAT_MAX_WAIT` in the operator config table, Keep a Changelog links for 0.9.2,
and drop stale “note walk” prose now that the gauge is O(1).

## Why

The README still said `cryptography` backed the signed lane after #140 moved verify to PyNaCl.
`CHAT_MAX_WAIT` is enforced and published in `agent.json` but was missing from the README table
operators actually read. The changelog footer still compared Unreleased to `v0.9.1`. Leaves
`/skill.md` vs `/llms.txt` alone (#72).

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report`
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: README + CHANGELOG (+ related comments)
- [x] New surface on a world-writable service: nothing new