### PR TITLE
feat(read): ?from=<did> and ?signed=1 filter a room read by verified signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ backs `scripts/sign.py` and the docs examples, not the verify path.
 
 | | |
 |---|---|
-| `GET /r/<room>` | last 50 messages, oldest first (`?since=<seq>`, `?limit=1..200`, `?format=json`) |
+| `GET /r/<room>` | last 50 messages, oldest first (`?since=<seq>`, `?limit=1..200`, `?format=json`; `?from=<did:key…>` or `?signed=1` keep only one verified signer or the signed lane) |
 | `GET /r/<room>?since=<seq>&wait=<0..10>` | long-poll: returns as soon as a message lands, else empty after the requested wait |
 | `GET /r/<room>/export` | the retained ring as raw JSONL, byte-exact and snapshotted at open, so signed records re-verify from the dump alone; `X-Room-Generation` stamps the epoch |
 | `GET /r/<room>/say/<nick>/<text>` | append (URL-encoded, single-line) |

--- a/docs/store.md
+++ b/docs/store.md
@@ -17,7 +17,8 @@ via stdlib `inspect` — never edited by hand; a test regenerates and diffs this
 - `note_set(root: pathlib.Path, ns: str, key: str, value: str, expect: str | None = None, expect_absent: bool = False) -> dict` — Write a note, optionally only if it still holds what the caller last read.
 - `note_stats(root: pathlib.Path) -> dict` — Aggregate note usage. Deliberately blind: no namespace, no key, ever.
 - `ownable(name: str) -> bool` — (undocumented)
-- `read_messages(root: pathlib.Path, room: str, limit: int = 50, since: int | None = None) -> dict` — Return the newest `limit` messages (oldest-first) with seq > `since`.
+- `read_filter(writer: str | None) -> collections.abc.Callable[[dict], bool] | None` — Keep only records a verified writer signed, and only `writer`'s if one is named.
+- `read_messages(root: pathlib.Path, room: str, limit: int = 50, since: int | None = None, keep: collections.abc.Callable[[dict], bool] | None = None) -> dict` — Return the newest `limit` messages (oldest-first) with seq > `since`.
 - `reverse_lines(f, chunk_size: int = 65536, max_bytes: int = 1048576)` — Yield complete lines from the end of a binary file, newest first.
 - `room_bytes_used(root: pathlib.Path) -> int` — Total room bytes at the last reap pass, or 0 if none has run yet.
 - `room_classes(name: str) -> frozenset[str]` — The leading `<class>-` markers on a name, so classes compose by prefix.

--- a/src/app.py
+++ b/src/app.py
@@ -21,6 +21,7 @@ from collections.abc import Mapping
 from contextlib import asynccontextmanager, contextmanager
 from functools import lru_cache
 from pathlib import Path
+from urllib.parse import quote
 
 import orjson
 from starlette.applications import Starlette
@@ -429,7 +430,7 @@ def who(name: str) -> str:
     return didkey.abbreviate(name) if didkey.is_did(name) else f"~{name}"
 
 
-def render(view: dict) -> str:
+def render(view: dict, suffix: str = "") -> str:
     lines = [
         f"# room {view['room']}  messages {view['count']}  "
         f"range {view['first_seq']}..{view['last_seq']}",
@@ -447,18 +448,20 @@ def render(view: dict) -> str:
         if store.is_mailbox(view["room"])
         else f"say:  /r/{view['room']}/say/<nick>/<text%20url%20encoded>"
     )
-    lines += ["", f"next: /r/{view['room']}?since={view['last_seq']}", say]
+    lines += ["", f"next: /r/{view['room']}?since={view['last_seq']}{suffix}", say]
     return "\n".join(lines)
 
 
-def respond(request: Request, view: dict, body_text: str | None = None, note: str = "") -> Response:
+def respond(
+    request: Request, view: dict, body_text: str | None = None, note: str = "", suffix: str = ""
+) -> Response:
     if request.query_params.get("format") == "json":
         return Response(
             json.dumps(view, ensure_ascii=False, indent=1) + "\n",
             media_type="application/json",
             headers={"Cache-Control": "no-store", "X-Robots-Tag": "noindex"},
         )
-    return text((body_text if body_text is not None else render(view)) + note)
+    return text((body_text if body_text is not None else render(view, suffix)) + note)
 
 
 def _edge_cacheable(resp: Response, secs: int | None = None, swr: int | None = None) -> Response:
@@ -1004,6 +1007,20 @@ def __getattr__(name: str):
     return getattr(limit, name)
 
 
+def _filter(writer: str | None, signed: str | None) -> tuple[store.Keep, str]:
+    """The read filters: `store.read_filter`'s predicate plus the query suffix the `next:`
+    footer must carry, so a caller following it keeps the same collection.
+
+    The suffix is echoed URL-encoded, valid or not, so the footer keeps exactly the
+    asked-for collection (a matches-nothing filter stays one) and no caller-chosen byte
+    reaches the line format.
+    """
+    if writer is None and signed != "1":
+        return None, ""
+    suffix = f"&from={quote(writer, safe=':')}" if writer is not None else ""
+    return store.read_filter(writer), suffix + ("&signed=1" if signed == "1" else "")
+
+
 async def room_read(request: Request) -> Response:
     left, retry = take(request, "read", RATE_READ)
     if retry:
@@ -1013,32 +1030,42 @@ async def room_read(request: Request) -> Response:
     # `tail`, not `limit`: the query param keeps its published name, the local must not
     # shadow the limit module the refusal two lines above calls into.
     tail = _cursor(q.get("limit"), 50)
+    keep, suffix = _filter(q.get("from"), q.get("signed"))
     room = request.path_params["room"]
     # Tail reads are blocking file IO. This route is async for the waiting half, so the
     # read has to go to a thread explicitly — as a sync route Starlette did that for us.
-    view = await run_in_threadpool(store.read_messages, config.ROOT, room, limit=tail, since=since)
+    view = await run_in_threadpool(store.read_messages, config.ROOT, room, tail, since, keep)
 
     # Waiting only means anything with a cursor: without `since` a read always returns the
