### PR TITLE
fix(rooms): tolerate window memo eviction after cache hit

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -19,7 +19,7 @@ import time
 import unicodedata
 from collections import OrderedDict
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
@@ -928,10 +928,10 @@ _window_memo: OrderedDict[tuple, tuple] = OrderedDict()
 
 
 def _cached_window(root: Path, name: str, stamp: tuple) -> tuple[int, list[str]]:
-    key = (str(root), name)
-    hit = _window_memo.get(key)
+    hit = _window_memo.get(key := (str(root), name))
     if hit and hit[0] == stamp:
-        _window_memo.move_to_end(key)
+        with suppress(KeyError):
+            _window_memo.move_to_end(key)
         return hit[1]
     view = room_window(root, name)
     _window_memo[key] = (stamp, view)

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -16,9 +16,9 @@
       "tokens_per_line": 7.78
     },
     "core/config.py": {
-      "raw_lines": 324,
+      "raw_lines": 312,
       "code_lines": 61,
-      "comment_lines": 207,
+      "comment_lines": 195,
       "tokens_per_line": 12.56
     },
     "core/didkey.py": {
@@ -40,8 +40,8 @@
       "tokens_per_line": 7.38
     },
     "extra/manifest.py": {
-      "raw_lines": 1819,
-      "code_lines": 1321,
+      "raw_lines": 1818,
+      "code_lines": 1320,
       "comment_lines": 152,
       "tokens_per_line": 3.83
     }

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -16,9 +16,9 @@
       "tokens_per_line": 7.78
     },
     "core/config.py": {
-      "raw_lines": 312,
+      "raw_lines": 324,
       "code_lines": 61,
-      "comment_lines": 195,
+      "comment_lines": 207,
       "tokens_per_line": 12.56
     },
     "core/didkey.py": {
@@ -34,14 +34,14 @@
       "tokens_per_line": 8.48
     },
     "core/store.py": {
-      "raw_lines": 2088,
+      "raw_lines": 2089,
       "code_lines": 883,
       "comment_lines": 462,
       "tokens_per_line": 7.38
     },
     "extra/manifest.py": {
-      "raw_lines": 1818,
-      "code_lines": 1320,
+      "raw_lines": 1819,
+      "code_lines": 1321,
       "comment_lines": 152,
       "tokens_per_line": 3.83
     }

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -338,6 +338,46 @@ def test_a_rewalked_entry_is_the_newest_and_the_oldest_is_what_leaves(client, mo
         assert list(app_module._rooms_cache) == [2, 4], "the oldest walk is what leaves"
 
 
+def test_rooms_survives_a_window_memo_hit_evicted_before_promotion(client, tmp_path, monkeypatch):
+    """A full window memo can evict a valid hit before this request promotes it.
+
+    The memo holds 512 of up to 5120 rooms. Once full, another /rooms refresh can insert
+    a newly active room after this one reads a hit but before it calls move_to_end. The
+    lost LRU promotion is harmless; its KeyError reaching the caller as a 500 is not.
+
+    Evicting on get is the deterministic form of that exact interleaving. Assert through
+    the HTTP status a caller sees, and assert the hook fired so this cannot pass while
+    proving nothing.
+    """
+    from collections import OrderedDict
+
+    from starlette.testclient import TestClient
+
+    import app as app_module
+    import config
+    import store
+
+    store._window_memo.clear()
+    with config.override(ROOMS_CACHE_SECONDS=0):
+        client.get("/r/cache-hit/say/bot/hello")
+        assert client.get("/rooms?limit=2").status_code == 200
+
+        fired = []
+
+        class EvictHit(OrderedDict):
+            def get(self, key, default=None):
+                hit = super().get(key, default)
+                if hit is not None and not fired:
+                    fired.append(key)
+                    super().pop(key)
+                return hit
+
+        monkeypatch.setattr(store, "_window_memo", EvictHit(store._window_memo))
+        caller = TestClient(app_module.app, raise_server_exceptions=False)
+        assert caller.get("/rooms?limit=2").status_code == 200
+        assert fired, "no memo hit was evicted — this test proved nothing"
+
+
 def test_rooms_overview_carries_stats_newest_first(client, tmp_path):
     import store
 


### PR DESCRIPTION
Closes #229.

## What

`GET /rooms` now tolerates a window-memo hit being evicted before LRU promotion. It returns the captured view instead of 500. No contract or cache bound changes.

## Why

`_cached_window()` reads and promotes a hit separately. A concurrent refresh can fill the 512-entry memo and evict the key between `get()` and `move_to_end()`. The captured value remains valid for the request's `(mtime_ns, size)` stamp, so only the lost promotion is suppressed.

| State | Result |
| --- | --- |
| valid hit, still present | promoted and returned |
| valid hit, concurrently evicted | captured view returned |
| stale or missing hit | recomputed as before |

The HTTP regression forces this eviction and fails on current `main` with `500 != 200`. This is separate from #245 (`app._rooms_cache`); this fix concerns `store._window_memo`.

## Checks

- [x] Full suite: 399 passed; branch coverage 97.56%
- [x] Ruff lint/format and `ty check`
- [x] `sz.py --check` and `--caps`
- [x] No public-contract documentation change; nothing new for abusive callers

Proposed release note: Prevent `/rooms` from returning 500 when a concurrent refresh evicts a valid window-cache hit before LRU promotion.
