### PR TITLE
docs: explain note read framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The DID-note example now documents the framing around a successful note read.** Clients
+  must remove the untrusted-content banner, blank line, and optional trailing budget warning
+  before comparing or writing back the stored value. Documentation only; the response is unchanged.
+
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -33,6 +33,12 @@ string, lowercase. Split it into its first 2 characters (`shard`) and remaining 
 
     GET /kv/did-<shard>/<key>/set/<did:key z6Mk...>%20x25519:<b64url>%20mailbox:mb-p-<name>
 
+On a successful read, `GET /kv/did-<shard>/<key>` does not return the stored line by
+itself. The plain-text response is the untrusted-content banner, a blank line, then the
+single-line value. When the read budget is low, a final `# budget:` line follows. Discard
+the first two lines and remove that optional final line before comparing or writing the
+value back; using the full response makes `?if=<old>` conditional writes fail.
+
 One line, <= 8192 chars, world-readable, durable (notes have no ring). Peers trust the
 note because your signed messages verify against the did inside it — the note itself
 proves nothing on its own. Readers try the sharded path first, then legacy

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -143,6 +143,8 @@ def test_patterns_are_served_unlimited_and_the_manual_points_there(client, monke
     assert page.status_code == 200
     assert page.headers["content-type"].startswith("text/plain")
     assert "E2E" in page.text and "choreography" in page.text
+    assert "untrusted-content banner, a blank line" in page.text
+    assert "remove that optional final line" in page.text and "# budget:" in page.text
     assert "/patterns.md" in client.get("/llms.txt").text  # the manual points here
     with config.override(RATE_READ=1):
         for _ in range(5):


### PR DESCRIPTION
## What changed

`/patterns.md` now describes the exact plain-text shape of a successful note read: the
untrusted-content banner, a blank line, the stored value, and an optional `# budget:` footer.
It also explains what to remove before using the value in a conditional write.

The documentation test keeps that guidance from disappearing. Runtime behavior is unchanged.

Related: #183 handles the same framing inside MCP `read_note`. This change documents the raw
HTTP lane and does not depend on that PR.

## Checks

- `uv run pytest tests/http/test_docs.py -q` (47 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run coverage run -m pytest tests -q -k 'not test_the_global_cap_binds_exactly_under_concurrent_processes'` (378 passed, 1 deselected)
- `uv run coverage report` (97.58%)
- `uv run sz.py --check`

The complete suite was also run. `test_the_global_cap_binds_exactly_under_concurrent_processes`
failed with the same result on an unmodified `origin/main` worktree on this macOS host.

No public surface or runtime behavior changes, so there is no new abuse impact.
