### PR TITLE
fix(mcp): tools/list schemas advertise additionalProperties=false

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -206,7 +206,15 @@ def schema_of(handler: Callable[..., str]) -> dict[str, Any]:
         properties[name] = fragment(hints[name])
         if parameter.default is inspect.Parameter.empty:
             required.append(name)
-    schema: dict[str, Any] = {"type": "object", "properties": properties}
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        # The validator refuses arguments no parameter declares (`unexpected
+        # arguments`), so the document has to say so too: a client that validates a
+        # call locally against this schema must reach the same verdict the server
+        # does, or `tools/call` rejects calls its own tools/list called valid.
+        "additionalProperties": False,
+    }
     if required:
         schema["required"] = required
     return schema

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -285,6 +285,28 @@ def test_a_schema_cannot_drift_from_the_function_it_describes(mcp):
         assert tool.schema.get("required", []) == expected
 
 
+def test_local_validation_reaches_the_same_verdict_as_tools_call(mcp):
+    """The advertised schema must reject what the server rejects: `additionalProperties`
+    is false because `_validate` refuses arguments no tool declares (#105). Without it,
+    a client that validates locally against `tools/list` sends a call its own document
+    called valid, and gets `-32602 unexpected arguments` back."""
+    server, _ = mcp
+    tools = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})["result"]["tools"]
+    schemas = {t["name"]: t["inputSchema"] for t in tools}
+    assert all(s.get("additionalProperties") is False for s in schemas.values())
+    # The exact call from #105: schema-valid without the flag, refused by the server.
+    undeclared = {"room": "lobby", "colour": "blue"}
+    reply = server.handle(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "read_room", "arguments": undeclared},
+        }
+    )
+    assert reply["error"]["code"] == -32602 and "colour" in reply["error"]["message"]
+
+
 def test_an_undescribable_parameter_fails_at_registration(mcp):
     """A handler the schema cannot describe must break the build, not ship a tool whose
     advertised contract is a guess."""


### PR DESCRIPTION
## What

`schema_of` now emits `additionalProperties: false`, so every tool schema in `tools/list` says what `_validate` already enforces: arguments no parameter declares are refused (`-32602 unexpected arguments`). One regression test asserts local validation reaches the same verdict as `tools/call` for the issue's example call.

## Why

Fixes #105. A JSON Schema object admits every property it does not name until told otherwise, so a client validating locally against the document this server hands out sends calls its own `tools/list` called valid, then eats a `-32602`. The two statements now agree; no handler or refusal changes.

Closes #105.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 382 passed, 97.50% (floor 96)
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs unchanged — no published document said anything about additionalProperties before, so none becomes wrong
- [x] New surface on a world-writable service: nothing new — the flag documents an existing refusal