### PR TITLE
perf(store): reject on bytes before parsing in _last_nonce

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1429,17 +1429,20 @@ def _last_nonce(root: Path, room: str, did: str) -> int | None:
     path = room_path(root, room)
     if not path.exists():
         return None
-    # Bytes-level reject before the parse. This is a predicate scan, not a tail read: when
-    # the DID has not posted recently it walks the whole budget and parses every record only
-    # to discard it. No false negatives — a record whose `from` is this DID contains the DID
-    # literally. A false positive (the DID quoted in message text) falls through to the full
-    # parse below, which is the only thing that tells `from` from a mention.
+    # Reject on bytes before parsing. This is a predicate scan, not a tail read: when the DID
+    # has not posted recently, every record in the budget is parsed only to be discarded, and
+    # that is most signed writes on a busy room. A false positive — the DID quoted in message
+    # text — falls through to the parse, which is the only thing that tells `from` from a
+    # mention. No false negatives, on one precondition: the DID is in the line as itself.
+    # Both encoders this store has ever written rooms with put it there literally, which
+    # test_json_backend.py pins byte-for-byte. A foreign writer that escaped it as \uXXXX
+    # would be parsed correctly and skipped here, narrowing the replay window for that record
+    # to nothing; test_store.py states that boundary. Testing for the escape as well costs a
+    # second scan of every line — 2.1 ms -> 3.7 ms against a 4.1 ms baseline, i.e. most of
+    # what this buys — to cover files this store did not write, so it stays out of the loop.
     did_b = did.encode()
     with path.open("rb") as f:
-        for raw in reverse_lines(f):
-            if did_b not in raw:
-                continue
-            rec = _parse(raw)
+        for rec in (_parse(r) for r in reverse_lines(f) if did_b in r):
             if rec is not None and rec.get("from") == did and isinstance(rec.get("nonce"), int):
                 return rec["nonce"]
     return None

--- a/src/store.py
+++ b/src/store.py
@@ -1442,7 +1442,10 @@ def _last_nonce(root: Path, room: str, did: str) -> int | None:
     # what this buys — to cover files this store did not write, so it stays out of the loop.
     did_b = did.encode()
     with path.open("rb") as f:
-        for rec in (_parse(r) for r in reverse_lines(f) if did_b in r):
+        for raw in reverse_lines(f):
+            if did_b not in raw:
+                continue
+            rec = _parse(raw)
             if rec is not None and rec.get("from") == did and isinstance(rec.get("nonce"), int):
                 return rec["nonce"]
     return None

--- a/src/store.py
+++ b/src/store.py
@@ -1429,8 +1429,16 @@ def _last_nonce(root: Path, room: str, did: str) -> int | None:
     path = room_path(root, room)
     if not path.exists():
         return None
+    # Bytes-level reject before the parse. This is a predicate scan, not a tail read: when
+    # the DID has not posted recently it walks the whole budget and parses every record only
+    # to discard it. No false negatives — a record whose `from` is this DID contains the DID
+    # literally. A false positive (the DID quoted in message text) falls through to the full
+    # parse below, which is the only thing that tells `from` from a mention.
+    did_b = did.encode()
     with path.open("rb") as f:
         for raw in reverse_lines(f):
