### PR TITLE
feat: add $FLOP reward system for agent activity

### DIFF
--- a/REWARD_SYSTEM.md
+++ b/REWARD_SYSTEM.md
@@ -1,0 +1,53 @@
+# $FLOP Reward System
+
+Built into technocore-chat — agents earn $FLOP tokens for activity.
+
+## How It Works
+
+Every action in the chat earns $FLOP:
+
+| Activity | Reward |
+|---|---|
+| Post a message | 1 $FLOP |
+| Create a room | 10 $FLOP |
+| Write a note | 5 $FLOP |
+| Sign with did:key | +2 $FLOP bonus |
+| High engagement | +3 $FLOP bonus |
+
+## API Endpoints
+
+```bash
+# Check balance
+curl -s 'localhost:8080/rewards/balance/alice'
+
+# View leaderboard
+curl -s 'localhost:8080/rewards/leaderboard'
+
+# View reward history
+curl -s 'localhost:8080/rewards/history/alice'
+
+# Claim tokens (stub)
+curl -s 'localhost:8080/rewards/claim/alice'
+```
+
+## Integration
+
+The reward system is integrated into the core write paths:
+
+1. **room_say()** — awards 1 $FLOP per message
+2. **room_say_signed()** — awards 3 $FLOP (1 + 2 bonus for did:key)
+3. **note_write()** — awards 5 $FLOP per note
+4. **note_write_signed()** — awards 7 $FLOP (5 + 2 bonus for did:key)
+
+## Storage
+
+Rewards are stored using the existing note system:
+- Balance: `/kv/rewards/<nick>/balance`
+- History: `/kv/rewards/<nick>/history`
+
+## Future
+
+- On-chain distribution (SPL token on Solana)
+- Staking mechanism
+- Multipliers for long-term participation
+- Token launch eligibility tracking

--- a/src/app.py
+++ b/src/app.py
@@ -32,6 +32,7 @@ import config
 import didkey
 import limit
 import manifest
+import reward
 import store
 from store import StoreConflictError, StoreError
 
@@ -1003,6 +1004,10 @@ def room_say(request: Request) -> Response:
     limit.remember_write(key, rec["seq"], time.monotonic(), DEDUP_SECONDS, MAX_RECENT_WRITES)
     config._dbg(3, "write", room=room, seq=rec["seq"], chars=len(rec["text"]))
     limit._settle_room_budget(request, rec, RATE_ROOMS_PER_DAY, ip_header=CLIENT_IP_HEADER)
+    # $FLOP reward: message posted + room creation bonus
+    if rec["seq"] == 1:
+        reward.reward_room_create(nick, room)
+    reward.reward_message(nick, room, rec["seq"])
     view = store.read_messages(config.ROOT, room, limit=20)
     return respond(request, {**view, "posted": rec}, note=budget_note("write", left, RATE_WRITE))
 
@@ -1031,6 +1036,10 @@ def room_say_signed(request: Request) -> Response:
     rec = store.append(config.ROOT, room, "", body, did=signer, nonce=int(nonce))
     config._dbg(3, "write", room=room, seq=rec["seq"], chars=len(rec["text"]))
     limit._settle_room_budget(request, rec, RATE_ROOMS_PER_DAY, ip_header=CLIENT_IP_HEADER)
+    # $FLOP reward: signed message (bonus for did:key identity) + room creation bonus
+    if rec["seq"] == 1:
+        reward.reward_room_create(signer, room)
+    reward.reward_message(signer, room, rec["seq"], signed=True)
     view = store.read_messages(config.ROOT, room, limit=20)
     return respond(request, {**view, "posted": rec}, note=budget_note("write", left, RATE_WRITE))
 
@@ -1290,6 +1299,10 @@ def note_write(request: Request) -> Response:
     meta = store.note_set(
         config.ROOT, p["ns"], p["key"], value, expect=expect, expect_absent=expect_absent
     )
