### PR TITLE
fix(http): /rooms survives a cache clear landing mid-refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`GET /rooms` no longer answers 500 when a write clears its cache mid-refresh.** The refresh
+  promoted its cache entry with `move_to_end` in a separate step from the insert, and a concurrent
+  write clearing the cache between the two left no key to promote. The entry is popped before it is
+  re-inserted instead, which is the same promotion with no key that can go missing.
+
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation

--- a/src/app.py
+++ b/src/app.py
@@ -661,8 +661,14 @@ def _rooms_view(limit: int) -> dict:
         round(view["notes"]["total"] / seen, 4) if seen else None
     )
     if config.ROOMS_CACHE_SECONDS > 0:
+        # Popped before it is re-inserted, because a concurrent write clears this cache
+        # (see `take`) and sync endpoints run in the threadpool, so the clear really can
+        # land between two of these lines. move_to_end was then promoting a key that was
+        # no longer there, and its KeyError answered the most polled read on the service
+        # with a 500. A fresh insert is already last, so this buys the same LRU promotion
+        # with no key to go missing.
+        _rooms_cache.pop(limit, None)
         _rooms_cache[limit] = (stamp, now, view)
-        _rooms_cache.move_to_end(limit)
         while len(_rooms_cache) > MAX_ROOMS_CACHE:
             _rooms_cache.popitem(last=False)
     return view

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -940,3 +940,41 @@ def test_polled_reads_are_edge_cacheable_and_held_or_write_replies_never_are(cli
     with config.override(EDGE_CACHE_SECONDS=0):
         assert client.get("/rooms").headers["cache-control"] == "no-store"
         assert client.get("/r/lobby").headers["cache-control"] == "no-store"
+
+
+def test_a_write_clearing_the_cache_mid_refresh_is_not_a_500(client, monkeypatch):
+    """`take` drops the /rooms cache on every write, and the refresh that repopulates it
+    mutates the shared OrderedDict in more than one step. Sync endpoints run in the
+    threadpool, so that clear can land between two of those steps, and it must not reach
+    the caller as a 500 on the most polled read on the service.
+    """
+    from collections import OrderedDict
+
+    import app
+
+    fired = []
+
+    class ClearingCache(OrderedDict):
+        # A real OrderedDict. The only addition is that the first insert lets a real
+        # write through, which is the interleaving take() -> _rooms_cache.clear() makes.
+        def __setitem__(self, key, value):
+            super().__setitem__(key, value)
+            if not fired:
+                fired.append(True)
+                client.get("/r/cache-race/say/writer/hello")
+
+    monkeypatch.setattr(app, "_rooms_cache", ClearingCache())
+    assert client.get("/rooms?format=json").status_code == 200
+    assert fired, "the cache was never cleared mid-refresh — this test proved nothing"
+
+
+def test_the_rooms_cache_still_evicts_down_to_its_cap(client):
+    """The promotion moved, so the bound it feeds has to be pinned: one entry per distinct
+    ?limit=, oldest evicted first, never more than the cap.
+    """
+    import app
+
+    client.get("/r/kept/say/alice/hello")
+    for n in range(app.MAX_ROOMS_CACHE + 20):
+        assert client.get(f"/rooms?limit={n + 1}").status_code == 200
+    assert len(app._rooms_cache) == app.MAX_ROOMS_CACHE


### PR DESCRIPTION
## What

`GET /rooms` stops answering 500 when a concurrent write clears its cache while the
refresh is repopulating it. Nothing else about the response, the cache window or the
eviction bound changes.

## Why

Fixes #212. `_rooms_view` inserted its cache entry and promoted it with `move_to_end` in a
second step, and `take` clears that cache on every write. Sync endpoints run in the
threadpool, so a clear landing between the two left `move_to_end` no key to promote — a
`KeyError` out of the most polled read on the service.

Popping the key before re-inserting it is the same LRU promotion, because a fresh insert
is already last, and there is no key left that can go missing. Core code-lines are
unchanged (`sz.py --check` clean), so this stays a swap rather than growth.

Two tests: the first drives the reported interleaving through the real endpoints and
asserts the race actually fired, so it cannot pass by proving nothing; the second pins the
eviction bound, since the promotion it feeds moved.

One judgment call left alone: the `popitem(last=False)` three lines below can raise the
same way if a clear lands between the length check and the pop. That needs more than 64
distinct `?limit=` values cached first, and it is a different window, so I kept it out to
keep this to one problem. Happy to follow up if you want it closed here.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 383 passed, 97.50%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: none apply; no documented behaviour moves
- [x] New surface on a world-writable service: nothing new — no route, parameter or cap changes
