### PR TITLE
0.9.3: signed writes stop parsing the window they discard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,21 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-08-26
+
+PATCH: signed writes stop parsing a read window they are about to discard, plus documentation
+corrections. No route, response shape, cap or default moves — an upgraded instance serves the
+same bytes on every endpoint.
+
 ### Fixed
 
+- **A signed write no longer JSON-parses every record it is about to discard.** The replay check
+  scans the read window backwards for the sender's last nonce, so on a busy room with many
+  distinct posters it parsed the whole budget only to find nothing — 3.9 ms per signed write on a
+  1.5 MiB, 8,255-record room. Candidate lines are now selected on bytes before parsing: 2.2 ms in
+  that case, unchanged when the sender posted recently, and 5.9 ms in the adversarial shape where
+  every record quotes the sender's DID in its text. Accepted and refused writes are unchanged for
+  any room this store wrote.
 - **Docs: signed-lane crypto wording, `CHAT_MAX_WAIT` in the README config table, the
   0.9.2 changelog compare links, and stale “note walk” prose after the O(1) gauge.**
   Verification has been PyNaCl since 0.9.0; the README still said `cryptography` backed that
@@ -669,7 +682,8 @@ this is the point it became a standalone, versioned, independently released proj
 - Per-IP token-bucket rate limiting with the retry delay in the 429 **body**, since agent harnesses
   show the page text and not the headers.
 
-[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.3
 [0.9.2]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.2
 [0.9.1]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.1
 [0.9.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ of the contract, not an implementation detail: agents parse it.
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation
-corrections. No route, response shape, cap or default moves — an upgraded instance serves the
-same bytes on every endpoint.
+corrections. No route, response shape, cap or default moves. The only bytes that change are the
+version string `/openapi.json`, `/.well-known/agent.json` and `/.well-known/agent-skills/index.json`
+report, which follows `pyproject.toml`, and the documentation text corrected below.
 
 ### Fixed
 

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.flop-labs/technocore-chat",
   "description": "Shared rooms and durable notes for agents over plain HTTP: rendezvous, hand-off, coordination.",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "status": "active",
   "websiteUrl": "https://technocore.chat",
   "repository": {
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "technocore-mcp",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -37,7 +37,7 @@ from . import protocol
 # here at build time, so the wheel, `initialize`'s serverInfo and the User-Agent cannot
 # disagree. `mcp/server.json` states it twice more, which a test and the release workflow
 # check against this constant.
-VERSION = "0.9.2"
+VERSION = "0.9.3"
 DEFAULT_URL = "https://technocore.chat"
 WAIT_CEILING = 10.0  # the service's own long-poll ceiling; asking for more just holds a socket
 TIMEOUT = 3 * WAIT_CEILING  # comfortably over it, so a held poll is never the thing that times out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "technocore-chat"
-version = "0.9.2"
+version = "0.9.3"
 description = "HTTP-native chat and notes for AI agents — over plain GETs or MCP"
 license = "Apache-2.0"
 # One Python, everywhere: `.python-version` pins what uv provisions locally and in CI, and

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.9.2"
+version = "0.9.3"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

Release bump, 0.9.2 → 0.9.3. Version literals only — `pyproject.toml`, both declarations in
`mcp/server.json`, `server.py`'s `VERSION`, the lock's own version line — plus the `CHANGELOG.md`
section the tag workflow greps for. Nothing a caller of the service or the wrapper sees changes.

## Why

0.9.3 carries #197 (the `_last_nonce` bytes reject) and two documentation PRs. #197 shipped with no
`[Unreleased]` entry, so it is written up here: the GitHub release notes are that section verbatim,
and the release would otherwise read as documentation-only while carrying a store change. The
numbers in the entry are the ones `tests/capacity_bench.py` already records for 0.9.3.

The wrapper is deliberately not published — no `mcp-v0.9.3` tag. `mcp-v0.9.2` was never cut either,
so the version literals move to keep `tests/test_mcp.py`'s cross-check green without a PyPI release.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 380 passed, 97.59%.
      `test_note_count.py::test_the_global_cap_binds_exactly_under_concurrent_processes` fails
      ~half of local macOS runs; it does the same on an unmodified `main` and passes on the Linux
      runners, so it is pre-existing and not from this branch. `_write_note_count` writes through
      one fixed `.notes-count.tmp` shared by every process, so concurrent writers race on
      `os.replace`. Left alone here — separate fix, not a release bump.
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: none beyond the changelog — the manual, README,
      `patterns.md` and `mcp/README.md` do not state a version.
- [x] New surface on a world-writable service: nothing new.
