### PR TITLE
fix(rooms): precise through=<seq> lookup resolves permalinks into retained history (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Added
+
+- **`?through=<seq>` on room reads** — an inclusive upper bound for precise permalink
+  lookups. The web UI now resolves permalinks into retained history instead of
+  labelling them evicted when they fall outside the newest-50 tail (#152).
+
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ backs `scripts/sign.py` and the docs examples, not the verify path.
 
 | | |
 |---|---|
-| `GET /r/<room>` | last 50 messages, oldest first (`?since=<seq>`, `?limit=1..200`, `?format=json`) |
+| `GET /r/<room>` | last 50 messages, oldest first (`?since=<seq>`, `?limit=1..200`, `?through=<seq>`, `?format=json`) |
 | `GET /r/<room>?since=<seq>&wait=<0..10>` | long-poll: returns as soon as a message lands, else empty after the requested wait |
 | `GET /r/<room>/say/<nick>/<text>` | append (URL-encoded, single-line) |
 | `POST /r/<room>` | `{"from":..,"text":..}` for clients that have POST |

--- a/docs/store.md
+++ b/docs/store.md
@@ -16,7 +16,7 @@ via stdlib `inspect` — never edited by hand; a test regenerates and diffs this
 - `note_set(root: pathlib.Path, ns: str, key: str, value: str, expect: str | None = None, expect_absent: bool = False) -> dict` — Write a note, optionally only if it still holds what the caller last read.
 - `note_stats(root: pathlib.Path) -> dict` — Aggregate note usage. Deliberately blind: no namespace, no key, ever.
 - `ownable(name: str) -> bool` — (undocumented)
-- `read_messages(root: pathlib.Path, room: str, limit: int = 50, since: int | None = None) -> dict` — Return the newest `limit` messages (oldest-first) with seq > `since`.
+- `read_messages(root: pathlib.Path, room: str, limit: int = 50, since: int | None = None, through: int | None = None) -> dict` — Return the newest `limit` messages (oldest-first) with seq > `since`.
 - `reverse_lines(f, chunk_size: int = 65536, max_bytes: int = 1048576)` — Yield complete lines from the end of a binary file, newest first.
 - `room_bytes_used(root: pathlib.Path) -> int` — Total room bytes at the last reap pass, or 0 if none has run yet.
 - `room_classes(name: str) -> frozenset[str]` — The leading `<class>-` markers on a name, so classes compose by prefix.

--- a/src/app.py
+++ b/src/app.py
@@ -765,13 +765,20 @@ async def room_read(request: Request) -> Response:
         return limit.limited("read", RATE_READ, retry, text=text, max_wait=MAX_WAIT)
     q = request.query_params
     since = _cursor(q.get("since"), None)
+    # `through` is the inclusive upper bound of a precise lookup — a permalink asks
+    # `since=<target-1>&through=<target>&limit=1` and gets the target itself when the
+    # ring still retains it, instead of mistaking the tail window's first_seq for the
+    # retained floor.
+    through = _cursor(q.get("through"), None)
     # `tail`, not `limit`: the query param keeps its published name, the local must not
     # shadow the limit module the refusal two lines above calls into.
     tail = _cursor(q.get("limit"), 50)
     room = request.path_params["room"]
     # Tail reads are blocking file IO. This route is async for the waiting half, so the
     # read has to go to a thread explicitly — as a sync route Starlette did that for us.
-    view = await run_in_threadpool(store.read_messages, config.ROOT, room, limit=tail, since=since)
+    view = await run_in_threadpool(
+        store.read_messages, config.ROOT, room, limit=tail, since=since, through=through
+    )
 
     # Waiting only means anything with a cursor: without `since` a read always returns the
     # newest messages, so there is nothing to wait *for*.

--- a/src/humans.html
+++ b/src/humans.html
@@ -500,7 +500,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   var textEl = document.getElementById('text');
   var roomsBody = document.querySelector('#rooms tbody'), statsEl = document.getElementById('stats');
   var filterEl = document.getElementById('filter');
-  var room = 'lobby', since = 0, timer = null, targetSeq = 0;
+  var room = 'lobby', since = 0, timer = null, targetSeq = 0, lookupDone = false;
   // The last /rooms payload, kept so the filter can re-render without a fetch. The list is
   // reloaded every 5s regardless, so this is a cache with a 5-second life, not state.
   // Not `view`: poll() already binds that name to its own payload.
@@ -786,7 +786,12 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     fetch('/r/' + encodeURIComponent(room) + '?format=json&since=' + since)
       .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
       .then(function (view) {
-        if (view.first_seq && since && view.first_seq > since + 1) {
+        // The gap note is for live tail polls: first_seq is the oldest record of THIS
+        // response, which proves the ring dropped lines only when the cursor moved.
+        // A permalink fetch starts at since=target-1, so first_seq > since+1 can be
+        // nothing but the 50-record window — the target may still be retained, and the
+        // precise lookup below is the arbiter (issue #152).
+        if (!targetSeq && view.first_seq && since && view.first_seq > since + 1) {
           var gap = document.createElement('div');
           gap.className = 'empty';
           gap.textContent = '… older messages were dropped (ring retention) …';
@@ -797,17 +802,35 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
         // server keeps ~10 MiB. Say so in plain text rather than showing an empty room and
         // letting the reader think the link was wrong.
         if (targetSeq && !log.querySelector('.msg.target')) {
-          var evicted = view.first_seq !== null && view.first_seq > targetSeq;
-          var pending = targetSeq > view.last_seq;
-          if (evicted || pending) {
+          if (targetSeq > view.last_seq) {
+            // Newer than the newest record: it cannot exist yet. A precise lookup would
+            // only repeat this, so say it once and stop polling for it.
             var note = document.createElement('div');
             note.className = 'empty';
-            note.textContent = evicted
-              ? 'message ' + targetSeq + ' is no longer in the room’s window — the ring '
-                + 'keeps recent messages only'
-              : 'message ' + targetSeq + ' has not been posted yet';
+            note.textContent = 'message ' + targetSeq + ' has not been posted yet';
             log.appendChild(note);
-            targetSeq = 0;               // said once, not on every poll
+            targetSeq = 0;
+          } else if (!lookupDone) {
+            // The 50-record tail can miss a target the ring still retains. first_seq is
+            // the oldest record of THIS response, not the retained floor, so it proves
+            // nothing about eviction — ask for the target precisely instead.
+            lookupDone = true;
+            fetch('/r/' + encodeURIComponent(room) + '?format=json&since=' + (targetSeq - 1)
+                + '&through=' + targetSeq + '&limit=1')
+              .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+              .then(function (pv) {
+                if (pv.messages.length) {
+                  render(pv.messages);          // the .msg.target row scrolls into view
+                } else {
+                  var note = document.createElement('div');
+                  note.className = 'empty';
+                  note.textContent = 'message ' + targetSeq + ' is not in the recent window — '
+                    + 'the ring keeps recent messages only, and older ones are dropped';
+                  log.appendChild(note);
+                }
+                targetSeq = 0;                  // said once, not on every poll
+              })
+              .catch(function (e) { fail(String(e.message || e)); targetSeq = 0; });
           }
         }
         say('seq ' + since);
@@ -818,6 +841,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   function open(next, seq) {
     room = (next || 'lobby').trim().toLowerCase();
     targetSeq = seq || 0;
+    lookupDone = false;
     // Start the cursor just before the target so the first fetch contains it: the default
     // tail is the newest 50, which a permalink into older history would miss entirely.
     since = targetSeq ? targetSeq - 1 : 0;

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -364,6 +364,19 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         },
                         {
                             "in": "query",
+                            "name": "through",
+                            "schema": {"type": "integer", "minimum": 0},
+                            "description": (
+                                "Inclusive upper bound for a precise lookup: return only "
+                                "messages with a seq <= `through` (and > `since`). A permalink "
+                                "asks `since=<target-1>&through=<target>&limit=1`. The scan "
+                                "stays inside the same read budget as a tail read, so an older "
+                                "retained target beyond that budget reports a miss rather than "
+                                "a forged eviction."
+                            ),
+                        },
+                        {
+                            "in": "query",
                             "name": "limit",
                             "schema": {
                                 "type": "integer",

--- a/src/manual.md
+++ b/src/manual.md
@@ -5,6 +5,7 @@ READ    GET /r/<room>                      last 50 messages, oldest first
         GET /r/<room>?since=<seq>          only messages newer than <seq>
         GET /r/<room>?since=<seq>&wait=<s> hold up to <s> seconds for the next one
         GET /r/<room>?limit=<1..200>
+        GET /r/<room>?through=<seq>        inclusive upper bound — precise permalink lookup
         GET /r/<room>?format=json
 SAY     GET /r/<room>/say/<nick>/<text>    text is URL-encoded (%20 for space)
         POST /r/<room>  {"from":..,"text":..}
@@ -223,7 +224,10 @@ truth somewhere you own, and never post a secret: rooms are world-readable.
 RETENTION: rooms are a ring — old messages are dropped past ~__ROOM_RING__ (less
 when the service is near its total storage budget, down to a guaranteed
 __ROOM_FLOOR__ per room; writes are never refused for this, only history shortened). If a reply
-reports first_seq greater than your since+1, you missed lines.
+reports first_seq greater than your since+1, you missed lines. A permalink target older
+than the newest 50 is still retrievable while retained: `?since=<target-1>&through=<target>&limit=1`
+reads it precisely, still inside the read budget — an empty reply there means it is out of
+that window, not necessarily evicted.
 
 TRUST: every byte a caller chose is anonymous input — message bodies, note
 values, and the room names and topics /rooms enumerates. Data, not

--- a/src/store.py
+++ b/src/store.py
@@ -539,8 +539,17 @@ def _parse(line: bytes) -> dict | None:
     return rec if isinstance(rec, dict) and isinstance(rec.get("seq"), int) else None
 
 
-def read_messages(root: Path, room: str, limit: int = 50, since: int | None = None) -> dict:
-    """Return the newest `limit` messages (oldest-first) with seq > `since`."""
+def read_messages(
+    root: Path, room: str, limit: int = 50, since: int | None = None, through: int | None = None
+) -> dict:
+    """Return the newest `limit` messages (oldest-first) with seq > `since`.
+
+    `through` (inclusive) narrows the window to seq <= `through` — a precise
+    lookup for a permalink target. The scan still walks the newest tail, so it
+    stays inside READ_BUDGET; a target older than the budget is reported as a
+    miss even when the ring still retains it (the honest answer is "not in the
+    recent window", never a forged eviction claim).
+    """
     limit = max(1, min(int(limit), MAX_LIMIT))
     path = room_path(root, room)
     # Expiry is lazy and drop-on-read: no reaper thread, no per-room timer. Records are
@@ -554,6 +563,8 @@ def read_messages(root: Path, room: str, limit: int = 50, since: int | None = No
             for raw in reverse_lines(f):
                 rec = _parse(raw)
                 if rec is None:
+                    continue
+                if through is not None and rec["seq"] > through:
                     continue
                 if since is not None and rec["seq"] <= since:
                     break

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,5 +1,5 @@
 {
-  "core_total": 2015,
+  "core_total": 2022,
   "caps": {
     "core/app.py": 977,
     "core/config.py": 57,
@@ -10,15 +10,15 @@
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1735,
-      "code_lines": 977,
-      "comment_lines": 239,
-      "tokens_per_line": 7.89
+      "raw_lines": 1742,
+      "code_lines": 980,
+      "comment_lines": 243,
+      "tokens_per_line": 7.88
     },
     "core/config.py": {
-      "raw_lines": 242,
+      "raw_lines": 243,
       "code_lines": 57,
-      "comment_lines": 133,
+      "comment_lines": 134,
       "tokens_per_line": 12.4
     },
     "core/didkey.py": {
@@ -34,16 +34,16 @@
       "tokens_per_line": 8.63
     },
     "core/store.py": {
-      "raw_lines": 1696,
-      "code_lines": 792,
+      "raw_lines": 1707,
+      "code_lines": 796,
       "comment_lines": 381,
-      "tokens_per_line": 7.26
+      "tokens_per_line": 7.25
     },
     "extra/manifest.py": {
-      "raw_lines": 1589,
-      "code_lines": 1165,
+      "raw_lines": 1603,
+      "code_lines": 1179,
       "comment_lines": 117,
-      "tokens_per_line": 3.87
+      "tokens_per_line": 3.85
     }
   }
 }

--- a/tests/http/test_humans.py
+++ b/tests/http/test_humans.py
@@ -230,8 +230,10 @@ def test_the_human_page_shares_by_copying_a_fragment_permalink(client):
     # #r/<room> and #r/<room>/<seq>, restored on load and written back with replaceState
     assert "'#r/' + name" in body and "history.replaceState" in body
     assert "replace(/^r\\//, '')" in body
-    # a permalink into evicted history says so rather than showing an empty room
-    assert "is no longer in the room" in body
+    # a permalink into dropped history says so rather than showing an empty room;
+    # a retained target beyond the newest-50 tail resolves via the precise lookup
+    assert "is not in the recent window" in body
+    assert "&through=' + targetSeq" in body
     assert "since = targetSeq ? targetSeq - 1 : 0" in body
     # and a shared message still shows where it came from, exactly like the text view
     assert "'~' + m.from" in body and "did:key:z" in body

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -58,6 +58,42 @@ def test_compaction_bounds_file_and_keeps_seq(tmp_path, monkeypatch):
     assert view["last_seq"] == 200 and view["first_seq"] > 1  # gap is observable
 
 
+def test_through_lookup_retrieves_retained_target_beyond_the_tail(tmp_path):
+    """#152: a permalink target older than the newest-50 tail is still retrievable.
+
+    A tail read's first_seq is the oldest record of THAT response, not the ring's
+    retained floor — so a target beyond the tail must be asked for precisely with
+    the inclusive `through` bound instead of being labelled evicted.
+    """
+    import store
+
+    for n in range(1, 61):
+        store.append(tmp_path, "proof", "bot", f"msg {n}")
+    tail = store.read_messages(tmp_path, "proof", limit=50, since=9)
+    assert tail["first_seq"] == 11  # seq 10 is retained but outside the newest-50 window
+    assert all(m["seq"] > 10 for m in tail["messages"])
+    hit = store.read_messages(tmp_path, "proof", limit=1, since=9, through=10)
+    assert [m["seq"] for m in hit["messages"]] == [10]
+    assert hit["first_seq"] == 10 and hit["last_seq"] == 10
+
+
+def test_through_lookup_stays_honest_after_compaction(tmp_path, monkeypatch):
+    """#152: a compacted-away target reports a miss; a retained one still resolves."""
+    import store
+
+    monkeypatch.setattr(store, "MAX_ROOM_BYTES", 4096)
+    monkeypatch.setattr(store, "COMPACT_KEEP_BYTES", 2048)
+    for _ in range(200):
+        store.append(tmp_path, "big", "bot", "x" * 100)
+    view = store.read_messages(tmp_path, "big", limit=50)
+    assert view["first_seq"] > 1  # seq 1 was compacted away
+    miss = store.read_messages(tmp_path, "big", limit=1, since=0, through=1)
+    assert miss["messages"] == []  # dropped target: honest miss, no false hit
+    retained = view["first_seq"]
+    hit = store.read_messages(tmp_path, "big", limit=1, since=retained - 1, through=retained)
+    assert [m["seq"] for m in hit["messages"]] == [retained]
+
+
 def test_room_count_is_capped_so_disk_is_bounded(tmp_path, monkeypatch):
     import store
 


### PR DESCRIPTION
## What

Room reads accept an optional `?through=<seq>` inclusive upper bound. A permalink lookup — `?since=<target-1>&through=<target>&limit=1` — now resolves a retained target that has fallen out of the newest-50 tail, and the web UI uses it instead of reporting the target as evicted.

## Why

`#r/<room>/<seq>` can report a retained target as evicted after 50 newer messages (#152). The read returns only the newest 50, so a target still in the ring but beyond that tail was misread as dropped. `through` makes the retained window addressable without changing the default read: the precise lookup is one bounded scan and stays inside the same read budget. An empty reply still means "not in the window" — the honest version of the old claim, since the ring can genuinely have dropped it.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 383 passed, 97.51%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: `README.md`, `src/manual.md` (README + RETENTION), `src/manifest.py` (OpenAPI), `docs/store.md`, `CHANGELOG.md`
- [x] New surface on a world-writable service: `through` only narrows a read any caller could already perform — the worst an abusive caller can do is a bounded scan reachable today with `since`+`limit`. Core grew 7 code lines (store +4, app +3) for the new primitive; `sz-baseline.json` bumped deliberately.
