### PR TITLE
fix(http): send nosniff on the JSON response lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **HTTP: the JSON response lanes send `X-Content-Type-Options: nosniff`**, matching the
+  plain-text lanes. The `?format=json` replies, the service-shape documents and `/stats` answer
+  with stored user text; the agent-surface regression test now fetches the JSON variants, so the
+  header cannot drift again. Core caps raised five lines to record the deliberate growth.
+
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation

--- a/src/app.py
+++ b/src/app.py
@@ -368,12 +368,22 @@ def render(view: dict) -> str:
     return "\n".join(lines)
 
 
+# The JSON lanes answer with stored user text (message bodies, topics anyone can set on
+# any room), so they carry the same nosniff the text() lanes always sent. One dict:
+# respond() and stats() want the identical header set.
+JSON_HEADERS = {
+    "Cache-Control": "no-store",
+    "X-Robots-Tag": "noindex",
+    "X-Content-Type-Options": "nosniff",
+}
+
+
 def respond(request: Request, view: dict, body_text: str | None = None, note: str = "") -> Response:
     if request.query_params.get("format") == "json":
         return Response(
             json.dumps(view, ensure_ascii=False, indent=1) + "\n",
             media_type="application/json",
-            headers={"Cache-Control": "no-store", "X-Robots-Tag": "noindex"},
+            headers=JSON_HEADERS,
         )
     return text((body_text if body_text is not None else render(view)) + note)
 
@@ -451,7 +461,7 @@ def _document(doc: dict) -> Response:
     return Response(
         json.dumps(doc, ensure_ascii=False, indent=1) + "\n",
         media_type="application/json",
-        headers={"Cache-Control": "public, max-age=3600"},
+        headers={"Cache-Control": "public, max-age=3600", "X-Content-Type-Options": "nosniff"},
     )
 
 
@@ -1561,7 +1571,7 @@ async def stats(request: Request) -> Response:
     return Response(
         json.dumps(view, ensure_ascii=False, indent=1) + "\n",
         media_type="application/json",
-        headers={"Cache-Control": "no-store", "X-Robots-Tag": "noindex"},
+        headers=JSON_HEADERS,
     )
 
 

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,24 +1,24 @@
 {
-  "core_total": 2015,
+  "core_total": 2020,
   "caps": {
-    "core/app.py": 977,
+    "core/app.py": 982,
     "core/config.py": 57,
     "core/didkey.py": 57,
     "core/limit.py": 132,
     "core/store.py": 792,
-    "core_total": 2015
+    "core_total": 2020
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1735,
-      "code_lines": 977,
-      "comment_lines": 239,
-      "tokens_per_line": 7.89
+      "raw_lines": 1745,
+      "code_lines": 982,
+      "comment_lines": 242,
+      "tokens_per_line": 7.85
     },
     "core/config.py": {
-      "raw_lines": 242,
+      "raw_lines": 243,
       "code_lines": 57,
-      "comment_lines": 133,
+      "comment_lines": 134,
       "tokens_per_line": 12.4
     },
     "core/didkey.py": {
@@ -40,8 +40,8 @@
       "tokens_per_line": 7.26
     },
     "extra/manifest.py": {
-      "raw_lines": 1589,
-      "code_lines": 1165,
+      "raw_lines": 1590,
+      "code_lines": 1166,
       "comment_lines": 117,
       "tokens_per_line": 3.87
     }

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -112,6 +112,13 @@ def test_agent_surfaces_are_never_html(client):
             assert "public" in r.headers["cache-control"], path
         else:
             assert r.headers["cache-control"] == "no-store", path
+    # The JSON variants of those surfaces answer with stored user text (message bodies,
+    # topics), so they carry nosniff too. The regression test used to fetch only the
+    # plain-text lanes. That is how the JSON lanes drifted.
+    for path in ("/r/lobby?format=json", "/rooms?format=json", "/openapi.json"):
+        r = client.get(path)
+        assert r.headers["content-type"].startswith("application/json"), path
+        assert r.headers["x-content-type-options"] == "nosniff", path
 
 
 def test_robots_keeps_rooms_out_of_indexes_but_invites_the_manual(client):


### PR DESCRIPTION
## What

`text()` and `humans()` always send `X-Content-Type-Options: nosniff`. Three emitters build `Response(...)` directly and never did: the `?format=json` branch of `respond()`, `_document()`, and `stats()`. This adds the header to all three. The agent-surface test now fetches `/r/lobby?format=json`, `/rooms?format=json` and `/openapi.json`.

## Why

The JSON bodies carry stored user text: message `text`, and `topic`. Anyone can set a topic on any room through `/kv/topic/<room>`. design.md 4.1 says every agent surface is `nosniff`, but `test_agent_surfaces_are_never_html` fetched only the plain-text variants. The JSON lanes drifted with no CI signal. `application/json` is not sniffed by current browsers, so this is hygiene, not an open sink.

`sz-baseline.json` caps record the deliberate five-line growth (`app.py` 977 to 982), same precedent as the 0.9.0 bump.

## Checks

- [x] Extended test fails without the fix (`KeyError: 'x-content-type-options'`). Passes with it.
- [x] `uv run python -m pytest tests/http/test_docs.py -q`: 47 passed
- [x] `ruff check`, `ruff format --check`, `ty check`, `sz.py --check`