-    # newest messages, so there is nothing to wait *for*.
+    # newest messages, so there is nothing to wait *for*. Under a filter the wait ends on
+    # the next *matching* line: "wake me when this key speaks".
     wait = _seconds(q.get("wait"))
     unheld = ""
     if wait and since is not None and not view["messages"]:
-        fresh, unheld = await _await_messages(request, room, tail, since, wait)
+        fresh, unheld = await _await_messages(request, room, tail, view, wait, keep)
         # The JSON lane's half of the note below, since a program gets no footer and must
-        # not infer a refusal from latency. Only when a wait returned nothing: one that
-        # produced messages was held by definition.
-        view = fresh if fresh is not None else {**view, "wait_held": not unheld}
+        # not infer a refusal from latency. Only when the wait returned nothing: one that
+        # produced messages was held by definition. A wait that ended empty still comes
+        # back as a view — its cursor moved past the lines it scanned — so the test is
+        # whether messages arrived, not whether `fresh` was None.
+        view = fresh if fresh is not None else view
+        view = view if view["messages"] else {**view, "wait_held": not unheld}
     # Ahead of the budget footer: a wait that did not happen is what the caller must act
     # on first, and acting on it is what stops the next request being an instant re-poll.
     note = unheld + budget_note("read", left, RATE_READ)
-    resp = respond(request, view, note=note)
+    resp = respond(request, view, note=note, suffix=suffix)
     return resp if wait or note else _edge_cacheable(resp)
 
 
 async def _await_messages(
-    request: Request, room: str, limit: int, since: int, wait: float
+    request: Request, room: str, limit: int, view: dict, wait: float, keep=None
 ) -> tuple[dict | None, str]:
-    """Poll the room until something arrives past `since`, or the budget runs out.
+    """Poll the room until something arrives past the empty `view`'s cursor, or the budget
+    runs out.
+
+    Returns the messages (or None) and, when no waiter slot was free, the note saying so:
+    both exits are empty, but one waited and the other never did, and a caller told only
+    "nothing" cannot tell which — see `limit.waiter_note`.
 
     Returns the messages (or None) and, when no waiter slot was free, the note saying so:
     both exits are empty, but one waited and the other never did, and a caller told only
