### PR TITLE
fix(store): keep reaped writes inside capacity gates

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1634,7 +1634,9 @@ def _check_note_capacity(root: Path, ns_dir: Path, path: Path) -> None:
 
 @contextmanager
 def _create_gate(gate: Path, path: Path, check, counted=None):
-    """Serialise *creation* so a cap counted across files is exact, not merely likely.
+    """Lock one object and serialise its creation so shared caps stay exact.
+
+    Yields whether the protected write creates the object.
 
     A per-file lock cannot enforce a cap over other files: two concurrent creates of
     different names each pass their own lock, each count `cap - 1`, and both write, so
@@ -1656,28 +1658,36 @@ def _create_gate(gate: Path, path: Path, check, counted=None):
         hence the second `path.exists()`, which is not the one above it: that one runs
         before the wait, this one after.
     """
+    # Keep ordinary overwrites off the shared gate, but recheck under their own lock: the
+    # reaper can delete the file between this first look and the lock acquisition. Such a
+    # write is a create again and must take the shared gate below.
     if path.exists():
-        yield
-        return
+        with _locked(path):
+            if path.exists():
+                yield False
+                return
     with _locked(gate):
-        if path.exists():  # created while we waited: this is an overwrite now, not a create
-            yield
-            return
-        check()  # authoritative: nothing else can create between this count and the write
-        if counted is not None:
-            # Before the write, not after: a crash in between leaves the count one too
-            # high, which refuses a create that was allowed. The other order leaves it one
-            # too low, which allows one that should have been refused.
-            counted(1)
-        try:
-            yield
-        finally:
-            # Exact rather than merely fail-closed: a reservation nothing was written
-            # against is given back. Keyed on the file rather than on whether the body
-            # raised, because "was a note created" is the question, and the file is the
-            # only thing that answers it.
-            if counted is not None and not path.exists():
-                counted(-1)
+        existed = path.exists()  # it may have been created while we waited for the gate
+        if not existed:
+            check()  # refuse a truly new name before its sidecar lock can be created
+        with _locked(path):
+            creating = not path.exists()
+            if creating and existed:  # the reaper won the second gate-to-object gap
+                check()
+            if creating and counted is not None:
+                # Before the write, not after: a crash in between leaves the count one too
+                # high, which refuses a create that was allowed. The other order leaves it
+                # one too low, which allows one that should have been refused.
+                counted(1)
+            try:
+                yield creating
+            finally:
+                # Exact rather than merely fail-closed: a reservation nothing was written
+                # against is given back. Keyed on the file rather than on whether the body
+                # raised, because "was a note created" is the question, and the file is the
+                # only thing that answers it.
+                if creating and counted is not None and not path.exists():
+                    counted(-1)
 
 
 def append(
@@ -1795,17 +1805,13 @@ def _write_record(
     # behind every other create, and a rotating room name flooding rejections should not
     # queue up behind them. The check inside the gate stays authoritative.
     _check_room_capacity(root, path)
-    with (
-        _create_gate(
-            root / ".rooms-create",
-            path,
-            lambda: _check_room_capacity(root, path),
-        ),
-        _locked(path),
-    ):
+    with _create_gate(
+        root / ".rooms-create",
+        path,
+        lambda: _check_room_capacity(root, path),
+    ) as created:
         # Under the lock, before the write: two concurrent first-writers must not both
         # decide they created the room and announce it twice.
-        created = not path.exists()
         # Also under the lock, or two concurrent replays of one captured URL would both
         # read the same "last nonce" and both write.
         if did is not None:
@@ -1916,20 +1922,17 @@ def note_set(
     _reap(root)
     # The global half only, and only for a create. This used to be the whole check, which
     # meant every create scanned its namespace twice — once here and once as the gate's
-    # own check — to buy a property the gate already has: its check runs in `__enter__`,
-    # strictly before `_locked(path)` is entered, so a refusal never leaves a sidecar lock
-    # or a namespace directory behind either way. What this call is actually worth is
+    # own check — to buy a property the gate already has: its check refuses a genuinely new
+    # name before taking its object lock, so the refusal leaves no sidecar or namespace.
+    # What this call is actually worth is
     # shedding a full store's worth of refusals without queueing for the gate first.
     if not path.exists():
         _check_note_total(root)
-    with (
-        _create_gate(
-            root / ".notes-create",
-            path,
-            lambda: _check_note_capacity(root, ns_dir, path),
-            lambda d: _count_new_note(root, ns_dir, len(value.encode("utf-8")), d),
-        ),
-        _locked(path),
+    with _create_gate(
+        root / ".notes-create",
+        path,
+        lambda: _check_note_capacity(root, ns_dir, path),
+        lambda d: _count_new_note(root, ns_dir, len(value.encode("utf-8")), d),
     ):
         if expect_absent or expect is not None:
             current = path.read_text(encoding="utf-8") if path.exists() else None

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -186,6 +186,58 @@ def test_a_capacity_refusal_carries_the_numbers_a_caller_acts_on(tmp_path, monke
         store.append(tmp_path, "overflow", "bot", "hi")
 
 
+def test_reaped_room_overwrite_reenters_the_creation_gate(tmp_path, monkeypatch):
+    """A room that vanishes before its object lock is a create again, not an overwrite.
+
+    The overwrite fast path used to skip the shared creation gate before taking the room
+    lock. The reaper could delete that room in the gap, another caller could fill the freed
+    slot, and the stalled writer would then recreate its room past the hard cap.
+    """
+    import store
+
+    monkeypatch.setattr(store, "MAX_ROOMS", 1)
+    old = store.room_path(tmp_path, "p-old")
+    store.append(tmp_path, "p-old", "bot", "first")
+    _age(old, store.IDLE_SECONDS + 60)
+
+    def reap_and_fill_slot():
+        _reap_now(tmp_path)
+        assert not old.exists()
+        store.append(tmp_path, "p-new", "bot", "replacement")
+
+    raced = _race_before_lock(monkeypatch, store, old, reap_and_fill_slot)
+    with pytest.raises(store.StoreError, match="room limit"):
+        store.append(tmp_path, "p-old", "bot", "late overwrite")
+
+    assert raced, "the room never vanished in the overwrite-to-lock gap"
+    assert store.room_path(tmp_path, "p-new").exists()
+    assert store._scan(tmp_path / "rooms", ".jsonl")[0] == 1
+
+
+def test_reaped_note_overwrite_reenters_the_creation_gate(tmp_path, monkeypatch):
+    """A reaped note cannot recreate outside the cap and its cached count."""
+    import store
+
+    monkeypatch.setattr(store, "MAX_NOTES_TOTAL", 1)
+    monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 1)
+    old = store.note_path(tmp_path, "plans", "old")
+    store.note_set(tmp_path, "plans", "old", "first")
+    _age(old, store.IDLE_SECONDS + 60)
+
+    def reap_and_fill_slot():
+        _reap_now(tmp_path)
+        assert not old.exists()
+        store.note_set(tmp_path, "plans", "new", "replacement")
+
+    raced = _race_before_lock(monkeypatch, store, old, reap_and_fill_slot)
+    with pytest.raises(store.StoreError, match="note limit"):
+        store.note_set(tmp_path, "plans", "old", "late overwrite")
+
+    assert raced, "the note never vanished in the overwrite-to-lock gap"
+    assert store.list_notes(tmp_path, "plans") == ["new"]
+    assert store.note_stats(tmp_path)["total"] == 1
+
+
 def test_an_empty_usage_file_reads_as_no_pressure(tmp_path):
     """A write cut short leaves the file there and empty. Reading that as *some* pressure
     would throttle every room to its floor on the strength of a truncated write; the


