### PR TITLE
fix(http): answer the name grammar before room class questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **An unsigned room write with an invalid name now answers `400 bad name`, not
+  `403 mailbox`.** The write gate classified the room before checking the name
+  grammar, so `mb-FOO` (a class prefix that fails `NAME_RE`) fell into the mailbox
+  branch on the `say` lane. The gate now checks `valid_name` first, matching the
+  read and signed lanes.
+
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation

--- a/src/app.py
+++ b/src/app.py
@@ -845,6 +845,7 @@ def _allowed_keys(room: str) -> set[str]:
 def _room_write_gate(request: Request, room: str, signer: str | None) -> Response | None:
     """Every write to a room passes here, signed or not. Fail closed: a class that demands
     a signature refuses the unsigned lane outright, and the reply says what to send."""
+    store.valid_name(room)  # grammar before class: a bad name is a bad name
     denied = _reject_if_events_room(room)
     if denied:
         return denied

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -490,6 +490,15 @@ def test_a_mailbox_room_refuses_the_unsigned_lane(client):
     assert "say:  /r/lobby/say/<nick>" in client.get("/r/lobby").text
 
 
+def test_a_class_prefixed_name_that_fails_the_grammar_is_a_bad_name(client):
+    # `mb-FOO` carries the mailbox class from its `mb-` prefix, but the name fails NAME_RE.
+    # The grammar answers before any class question: a name the service will never store is
+    # a bad name, whatever class its prefix happens to spell.
+    r = client.get("/r/mb-FOO/say/bot/hi")
+    assert r.status_code == 400 and "bad name" in r.text
+    assert client.post("/r/mb-FOO", json={"from": "bot", "text": "hi"}).status_code == 400
+
+
 def test_room_classes_compose_by_prefix(client):
     import store
 


### PR DESCRIPTION
## What

An unsigned room write whose name fails the grammar now answers `400 bad name`
before its class is checked. A caller sending to `mb-FOO` on the `say` lane sees
`400 bad name` instead of `403 mailbox`.

## Why

The write gate classified the room (`is_mailbox`) before validating the name
grammar (`valid_name`), so a name that carries a class prefix but fails `NAME_RE`
fell into the mailbox branch on the unsigned lane only — the read and signed lanes
already checked the name first. Fixes #109.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 382 passed, 97.59%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated — no manual/manifest change needed
      (both 400 and 403 remain documented); CHANGELOG notes the fix under [Unreleased]
- [x] New surface on a world-writable service: nothing new — the write lane already
      validated names, this only reorders when that happens
