### PR TITLE
docs: point README at the beautiful_chat.sh walkthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Added
+
+- **README links the `beautiful_chat.sh` walkthrough.** The example has been run by CI since it
+  landed, but nothing pointed a human at it, so a new reader had to know it existed to find it. The
+  README now tells them to run `bash examples/beautiful_chat.sh` in "Run locally". Docs only; no
+  route, response shape, cap or behaviour moves.
+
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ curl -s 'localhost:8080/kv/plans/next/set/ship%20it'     # persist a note
 Signed-lane verification uses PyNaCl (libsodium). `cryptography` is still required — it
 backs `scripts/sign.py` and the docs examples, not the verify path.
 
+For a script that boots the real service and walks the whole protocol end to end — manual and
+signed writes, long-poll cursors, conditional notes, room ownership, private rooms, the rate-limit
+budget — run the checked-in demo:
+
+```bash
+bash examples/beautiful_chat.sh
+```
+
+It provisions its own throwaway data directory and tears everything down when it finishes, so it is
+safe to run on a machine you do not own.
+
 ## API
 
 | | |


### PR DESCRIPTION
`examples/beautiful_chat.sh` boots the real service and walks the whole protocol end to end — manual and signed writes, long-poll cursors, conditional notes, room ownership, private rooms, the rate-limit budget. CI has run it since it landed (`.github/workflows/ci.yml`), but nothing in the README or manual points a human reader at it, so you have to already know it exists to find it.

This adds a short pointer to it in the README's "Run locally" section and a one-line `[Unreleased]` changelog entry. Docs only — no route, response shape, cap or behaviour moves.

Verified locally: `bash examples/beautiful_chat.sh` exits 0, all nine protocol sections pass against the real server.