### PR TITLE
fix(http): the room-creation refusal stops offering a room that may not exist

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -996,9 +996,14 @@ def _room_create_gate(request: Request, room: str) -> Response | None:
         f"retry after: {wait}s — the budget refills continuously (one room every {every}s), "
         f"so it is never all-or-nothing at a reset, and waiting longer buys a bigger burst "
         f"up to {RATE_ROOMS_PER_DAY}.\n"
+        # No lobby here. It is an ordinary room that exists only once somebody has written
+        # to it, so on a deployment where nobody has, writing to lobby IS a creation and
+        # costs the token this caller just spent — the refusal would name itself as the way
+        # out, one line after saying the room does not exist. /rooms and /r/events point at
+        # rooms that demonstrably exist on this instance, which is what the caller needs.
         f"still open: writing to a room that ALREADY EXISTS is unaffected and costs nothing "
-        f"from this budget. GET /rooms lists what exists, /r/events announces new public "
-        f"rooms, and /r/lobby always accepts a message — reuse one rather than waiting.\n"
+        f"from this budget. GET /rooms lists what exists and /r/events announces new public "
+        f"rooms — reuse one rather than waiting.\n"
         f"why: rooms are a shared capped resource ({store.MAX_ROOMS} of them, reclaimed "
         f"after 7 days idle); this bounds how much of it one caller can hold at once.\n"
         f"the enforced number is also published at /.well-known/agent.json under "

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -262,8 +262,10 @@ def test_new_rooms_are_budgeted_per_ip_and_say_when_to_retry(client, monkeypatch
         # show
         assert "room-creation budget spent" in r.text
         # The refusal has to leave the caller something to do *now*, or it is an outage
-        # with a timer on it. Rooms that exist are the answer, so the reply has to say so.
-        assert "ALREADY EXISTS" in r.text and "/r/lobby" in r.text
+        # with a timer on it. Rooms that exist are the answer, so the reply has to say so —
+        # and it has to point only at ways of finding one that work from here. This ROOT is
+        # fresh, so lobby is not among them; see the test below.
+        assert "ALREADY EXISTS" in r.text and "/rooms" in r.text
         assert "one-too-many" not in client.get("/rooms").text  # and nothing was created
 
         # The budget refills rather than resetting: no cliff, no stampede at a window
@@ -271,6 +273,33 @@ def test_new_rooms_are_budgeted_per_ip_and_say_when_to_retry(client, monkeypatch
         assert "refills continuously" in r.text
         # Rooms this IP already has are untouched — the property that keeps work moving.
         assert client.get("/r/fresh0/say/bot/still%20here").status_code == 200
+
+
+def test_the_creation_refusal_does_not_offer_a_room_that_does_not_exist(client):
+    """The way out a refusal names has to work from where the caller is standing.
+
+    lobby is an ordinary room: nothing seeds it, and a deployment gets one when somebody
+    writes to it. So on an instance where nobody has, writing to lobby IS a creation and
+    costs the token the caller just ran out of. Naming it as the escape made the refusal
+    contradict its own first line, which had already said the room does not exist, and it
+    is the failure limit.FREE_PATHS exists to avoid: advice that fails at exactly the
+    moment it is taken. What survives is what is true on every deployment, /rooms and
+    /r/events, which report rooms this instance actually has.
+    """
+    import config
+
+    with config.override(RATE_ROOMS_PER_DAY=1):
+        assert client.get("/r/first/say/bot/hi").status_code == 200
+
+        refused = client.get("/r/second/say/bot/hi")
+        assert refused.status_code == 429
+        # Follow the refusal's own advice: every route it names must be one that works.
+        assert "/r/lobby" not in refused.text
+        assert "ALREADY EXISTS" in refused.text
+        assert "/rooms" in refused.text and "/r/events" in refused.text
+
+        # And the advice is true: a room this caller already has still takes writes.
+        assert client.get("/r/first/say/bot/again").status_code == 200
 
 
 def test_writing_to_an_existing_room_never_spends_the_room_budget(client, monkeypatch):


### PR DESCRIPTION
The 429 for a spent room-creation budget ends with:

```
still open: writing to a room that ALREADY EXISTS is unaffected and costs nothing from
this budget. GET /rooms lists what exists, /r/events announces new public rooms, and
/r/lobby always accepts a message - reuse one rather than waiting.
```

lobby is an ordinary room. Nothing seeds it, and an instance gets one the first time somebody writes to it. So on a deployment where nobody has, writing to lobby *is* a creation, and it costs the token the caller just ran out of.

The reply contradicts itself inside a single body. Fresh `CHAT_ROOT`, `CHAT_RATE_ROOMS_PER_DAY=2`, two rooms already created, then the advice taken literally:

```
$ curl -X POST -d '{"from":"p","text":"following the advice in the refusal"}' localhost/r/lobby

429 room-creation budget spent: /r/lobby does not exist yet, and this IP has created its
2 rooms for the day.
...
still open: ... and /r/lobby always accepts a message - reuse one rather than waiting.
```

Line 1 says lobby does not exist. Line 3 says lobby always accepts a message. The way out that the refusal names is the request that just got refused.

`limit.py` already writes down why this matters, next to `FREE_PATHS`:

> A 429 that points at a path which is itself rate limited is advice that fails at exactly the moment it is taken.

That is the same failure, one file over.

### Why remove the clause instead of making it conditional

`", and /r/lobby accepts a message" if _room_exists("lobby") else ""` also works, and I had it working first. It costs one core code line, and `sz.py --caps` says there is nowhere to put it:

```
core/app.py    977    977    0
core/limit.py  132    132    0
core/store.py  789    789    0
core total    2012   2012    0
```

Every core file sits exactly on its cap, and `--check` rejects a value past its cap even when the baseline is raised to match. So the conditional is not available without a decision about the ceiling that is not mine to make. Deleting the clause is zero lines, and `/rooms` and `/r/events` were already in the sentence: both report rooms this instance actually has, which is what the caller needs.

The cost, stated plainly: on a deployment where lobby is busy, such as technocore.chat, the refusal no longer names it directly. If you would rather keep that pointer and spend the line on the conditional, say so and I will switch it.

### The existing test was pinning the bug

`test_a_room_creation_budget_bounds_how_fast_one_ip_can_take_rooms` asserted `"/r/lobby" in r.text`, running under the `client` fixture, which gives a fresh `ROOT` per test. lobby does not exist there either. The assertion now names the routes that are true on every deployment.

### Checks

`ruff check`, `ruff format --check`, `ty check` clean. 380 tests pass. `coverage report` 97.50%. `sz.py --check` ok with the core total unchanged at 2012. The new test fails on `main` with `assert '/r/lobby' not in '429 room-cr...'`.

Not in scope: the creation token being spent by writes that fail validation (#131, and #99 / #132 both fix it). Those touch the accounting in the same function; this touches only the refusal text, and the two do not overlap.

---

I used Claude to help investigate this. The verification against a running instance, and the writing, are mine.
