### PR TITLE
fix: reserve server nickname for event messages

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1389,6 +1389,9 @@ def append(
     primitive that already exists does the rest — `?since=` for incremental reads,
     `?format=json`, `?wait=` for near-real-time, ring retention, the same rate limits.
     """
+    if did is None and nick == EVENTS_NICK:
+        raise StoreError(f"reserved nickname: {EVENTS_NICK}")
+
     rec, created = _write_record(root, room, nick, text, did=did, nonce=nonce)
     # Counted here rather than in `_write_record`, so the server's own announcements
     # (`_log_event` writes one per created room) never inflate the message count. This

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -27,6 +27,13 @@ def test_say_then_read(client):
     assert "UNTRUSTED CONTENT" in body  # injection framing always present
 
 
+def test_unsigned_writer_cannot_impersonate_server(client):
+    response = client.get("/r/lobby/say/server/created%20official-room")
+
+    assert response.status_code == 400
+    assert "<~server>" not in client.get("/r/lobby").text
+
+
 def test_since_cursor_returns_only_new(client):
     for i in range(3):
         client.get(f"/r/lobby/say/bot/msg{i}")


### PR DESCRIPTION
## Summary

Fixes #137.

Unsigned callers could use the nickname `server`, which renders as `<~server>` and is indistinguishable from the service's own event author in text views.

This change reserves `server` for server-authored event records by rejecting unsigned `store.append(...)` calls that use `EVENTS_NICK`. Genuine event announcements remain unchanged because `_log_event()` writes through `_write_record()` directly.

## Caller-visible impact

- Unsigned writes with `nick=server` now return HTTP 400.
- Other unsigned nicknames are unchanged.
- Signed writes are unchanged because their stored `from` value is the verified DID, not the nickname.
- Genuine `/r/events` announcements continue to render as `<~server>`.

## Reproduction and validation

Before the fix, the regression test reproduced the issue with `assert 200 == 400` for:

`GET /r/lobby/say/server/created%20official-room`

After the fix:

- `tests/http/test_rooms.py::test_unsigned_writer_cannot_impersonate_server` → passed
- `tests/http/test_rooms.py::test_new_public_rooms_are_announced` → passed
- `tests/http/test_rooms.py` → 49 passed
- `uv run --group dev ruff check .` → passed
- `uv run --group dev ruff format --check .` → passed
- `uv run --group dev ty check` → passed
- `git diff --check` → passed

## Abuse / compatibility impact

This removes one impersonation path from the unsigned lane without changing room authorization, event storage, response shapes, or signed identity semantics.