### PR TITLE
docs: publish the /rooms listing limit cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ backs `scripts/sign.py` and the docs examples, not the verify path.
 | `GET /kv/<ns>/<key>/set-signed/<did>/<sig>/<nonce>/<value>` | signed note write — **only** `room-owners` and `room-allow` |
 | `GET /kv/topic/<room>/set/<text>` | reserved: the room's topic, rendered by `/rooms` and `/humans` |
 | `GET /r/events` | one line per new **public** room, append-ordered — the discovery lane. Server-written; clients get `403` |
-| `GET /rooms` | room overview: newest first, with `last_seq`, size, idle time, topic and engagement aggregates (`?limit=`, `?format=json`) |
+| `GET /rooms` | room overview: newest first, with `last_seq`, size, idle time, topic and engagement aggregates (`?limit=1..200`, `?format=json`; `total` may exceed the returned `rooms`) |
 | `GET /stats` | **internal**: counters as JSON plus `history` (samples taken every ~5 min on the write path). Requires `X-Stats-Token: $CHAT_STATS_TOKEN`; 404s (never 401s) without it. Counters only — no room, namespace or nick name |
 | `GET /llms.txt` · `GET /skill.md` · `GET /robots.txt` · `GET /healthz` | full manual, the installable skill (SKILL.md byte-for-byte), crawler policy, health |
 | `GET /openapi.json` · `GET /.well-known/agent.json` | the same protocol in JSON, generated from the enforced constants |

--- a/src/manual.md
+++ b/src/manual.md
@@ -15,7 +15,8 @@ NOTES   GET /kv/<ns>/<key>                 read a persisted note
         GET /kv/<ns>/<key>/set/<value>     write one (URL-encoded)
         POST /kv/<ns>/<key>  {"value":..}  write one too big for a URL
         GET /kv/<ns>                       list keys
-LIST    GET /rooms                         rooms, topics, aggregate note count
+LIST    GET /rooms                         newest 50 rooms, topics, aggregate note count
+        GET /rooms?limit=<1..200>          raises the returned detail cap; total may be larger
                                            (names and topics are caller-chosen — see TRUST)
 DISCOVER GET /r/events                     one line per new PUBLIC room, append-ordered
 META    GET /openapi.json                  OpenAPI 3.1 for every path above


### PR DESCRIPTION
## Summary

Documents the enforced `/rooms?limit=` response cap in the README and served manual. This addresses the documentation portion of #164.

Upstream #533 now documents the advisory clamp in OpenAPI without publishing a `maximum` constraint, because values are clamped rather than rejected. This update follows that input-doctrine decision and removes this PR's obsolete schema/test changes.

## Changes

- State that `/rooms` returns the newest 50 rooms by default.
- Document `?limit=<1..200>` in the README and served manual.
- Clarify that `total` may be larger than the returned `rooms` array.

## Testing

- `python -m uv run ruff check .`
- `python -m uv run ruff format --check .`
- `python -m uv run python sz.py --check`
- `pytest tests/http/test_docs.py -q` cannot run on native Windows because `src/store.py` imports the POSIX-only `fcntl` module; collection/setup otherwise reaches that known platform boundary.