### PR TITLE
fix(app): a write no longer 500s a concurrent /rooms refresh (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A write arriving during a `/rooms` refresh no longer returns 500.** A write used to clear the
+  listing cache from inside the rate-limit gate; when that landed between the refresh inserting an
+  entry and promoting it, the promotion hit a missing key and 500'd. Freshness already comes from the
+  generation stamp, so the clear is gone.
+
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation

--- a/src/app.py
+++ b/src/app.py
@@ -167,15 +167,16 @@ def take(request, kind, per_min, burst=None) -> tuple[int, float]:
     # Thin adapter over limit.take: the knobs are read HERE, at call time, so
     # monkeypatch.setattr(app, "MAX_BUCKETS", ...) and config.override() keep reaching
     # the bucket arithmetic.
-    left, wait = limit.take(
+    #
+    # This used to also drop the /rooms cache on a write, as a fast path. It no longer
+    # does. That clear ran *before* the store write, so it was never the freshness
+    # guarantee (see `_rooms_stamp`), and it reached across requests to mutate a dict a
+    # concurrent /rooms refresh was mid-mutation on — clearing the entry that refresh had
+    # just inserted and was about to promote, which turned the refresh into a 500 (#212).
+    # The stamp already invalidates on every counted mutation, so the clear was pure cost.
+    return limit.take(
         request, kind, per_min, burst, ip_header=CLIENT_IP_HEADER, max_buckets=MAX_BUCKETS
     )
-    # The /rooms cache is dropped here — the fast path, not the guarantee: it runs
-    # *before* the store write, so `_rooms_stamp` (which covers note writes too, via
-    # notes_written) is what closes the race against a concurrent walker.
-    if kind == "write":
-        _rooms_cache.clear()
-    return left, wait
 
 
 def _room_exists(room: str) -> bool:
@@ -590,14 +591,15 @@ def _rooms_stamp() -> tuple:
     """A cheap value that changes whenever the room list does. One small file read against
     a ~46k-file walk.
 
-    This is what makes the cache correct rather than merely quick. Clearing on write (see
-    `take`) is not enough on its own: the clear happens *before* the store write, so a
-    /rooms request that arrives while the writer is still in fsync, the reaper or the
-    create lock can walk the pre-write state and cache it — and nothing clears it again
-    afterwards. Validating against a stamp has no such ordering: store.append bumps these
-    counters *after* the record is on disk, so a stamp read before the walk can never be
-    newer than the data the walk sees. A stale entry is therefore always detected, whatever
-    order the two requests interleaved in.
+    This is the sole freshness mechanism, not merely a speed-up. A bare clear-on-write
+    could not be one: it ran *before* the store write, so a /rooms request arriving while
+    the writer was still in fsync, the reaper or the create lock could walk the pre-write
+    state and cache it, with nothing to clear it again afterwards. Validating against a
+    stamp has no such ordering: store.append bumps these counters *after* the record is on
+    disk, so a stamp read before the walk can never be newer than the data the walk sees.
+    A stale entry is therefore always detected, whatever order the two requests interleaved
+    in — and no writer has to reach into this cache to invalidate it, which is what used to
+    let a concurrent write turn a /rooms refresh into a 500 (#212).
 
     notes_written makes note and topic writes invalidate too, from any worker.
     """

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -92,9 +92,10 @@ def test_rooms_is_cached_but_never_stale_for_a_caller_that_just_wrote(client):
     """The /rooms walk is cached; read-your-writes is what makes that safe.
 
     A time-only cache breaks the one thing the view is for: an agent creates a room, checks
-    /rooms, and does not find it. Writes therefore invalidate, and they do it in `take` —
-    the single point every write route already passes through — so a route added later
-    cannot forget to.
+    /rooms, and does not find it. The stamp is what invalidates — store.append bumps the
+    on-disk counters `_rooms_stamp` reads, so a walk that runs after the write can never
+    match an entry stamped before it. A route added later cannot forget to invalidate,
+    because it goes through the same store the stamp watches.
     """
     client.get("/r/first/say/bot/hi")
     assert "first" in client.get("/rooms").text  # populates the cache
@@ -135,6 +136,41 @@ def test_rooms_cache_can_be_disabled_and_never_grows_past_its_bound(client, monk
         for limit in (1, 2, 3):
             client.get(f"/rooms?limit={limit}")
         assert list(app_module._rooms_cache) == [2, 3]
+
+
+def test_a_write_during_a_rooms_refresh_does_not_500(client, monkeypatch):
+    """A write arriving mid-refresh must not turn /rooms into a 500 (#212).
+
+    `_rooms_view` inserts the fresh entry and then promotes it to most-recently-used. A
+    write used to clear the whole cache from inside `take`; when that clear landed between
+    the insert and the promotion, the promotion referenced a key that was gone and the
+    refresh 500'd. Freshness is the stamp's job, not the clear's, so the listing has to
+    survive a write interleaved at exactly that point.
+
+    The interleaving is made deterministic the way the store races are (see
+    `_race_before_lock`): a real write is driven through the app at the one instruction
+    where the window is, not by threads and timing.
+    """
+    import collections
+
+    import app as app_module
+
+    client.get("/r/seed/say/bot/hi")  # a room to list, and the events room it announces
+    fired = []
+
+    class RacingCache(collections.OrderedDict):
+        def move_to_end(self, key, last=True):
+            if not fired:
+                fired.append(True)
+                client.get("/r/racer/say/writer/hi")  # a real write, mid-promotion
+            return super().move_to_end(key, last)
+
+    monkeypatch.setattr(app_module, "_rooms_cache", RacingCache())
+    refreshed = client.get("/rooms")
+
+    assert fired, "the refresh never reached the promotion — this test proved nothing"
+    assert refreshed.status_code == 200
+    assert "racer" in client.get("/rooms").text  # and the interleaved write is now visible
 
 
 def test_rooms_overview_carries_stats_newest_first(client, tmp_path):


### PR DESCRIPTION
## What

A write that arrives while `/rooms` is refreshing its cache no longer turns that refresh into a 500. Callers see the listing return normally under concurrent writes; response shapes and caps are unchanged.

## Why

Fixes #212. The rate-limit gate cleared the `/rooms` listing cache on every write. When that clear landed between `_rooms_view` inserting a fresh entry and promoting it to most-recently-used, the promotion referenced a key that was already gone and raised `KeyError`, surfacing as a 500.

The clear was never the freshness guarantee — it runs *before* the store write, so `_rooms_stamp` (bumped by `store.append` on every counted mutation, notes included) is what actually invalidates the cache. Removing the clear deletes the race at its source and leaves read-your-writes intact, rather than papering over it with a lock or a tolerant update. Net code lines are negative, so the `sz.py` cap holds.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 382 passed, 97.50%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — all pass
- [x] Docs that would now be wrong are updated: the `_rooms_stamp` docstring now names the stamp as the sole freshness mechanism; no manual/README surface changed
- [x] New surface on a world-writable service: nothing new — this only removes a redundant cache clear