@@ -1057,23 +1084,39 @@ async def _await_messages(
     A cross-process wakeup bus would buy the rest of that interval for a background task, a
     lifespan hook and a broadcast primitive that actually fans out (a FIFO does not: one
     reader consumes each byte, so N-1 workers miss it).
+
+    Each empty poll moves the cursor to the newest line it scanned, so under a filter the
+    next poll reads only what arrived since — never the same unmatched tail again. The
+    reply describes the whole wait as one scan: `first_seq` is the oldest line any poll
+    saw, `last_seq` the newest, whether a match arrived or the wait ran out. The one
+    exceptions are a poll that ran out of budget itself and a poll that crossed into a new
+    `generation` — each is returned as is, because its gap (or its epoch) is the news and a
+    single scan's `first_seq` cannot span two of them. A room reaped and recreated under a
+    waiter is precisely what `generation` exists to announce, so the wait ends rather than
+    carrying a cursor from the conversation that is gone. Without a filter an empty
+    view's `last_seq` is its `since` and its `first_seq` is None, so none of this moves.
     """
     ip = client_ip(request)  # once: client_ip counts proxy evidence as a side effect
     with _waiter_slot(ip) as granted:
         if not granted:
             return None, waiter_note(ip, MAX_WAITERS_TOTAL, MAX_WAITERS_PER_IP, wait)
         deadline = time.monotonic() + wait
+        since, first = view["last_seq"], view["first_seq"]
         while time.monotonic() < deadline:
             await asyncio.sleep(min(WAIT_POLL, max(0.0, deadline - time.monotonic())))
             # Stop burning tail reads on a caller that has already hung up.
             if await request.is_disconnected():
                 return None, ""
-            view = await run_in_threadpool(
-                store.read_messages, config.ROOT, room, limit=limit, since=since
+            fresh = await run_in_threadpool(
+                store.read_messages, config.ROOT, room, limit=limit, since=since, keep=keep
             )
-            if view["messages"]:
-                return view, ""
-    return None, ""
+            if fresh["generation"] != view["generation"] or (fresh["first_seq"] or 0) > since + 1:
+                return fresh, ""
+            first = fresh["first_seq"] if first is None else first
+            if fresh["messages"]:
+                return {**fresh, "first_seq": first}, ""
+            view, since = fresh, fresh["last_seq"]
+    return {**view, "first_seq": first, "last_seq": since}, ""
 
 
 def room_export(request: Request) -> Response:

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -254,17 +254,30 @@ _ROOM_VIEW_SCHEMA = {
         "first_seq": {
             "type": ["integer", "null"],
             "description": (
-                "Oldest seq in this response. Greater than your `since` + 1 means the ring "
-                "dropped messages you never read."
+                "Oldest line scanned — for an unfiltered read, the oldest in this response. "
+                "Greater than your `since` + 1 means lines you never saw: the ring dropped "
+                "them or the read budget stopped short. Under `from=` or `signed=1` a line "
+                "missing between `first_seq` and `last_seq` was dropped by the filter, not "
+                "lost."
             ),
         },
-        "last_seq": {"type": "integer", "description": "Pass back as `since` to poll."},
+        "last_seq": {
+            "type": "integer",
+            "description": (
+                "Pass back as `since` to poll: the newest line scanned. Under `from=` or "
+                "`signed=1` that can be a line you were not shown, so a filtered cursor "
+                "still advances; a line missing between `first_seq` and `last_seq` was "
+                "dropped by the filter, not lost."
+            ),
+        },
         "messages": {"type": "array", "items": _MESSAGE_SCHEMA},
         "wait_held": {
             "type": "boolean",
             "description": (
                 "Present only on a `wait=` read that returned no messages. True: the wait "
-                "was held and the room stayed quiet, so poll again. False: no long-poll "
+                "was held and nothing you asked for arrived, so poll again — under `from=` "
+                "or `signed=1` the room may have moved a long way, which is what `last_seq` "
+                "is for. False: no long-poll "
                 "slot was free, so the reply is immediate rather than waited — sleep about "
                 "the wait you asked for first, or you re-read for nothing. The text/plain "
                 "lane says the same in a `# wait: not held` footer."
@@ -574,9 +587,35 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                 f"message, clamped to {max_wait:g}. Needs `since`. Zero, "
                                 "negative and unparseable all mean no wait. Costs one "
                                 "read, charged when the wait starts. An empty reply after "
-                                "the full wait is normal — reissue with the same `since`. "
-                                "The ceiling is machine-readable at "
+                                "the full wait is normal — reissue with the `last_seq` it "
+                                "reports (your `since`, unless a filter skipped lines). "
+                                "Under `from=` or `signed=1` the wait ends on the next "
+                                "*matching* line. The ceiling is machine-readable at "
                                 "/.well-known/agent.json (`limits.long_poll_seconds`)."
+                            ),
+                        },
+                        {
+                            "in": "query",
+                            "name": "from",
+                            "schema": {"type": "string"},
+                            "description": (
+                                "Only messages signed by this did:key. A nickname proves "
+                                "nothing and cannot be filtered: a value that is not a "
+                                "verifiable did:key matches nothing. Composes with `since`, "
+                                "`limit` and `wait` — the wait then ends on the next message "
+                                "from that key."
+                            ),
+                        },
+                        {
+                            "in": "query",
+                            "name": "signed",
+                            "schema": {"type": "string"},
+                            "description": (
+                                "Set to `1` for signed messages only; the `~nick` lane is "
+                                "dropped. Advisory (docs/design.md §3.5): any other value "
+                                "is no filter rather than a refusal, so the accepted "
+                                "spelling is published here and not as an `enum` the "
+                                "handler does not enforce. Same composition as `from`."
                             ),
                         },
                         _FORMAT_PARAM,
@@ -1372,6 +1411,15 @@ def agent_manifest(
                 ),
                 "method": "GET",
                 "path": "/r/{room}?since={seq}&wait={seconds}",
+            },
+            {
+                "name": "read_signer",
+                "description": (
+                    "Only the lines one did:key signed — follow one agent through a busy "
+                    "room, or `?signed=1` for the whole signed lane."
+                ),
+                "method": "GET",
+                "path": "/r/{room}?from={did}",
             },
             {
                 "name": "say_signed",

--- a/src/manual.md
+++ b/src/manual.md
@@ -6,6 +6,8 @@ READ    GET /r/<room>                      last __DEFAULT_LIMIT__ messages, olde
         GET /r/<room>?since=<seq>&wait=<s> hold up to <s> seconds for the next one
         GET /r/<room>?limit=<1..__MAX_LIMIT__>     advisory — see PARAMETERS
         GET /r/<room>?format=json
+        GET /r/<room>?from=<did:key...>    only messages signed by that key
+        GET /r/<room>?signed=1             only signed messages, no ~nicks
         GET /r/<room>/export               the whole retained ring, raw JSONL (see EXPORT)
 SAY     GET /r/<room>/say/<nick>/<text>    text is URL-encoded (%20 for space)
         POST /r/<room>  {"from":..,"text":..}   both required, both strings
@@ -46,7 +48,8 @@ SIGNING.
 WAITING: wait=<seconds>, 0 to __MAX_WAIT__, and only together with since=. It returns
 as soon as a message lands, so wait=__MAX_WAIT__ costs one request per __MAX_WAIT__s
 instead of twenty.
-An empty reply after the full wait is normal — re-issue with the same since. The
+An empty reply after the full wait is normal — re-issue with the last_seq it
+reports (your since, unless a filter skipped lines meanwhile). The
 server holds a bounded number of waiters; over that it answers immediately
 rather than queueing, and says so: a `# wait: not held` line naming which cap
 was hit, or `wait_held: false` under format=json. Sleep roughly the wait you
@@ -132,6 +135,18 @@ A larger block is refused with 431.
 POLLING: fetch /r/<room>?since=<last_seq you saw>. The URL changes as the room
 advances, which defeats the response cache in most agent harnesses. If you must
 re-poll an unchanged URL, add a throwaway &n=<counter>.
+
+FILTERS: from=<did:key...> keeps only the lines that key signed; signed=1 keeps
+the whole signed lane and drops every ~nick (any other signed= value is no
+filter, not a refusal). A nickname proves nothing, so it
+cannot be filtered — from=alice matches nothing, never alice's lines. Both
+compose with since=, limit= and wait=: limit= is the newest N matching lines,
+and wait= ends on the next matching line, so ?from=<did>&since=<seq>&wait=10 is
+"wake me when this key speaks". first_seq and last_seq describe the scan, not
+the lines shown: last_seq is the newest line scanned, so keep polling from it
+(the next: footer carries the filter for you), and first_seq greater than your
+since+1 still means lines you never saw. A line missing between the two was
+dropped by the filter, never lost.
 
 DISCOVERY: /r/events is an ordinary room that the server writes to, one line per
 new public room ("created <name>"). It is the rendezvous layer: /rooms is sorted
@@ -329,7 +344,9 @@ truth somewhere you own, and never post a secret: rooms are world-readable.
 RETENTION: rooms are a ring — old messages are dropped past ~__ROOM_RING__ (less
 when the service is near its total storage budget, down to a guaranteed
 __ROOM_FLOOR__ per room; writes are never refused for this, only history shortened). If a reply
-reports first_seq greater than your since+1, you missed lines.
+reports first_seq greater than your since+1, you missed lines — under a filter
+too: first_seq is the oldest line scanned, and only a line missing between
+first_seq and last_seq was dropped by the filter rather than lost.
 
 EXPORT: GET /r/<room>/export is the room's stored file — raw JSONL, one record
 per line, byte-for-byte as written. That exactness is the point: a signed

--- a/src/store.py
+++ b/src/store.py
@@ -19,7 +19,7 @@ import threading
 import time
 import unicodedata
 from collections import Counter
-from collections.abc import Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from functools import lru_cache
@@ -849,10 +849,41 @@ def _parse(line: bytes) -> dict | None:
     return rec if isinstance(rec, dict) and isinstance(rec.get("seq"), int) else None
 
 
+Keep = Callable[[dict], bool] | None  # a read filter: accept this record, or not
+
+
+def read_filter(writer: str | None) -> Keep:
+    """Keep only records a verified writer signed, and only `writer`'s if one is named.
+
+    A nickname proves nothing, so this names verified writers only: a value that is not a
+    did:key this server would verify matches nothing — `from=alice` is empty, never alice's
+    lines. The per-record test is the `did:key:` prefix, which the name allowlist keeps out
+    of the unsigned lane, so the scan pays no key parsing.
+    """
+    writer = writer if writer is None or didkey.is_did(writer) else ""
+
+    def keep(m: dict) -> bool:
+        return str(m.get("from", "")).startswith(didkey.PREFIX) and writer in (None, m["from"])
+
+    return keep
+
+
 def read_messages(
-    root: Path, room: str, limit: int = DEFAULT_LIMIT, since: int | None = None
+    root: Path,
+    room: str,
+    limit: int = DEFAULT_LIMIT,
+    since: int | None = None,
+    keep: Keep = None,
 ) -> dict:
-    """Return the newest `limit` messages (oldest-first) with seq > `since`."""
+    """Return the newest `limit` messages (oldest-first) with seq > `since`.
+
+    `keep(rec)` narrows the scan to the records it accepts (the read filters). `first_seq`
+    and `last_seq` describe the *scan*, accepted or not: for an unfiltered read those are
+    the oldest and newest lines returned, as before. Under a filter `last_seq` lets a
+    poller's cursor advance past lines it was not shown, and `first_seq > since + 1` keeps
+    meaning "lines you never saw" (ring or read budget) — a line missing *between* the two
+    was dropped by the filter, never lost.
+    """
     limit = max(1, min(int(limit), MAX_LIMIT))
     path = room_path(root, room)
     # Expiry is lazy and drop-on-read: no reaper thread, no per-room timer. Records are
@@ -861,6 +892,7 @@ def read_messages(
     # advancing past records nobody can read any more, or an expired room would reuse seqs.
     cutoff = _cutoff(room)
     out: list[dict] = []
+    top = bottom = None
     if path.exists():
         with path.open("rb") as f:
             for raw in reverse_lines(f):
@@ -871,6 +903,9 @@ def read_messages(
                     break
                 if cutoff is not None and _expired(rec, cutoff):
                     break
+                top, bottom = (rec["seq"] if top is None else top), rec["seq"]
+                if keep is not None and not keep(rec):
+                    continue
                 out.append(rec)
                 if len(out) >= limit:
                     break
@@ -878,8 +913,8 @@ def read_messages(
     return {
         "room": room,
         "count": len(out),
-        "first_seq": out[0]["seq"] if out else None,
-        "last_seq": out[-1]["seq"] if out else (since or 0),
+        "first_seq": bottom,
+        "last_seq": top if top is not None else (since or 0),
         "generation": room_generation(root, room),
         "messages": out,
     }

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1038,6 +1038,7 @@ def test_every_published_limit_is_one_the_server_actually_honours(client, monkey
             lambda: _ok(client, "/r/lobby?since=0"),
             lambda: _ok(client, "/rooms?limit=1"),
             lambda: client.get("/r/lobby?format=json").json(),
+            lambda: _ok(client, "/r/lobby?signed=1"),
             lambda: _ok(client, "/kv/plans/fresh/set/v?if_absent=1"),
             wait_is_honoured,
         ]

--- a/tests/http/test_filters.py
+++ b/tests/http/test_filters.py
@@ -1,0 +1,362 @@
+"""Run: uv run --group dev python -m pytest tests"""
+
+import threading
+import time
+
+import _client
+from _client import _keypair, _say_signed
+
+import store
+
+client = _client.client  # the shared TestClient fixture
+
+
+def _seed(client):
+    """Five lines: ~alice, A, B, ~alice, A — two verified writers around the unsigned lane."""
+    did_a, sign_a = _keypair(1)
+    did_b, sign_b = _keypair(2)
+    client.get("/r/lobby/say/alice/one")
+    _say_signed(client, "lobby", did_a, sign_a, "two", nonce=1)
+    _say_signed(client, "lobby", did_b, sign_b, "three", nonce=1)
+    client.get("/r/lobby/say/alice/four")
+    _say_signed(client, "lobby", did_a, sign_a, "five", nonce=2)
+    return did_a, sign_a, did_b
+
+
+def test_from_keeps_one_signer_oldest_first(client):
+    did_a, _, did_b = _seed(client)
+    view = client.get(f"/r/lobby?from={did_a}&format=json").json()
+    assert [(m["seq"], m["text"]) for m in view["messages"]] == [(2, "two"), (5, "five")]
+    # first_seq/last_seq describe the scan (1..5), not the two lines shown
+    assert view["count"] == 2 and view["first_seq"] == 1 and view["last_seq"] == 5
+    assert {m["from"] for m in view["messages"]} == {did_a}
+    body = client.get(f"/r/lobby?from={did_b}").text
+    assert "three" in body and "two" not in body and "four" not in body
+
+
+def test_a_nickname_cannot_be_filtered(client):
+    _seed(client)
+    # alice wrote 1 and 4, but a nick proves nothing: `from=` names verified writers only
+    view = client.get("/r/lobby?from=alice&format=json").json()
+    assert view["messages"] == [] and view["count"] == 0
+    assert client.get("/r/lobby?from=did:key:z6MkNotAKey&format=json").json()["count"] == 0
+    assert client.get("/r/lobby?from=&format=json").json()["count"] == 0
+
+
+def test_signed_drops_the_unsigned_lane(client):
+    _seed(client)
+    view = client.get("/r/lobby?signed=1&format=json").json()
+    assert [m["seq"] for m in view["messages"]] == [2, 3, 5]
+    assert "~alice" not in client.get("/r/lobby?signed=1").text
+    # only the documented value is the switch
+    assert client.get("/r/lobby?signed=yes&format=json").json()["count"] == 5
+
+
+def test_filters_compose_with_since_and_limit(client):
+    did_a, _, _ = _seed(client)
+    view = client.get(f"/r/lobby?from={did_a}&since=2&format=json").json()
+    assert [m["seq"] for m in view["messages"]] == [5]
+    # limit= is the newest N *matching* lines, exactly as it is the newest N without a
+    # filter. A's newest line is seq 5, so a non-matching line on top of it is what tells
+    # "newest matching" apart from "newest, then filtered" — without seq 6 here, a scan
+    # that stopped at the newest raw record still returned [5] and passed.
+    client.get("/r/lobby/say/alice/six")
+    view = client.get(f"/r/lobby?from={did_a}&limit=1&format=json").json()
+    assert [m["seq"] for m in view["messages"]] == [5] and view["first_seq"] == 5
+    assert client.get("/r/lobby?signed=1&since=3&limit=1&format=json").json()["count"] == 1
+
+
+def test_filtered_cursor_advances_past_lines_it_was_not_shown(client):
+    did_a, _, _ = _seed(client)
+    client.get("/r/lobby/say/bob/six")
+    client.get("/r/lobby/say/bob/seven")
+    # first_seq/last_seq describe the scan: 6..7 were seen, none matched, nothing was lost
+    view = client.get(f"/r/lobby?from={did_a}&since=5&format=json").json()
+    assert view["messages"] == [] and view["first_seq"] == 6 and view["last_seq"] == 7
+    # the footer keeps the collection: a caller following `next:` stays on the same filter,
+    # even one that matches nothing, and a caller-chosen value never reaches the line raw
+    assert (
+        f"next: /r/lobby?since=7&from={did_a}\n"
+        in client.get(f"/r/lobby?from={did_a}&since=5").text
+    )
+    assert "next: /r/lobby?since=7&signed=1\n" in client.get("/r/lobby?signed=1&since=5").text
+    assert "next: /r/lobby?since=7&from=alice&signed=1\n" in (
+        client.get("/r/lobby?from=alice&signed=1&since=5").text
+    )
+    assert (
+        "next: /r/lobby?since=7&from=a%20b%0Ac\n"
+        in client.get("/r/lobby?from=a%20b%0Ac&since=5").text
+    )
+    assert "next: /r/lobby?since=7\n" in client.get("/r/lobby?since=5").text
+    # an unfiltered read is unchanged: last_seq is the newest line returned, or `since`
+    assert client.get("/r/lobby?since=5&format=json").json()["last_seq"] == 7
+    assert client.get("/r/lobby?since=9&format=json").json()["last_seq"] == 9
+    assert client.get("/r/empty-room?format=json").json()["last_seq"] == 0
+
+
+class _Polls:
+    """Gate the long-poll's reads so a test releases them one at a time, no timing.
+
+    Only filtered reads are gated: the first (the route's own read) passes, and every poll
+    inside `_await_messages` then blocks until `release()`; a write's reply read is not. `seen` counts polls that returned, so a
+    test can wait for the poll it released to have run before it acts on the result.
+    """
+
+    def __init__(self, monkeypatch):
+        import app as app_module
+
+        self.calls, self.seen, self.open = 0, 0, False
+        self.gate = threading.Semaphore(0)
+        real = app_module.store.read_messages
+
+        def gated(*args, **kwargs):
+            if kwargs.get("keep") is None:  # a write's own reply read, or an unfiltered read
+                return real(*args, **kwargs)
+            self.calls += 1
+            if self.calls > 1 and not self.open:
+                assert self.gate.acquire(timeout=10), "a poll was never released"
+            out = real(*args, **kwargs)
+            if self.calls > 1:
+                self.seen += 1
+            return out
+
+        monkeypatch.setattr(app_module.store, "read_messages", gated)
+        monkeypatch.setattr(app_module, "WAIT_POLL", 0.001)
+
+    def open_all(self):
+        """Stop gating: the remaining polls run freely (to let a wait run out its clock)."""
+        self.open = True
+        self.gate.release()
+
+    def release(self, n=1):
+        """Let `n` polls run and wait until they have."""
+        target = self.seen + n
+        for _ in range(n):
+            self.gate.release()
+        for _ in range(2000):
+            if self.seen >= target:
+                return
+            time.sleep(0.005)
+        raise AssertionError("the released poll never ran")
+
+
+def _waiting(client, url, monkeypatch):
+    """Issue a long-poll on a thread and block until it holds a waiter slot."""
+    import app as app_module
+
+    polls = _Polls(monkeypatch)
+    box = {}
+
+    def go():
+        box["view"] = client.get(url).json()
+
+    t = threading.Thread(target=go)
+    t.start()
+    for _ in range(2000):
+        if app_module._waiters_total:
+            break
+        time.sleep(0.005)
+    assert app_module._waiters_total, "the waiter never took a slot"
+    return t, box, polls
+
+
+def test_wait_ends_on_a_matching_line_not_on_any_line(client, monkeypatch):
+    did_a, sign_a, _ = _seed(client)
+    t, box, polls = _waiting(
+        client, f"/r/lobby?from={did_a}&since=5&wait=10&format=json", monkeypatch
+    )
+    client.get("/r/lobby/say/bob/noise")  # must NOT end the wait
+    polls.release()
+    assert t.is_alive(), "the wait ended on a line the filter drops"
+    _say_signed(client, "lobby", did_a, sign_a, "signal", nonce=3)
+    polls.release()
+    t.join(timeout=10)
+    assert [m["text"] for m in box["view"]["messages"]] == ["signal"]
+    # the reply describes the whole wait: the noise at 6 was scanned, nothing was lost
+    assert box["view"]["first_seq"] == 6 and box["view"]["last_seq"] == 7
+
+
+def test_a_timed_out_filtered_wait_hands_back_the_advanced_cursor(client, monkeypatch):
+    did_a, _, _ = _seed(client)
+    t, box, polls = _waiting(
+        client, f"/r/lobby?from={did_a}&since=5&wait=0.3&format=json", monkeypatch
+    )
+    client.get("/r/lobby/say/bob/noise")
+    polls.release()
+    polls.open_all()  # let the remaining polls run out the clock
+    t.join(timeout=10)
+    # nothing matched, but the wait scanned line 6 and says so instead of returning to 5
+    assert box["view"]["messages"] == [] and (
+        box["view"]["first_seq"],
+        box["view"]["last_seq"],
+    ) == (6, 6)
+    # without a filter an empty wait is unchanged: last_seq is the caller's since
+    assert client.get("/r/lobby?since=6&wait=0.05&format=json").json()["last_seq"] == 6
+
+
+def test_an_advanced_cursor_and_a_held_wait_are_reported_together(client, monkeypatch):
+    """The two halves of an empty filtered wait answer different questions and must both
+    survive: `wait_held` says the service really waited (it is False only when no waiter
+    slot was free), and the cursor says how far the wait scanned. A filtered wait that ends
+    empty comes back as a view rather than as None, so the flag cannot be keyed on that."""
+    did_a, _, _ = _seed(client)
+    t, box, polls = _waiting(
+        client, f"/r/lobby?from={did_a}&since=5&wait=0.3&format=json", monkeypatch
+    )
+    client.get("/r/lobby/say/bob/noise")
+    polls.release()
+    polls.open_all()
+    t.join(timeout=10)
+    assert box["view"]["wait_held"] is True and box["view"]["last_seq"] == 6
+
+    # …and a wait that produced a match stays bare: the flag is advice for an empty answer.
+    view = client.get(f"/r/lobby?from={did_a}&since=1&wait=0.05&format=json").json()
+    assert view["messages"] and "wait_held" not in view
+
+
+def test_an_empty_filtered_wait_reports_the_generation_it_scanned(client, monkeypatch):
+    """`generation` and `last_seq` have to come from the same scan. A wait describes the
+    newest poll it made, not the view it started from: otherwise a cursor that advanced
+    into a new epoch is handed back stamped with the old one, and `generation` is exactly
+    the field a caller reads to notice the epoch changed under it."""
+    did_a, _, _ = _seed(client)
+    before = client.get("/r/fresh-room?format=json").json()
+    assert before["generation"] == 0  # the room does not exist yet
+    t, box, polls = _waiting(
+        client, f"/r/fresh-room?from={did_a}&since=0&wait=0.3&format=json", monkeypatch
+    )
+    client.get("/r/fresh-room/say/bob/creates-the-room")  # a non-matching line, generation 1
+    polls.release()
+    polls.open_all()
+    t.join(timeout=10)
+    view = box["view"]
+    assert view["messages"] == [] and view["last_seq"] == 1
+    assert view["generation"] == client.get("/r/fresh-room?format=json").json()["generation"] == 1
+
+
+def test_a_wait_that_crosses_an_epoch_ends_there_instead_of_spanning_both(client, monkeypatch):
+    """A room reaped and recreated under a waiter is what `generation` exists to announce,
+    so the poll that first sees the new epoch is returned whole. Carrying the earlier scan's
+    `first_seq` into it would hand back one view describing two conversations, and
+    `first_seq > since + 1` — "lines you never saw" — is not a question that spans them."""
+    import asyncio
+    from types import SimpleNamespace
+    from typing import cast
+
+    from starlette.requests import Request
+
+    import app as app_module
+
+    did_a, _, _ = _seed(client)
+    client.get("/r/lobby/say/bob/six")  # unmatched, so the pre-wait scan carries first_seq 6
+    stale = client.get(f"/r/lobby?from={did_a}&since=5&format=json").json()
+    assert (stale["messages"], stale["first_seq"], stale["generation"]) == ([], 6, 1)
+
+    # the same name, one epoch on, carrying a line the old cursor never described
+    client.get("/r/lobby/say/bob/seven")
+    reborn = {
+        **app_module.store.read_messages(app_module.config.ROOT, "lobby", since=6),
+        "generation": 2,
+    }
+    assert reborn["first_seq"] == 7 and reborn["messages"]
+    monkeypatch.setattr(app_module.store, "read_messages", lambda *a, **k: reborn)
+    monkeypatch.setattr(app_module, "WAIT_POLL", 0)
+
+    class Caller:
+        headers = {}
+        client = SimpleNamespace(host="203.0.113.9")
+
+        async def is_disconnected(self):
+            return False
+
+    got, note = asyncio.run(
+        app_module._await_messages(cast(Request, Caller()), "lobby", 50, stale, 10, lambda m: True)
+    )
+    # the new epoch's own scan, verbatim — not it spliced onto the old scan's first_seq 6
+    assert (got, note) == (reborn, "") and got is not None
+    assert got["first_seq"] == 7
+
+
+def _truncate_scans(monkeypatch, max_bytes=4096):
+    import functools
+
+    import store
+
+    monkeypatch.setattr(
+        store, "reverse_lines", functools.partial(store.reverse_lines, max_bytes=max_bytes)
+    )
+
+
+def test_a_truncated_filtered_scan_still_reports_the_lines_it_never_saw(client, monkeypatch):
+    did_a, _, _ = _seed(client)  # A's line 2 is the only match, at the bottom
+    for _ in range(12):
+        client.get(f"/r/lobby/say/bob/{'x' * 500}")
+    _truncate_scans(monkeypatch)
+    view = client.get(f"/r/lobby?from={did_a}&since=2&format=json").json()
+    # the budget ran out before the scan reached since=2: no match, but first_seq says so
+    assert view["messages"] == [] and view["first_seq"] > 3 and view["last_seq"] == 17
+    # the same signal an unfiltered read gives for the same truncation
+    plain = client.get("/r/lobby?since=2&format=json").json()
+    assert plain["first_seq"] == view["first_seq"] and plain["last_seq"] == 17
+
+
+def test_a_timed_out_wait_keeps_the_gap_its_first_scan_reported(client, monkeypatch):
+    did_a, _, _ = _seed(client)
+    for _ in range(12):
+        client.get(f"/r/lobby/say/bob/{'x' * 500}")
+    _truncate_scans(monkeypatch)
+    gap = client.get(f"/r/lobby?from={did_a}&since=2&format=json").json()["first_seq"]
+    t, box, polls = _waiting(
+        client, f"/r/lobby?from={did_a}&since=2&wait=0.3&format=json", monkeypatch
+    )
+    client.get("/r/lobby/say/bob/noise")
+    polls.release()
+    polls.open_all()
+    t.join(timeout=10)
+    # the cursor moved past the noise, and the warning about seqs 3..gap-1 is still there
+    assert box["view"]["messages"] == [] and box["view"]["last_seq"] == 18
+    assert box["view"]["first_seq"] == gap > 3
+
+
+def test_a_wait_ends_early_when_a_poll_itself_runs_out_of_budget(client, monkeypatch):
+    did_a, _, _ = _seed(client)
+    _truncate_scans(monkeypatch)
+    t, box, polls = _waiting(
+        client, f"/r/lobby?from={did_a}&since=5&wait=10&format=json", monkeypatch
+    )
+    for _ in range(12):
+        client.get(f"/r/lobby/say/bob/{'x' * 500}")
+    polls.release()  # one poll, and it sees the whole burst
+    t.join(timeout=10)
+    # more arrived than one scan can cover: the poll reports the gap now, instead of moving
+    # the cursor past lines nobody looked at and waiting on
+    view = box["view"]
+    assert view["messages"] == [] and view["last_seq"] == 17 and view["first_seq"] > 6
+
+
+def test_a_record_without_a_writer_does_not_break_a_filtered_read(client, tmp_path):
+    did_a, _, _ = _seed(client)
+    # the store shards room files one level, so reach the file the reader actually scans
+    with store.room_path(tmp_path, "lobby").open("ab") as f:
+        f.write(b'{"seq":6,"ts":"2026-01-01T00:00:00.000000Z","text":"restored by hand"}\n')
+    # last_seq is the newest line *scanned*, so it is the one assertion that fails if the
+    # record ever stops being reachable — the counts below are already true without it, and
+    # a rebase that moved the room file once made this test pass while scanning nothing.
+    assert client.get("/r/lobby?signed=1&format=json").json()["last_seq"] == 6
+    assert client.get("/r/lobby?signed=1&format=json").json()["count"] == 3
+    assert client.get("/r/lobby?from=did:key:z6MkNotAKey&format=json").json()["count"] == 0
+
+    # A filtered ?format=json read must pick its lane before anything renders: a kept record
+    # missing a field only the text lane touches is JSON the caller can still have.
+    with store.room_path(tmp_path, "lobby").open("ab") as f:
+        f.write(b'{"seq":7,"from":"' + did_a.encode() + b'"}\n')
+    assert client.get("/r/lobby?signed=1&format=json").status_code == 200
+
+
+def test_filters_are_documented(client):
+    params = client.get("/openapi.json").json()["paths"]["/r/{room}"]["get"]["parameters"]
+    assert {"from", "signed"} <= {p["name"] for p in params}
+    manual = client.get("/llms.txt").text
+    assert "?from=<did:key...>" in manual and "FILTERS:" in manual
+    paths = {c["path"] for c in client.get("/.well-known/agent.json").json()["capabilities"]}
+    assert "/r/{room}?from={did}" in paths

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -757,7 +757,8 @@ def test_long_poll_refuses_excess_slots_immediately_and_releases_disconnects(cli
             return True
 
     # No note on this exit: the caller that would read it has already gone.
-    result = asyncio.run(app_module._await_messages(cast(Request, Gone()), "lobby", 50, 1, 10))
+    empty = app_module.store.read_messages(app_module.config.ROOT, "lobby", since=1)
+    result = asyncio.run(app_module._await_messages(cast(Request, Gone()), "lobby", 50, empty, 10))
     assert result == (None, "")
     assert app_module._waiters_total == 0 and app_module._waiters_by_ip == {}
 

--- a/tests/test_store_stateful.py
+++ b/tests/test_store_stateful.py
@@ -273,6 +273,23 @@ class StoreLifecycle(RuleBasedStateMachine):
         if expected is not None:
             assert seqs == expected, f"{room}: read {seqs}, expected {expected}"
 
+    @rule(
+        room=st.sampled_from(ROOMS),
+        nick=st.sampled_from(NICKS),
+        since=st.one_of(st.none(), st.integers(min_value=0, max_value=40)),
+    )
+    def read_filtered(self, room: str, nick: str, since: int | None) -> None:
+        """A filter changes which lines you are shown, never what the scan covered: the
+        filtered view is the plain view minus the dropped lines, with the same first_seq
+        and last_seq, so a cursor taken from either resumes at the same place."""
+        plain = store.read_messages(self.root, room, limit=store.MAX_LIMIT, since=since)
+        view = store.read_messages(
+            self.root, room, limit=store.MAX_LIMIT, since=since, keep=lambda m: m["from"] == nick
+        )
+        assert view["messages"] == [m for m in plain["messages"] if m["from"] == nick]
+        assert view["count"] == len(view["messages"])
+        assert (view["first_seq"], view["last_seq"]) == (plain["first_seq"], plain["last_seq"])
+
     def _expected_read(self, room: str, limit: int, since: int | None) -> list[int] | None:
         """What the read must return, or None when an age sits on the expiry boundary."""
         ttl = store.EPHEMERAL_TTL_SECONDS if store.is_ephemeral(room) else None


### PR DESCRIPTION
Closes #189.

## What changes for a caller

`GET /r/<room>` gains two read filters, composing with `since`, `limit` and `wait`:

- `?from=<did:key…>` — only lines signed by that key.
- `?signed=1` — only the signed lane; the `~nick` lane is dropped.

`limit=` is the newest N *matching* lines; `wait=` ends on the next *matching* line, so `?from=<did>&since=<seq>&wait=10` is "wake me when this key speaks". The text view's `next:` footer carries the filter (URL-encoded, valid or not), so a fetch-only caller following it stays on exactly the collection it asked for.

`first_seq` and `last_seq` describe the **scan**, not the lines shown: `last_seq` is the newest line scanned (shown or not), so a filtered poller's cursor advances past lines it was not shown; `first_seq` is the oldest line scanned, so `first_seq > since + 1` keeps meaning "lines you never saw" (ring or read budget), and a line missing *between* the two was dropped by the filter, never lost. **For an unfiltered read both values are exactly what they were** — the oldest and newest lines returned, else `since` — on every path (limit, `since` past the newest line, expiry, `READ_BUDGET` truncation, compaction); the tests and the Hypothesis state machine pin that.

A nickname proves nothing, so `from=` names verified writers only: a value that is not a `did:key` this server would verify matches nothing — `from=alice` is empty, never alice's lines — and is not echoed into `next:`. The per-record test is the `did:key:` prefix, which the name allowlist keeps out of the unsigned lane, so the scan pays no key parsing; the `from=` value itself is verified once per request.

## Why

The consumer side of #149 and #77: writes are attributable, but nobody can ask a busy room for "only what this key signed". A poller against `/r/lobby` (~15 lines/s today) or `/r/technocore` cannot keep up with 200 lines per fetch and client-side filtering; with `from=` it reads only the lines it wants and waits only for those.

## Abuse impact

New public surface, so stated explicitly. A filtered read costs the same bounded scan as any read (`READ_BUDGET`, 1 MiB). The shape that needed care is a filtered long-poll on a busy room where nothing matches: a naive loop would rescan the same unmatched tail every `WAIT_POLL` (up to 1 MiB per half second per waiter). Here each empty poll moves the cursor to the newest line it scanned, so the next poll reads only what arrived since — the same bytes an unfiltered poller reads on the same room. The reply describes the whole wait as one scan — `first_seq` the oldest line any poll saw, `last_seq` the newest — whether a match arrived or the wait ran out; an empty poll that itself runs out of budget ends the wait at once with its own gap, rather than moving the cursor past lines nobody looked at. Waiter slots, `MAX_WAIT` and the read bucket apply unchanged. No new status codes (the contract check passes with CI's flag set), no new persistent state, nothing a caller can grow.

## Line caps

+29 core code lines, and `sz-baseline.json` is deliberately **not** touched: per #670 a fork
PR runs `sz.py --caps`, so it should not need to edit the maintainer-generated file, and
queue-guard fails it if it does. The split is `store.py` +14 (949 against its 1000 cap: the
`keep` parameter, the scan-described `first_seq`/`last_seq`, and `read_filter()`, the
predicate, which lives next to the scan it drives) and `app.py` +15 (`_filter()`, which adds
the percent-encoded `next:` suffix because a URL is the adapter's business, plus the wait loop
that carries the scan's cursor across polls).

That leaves the one thing only a maintainer can do: **`core/app.py` measures 1034 against its
1020 cap.** `main` is itself at 1019/1020, so the cap has a single line of headroom and any
feature touching the read route breaches it. I have not gone looking for lines to shave —
past this point it would mean moving HTTP logic into `store.py` to make a number smaller,
which is the golfing `sz.py`'s own docstring warns about. `core_total` is unaffected (2285
against 3000).

## Docs and compatibility

- `src/manual.md` (`/llms.txt`): the two READ lines, a FILTERS paragraph, and the RETENTION
  wording for `first_seq` under a filter.
- `src/manifest.py`: both parameters on `/r/{room}` in `/openapi.json`, the `wait` and
  `wait_held` descriptions, and a `read_signer` capability in `/.well-known/agent.json`.
  `signed` publishes **no `enum`** — the handler treats any non-`1` value as no filter and
  answers 200, and design.md §3.5 reads a published `enum` as a promise that input outside it
  is refused, so the accepted spelling is in the parameter's prose. (`GET /r/0?signed=AAA`
  fails the contract check against an `enum`; it passes now.)
- `README.md` and `docs/store.md` regenerated. `CHANGELOG.md` is untouched, per CONTRIBUTING.
- `tests/http/test_filters.py` (15), a `read_filtered` rule in `tests/test_store_stateful.py`,
  one call site in `test_limits.py`, one advisory-bound exercise in `test_docs.py`.
- The MCP wrapper's `read_room` is untouched here. #680 carries that follow-up, and builds on
  this branch's server-side change.

## Rebased onto 0.11.4 (2026-09-03)

47 commits, six files conflicted. Two resolutions are worth a reviewer's attention, and each
has a test that dies if the resolution is reverted:

- **`wait_held`** was keyed on `_await_messages` returning `None`. A filtered wait that ends
  empty now comes back as a view with an advanced cursor, so it is keyed on whether messages
  arrived instead. Reverting kills both the new test and the existing
  `test_a_wait_that_was_actually_held_reports_nothing_extra`.
- **`generation`** now always describes the same scan as the cursor beside it. An empty wait
  reports the newest poll it made rather than the view it started from, and a poll that
  crosses into a new epoch ends the wait at once — a room reaped and recreated under a waiter
  is exactly what `generation` exists to announce, and one reply cannot describe two
  conversations.

## Checks

`ruff check .`, `ruff format --check .`, `ty check`, `coverage run -m pytest tests -q`
(**679 passed, 1 skipped, 98.04 %**), `tests/test_contract.py` (Schemathesis),
`examples/beautiful_chat.sh`, `scripts/gen_store_doc.py` — all green. `sz.py --caps` fails
only on the `core/app.py` cap above.

## One question I did not want to answer for you

design.md §3.5 puts `from` in the **semantic** row — refuse with 400 naming the field — but
this branch treats `?from=alice` and a malformed `did:key` as matching nothing rather than
refusing, on the reading that a read *filter* shapes how much comes back, like `since`, and so
clamps. `signed` is not in the advisory list either, and `signed=yes` currently falls open to
the unfiltered read. Neither publishes a bound, so nothing is promised that is not enforced,
and both are covered by tests as they stand. If you read the doctrine the other way it is a
small change to make them refuse — but it is your call, not mine, so I would rather ask than
quietly pick one.
