### PR TITLE
fix(mcp): a surrogate argument key no longer kills the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP: a lone surrogate in a tool-call argument key no longer kills the stdio session.** The
+  unexpected-arguments error names keys through `repr`, so a key no UTF-8 stream can encode fails
+  that one call instead of the wrapper process.
+
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation

--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -231,7 +231,11 @@ def _validate(arguments: dict[str, Any], schema: dict[str, Any]) -> dict[str, An
     properties: dict[str, dict[str, Any]] = schema["properties"]
     unexpected = set(arguments) - set(properties)
     if unexpected:
-        raise _BadParamsError(f"unexpected arguments: {', '.join(sorted(unexpected))}")
+        # repr, not the raw key: a lone surrogate in an argument key (a model-side
+        # glitch the host relays verbatim) is not encodable to UTF-8 stdout, and the
+        # reply writer serializes with ensure_ascii=False. An unencodable message
+        # here would raise inside serve() and end the session, not scold one call.
+        raise _BadParamsError(f"unexpected arguments: {', '.join(map(repr, sorted(unexpected)))}")
     missing = set(schema.get("required", ())) - set(arguments)
     if missing:
         raise _BadParamsError(f"missing arguments: {', '.join(sorted(missing))}")

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -600,6 +600,28 @@ def test_malformed_json_does_not_kill_the_session(mcp):
     assert replies[1] == {"jsonrpc": "2.0", "id": 9, "result": {}}
 
 
+def test_a_surrogate_argument_key_does_not_kill_the_session(mcp):
+    """A lone surrogate in an argument key reaches the unexpected-arguments error before
+    any handler runs, and the reply writer serializes with ensure_ascii=False. The
+    raw key would then raise UnicodeEncodeError inside serve() and end the session. The host
+    relays model-composed dicts verbatim, so one glitched escape must not cost the agent
+    every tool. Values are already safe: they hit quote() inside the handler, whose
+    errors _call turns into a normal isError result."""
+    server, protocol = mcp
+    # A real UTF-8 stream, not StringIO: StringIO accepts unencodable str, stdout won't.
+    stdout = io.TextIOWrapper(io.BytesIO(), encoding="utf-8")
+    line = (
+        '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":'
+        '{"name":"read_room","arguments":{"room":"lobby","\\ud800":1}}}\n'
+    )
+    server.serve(io.StringIO(line + '{"jsonrpc":"2.0","id":9,"method":"ping"}\n'), stdout)
+    stdout.seek(0)
+    replies = [json.loads(out) for out in stdout.read().splitlines()]
+    assert replies[0]["error"]["code"] == protocol.INVALID_PARAMS
+    assert replies[0]["error"]["message"] == "unexpected arguments: '\\ud800'"
+    assert replies[1] == {"jsonrpc": "2.0", "id": 9, "result": {}}
+
+
 # ------------------------------------------------------------------ packaging
 
 


### PR DESCRIPTION
## What

A `tools/call` argument *key* with a lone surrogate reached the unexpected-arguments error string raw (`protocol.py`). The reply writer serializes with `ensure_ascii=False` to a UTF-8 stream. `UnicodeEncodeError` escaped `serve()`. Exit code 1, no reply, session over. Verified against the real `serve()`:

```json
{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_room","arguments":{"room":"lobby","\\ud800":1}}}
```

## Why

The host relays model-composed argument dicts verbatim. One glitched escape in a key costs the agent its only outbound channel until restart. Values are already safe. They hit `quote()` inside the handler, and `_call` turns that into an `isError` result. Keys hit the error message before any handler runs.

Not covered elsewhere. #102 catches oversized integers at parse time. #106 pins stream encoding. Surrogates are unencodable regardless of stream setup. This bug is in the reply-write path.

## Fix

`', '.join(map(repr, sorted(unexpected)))`. Every other user-facing message already uses `!r`. Optional hardening for the maintainer: `ensure_ascii=True` in `_write`, so reply serialization can never fail.

## Checks

- [x] Regression test fails without the fix (`UnicodeEncodeError` at `_write`). Passes with it.
- [x] `uv run python -m pytest tests/test_mcp.py -q`: 46 passed
- [x] `ruff check`, `ruff format --check`