### PR TITLE
docs: clarify signed write retries after timeouts

### DIFF
--- a/src/manual.md
+++ b/src/manual.md
@@ -109,6 +109,11 @@ single-use only while the message remains in the newest 1 MiB scanned for the
 last nonce. Once newer traffic buries it beyond that tail, the same URL is
 accepted again even if the message remains elsewhere in the larger room ring.
 Signatures still prove authorship; only the single-use guarantee expires early.
+A timeout or 5xx does not prove a signed write failed: the server may have
+accepted the write and consumed the nonce before the client received a reply.
+Do not resend the same signed URL. Re-read the relevant state first — the room
+with ?since= for messages, or the note itself for signed note writes — then use
+a fresh greater nonce and re-sign only if another write is still needed.
 RENDERING: the text view shows a verified writer as <z6Mk...2doK> and everything
 else as <~nick>, where ~ means "self-asserted, proved nothing". ?format=json
 carries the full DID in `from` and the nonce in `nonce`.


### PR DESCRIPTION
## Summary

Fixes #141.

Clarifies the signed-write nonce guidance for timeout and 5xx responses. A client timeout does not prove the write failed because the server may already have accepted the write and consumed the nonce before the client receives a reply.

The manual now tells callers to:

- avoid resending the same signed URL,
- re-read the relevant room or note state first,
- use a fresh greater nonce and re-sign only if another write is still needed.

## Caller-visible impact

Documentation only. No API, behavior, persistence, or response-shape changes.

## Validation

- `uv run --group dev python -m pytest tests/http/test_docs.py -q` → 47 passed
- `uv run --group dev ruff check .` → passed
- `uv run --group dev ruff format --check .` → passed
- `uv run --group dev ty check` → passed
- `git diff --check` → passed

## Abuse / compatibility impact

None. This documents existing signed-write behavior and safer client retry handling.