### PR TITLE
fix(rooms): the trim tolerates a cache clear landing after it measured (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`GET /rooms` no longer returns 500 when a write clears the cache between the trim
+  measuring it and evicting from it.** The bound is applied by reading the size and then
+  calling `popitem`, and a writer's `_rooms_cache.clear()` (see `take`) landing between the
+  two left nothing to pop. The eviction now stops instead of raising. Same payload, same
+  cache bound.
+
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation

--- a/src/app.py
+++ b/src/app.py
@@ -664,7 +664,10 @@ def _rooms_view(limit: int) -> dict:
         _rooms_cache[limit] = (stamp, now, view)
         _rooms_cache.move_to_end(limit)
         while len(_rooms_cache) > MAX_ROOMS_CACHE:
-            _rooms_cache.popitem(last=False)
+            try:
+                _rooms_cache.popitem(last=False)
+            except KeyError:  # a write cleared it between the measurement and the eviction
+                break
     return view
 
 

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,19 +1,19 @@
 {
-  "core_total": 2015,
+  "core_total": 2018,
   "caps": {
-    "core/app.py": 977,
+    "core/app.py": 980,
     "core/config.py": 57,
     "core/didkey.py": 57,
     "core/limit.py": 132,
     "core/store.py": 792,
-    "core_total": 2015
+    "core_total": 2018
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1735,
-      "code_lines": 977,
-      "comment_lines": 239,
-      "tokens_per_line": 7.89
+      "raw_lines": 1738,
+      "code_lines": 980,
+      "comment_lines": 240,
+      "tokens_per_line": 7.87
     },
     "core/config.py": {
       "raw_lines": 242,

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -137,6 +137,37 @@ def test_rooms_cache_can_be_disabled_and_never_grows_past_its_bound(client, monk
         assert list(app_module._rooms_cache) == [2, 3]
 
 
+def test_rooms_trim_survives_a_cache_clear_after_it_measured(client, monkeypatch):
+    """`take` clears this cache on every write, from another thread, at a moment the
+    refresh does not choose. The trim reads the size and then evicts in a second step, so
+    a clear landing between them leaves `popitem` with nothing to pop — and its `KeyError`
+    reaches the caller as a 500 on the most polled read on the service.
+
+    Asserted through the status a caller sees. The mapping clears itself the instant its
+    size is taken, which is that interleaving and nothing else: no other step is disturbed.
+    """
+    from collections import OrderedDict
+
+    from starlette.testclient import TestClient
+
+    import app as app_module
+    import config
+
+    class ClearAfterLen(OrderedDict):
+        def __len__(self):
+            measured = super().__len__()
+            super().clear()
+            return measured
+
+    # The default TestClient re-raises, which would report this as a KeyError rather than
+    # as the 500 a real caller receives.
+    caller = TestClient(app_module.app, raise_server_exceptions=False)
+    with config.override(ROOMS_CACHE_SECONDS=60):
+        monkeypatch.setattr(app_module, "MAX_ROOMS_CACHE", 0)
+        monkeypatch.setattr(app_module, "_rooms_cache", ClearAfterLen())
+        assert caller.get("/rooms?limit=5").status_code == 200
+
+
 def test_rooms_overview_carries_stats_newest_first(client, tmp_path):
     import store
 


### PR DESCRIPTION
The second window in #212. The first one — `move_to_end` promoting an entry the clear removed — is the subject of #216, and nothing here touches it.

## What changes for a caller

`GET /rooms` returned 500 when a write's cache invalidation landed between the trim measuring the cache and evicting from it. It now returns the payload it always did. No route, response shape, cap or default moves.

## The window

`take` clears `_rooms_cache` on every write, from another thread, at a moment the refresh does not choose. The bound is applied in two steps:

```python
while len(_rooms_cache) > MAX_ROOMS_CACHE:
    _rooms_cache.popitem(last=False)
```

`len` authorises an eviction, the clear empties the mapping, and `popitem` finds nothing. `KeyError` then propagates out of the most polled read on the service.

This is independent of the `move_to_end` window. Applying #216's fix on top of current `main` and running the test below still fails — the promotion is gone, but the trim is untouched:

```
RUN 1  untouched main .......................... FAILED (assert 500 == 200)
RUN 2  with #216's fix applied .................. FAILED (assert 500 == 200)
RUN 3  with the change in this PR ............... passed
```

#216 flagged this window in its own description and scoped it out deliberately. #220 would have closed it from the other end by removing the clear entirely, and has since been closed in favour of #216 — so the trim keeps its concurrent clear, and the window stays open.

It is not an exotic one. `limit` is clamped to `1..MAX_LIMIT` (200), so 65 requests to distinct `?limit=` values put the cache over `MAX_ROOMS_CACHE`; at the documented 600 reads/min/IP that is about six and a half seconds, unauthenticated.

## Why `try`/`except` and not a snapshot

`list(_rooms_cache)[: len(...) - MAX_ROOMS_CACHE]` is line-neutral and looks tidier, but it is wrong here: iterating the mapping while a clear lands turns the same interleaving into `RuntimeError: OrderedDict changed size during iteration`. That is the same 500 by another name. The loop that never iterates, and stops when there is nothing to evict, is the smallest thing that is actually safe.

## Scope

`_rooms_cache` is the only mapping in `src/` that anything calls `.clear()` on. `_buckets`, `_recent` and `_window_memo` use the same `move_to_end`/`popitem` shape but have no cross-request clear, so the interleaving cannot arise for them. Nothing else is touched.

## Tests

`tests/http/test_rooms.py::test_rooms_trim_survives_a_cache_clear_after_it_measured` drives exactly this interleaving with a mapping that clears itself the instant its size is taken, and asserts on the status a caller sees rather than on cache internals. It fails on `main` and passes with the change.

## Checks

```
ruff check .                All checks passed
ruff format --check .       54 files already formatted
ty check                    All checks passed
pytest tests                382 passed
coverage report             97.51% total  (main: 97.50%, fail_under = 96)
sz.py --check               ok
contract (schemathesis)     867 generated, 867 passed, no issues
```

The contract job was run with the check and warning lists from `.github/workflows/ci.yml` rather than the shortened form in `CONTRIBUTING.md`, since the two defaults that form omits are the ones this service breaks on purpose.

## Core size

The guard costs three code lines in `core/app.py`, which sat exactly at its cap. `caps["core/app.py"]` 977 → 980 and `caps["core_total"]` 2015 → 2018 — the same shape and size as #197, which moved `core/store.py` 789 → 792.

`sz.py --update-baseline` was not committed wholesale: on untouched `main` it also rewrites the `config.py` and `manifest.py` rows, drift that predates this change. Only the `core/app.py` row and the two totals move here.

## Documentation and compatibility

`CHANGELOG.md` under `[Unreleased]`. No manual, `manifest.py` or `openapi.json` change: no route, status code or response field moves, and the cache's LRU order and bound are unchanged.

## Abuse impact

None. No new public surface, and the eviction bound is unchanged — a caller cannot use this to grow the cache past `MAX_ROOMS_CACHE`.

## Dependencies

None. Independent of #216 — a different statement, and applying #216's fix leaves the test below failing. #220 is closed.
