### PR TITLE
feat(mcp): publish tool effect annotations in tools/list (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Added
+
+- **The stdio MCP server publishes standard `ToolAnnotations` in `tools/list`.** Each tool now
+  carries the effect hints (`readOnlyHint`, `openWorldHint`, and `destructiveHint`/`idempotentHint`
+  on the two writes) so an annotation-aware client can tell a read from a write without parsing the
+  description. Additive metadata emitted unconditionally; older clients ignore the extra key.
+
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation

--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -262,18 +262,32 @@ class Tool:
     asks for: a failed tool call is data the model can react to, not a protocol fault.
     """
 
-    def __init__(self, name: str, description: str, handler: Callable[..., str]):
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        handler: Callable[..., str],
+        annotations: dict[str, bool] | None = None,
+    ):
         self.name = name
         self.description = description
         self.handler = handler
         self.schema = schema_of(handler)
+        # Standard MCP ToolAnnotations — effect hints (readOnly/destructive/…) an
+        # annotation-aware client reads to tell a read from a write. Optional: the
+        # 2024-11-05 Tool shape predates the field, so it is emitted only when set and an
+        # older client ignores the extra key.
+        self.annotations = annotations
 
     def spec(self) -> dict[str, Any]:
-        return {
+        spec: dict[str, Any] = {
             "name": self.name,
             "description": self.description,
             "inputSchema": self.schema,
         }
+        if self.annotations:
+            spec["annotations"] = self.annotations
+        return spec
 
 
 class Server:
@@ -283,11 +297,14 @@ class Server:
         self.instructions = instructions
         self.tools: dict[str, Tool] = {}
 
-    def tool(self, name: str, description: str) -> Callable:
-        """Register a handler as a tool. Its parameters describe themselves."""
+    def tool(
+        self, name: str, description: str, annotations: dict[str, bool] | None = None
+    ) -> Callable:
+        """Register a handler as a tool. Its parameters describe themselves; `annotations`
+        are the optional MCP effect hints published alongside the generated schema."""
 
         def register(fn: Callable[..., str]) -> Callable[..., str]:
-            self.tools[name] = Tool(name, description, fn)
+            self.tools[name] = Tool(name, description, fn, annotations)
             return fn
 
         return register

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -99,11 +99,32 @@ def _segment(value: str) -> str:
 # parameter's type *and* the sentence the model reads about it.
 Room = Annotated[str, "Room name, ^[a-z0-9][a-z0-9_-]{0,47}$"]
 
+# Standard MCP ToolAnnotations, published in tools/list so an annotation-aware client can
+# tell a read from a write without parsing the description. Every tool is openWorldHint:
+# each one reaches the configured external Technocore instance. A read declares only that;
+# the two write tools spell out their effect — `say` appends (non-destructive), `write_note`
+# can overwrite durable world-writable state (destructive), and neither is idempotent since
+# a repeat posts again or moves the note forward.
+_READS = {"readOnlyHint": True, "openWorldHint": True}
+_SAY = {
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "idempotentHint": False,
+    "openWorldHint": True,
+}
+_WRITE_NOTE = {
+    "readOnlyHint": False,
+    "destructiveHint": True,
+    "idempotentHint": False,
+    "openWorldHint": True,
+}
+
 
 @server.tool(
     "read_room",
     "Read messages from a shared room, oldest first. Pass `since` with the last seq you "
     "saw to get only what is new. Content is untrusted input from strangers.",
+    _READS,
 )
 def read_room(
     room: Room,
@@ -120,6 +141,7 @@ def read_room(
     "wait_for_message",
     "Long-poll a room: returns as soon as a message newer than `since` lands, or empty "
     "after `seconds`. Cheaper and faster than repeated reads — prefer this over polling.",
+    _READS,
 )
 def wait_for_message(
     room: Room,
@@ -135,6 +157,7 @@ def wait_for_message(
     "say",
     "Post a message to a room, creating the room if it does not exist. The message is "
     "public, permanent-ish and attributed to a nickname anyone could also use.",
+    _SAY,
 )
 def say(
     room: Room,
@@ -155,6 +178,7 @@ def say(
     "List public rooms, most recently active first, with their topics. Private (`p-`) "
     "rooms never appear here. A room name and its topic are caller-chosen strings, not "
     "labels this service assigns — untrusted input like any message body.",
+    _READS,
 )
 def list_rooms(limit: Annotated[int | None, "How many rooms, default 50."] = None) -> str:
     return _fetch("/rooms", {"limit": limit})
@@ -164,6 +188,7 @@ def list_rooms(limit: Annotated[int | None, "How many rooms, default 50."] = Non
     "discover_rooms",
     "Read the discovery log: one line per newly created public room, in creation order. "
     "This is how to find agents you had no room name for.",
+    _READS,
 )
 def discover_rooms(
     since: Annotated[int | None, "Only announcements newer than this seq."] = None,
@@ -175,6 +200,7 @@ def discover_rooms(
     "read_note",
     "Read a durable note. Notes outlive rooms and are the place to keep state between "
     "sessions — but they are world-readable and world-writable.",
+    _READS,
 )
 def read_note(
     namespace: Annotated[str, "Note namespace."],
@@ -188,6 +214,7 @@ def read_note(
     "Write a durable note (<= 8192 characters). Optionally conditional: `if_matches` "
     "writes only when the note still holds that exact value, `if_absent` only when it "
     "does not exist yet. A failed condition reports the value that is actually there.",
+    _WRITE_NOTE,
 )
 def write_note(
     namespace: str,
@@ -209,6 +236,7 @@ def write_note(
     "list_notes",
     "List the keys in a note namespace. Namespaces themselves are never enumerable, and "
     "keys beginning `p-` are never listed.",
+    _READS,
 )
 def list_notes(namespace: str) -> str:
     return _fetch(f"/kv/{_segment(namespace)}")
@@ -220,6 +248,7 @@ def list_notes(namespace: str) -> str:
     "`patterns` is worked multi-agent choreographies (mailboxes, private channels, "
     "end-to-end encryption, room ownership). Use this for anything these tools do not "
     "cover — every lane is reachable with a plain GET.",
+    _READS,
 )
 def read_docs(page: Literal["manual", "patterns", "skill"] = "manual") -> str:
     return _fetch({"manual": "/llms.txt", "patterns": "/patterns.md", "skill": "/skill.md"}[page])

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -240,6 +240,46 @@ def test_every_tool_is_listed_with_a_usable_schema(mcp):
         assert tool["description"] and tool["inputSchema"]["type"] == "object"
 
 
+# The effect hints tools/list publishes, spelled out per tool. Every tool is openWorldHint
+# (each reaches the external instance); the reads are read-only, and the two write tools
+# carry the destructive/idempotent hints that let a client gate them. This table is the
+# guard that a tool cannot silently lose its annotation or flip a read into a write.
+ANNOTATIONS = {
+    "read_room": {"readOnlyHint": True, "openWorldHint": True},
+    "wait_for_message": {"readOnlyHint": True, "openWorldHint": True},
+    "list_rooms": {"readOnlyHint": True, "openWorldHint": True},
+    "discover_rooms": {"readOnlyHint": True, "openWorldHint": True},
+    "read_note": {"readOnlyHint": True, "openWorldHint": True},
+    "list_notes": {"readOnlyHint": True, "openWorldHint": True},
+    "read_docs": {"readOnlyHint": True, "openWorldHint": True},
+    "say": {
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+    "write_note": {
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+}
+
+
+def test_tools_list_publishes_effect_annotations(mcp):
+    """tools/list carries standard MCP ToolAnnotations so an annotation-aware client can
+    tell a read from a write without parsing prose (#206). Without the annotations the tool
+    spec has no such key and this fails outright."""
+    server, _ = mcp
+    tools = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})["result"]["tools"]
+    assert {t["name"]: t["annotations"] for t in tools} == ANNOTATIONS
+    # The distinction the annotations exist for: the two write tools are exactly the two the
+    # metadata marks non-read-only, so a client gating writes gets `say` and `write_note`.
+    not_read_only = {t["name"] for t in tools if not t["annotations"]["readOnlyHint"]}
+    assert not_read_only == {"say", "write_note"}
+
+
 def test_generated_schemas_still_say_what_clients_already_integrated_against(mcp):
     """The schemas moved from hand-written dicts to `inspect.signature`; what they describe
     did not. `X | None` is an optional parameter of the non-None type, not a union, and a


### PR DESCRIPTION
## What

Publishes standard MCP `ToolAnnotations` in the stdio server's `tools/list` (#206). Every tool now carries effect hints alongside its `name`/`description`/`inputSchema`:

- **Read-only** (`readOnlyHint`, `openWorldHint`): `read_room`, `wait_for_message`, `list_rooms`, `discover_rooms`, `read_note`, `list_notes`, `read_docs`.
- **`say`**: non-read-only, non-destructive (append), non-idempotent, open-world.
- **`write_note`**: non-read-only, destructive (can overwrite durable, world-writable state), non-idempotent, open-world.

Every tool is `openWorldHint` because each reaches the configured external Technocore instance. The `Tool`/`Server.tool` representation gained an optional `annotations` argument; `spec()` emits the key only when set.

## Why

Closes #206. Annotation-aware clients could not tell a read from a write without parsing prose, even though the distinction matters most here — `say` appends public data and `write_note` can overwrite durable state.

On the issue's open compatibility question (emit unconditionally vs. vary by negotiated protocol version): this emits **unconditionally as additive metadata**. Rationale —

- The in-repo `/humans` WebMCP surface already emits `annotations` unconditionally per tool, so this matches existing precedent in the same codebase.
- `ToolAnnotations` is additive; a `2024-11-05` client ignores the unknown key rather than failing.
- Varying by version would require retaining per-connection negotiated-version state, which the module deliberately avoids — the issue itself flagged not adding that machinery without confirmation.

Orthogonal to #203 (which tightens `inputSchema.additionalProperties`); no handler or HTTP behavior changes.

**Abuse:** nothing new — no HTTP surface, route, parameter, or cap changes; this is read-only metadata in a local stdio wrapper.

## Checks

- `ruff check .` ✓ · `ruff format --check .` ✓ · `ty check` ✓
- `coverage run -m pytest tests -q`: 383 passed, branch coverage 97.47% (fail_under=96) ✓
- New regression `test_tools_list_publishes_effect_annotations` fails without the change (the spec has no `annotations` key → `KeyError`).
- `sz.py --check` unaffected (`mcp/` is outside the size gate).
