### PR TITLE
fix: preserve leading zero bytes in base58btc decoding

### DIFF
--- a/src/didkey.py
+++ b/src/didkey.py
@@ -77,7 +77,9 @@ def _b58decode(raw: str) -> bytes:
         if digit is None:
             raise DidError(f"bad did:key: {ch!r} is not base58btc")
         n = n * 58 + digit
-    return n.to_bytes((n.bit_length() + 7) // 8, "big") if n else b""
+    leading = len(raw) - len(raw.lstrip("1"))
+    payload = n.to_bytes((n.bit_length() + 7) // 8, "big") if n else b""
+    return b"\x00" * leading + payload
 
 
 def public_key(did: str) -> bytes:

--- a/tests/_client.py
+++ b/tests/_client.py
@@ -62,12 +62,13 @@ def _multibase(raw: bytes) -> str:
     keys with the decoder's own inverse could not catch the decoder being wrong.
     """
     alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    leading = len(raw) - len(raw.lstrip(b"\x00"))
     n = int.from_bytes(raw, "big")
     out = ""
     while n:
         n, rem = divmod(n, 58)
         out = alphabet[rem] + out
-    return out
+    return "1" * leading + out
 
 
 def _keypair(seed: int = 1):

--- a/tests/unit/test_didkey.py
+++ b/tests/unit/test_didkey.py
@@ -40,3 +40,13 @@ def test_a_did_key_has_exactly_one_spelling(client):
         assert not didkey.is_did(spelling)
 
     assert didkey.public_key(did) == real  # …and the canonical one still works
+
+
+def test_base58btc_preserves_leading_zero_bytes():
+    import didkey
+
+    payload = b"\x00\x00" + b"\xab" * 32
+    encoded = _multibase(payload)
+
+    assert encoded.startswith("11")
+    assert didkey._b58decode(encoded) == payload


### PR DESCRIPTION
## Summary

Fixes #155.

`_b58decode` now preserves leading zero bytes represented by leading `1` characters in base58btc, instead of losing them during integer round-tripping.

The independent test encoder in `tests/_client.py` is updated to emit the same leading-zero representation, and a regression test verifies a payload beginning with two zero bytes round-trips correctly.

## Caller-visible impact

- Existing Ed25519 `did:key` identifiers are unchanged.
- Base58btc decoding now follows the expected leading-zero semantics.
- No API, route, persistence, or response-shape changes.

## Validation

- `uv run --group dev python -m pytest tests` → 380 passed
- `uv run --group dev ruff check .` → passed
- `uv run --group dev ruff format --check .` → passed
- `uv run --group dev ty check` → passed
- `git diff --check` → passed

## Abuse / compatibility impact

None. This only corrects decoding behavior for leading zero bytes and updates the corresponding test helper/regression coverage.