### PR TITLE
docs(manifest): describe the signed lane's text budget

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -495,6 +495,14 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "name": "text",
                             "required": True,
                             "schema": _TEXT_SCHEMA,
+                            "description": (
+                                "URL-encoded message body. This lane has the smaller URL "
+                                "budget of the two write lanes — DID, signature and nonce "
+                                f"sit ahead of it — so {store.MAX_TEXT_CHARS} ASCII characters fit, one CJK "
+                                "character is 9 bytes encoded, and long non-Latin text can "
+                                "exceed the edge's ceiling and die at the proxy with no "
+                                "status at all — use POST for anything long."
+                            ),
                         },
                     ],
                     "responses": {

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -718,6 +718,22 @@ def test_the_signed_lane_publishes_the_shape_it_actually_enforces(client):
     assert client.post("/r/lobby", json={"from": "b", "text": "hi", "sig": "x"}).status_code == 200
 
 
+def test_the_signed_lane_describes_the_text_budget_it_actually_has(client):
+    """The signed lane's `text` was the only write input published without a description,
+    on the lane with the least room for it — DID, signature and nonce sit ahead in the
+    path (#76). The failure is the opaque kind: 4096 CJK characters percent-encode well
+    past the edge's ceiling, so the request dies at the proxy with no status at all.
+    The description now carries what `maxLength` cannot say, pinned to the enforced cap."""
+    import store
+
+    doc = client.get("/openapi.json").json()
+    say = "/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}"
+    text = next(p for p in doc["paths"][say]["get"]["parameters"] if p["name"] == "text")
+    assert str(store.MAX_TEXT_CHARS) in text["description"]
+    # The one actionable escape a conforming client has when the URL budget runs out.
+    assert "POST" in text["description"]
+
+
 def test_a_free_form_field_publishes_that_it_cannot_be_empty(client):
     """`required: ["text"]` is satisfied by `""`, which is a 400 — the sweep leaves nothing
     visible. A generator reading only `required` emits a client whose empty-message call


### PR DESCRIPTION
## What

The say-signed lane's `text` param — the only write input published without a description — now carries one: the smaller URL budget relative to the unsigned lane, the percent-encoding math, and POST as the escape hatch. A regression test pins the description to the enforced `MAX_TEXT_CHARS` so it cannot drift.

## Why

Fixes #76, on the lane that needs the warning most: DID (56) + signature (86) + nonce (~13) sit ahead of `text`, leaving ~116 bytes less room than the lane that already warns. And the failure there is the opaque kind — 4096 CJK characters encode past the edge's ceiling, dying at the proxy with no status and no body. The prose covers this; only the machine-readable surface had the hole.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 382 passed, 97.50% (floor 96)
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs updated in the same change — the description *is* the doc fix
- [x] New surface on a world-writable service: nothing new — documentation only