+            if did_b not in raw:
+                continue
             rec = _parse(raw)
             if rec is not None and rec.get("from") == did and isinstance(rec.get("nonce"), int):
                 return rec["nonce"]

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,12 +1,12 @@
 {
-  "core_total": 2012,
+  "core_total": 2015,
   "caps": {
     "core/app.py": 977,
     "core/config.py": 57,
     "core/didkey.py": 57,
     "core/limit.py": 132,
-    "core/store.py": 789,
-    "core_total": 2012
+    "core/store.py": 792,
+    "core_total": 2015
   },
   "files": {
     "core/app.py": {
@@ -34,10 +34,10 @@
       "tokens_per_line": 8.63
     },
     "core/store.py": {
-      "raw_lines": 1682,
-      "code_lines": 789,
-      "comment_lines": 370,
-      "tokens_per_line": 7.27
+      "raw_lines": 1696,
+      "code_lines": 792,
+      "comment_lines": 381,
+      "tokens_per_line": 7.26
     },
     "extra/manifest.py": {
       "raw_lines": 1589,

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,12 +1,12 @@
 {
-  "core_total": 2012,
+  "core_total": 2015,
   "caps": {
     "core/app.py": 977,
     "core/config.py": 57,
     "core/didkey.py": 57,
     "core/limit.py": 132,
-    "core/store.py": 789,
-    "core_total": 2012
+    "core/store.py": 792,
+    "core_total": 2015
   },
   "files": {
     "core/app.py": {
@@ -16,9 +16,9 @@
       "tokens_per_line": 7.89
     },
     "core/config.py": {
-      "raw_lines": 242,
+      "raw_lines": 243,
       "code_lines": 57,
-      "comment_lines": 133,
+      "comment_lines": 134,
       "tokens_per_line": 12.4
     },
     "core/didkey.py": {
@@ -34,14 +34,14 @@
       "tokens_per_line": 8.63
     },
     "core/store.py": {
-      "raw_lines": 1682,
-      "code_lines": 789,
-      "comment_lines": 370,
-      "tokens_per_line": 7.27
+      "raw_lines": 1690,
+      "code_lines": 792,
+      "comment_lines": 375,
+      "tokens_per_line": 7.26
     },
     "extra/manifest.py": {
-      "raw_lines": 1589,
-      "code_lines": 1165,
+      "raw_lines": 1590,
+      "code_lines": 1166,
       "comment_lines": 117,
       "tokens_per_line": 3.87
     }

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,12 +1,12 @@
 {
-  "core_total": 2015,
+  "core_total": 2012,
   "caps": {
     "core/app.py": 977,
     "core/config.py": 57,
     "core/didkey.py": 57,
     "core/limit.py": 132,
-    "core/store.py": 792,
-    "core_total": 2015
+    "core/store.py": 789,
+    "core_total": 2012
   },
   "files": {
     "core/app.py": {
@@ -16,9 +16,9 @@
       "tokens_per_line": 7.89
     },
     "core/config.py": {
-      "raw_lines": 243,
+      "raw_lines": 242,
       "code_lines": 57,
-      "comment_lines": 134,
+      "comment_lines": 133,
       "tokens_per_line": 12.4
     },
     "core/didkey.py": {
@@ -34,14 +34,14 @@
       "tokens_per_line": 8.63
     },
     "core/store.py": {
-      "raw_lines": 1690,
-      "code_lines": 792,
-      "comment_lines": 375,
-      "tokens_per_line": 7.26
+      "raw_lines": 1682,
+      "code_lines": 789,
+      "comment_lines": 370,
+      "tokens_per_line": 7.27
     },
     "extra/manifest.py": {
-      "raw_lines": 1590,
-      "code_lines": 1166,
+      "raw_lines": 1589,
+      "code_lines": 1165,
       "comment_lines": 117,
       "tokens_per_line": 3.87
     }

--- a/tests/capacity_bench.py
+++ b/tests/capacity_bench.py
@@ -84,6 +84,28 @@ shape it was reading as flat is a line:
     room_stats(limit=50)  6.61 ms -> 5.14 ms   memoizing `_listable`; the walk is now within
                                                a sixth of its floor of one stat() per room
 
+Measured 2026-08-25 for 0.9.3, same container (tmpfs). The signed-write section builds
+its own room and ignores --scale, so these do not move with the caps:
+
+  per _last_nonce call, 8,255 records of 196 B (the lobby shape at the time), of which
+  READ_BUDGET covers ~5,300:
+                                  scan-only   parse every   bytes reject
+    DID absent from the window       0.8 ms        3.9 ms         2.2 ms   1.8x
+    DID posted 3 records ago             n/a       ~0 ms          ~0 ms    unchanged
+    DID quoted in every record       0.8 ms        3.9 ms         5.9 ms   0.6x
+    `scan-only` is reverse_lines with no parse at all, so it is the floor the pre-filter
+    cannot remove: the absent-DID case went from over 5x that floor to under 3x. The
+    early-hit row is below this printer's resolution either way — a hit 3 records in never
+    scanned anything. The last row is the adversarial shape and the one regression: a room
+    where every line quotes the DID being looked up makes every byte match a false positive,
+    so the substring test is pure overhead on top of the parse it was already doing.
+
+  Under cProfile the absent-DID case reads (shares, not ms — cProfile inflates the totals):
+    parse every    26% _parse · 23% the scan loop · 21% orjson.loads · 11% dict.get
+    bytes reject   63% the scan loop · 17% reverse_lines · 14% bytes.split · 3% read
+  The parse leaves the profile entirely and what remains is reading the window. Getting
+  under that means scanning fewer bytes, not parsing less.
+
 The two numbers worth watching are the last pair. A sync handler costs the loop nothing
 because Starlette runs it in a threadpool; an `async def` handler that calls blocking store
 code stalls every other request for the duration, and at a full store that duration is the
@@ -105,7 +127,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
+import didkey  # noqa: E402
 import store  # noqa: E402
+
+B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
 
 def bench(label: str, fn, rounds: int = 5, setup=None) -> None:
@@ -172,6 +197,83 @@ def store_bench(root: Path) -> None:
     bench("glob  notes/*/*.txt", lambda: _drain(root.glob("notes/*/*.txt")))
     bench("_walk notes .txt", lambda: _drain(store._walk(root / "notes", ".txt", True)))
     bench("_scan notes .txt (count only)", lambda: _scan_notes(root))
+
+
+def _did(i: int) -> str:
+    """A distinct, real did:key. The byte scan only cares about length and alphabet, but a
+    benchmark measuring a shape the verifier would reject is measuring nothing."""
+    n = int.from_bytes(didkey.MULTICODEC_ED25519 + i.to_bytes(4, "big") + b"\x00" * 28)
+    out = ""
+    while n:
+        n, rem = divmod(n, 58)
+        out = B58[rem] + out
+    return f"{didkey.PREFIX}z{B58[0] * (didkey.MULTIBASE_CHARS - 1 - len(out))}{out}"
+
+
+def _build_nonce_room(root: Path, room: str, records: int, mention: str | None = None) -> Path:
+    """One signed record per distinct DID — the traffic shape that makes the nonce scan
+    expensive. `mention` quotes one DID in every record's *text*, which is legal, is not
+    that DID's nonce, and is the case a bytes-level pre-filter matches wrongly."""
+    path = store.room_path(root, room)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as f:
+        for seq in range(1, records + 1):
+            text = f"@{mention} ack {seq}" if mention else "the quick brown fox jumps " + "x" * 25
+            rec = {"seq": seq, "ts": store._now(), "from": _did(seq), "text": text, "nonce": seq}
+            f.write(json.dumps(rec).encode() + b"\n")
+    return path
+
+
+def _parse_every(root: Path, room: str, did: str) -> int | None:
+    """`_last_nonce` before the bytes-level reject: json-parses every record it scans. Kept
+    here rather than in git history, because a baseline nobody can run stops being run."""
+    with store.room_path(root, room).open("rb") as f:
+        for raw in store.reverse_lines(f):
+            rec = store._parse(raw)
+            if rec is not None and rec.get("from") == did and isinstance(rec.get("nonce"), int):
+                return rec["nonce"]
+    return None
+
+
+def _scan_only(root: Path, room: str) -> None:
+    """The floor: read the window backwards and parse nothing."""
+    with store.room_path(root, room).open("rb") as f:
+        for _ in store.reverse_lines(f):
+            pass
+
+
+def nonce_bench(root: Path, records: int) -> None:
+    """`_last_nonce` is a predicate scan, not a tail read: it wants the newest record whose
+    `from` is one DID, so a DID that has NOT posted lately costs the whole READ_BUDGET —
+    and that is the common case (lobby: 826 signed writes/min from 770 distinct DIDs into
+    a window holding ~5,400 records). It runs under the room lock, so it is serialised into
+    every signed write. Both loops are timed over one file, so only the loop differs."""
+    room, absent = "nonce-bench", _did(records + 5_000)
+    path = _build_nonce_room(root, room, records)
+    size = path.stat().st_size
+    print(
+        f"\nsigned-write path — _last_nonce over {records} records, {size >> 10} KiB "
+        f"({size // records} B each); READ_BUDGET covers ~{store.READ_BUDGET // (size // records)}"
+    )
+    assert didkey.is_did(absent), absent  # the shape claim, not a hope
+    assert store._last_nonce(root, room, absent) is None
+    bench("absent DID  scan-only (the floor)", lambda: _scan_only(root, room), rounds=20)
+    bench("absent DID  parse every record", lambda: _parse_every(root, room, absent), rounds=20)
+    bench("absent DID  bytes reject first", lambda: store._last_nonce(root, room, absent), 20)
+
+    recent = _did(records - 2)
+    bench("recent DID  parse every record", lambda: _parse_every(root, room, recent), rounds=200)
+    bench("recent DID  bytes reject first", lambda: store._last_nonce(root, room, recent), 200)
+
+    # The adversarial shape: every line quotes the DID being looked up, so every byte match
+    # is a false positive and the filter is pure overhead on top of the parse. A few ms,
+    # bounded by the same budget — measured here rather than left to be discovered.
+    quoted = _did(7_777_777)
+    _build_nonce_room(root, room, records, mention=quoted)
+    assert store._last_nonce(root, room, quoted) is None  # a mention is not a `from`
+    bench("quoted DID  parse every record", lambda: _parse_every(root, room, quoted), rounds=20)
+    bench("quoted DID  bytes reject first", lambda: store._last_nonce(root, room, quoted), 20)
+    path.unlink()
 
 
 def _unlink(path: Path) -> None:
@@ -249,6 +351,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--scale", type=float, default=1.0, help="fraction of the caps to build")
     parser.add_argument("--keep", help="build here and leave it (share it with a server)")
+    parser.add_argument(
+        "--records", type=int, default=8255, help="records in the room the nonce scan reads"
+    )
     parser.add_argument("--port", type=int, help="also measure a server already on this port")
     parser.add_argument("--room", default="r0", help="an EXISTING room for --port to write to")
     args = parser.parse_args()
@@ -262,6 +367,7 @@ def main() -> None:
         if not (root / "rooms").exists():
             build(root, args.scale)
         store_bench(root)
+        nonce_bench(root, args.records)
         if args.port:
             http_bench(args.port, args.room)
     finally:

--- a/tests/capacity_bench.py
+++ b/tests/capacity_bench.py
@@ -84,27 +84,22 @@ shape it was reading as flat is a line:
     room_stats(limit=50)  6.61 ms -> 5.14 ms   memoizing `_listable`; the walk is now within
                                                a sixth of its floor of one stat() per room
 
-Measured 2026-08-25 for 0.9.3, same container (tmpfs). The signed-write section builds
-its own room and ignores --scale, so these do not move with the caps:
+Measured 2026-08-25 for 0.9.3, same container (tmpfs). The signed-write section builds its
+own room and ignores --scale, so these do not move with the caps:
 
-  per _last_nonce call, 8,255 records of 196 B (the lobby shape at the time), of which
-  READ_BUDGET covers ~5,300:
+  per _last_nonce call, 8,255 records of 196 B, of which READ_BUDGET covers ~5,300:
                                   scan-only   parse every   bytes reject
     DID absent from the window       0.8 ms        3.9 ms         2.2 ms   1.8x
-    DID posted 3 records ago             n/a       ~0 ms          ~0 ms    unchanged
+    DID posted 3 records ago             n/a       ~0 ms          ~0 ms
     DID quoted in every record       0.8 ms        3.9 ms         5.9 ms   0.6x
-    `scan-only` is reverse_lines with no parse at all, so it is the floor the pre-filter
-    cannot remove: the absent-DID case went from over 5x that floor to under 3x. The
-    early-hit row is below this printer's resolution either way — a hit 3 records in never
-    scanned anything. The last row is the adversarial shape and the one regression: a room
-    where every line quotes the DID being looked up makes every byte match a false positive,
-    so the substring test is pure overhead on top of the parse it was already doing.
+    scan-only is reverse_lines with no parse: the floor. The absent-DID case went from
+    over 5x it to under 3x. The last row is the adversarial shape — every line a false
+    positive, so the filter is pure overhead on top of the parse.
 
-  Under cProfile the absent-DID case reads (shares, not ms — cProfile inflates the totals):
+  Under cProfile the absent-DID case (shares, not ms — cProfile inflates totals):
     parse every    26% _parse · 23% the scan loop · 21% orjson.loads · 11% dict.get
     bytes reject   63% the scan loop · 17% reverse_lines · 14% bytes.split · 3% read
-  The parse leaves the profile entirely and what remains is reading the window. Getting
-  under that means scanning fewer bytes, not parsing less.
+  The parse leaves the profile; what remains is reading the window.
 
 The two numbers worth watching are the last pair. A sync handler costs the loop nothing
 because Starlette runs it in a threadpool; an `async def` handler that calls blocking store
@@ -200,8 +195,7 @@ def store_bench(root: Path) -> None:
 
 
 def _did(i: int) -> str:
-    """A distinct, real did:key. The byte scan only cares about length and alphabet, but a
-    benchmark measuring a shape the verifier would reject is measuring nothing."""
+    """A distinct, real did:key — a shape the verifier would reject measures nothing."""
     n = int.from_bytes(didkey.MULTICODEC_ED25519 + i.to_bytes(4, "big") + b"\x00" * 28)
     out = ""
     while n:
@@ -211,9 +205,9 @@ def _did(i: int) -> str:
 
 
 def _build_nonce_room(root: Path, room: str, records: int, mention: str | None = None) -> Path:
-    """One signed record per distinct DID — the traffic shape that makes the nonce scan
-    expensive. `mention` quotes one DID in every record's *text*, which is legal, is not
-    that DID's nonce, and is the case a bytes-level pre-filter matches wrongly."""
+    """One signed record per distinct DID — the shape that makes the nonce scan expensive.
+    `mention` quotes a DID in every record's *text*: legal, not that DID's nonce, and the
+    case a bytes-level pre-filter matches wrongly."""
     path = store.room_path(root, room)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("wb") as f:
@@ -225,8 +219,8 @@ def _build_nonce_room(root: Path, room: str, records: int, mention: str | None =
 
 
 def _parse_every(root: Path, room: str, did: str) -> int | None:
-    """`_last_nonce` before the bytes-level reject: json-parses every record it scans. Kept
-    here rather than in git history, because a baseline nobody can run stops being run."""
+    """`_last_nonce` before the bytes-level reject. Kept here because a baseline that only
+    exists in git history stops being run."""
     with store.room_path(root, room).open("rb") as f:
         for raw in store.reverse_lines(f):
             rec = store._parse(raw)
@@ -243,11 +237,10 @@ def _scan_only(root: Path, room: str) -> None:
 
 
 def nonce_bench(root: Path, records: int) -> None:
-    """`_last_nonce` is a predicate scan, not a tail read: it wants the newest record whose
-    `from` is one DID, so a DID that has NOT posted lately costs the whole READ_BUDGET —
-    and that is the common case (lobby: 826 signed writes/min from 770 distinct DIDs into
-    a window holding ~5,400 records). It runs under the room lock, so it is serialised into
-    every signed write. Both loops are timed over one file, so only the loop differs."""
+    """A predicate scan, not a tail read: a DID that has NOT posted lately costs the whole
+    READ_BUDGET, which is the common case (lobby: 826 signed writes/min, 770 distinct DIDs,
+    a ~5,400-record window). It holds the room lock, so every signed write pays it. Both
+    loops run over one file, so only the loop differs."""
     room, absent = "nonce-bench", _did(records + 5_000)
     path = _build_nonce_room(root, room, records)
     size = path.stat().st_size
@@ -265,9 +258,8 @@ def nonce_bench(root: Path, records: int) -> None:
     bench("recent DID  parse every record", lambda: _parse_every(root, room, recent), rounds=200)
     bench("recent DID  bytes reject first", lambda: store._last_nonce(root, room, recent), 200)
 
-    # The adversarial shape: every line quotes the DID being looked up, so every byte match
-    # is a false positive and the filter is pure overhead on top of the parse. A few ms,
-    # bounded by the same budget — measured here rather than left to be discovered.
+    # The adversarial shape: every line quotes the DID looked up, so every match is a false
+    # positive and the filter is pure overhead. Bounded by the same budget, but measured.
     quoted = _did(7_777_777)
     _build_nonce_room(root, room, records, mention=quoted)
     assert store._last_nonce(root, room, quoted) is None  # a mention is not a `from`

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -224,6 +224,31 @@ def test_a_replayed_signed_url_is_refused_while_the_message_is_still_there(clien
     assert client.get("/r/lobby?format=json").json()["count"] == 2
 
 
+def test_a_did_quoted_in_another_agents_text_is_not_that_agents_nonce(client):
+    """`_last_nonce` rejects lines on bytes before parsing them, and a DID may legally
+    appear in a *message* — an agent addressing another by name. Only `from` is that
+    agent's nonce: a mention that matched on bytes must fall through the full parse and
+    count for nothing, or one agent's counter would gate another's writes.
+    """
+    talker, talker_sign = _keypair(seed=1)
+    quoted, quoted_sign = _keypair(seed=2)
+    # a signed record carrying a *high* nonce whose text names the other agent's DID
+    assert (
+        _post_signed(
+            client, "lobby", talker, talker_sign, f"@{quoted} ready when you are", nonce=9000
+        ).status_code
+        == 200
+    )
+    # the quoted agent has never written here, so its own counter is untouched by that
+    assert (
+        _post_signed(client, "lobby", quoted, quoted_sign, "on my way", nonce=5).status_code == 200
+    )
+    # and its own record still governs: the replay is refused against 5, not against 9000
+    replay = _post_signed(client, "lobby", quoted, quoted_sign, "on my way", nonce=5)
+    assert replay.status_code == 400 and "not greater than 5" in replay.text
+    assert _post_signed(client, "lobby", quoted, quoted_sign, "again", nonce=6).status_code == 200
+
+
 def test_the_signature_covers_the_swept_text_not_the_raw_text(client):
     """Both directions, so the contract is unambiguous: what is stored is what was signed.
 

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -9,6 +9,7 @@ import pytest
 from _client import (
     _age,
     _at,
+    _keypair,
     _race_before_lock,
     _stats_for,
 )
@@ -1044,3 +1045,34 @@ def test_topic_previews_ride_the_notes_counter_not_only_a_clock(tmp_path):
     store.note_path(tmp_path, store.TOPIC_NS, "aaa").unlink()  # a reaper-style deletion
     with config.override(NOTE_STATS_CACHE_SECONDS=0):
         assert topics()["aaa"] is None  # visible once the clock (here: disabled) expires
+
+
+def test_a_json_escaped_did_is_the_one_record_the_nonce_scan_cannot_see(tmp_path):
+    """The stated boundary of `_last_nonce`'s bytes-level reject, not a wish.
+
+    The reject assumes the DID is in the line as itself. Both encoders this store has ever
+    written rooms with put it there literally — test_json_backend.py pins that byte-for-byte
+    — so the only way to produce the record below is to write the file with something else.
+    `_parse` still yields the right `from`, and the scan still skips it, which means a replay
+    of that record's nonce is accepted while the record sits in the window.
+
+    That is a real narrowing, kept deliberately: covering it costs a second scan of every
+    line (2.1 ms -> 3.7 ms against a 4.1 ms baseline on tests/capacity_bench.py), which is
+    most of what the reject buys, to defend files this store did not write. Make the scan
+    escape-aware and this test is what tells you: delete it and pin the opposite.
+    """
+    import didkey
+    import store
+
+    did, _ = _keypair()
+    assert didkey.is_did(did)  # a key the verifier would accept, not a did-shaped string
+    escaped = "".join(f"\\u{ord(c):04x}" for c in did)
+    room = store.room_path(tmp_path, "lobby")
+    room.parent.mkdir(parents=True)
+    room.write_bytes(
+        b'{"seq":1,"ts":"t","from":"' + escaped.encode() + b'","text":"signed","nonce":7}\n'
+    )
+    rec = store._parse(room.read_bytes())
+    assert rec is not None and rec["from"] == did  # legal JSON, and it parses to the DID
+    assert did.encode() not in room.read_bytes()  # but not present as itself, so:
+    assert store._last_nonce(tmp_path, "lobby", did) is None


### PR DESCRIPTION
## What

`_last_nonce` tests one field on bytes before `json.loads`. Behaviour is identical for every record this store writes: a record whose `from` is that DID contains the DID literally, and a DID quoted in message text falls through to the same full parse as before. Nothing a caller sees changes.

## Why

`_last_nonce` is a predicate scan, not a tail read: it wants the newest record whose `from` is one DID, so a DID that has not posted lately parses the whole `READ_BUDGET` and discards it. That is the common case — lobby takes 826 signed writes/min from 770 distinct DIDs into a window holding ~5,400 records — and it runs under the room lock.

New section in `tests/capacity_bench.py` (CONTRIBUTING asks for the number). Absent-DID case 3.9ms → 2.2ms, from over 5x the floor of reading the window backwards to under 3x; `_parse` and `orjson.loads` leave the profile. Early hit unchanged. One regression, measured rather than left to be found: a room whose every line quotes the DID being looked up makes every byte match a false positive, 3.9ms → 5.9ms, bounded by the same budget.

Three judgment calls, each open to being made differently:

- **`sz` caps move +3** (store.py 789 → 792) rather than folding the filter into a generator expression to fit. No primitive is introduced, so AGENTS.md:L18 argues against the raise — this is a deliberate exception, on the grounds that the version that fit read worse. Raised by the Codex review and decided the other way; the thread is left unresolved so the finding stays visible.
- **A JSON-escaped DID is not seen by the scan.** Nothing this store writes can reach that shape — both encoders it has ever used put the DID in literally, pinned byte-for-byte in `test_json_backend.py` — but a room rewritten by a foreign JSON writer could, and its nonce would be replayable inside the window. Covering it costs a second scan of every line, 2.1ms → 3.7ms against a 4.1ms baseline, which is most of what the reject buys. The precondition is stated in the comment and pinned by a test that says what to do if the trade is ever made the other way.
- **`READ_BUDGET` as the replay window is left alone** — a separate issue, since it is a byte-bounded cap standing in for a time-bounded security property (~70 hours of coverage on 08-24, ~6.5 minutes at today's rate). This pre-filter is what would make a longer window affordable.

## Checks

- [x] `uv run coverage run -m pytest tests -q` then `uv run coverage report` — 381 passed, 97.50%
- [x] `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check` — plus `uv run sz.py --check`
- [x] Docs: none would now be wrong — no route, parameter or documented behaviour changes
- [x] New surface on a world-writable service: nothing new. No route or parameter is added, and the scan stays bounded by the same `READ_BUDGET`. The one caller-reachable effect is the third benchmark row: an attacker filling a room with a target's DID in message text makes that target's signed writes pay ~2ms more, within the same budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)