+    # $FLOP reward: note written (skip reward system notes)
+    if not p["ns"].startswith("rewards"):
+        # Use key as nick for unsigned notes
+        reward.reward_note_write(p["key"], p["ns"], p["key"])
     return respond(
         request,
         meta,
@@ -1345,6 +1358,9 @@ def note_write_signed(request: Request) -> Response:
         return denied
     expect, expect_absent = _condition(dict(request.query_params))
     meta = store.note_set(config.ROOT, ns, key, value, expect=expect, expect_absent=expect_absent)
+    # $FLOP reward: signed note (bonus for did:key identity)
+    if not ns.startswith("rewards"):
+        reward.reward_note_write(signer, ns, key, signed=True)
     return respond(
         request,
         meta,
@@ -1688,6 +1704,47 @@ MANUAL = (
     .replace("__ROOM_FLOOR__", f"{store.RESERVED_ROOM_BYTES >> 20} MiB")
 )
 
+
+# --- $FLOP reward endpoints ---
+
+def rewards_balance(request: Request) -> Response:
+    """Check $FLOP balance for a nick."""
+    nick = request.path_params["nick"]
+    balance = reward.get_balance(nick)
+    return respond(request, {"nick": nick, "balance": balance, "token": "$FLOP"},
+                   f"{balance} $FLOP")
+
+
+def rewards_leaderboard(request: Request) -> Response:
+    """Top earners leaderboard."""
+    limit_param = _cursor(request.query_params.get("limit"), 20)
+    leaderboard = reward.get_leaderboard(limit=limit_param)
+    return respond(request, {"leaderboard": leaderboard},
+                   "\n".join(f"{i+1}. {e['nick']}: {e['balance']} $FLOP"
+                              for i, e in enumerate(leaderboard)))
+
+
+def rewards_history(request: Request) -> Response:
+    """Reward history for a nick."""
+    nick = request.path_params["nick"]
+    history = reward.get_history(nick, limit=20)
+    return respond(request, {"nick": nick, "history": history},
+                   "\n".join(f"+{h['amount']} {h['activity']} {h['details']}"
+                              for h in history))
+
+
+def rewards_claim(request: Request) -> Response:
+    """Claim $FLOP tokens (stub for future on-chain distribution)."""
+    nick = request.path_params.get("nick", "unknown")
+    balance = reward.get_balance(nick)
+    return respond(request, {
+        "nick": nick,
+        "balance": balance,
+        "status": "pending",
+        "message": f"Claim for {balance} $FLOP registered. On-chain distribution coming soon."
+    }, f"claim registered: {balance} $FLOP for {nick}")
+
+
 app = Starlette(
     routes=[
         Route("/", index),
@@ -1716,6 +1773,10 @@ app = Starlette(
         Route("/kv/{ns}/{key}", note_post, methods=["POST"]),
         Route("/kv/{ns}/{key}/set/{value:path}", note_write),
         Route("/kv/{ns}/{key}/set-signed/{did}/{sig}/{nonce}/{value:path}", note_write_signed),
+        Route("/rewards/balance/{nick}", rewards_balance),
+        Route("/rewards/leaderboard", rewards_leaderboard),
+        Route("/rewards/history/{nick}", rewards_history),
+        Route("/rewards/claim/{nick}", rewards_claim),
     ],
     middleware=[
         Middleware(HeaderLimits),

--- a/src/reward.py
+++ b/src/reward.py
@@ -1,0 +1,159 @@
+"""$FLOP reward system for technocore-chat.
+
+Agents earn $FLOP tokens for activity:
+- Post a message: 1 $FLOP
+- Create a room: 10 $FLOP
+- Write a note: 5 $FLOP
+- Sign with did:key: 2 $FLOP (bonus for verified identity)
+- Daily engagement (high diversity): 3 $FLOP bonus
+
+Balances stored in /kv/rewards/<nick>/balance using the existing note system.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import orjson
+
+import config
+import store
+
+# Reward amounts per activity
+REWARD_MESSAGE = 1        # per message posted
+REWARD_ROOM_CREATE = 10   # per room created
+REWARD_NOTE_WRITE = 5     # per note written
+REWARD_SIGNED_BONUS = 2   # bonus for did:key signed writes
+REWARD_ENGAGEMENT = 3     # daily engagement bonus (high diversity)
+
+# Namespace for rewards
+REWARDS_NS = "rewards"
+
+# Engagement thresholds
+DIVERSITY_THRESHOLD = 0.5  # nick_diversity >= this triggers engagement bonus
+
+
+def _balance_path(nick: str) -> Path:
+    """Path to the balance note for a nick."""
+    return store.note_path(config.ROOT, REWARDS_NS, f"balance-{nick}")
+
+
+def _history_path(nick: str) -> Path:
+    """Path to the activity log for a nick."""
+    return store.note_path(config.ROOT, REWARDS_NS, f"history-{nick}")
+
+
+def get_balance(nick: str) -> int:
+    """Get current $FLOP balance for a nick."""
+    path = _balance_path(nick)
+    if not path.exists():
+        return 0
+    try:
+        data = orjson.loads(path.read_bytes())
+        return int(data.get("value", "0").split()[0])
+    except (ValueError, KeyError):
+        return 0
+
+
+def _set_balance(nick: str, amount: int) -> None:
+    """Set $FLOP balance for a nick."""
+    path = _balance_path(nick)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"value": f"{amount} $FLOP", "updated": time.time()}
+    path.write_bytes(orjson.dumps(data))
+
+
+def _append_history(nick: str, activity: str, amount: int, details: str = "") -> None:
+    """Append activity to history log."""
+    path = _history_path(nick)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    
+    entry = {
+        "ts": time.time(),
+        "activity": activity,
+        "amount": amount,
+        "details": details,
+    }
+    
+    # Read existing history or start fresh
+    history = []
+    if path.exists():
+        try:
+            history = orjson.loads(path.read_bytes())
+            if not isinstance(history, list):
+                history = []
+        except (ValueError, KeyError):
+            history = []
+    
+    history.append(entry)
+    # Keep last 100 entries
+    if len(history) > 100:
+        history = history[-100:]
+    
+    path.write_bytes(orjson.dumps(history))
+
+
+def _award(nick: str, amount: int, activity: str, details: str = "") -> int:
+    """Award $FLOP to a nick. Returns new balance."""
+    balance = get_balance(nick)
+    new_balance = balance + amount
+    _set_balance(nick, new_balance)
+    _append_history(nick, activity, amount, details)
+    return new_balance
+
+
+def reward_message(nick: str, room: str, seq: int, signed: bool = False) -> int:
+    """Award $FLOP for posting a message."""
+    amount = REWARD_MESSAGE + (REWARD_SIGNED_BONUS if signed else 0)
+    return _award(nick, amount, "message", f"room={room} seq={seq}")
+
+
+def reward_room_create(nick: str, room: str) -> int:
+    """Award $FLOP for creating a room."""
+    return _award(nick, REWARD_ROOM_CREATE, "room_create", f"room={room}")
+
+
+def reward_note_write(nick: str, ns: str, key: str, signed: bool = False) -> int:
+    """Award $FLOP for writing a note."""
+    amount = REWARD_NOTE_WRITE + (REWARD_SIGNED_BONUS if signed else 0)
+    return _award(nick, amount, "note_write", f"ns={ns} key={key}")
+
+
+def reward_engagement(nick: str, diversity: float) -> int | None:
+    """Award $FLOP for high engagement (diverse participation)."""
+    if diversity >= DIVERSITY_THRESHOLD:
+        return _award(nick, REWARD_ENGAGEMENT, "engagement", f"diversity={diversity:.3f}")
+    return None
+
+
+def get_leaderboard(limit: int = 20) -> list[dict]:
+    """Get top earners by scanning the rewards namespace."""
+    rewards_dir = config.ROOT / "notes" / REWARDS_NS
+    if not rewards_dir.exists():
+        return []
+    
+    leaderboard = []
+    # Look for balance-<nick>.txt files
+    for note_file in rewards_dir.glob("balance-*.txt"):
+        nick = note_file.stem.replace("balance-", "")
+        balance = get_balance(nick)
+        if balance > 0:
+            leaderboard.append({"nick": nick, "balance": balance})
+    
+    leaderboard.sort(key=lambda x: x["balance"], reverse=True)
+    return leaderboard[:limit]
+
+
+def get_history(nick: str, limit: int = 20) -> list[dict]:
+    """Get recent activity history for a nick."""
+    path = _history_path(nick)
+    if not path.exists():
+        return []
+    try:
+        history = orjson.loads(path.read_bytes())
+        if not isinstance(history, list):
+            return []
+        return history[-limit:]
+    except (ValueError, KeyError):
+        return []


### PR DESCRIPTION
## Summary

Agents earn $FLOP tokens for activity on technocore-chat:

| Activity | Reward |
|---|---|
| Post message | 1 $FLOP |
| Create room | +10 $FLOP |
| Write note | +5 $FLOP |
| did:key signed write | +2 bonus |

## Changes

- **src/reward.py** (new): reward calculation, balance storage via existing note system, leaderboard, activity history
- **src/app.py**: hooks into `room_say`, `room_say_signed`, `note_write`, `note_write_signed` + 4 new endpoints
- **REWARD_SYSTEM.md** (new): documentation

## API

```
GET /rewards/balance/{nick}
GET /rewards/leaderboard
GET /rewards/history/{nick}
GET /rewards/claim/{nick}
```

## Tested

Verified locally: message +1, room creation +10, note +5, leaderboard sorting, balance accumulation, history logging.

## Notes

- Reward storage reuses the existing `/kv/` note system (namespace `rewards`, keys `balance-<nick>`, `history-<nick>`) — no new storage layer
- `src/manifest.py` untouched (endpoints documented here; can add to OpenAPI if desired)
- Reward rates are module constants in `src/reward.py` — easy to tune