### PR DESCRIPTION
## Problem

Room and note overwrites skip the shared creation gate when their file exists. The reaper can delete that file before the writer acquires its object lock. If another caller fills the freed slot first, the stalled overwrite recreates its object outside the shared gate.

Observed with both caps set to 1:

- two room files remain on disk after the race;
- two note files remain on disk while the cached note count still reports 1.

That breaks the fail-closed capacity invariant.

## What changes

`_create_gate` now owns the object lock as well as the shared creation gate:

- ordinary overwrites remain off the shared gate;
- an overwrite rechecks existence under its object lock;
- a vanished overwrite retries through the shared gate and current capacity check;
- genuinely new names are still refused before creating a sidecar lock;
- note reservations still roll back only when this call reserved a create.

The helper now yields whether the write created the object, avoiding another room-file stat in the caller.

## Regression proof

Two deterministic tests reproduce the same ordering for rooms and notes:

1. begin an overwrite of an idle object;
2. reap it before its object lock;
3. fill the only available capacity slot with another object;
4. resume the stalled overwrite.

Both tests fail on the old implementation because the old object is recreated past the cap. Both pass with this change because the resumed write gets the ordinary capacity refusal.

## Verification

- `uv sync --frozen`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run sz.py --check`: core shrinks from 2067 to 2065 code lines
- `uv run coverage run -m pytest tests -q`: 433 passed
- `uv run coverage report`: 97.61%
- `git diff --check`
- `git merge-tree --write-tree origin/main HEAD`

## Compatibility and abuse impact

No API, response, limit, or default changes. Existing objects keep accepting writes. This closes a race that could exceed hard room and note caps and make the note counter underreport stored state.

~ codex & piotr