### PR TITLE
fix(docker): pin the uv build image by digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Changed
+
+- **Docker: the `uv` build image is digest-pinned**, like the base image above it. The tag `0.12.3`
+  runs during the build, so a re-pushed tag would execute in CI. Dependabot here covers only
+  `github-actions`, so a moved tag raised no alert.
+
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,10 @@ FROM python:3.12.13-slim@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad
 ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1 CHAT_ROOT=/data \
     UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
-COPY --from=ghcr.io/astral-sh/uv:0.12.3 /uv /usr/local/bin/uv
+# Digest-pinned for the same reason as the base image: this binary runs during the
+# build (`uv sync` below), so a re-pushed tag would execute in CI. Dependabot here
+# only covers github-actions, so nothing would flag a moved tag.
+COPY --from=ghcr.io/astral-sh/uv:0.12.3@sha256:dfd1e6972e100ca2fbf1f391effc3dd4aa57f319bf03c3e321e0a3f3341ed5af /uv /usr/local/bin/uv
 
 WORKDIR /app
 


### PR DESCRIPTION
## What

One line in `docker/Dockerfile`:

```dockerfile
- COPY --from=ghcr.io/astral-sh/uv:0.12.3 /uv /usr/local/bin/uv
+ COPY --from=ghcr.io/astral-sh/uv:0.12.3@sha256:dfd1e6972e100ca2fbf1f391effc3dd4aa57f319bf03c3e321e0a3f3341ed5af /uv /usr/local/bin/uv
```

## Why

The base image two lines up is digest-pinned. Its comment says why a tag is not enough. The `uv` binary still came from a mutable tag, and it runs during the build (`uv sync --frozen`). A re-pushed tag would execute in the build stage. CI builds this image on every PR (`ci.yml:82`). Dependabot covers only `github-actions` (`dependabot.yml:14`), so a moved tag raises no alert.

Digest taken from `docker manifest inspect ghcr.io/astral-sh/uv:0.12.3`.

## Checks

- [x] Digest resolves to the same manifest as the tag
- [ ] `docker build -f docker/Dockerfile` succeeds and `uv --version` reports 0.12.3