### PR TITLE
Validate DID-note writes on the did/did-<shard> namespaces (closes #199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Changed
+
+- **DID-note writes are now validated on write.** A `did` / `did-<2hex>` note whose
+  value has no well-formed `did:key`, or whose `did:key` does not fingerprint to the
+  slot, is refused with `400` instead of `200`. The `did` namespace sits at its hard
+  cap, so this stops slots a working identity cannot have from filling with values
+  that answer no lookup (issue #199). Ordinary namespaces (`did-registry`, `did-xyz`)
+  are unaffected, and signed writes still get the lane-policy refusal first.
+
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation

--- a/src/app.py
+++ b/src/app.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import re
 import secrets
 import time
 import tomllib
@@ -1182,6 +1183,33 @@ def _condition(source: dict) -> tuple[str | None, bool]:
     return (str(expect) if expect is not None else None), False
 
 
+def _validate_did_note(ns: str, key: str, value: str) -> Response | None:
+    """Refuse DID-note writes that cannot answer the lookup the namespace exists for (#199).
+
+    The `did`/`did-<shard>` namespaces are at a hard cap; a value with no
+    well-formed did:key, or one whose fingerprint does not match the slot, wastes
+    a slot a working identity cannot have. Returns a 400 to refuse, else None.
+    """
+    if ns != "did" and not ns.startswith("did-"):
+        return None
+    m = re.search(r"did:key:z[1-9A-HJ-NP-Za-km-z]+", value)
+    if not m or not didkey.is_did(m.group(0)):
+        return text(
+            "400 a DID-note value must contain a well-formed did:key:z6Mk… "
+            "(ed25519-pub); storing other text wastes a capped-namespace slot.",
+            400,
+        )
+    fp = hashlib.sha256(m.group(0).encode()).hexdigest()[:16]
+    expected = (ns[4:] + key) if ns.startswith("did-") else key
+    if fp != expected:
+        return text(
+            f"400 the did:key in this note does not fingerprint to slot {expected}; "
+            "a reader following the documented path would never reach it.",
+            400,
+        )
+    return None
+
+
 def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Response | None:
     """Two reserved namespaces carry room ownership, and only those two take signed writes.
 
@@ -1191,6 +1219,9 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
     stranger cannot rewrite — without that, ownership is a note anyone can overwrite, which
     is not ownership.
     """
+    denied = _validate_did_note(ns, key, value)
+    if denied:
+        return denied
     if ns == store.NONCE_NS:
         return text(
             f"403 /kv/{store.NONCE_NS} is written by the server only — it is the replay "

--- a/src/app.py
+++ b/src/app.py
@@ -1186,25 +1186,34 @@ def _condition(source: dict) -> tuple[str | None, bool]:
 def _validate_did_note(ns: str, key: str, value: str) -> Response | None:
     """Refuse DID-note writes that cannot answer the lookup the namespace exists for (#199).
 
-    The `did`/`did-<shard>` namespaces are at a hard cap; a value with no
-    well-formed did:key, or one whose fingerprint does not match the slot, wastes
-    a slot a working identity cannot have. Returns a 400 to refuse, else None.
+    Only the DID-note namespaces are subject to it: the legacy `did/<16hex>` and the
+    sharded `did-<2hex per manual>` — matched exactly, so `did-registry` / `did-xyz`
+    stay ordinary world-writable namespaces. A value with no well-formed did:key, or
+    one whose fingerprint does not match the slot, wastes a slot a working identity
+    cannot have. Returns a 400 to refuse, else None.
     """
-    if ns != "did" and not ns.startswith("did-"):
+    if ns != "did" and not re.fullmatch(r"did-[0-9a-f]{2}", ns):
         return None
     m = re.search(r"did:key:z[1-9A-HJ-NP-Za-km-z]+", value)
     if not m or not didkey.is_did(m.group(0)):
         return text(
             "400 a DID-note value must contain a well-formed did:key:z6Mk… "
-            "(ed25519-pub); storing other text wastes a capped-namespace slot.",
+            "(ed25519-pub). For other state use a private namespace: "
+            "/kv/p-<random>/state (manual, PRIVATE).",
             400,
         )
     fp = hashlib.sha256(m.group(0).encode()).hexdigest()[:16]
+    if ns == "did" and not re.fullmatch(r"[0-9a-f]{16}", key):
+        return text(
+            "400 the did/ slot key must be the 16-hex SHA-256 fingerprint of the "
+            "did:key it stores; it is not a free-form name.",
+            400,
+        )
     expected = (ns[4:] + key) if ns.startswith("did-") else key
     if fp != expected:
         return text(
-            f"400 the did:key in this note does not fingerprint to slot {expected}; "
-            "a reader following the documented path would never reach it.",
+            f"400 the did:key in this note fingerprints to /kv/did-{fp[:2]}/{fp[2:]}, "
+            "not this slot; a reader following the documented path would never reach it.",
             400,
         )
     return None
@@ -1219,9 +1228,6 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
     stranger cannot rewrite — without that, ownership is a note anyone can overwrite, which
     is not ownership.
     """
-    denied = _validate_did_note(ns, key, value)
-    if denied:
-        return denied
     if ns == store.NONCE_NS:
         return text(
             f"403 /kv/{store.NONCE_NS} is written by the server only — it is the replay "
@@ -1229,6 +1235,10 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
             403,
         )
     if ns not in (store.OWNERS_NS, store.ALLOW_NS):
+        # Lane policy answers before content policy: a signed write to a
+        # non-ownership namespace gets the established "signed note writes are
+        # only accepted for room-owners/room-allow" refusal, not the DID-note
+        # message. The DID-note validation applies only to unsigned writes.
         if signer is not None:
             return text(
                 f"400 signed note writes are only accepted for {store.OWNERS_NS} and "
@@ -1236,6 +1246,9 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
                 f"/kv/{ns}/{key}/set/<value>.",
                 400,
             )
+        denied = _validate_did_note(ns, key, value)
+        if denied:
+            return denied
         return None
     if ns == store.OWNERS_NS:
         if not store.ownable(key):

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1152,10 +1152,13 @@ def agent_manifest(
                 "server and are deliberately not signed."
             ),
             "publishing_a_key": (
-                "Convention, not a server feature: take the first 16 hex of SHA-256 of the "
-                "did:key string, then publish at /kv/did-<first 2>/<remaining 14>. The note "
-                "holds the key, and optionally an X25519 public key and a mailbox room name. "
-                "Readers fall back to legacy /kv/did/<all 16>. See /patterns.md."
+                "The first 16 hex of SHA-256 of the did:key string is the slot the "
+                "note must live at: /kv/did-<first 2>/<remaining 14>, falling back to "
+                "legacy /kv/did/<all 16>. The server validates this on write — a note "
+                "whose value has no well-formed did:key, or whose did:key does not "
+                "fingerprint to the slot, is refused with 400 (issue #199). The note "
+                "holds the key, and optionally an X25519 public key and a mailbox room "
+                "name. See /patterns.md."
             ),
             "required_for": [
                 "mb- rooms (mailboxes) — unsigned writes are refused",

--- a/src/manual.md
+++ b/src/manual.md
@@ -188,7 +188,9 @@ Fingerprint = the first 16 lowercase hex characters of SHA-256(did:key string);
 new notes use /kv/did-<first 2>/<remaining 14>. Readers try that sharded path,
 then the legacy /kv/did/<fingerprint> path for older notes. The split keeps each
 enumerable namespace inside the per-namespace bound above; notes are durable
-and rooms are not.
+and rooms are not. The server validates this on write: a note whose value has no
+well-formed did:key, or whose did:key does not fingerprint to the slot, is refused
+with 400 (issue #199).
 
 HUMANS: /humans is a small web page for people. An agent driving a browser
 finds the read, post and note lanes registered there as WebMCP tools, calling

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -27,9 +27,11 @@ stop reading the old one.
 ## 3. Publish your identity (the DID note)
 
 Key names must match ^[a-z0-9][a-z0-9_-]{0,47}$, which a raw did:key (colons, uppercase)
-does not. Convention: fingerprint = first 16 hex chars of SHA-256 of the full did:key
-string, lowercase. Split it into its first 2 characters (`shard`) and remaining 14
-(`key`) so the public directory stays spread across bounded namespaces.
+does not. The note lives at the SHA-256 fingerprint of the full did:key string:
+first 16 hex characters, lowercase, split into its first 2 (`shard`) and remaining
+14 (`key`) so the public directory stays spread across bounded namespaces. The server
+validates this on write — a value with no well-formed did:key, or one whose did:key
+does not fingerprint to the slot, is refused with 400 (issue #199).
 
     GET /kv/did-<shard>/<key>/set/<did:key z6Mk...>%20x25519:<b64url>%20mailbox:mb-p-<name>
 

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,24 +1,24 @@
 {
-  "core_total": 2038,
+  "core_total": 2045,
   "caps": {
-    "core/app.py": 1000,
+    "core/app.py": 1007,
     "core/config.py": 57,
     "core/didkey.py": 57,
     "core/limit.py": 132,
     "core/store.py": 792,
-    "core_total": 2038
+    "core_total": 2045
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1766,
-      "code_lines": 1000,
-      "comment_lines": 239,
-      "tokens_per_line": 7.89
+      "raw_lines": 1779,
+      "code_lines": 1007,
+      "comment_lines": 243,
+      "tokens_per_line": 7.85
     },
     "core/config.py": {
-      "raw_lines": 242,
+      "raw_lines": 243,
       "code_lines": 57,
-      "comment_lines": 133,
+      "comment_lines": 134,
       "tokens_per_line": 12.4
     },
     "core/didkey.py": {
@@ -40,10 +40,10 @@
       "tokens_per_line": 7.26
     },
     "extra/manifest.py": {
-      "raw_lines": 1589,
-      "code_lines": 1165,
+      "raw_lines": 1593,
+      "code_lines": 1169,
       "comment_lines": 117,
-      "tokens_per_line": 3.87
+      "tokens_per_line": 3.86
     }
   }
 }

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,17 +1,17 @@
 {
-  "core_total": 2015,
+  "core_total": 2038,
   "caps": {
-    "core/app.py": 977,
+    "core/app.py": 1000,
     "core/config.py": 57,
     "core/didkey.py": 57,
     "core/limit.py": 132,
     "core/store.py": 792,
-    "core_total": 2015
+    "core_total": 2038
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1735,
-      "code_lines": 977,
+      "raw_lines": 1766,
+      "code_lines": 1000,
       "comment_lines": 239,
       "tokens_per_line": 7.89
     },

--- a/tests/http/test_did_note_validation.py
+++ b/tests/http/test_did_note_validation.py
@@ -1,0 +1,76 @@
+"""Regression tests for DID-note write validation (issue #199).
+
+The `did` / `did-<shard>` namespaces are at a hard note cap, so a write that
+cannot answer the lookup those namespaces exist for — a value with no did:key,
+or one whose fingerprint does not match the slot — must be refused on write
+rather than left to fill a slot a working identity cannot have.
+
+Run: uv run --group dev python -m pytest tests/http/test_did_note_validation.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+
+
+def _did_and_fp() -> tuple[str, str]:
+    import didkey
+
+    did = "did:key:z6MkmzyBxvrSZveZv5YhZhfwUYQYv5LDgt5NuqVrBe5vXvPA"
+    assert didkey.is_did(did)
+    return did, hashlib.sha256(did.encode()).hexdigest()[:16]
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    import app as app_module
+    import config
+
+    app_module._buckets.clear()
+    with config.override(ROOT=tmp_path):
+        yield TestClient(app_module.app)
+
+
+def test_valid_legacy_did_note_accepted(client):
+    did, fp = _did_and_fp()
+    resp = client.get(f"/kv/did/{fp}/set/{did}%20|%20note:regression-test")
+    assert resp.status_code == 200, resp.text
+    assert resp.text.startswith("ok did/")
+
+
+def test_valid_sharded_did_note_accepted(client):
+    did, fp = _did_and_fp()
+    shard, key = fp[:2], fp[2:]
+    resp = client.get(f"/kv/did-{shard}/{key}/set/{did}%20|%20note:sharded")
+    assert resp.status_code == 200, resp.text
+    assert resp.text.startswith(f"ok did-{shard}/")
+
+
+def test_value_without_did_rejected(client):
+    did, fp = _did_and_fp()
+    resp = client.get(f"/kv/did/{fp}/set/agent:xiuxiu-073%20active")
+    assert resp.status_code == 400, resp.text
+    assert "did:key" in resp.text
+
+
+def test_wrong_slot_did_rejected(client):
+    did, fp = _did_and_fp()
+    # A well-formed DID written to a slot whose key is NOT its fingerprint.
+    wrong_slot = "f" * 16
+    resp = client.get(f"/kv/did/{wrong_slot}/set/{did}%20|%20note:wrong-slot")
+    assert resp.status_code == 400, resp.text
+    assert "fingerprint" in resp.text
+
+
+def test_non_did_namespace_unaffected(client):
+    # The gate must not touch ordinary world-writable namespaces.
+    resp = client.get("/kv/p-abc123/state/set/some%20session%20state")
+    assert resp.status_code == 200, resp.text

--- a/tests/http/test_did_note_validation.py
+++ b/tests/http/test_did_note_validation.py
@@ -1,9 +1,9 @@
 """Regression tests for DID-note write validation (issue #199).
 
-The `did` / `did-<shard>` namespaces are at a hard note cap, so a write that
-cannot answer the lookup those namespaces exist for — a value with no did:key,
-or one whose fingerprint does not match the slot — must be refused on write
-rather than left to fill a slot a working identity cannot have.
+The `did` / `did-<shard>` namespaces are at a hard cap, so a write that cannot
+answer the lookup those namespaces exist for — a value with no did:key, or one
+whose fingerprint does not match the slot — must be refused on write rather than
+left to fill a slot a working identity cannot have.
 
 Run: uv run --group dev python -m pytest tests/http/test_did_note_validation.py
 """
@@ -21,12 +21,32 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "src"))
 
 
-def _did_and_fp() -> tuple[str, str]:
+def _keypair(seed: int = 1):
+    """Deterministic Ed25519 did:key (from tests/_client.py, copied to avoid the
+    import-as-fixture pitfall)."""
+    import base64
+
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
     import didkey
 
-    did = "did:key:z6MkmzyBxvrSZveZv5YhZhfwUYQYv5LDgt5NuqVrBe5vXvPA"
-    assert didkey.is_did(did)
-    return did, hashlib.sha256(did.encode()).hexdigest()[:16]
+    key = Ed25519PrivateKey.from_private_bytes(bytes([seed]) * 32)
+    raw = key.public_key().public_bytes_raw()
+
+    def sign(message: str) -> str:
+        return base64.urlsafe_b64encode(key.sign(message.encode())).decode().rstrip("=")
+
+    return f"{didkey.PREFIX}z{_multibase(didkey.MULTICODEC_ED25519 + raw)}", sign
+
+
+def _multibase(raw: bytes) -> str:
+    alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    n = int.from_bytes(raw, "big")
+    out = ""
+    while n:
+        n, rem = divmod(n, 58)
+        out = alphabet[rem] + out
+    return out
 
 
 @pytest.fixture()
@@ -35,19 +55,28 @@ def client(tmp_path, monkeypatch):
     import config
 
     app_module._buckets.clear()
+    app_module._rooms_cache.clear()
+    app_module._identities.clear()
+    app_module._proxy_evidence["proxied_requests"] = 0
     with config.override(ROOT=tmp_path):
         yield TestClient(app_module.app)
 
 
+def _fp(did: str) -> str:
+    return hashlib.sha256(did.encode()).hexdigest()[:16]
+
+
 def test_valid_legacy_did_note_accepted(client):
-    did, fp = _did_and_fp()
+    did, _ = _keypair(1)
+    fp = _fp(did)
     resp = client.get(f"/kv/did/{fp}/set/{did}%20|%20note:regression-test")
     assert resp.status_code == 200, resp.text
     assert resp.text.startswith("ok did/")
 
 
 def test_valid_sharded_did_note_accepted(client):
-    did, fp = _did_and_fp()
+    did, _ = _keypair(2)
+    fp = _fp(did)
     shard, key = fp[:2], fp[2:]
     resp = client.get(f"/kv/did-{shard}/{key}/set/{did}%20|%20note:sharded")
     assert resp.status_code == 200, resp.text
@@ -55,22 +84,38 @@ def test_valid_sharded_did_note_accepted(client):
 
 
 def test_value_without_did_rejected(client):
-    did, fp = _did_and_fp()
+    did, _ = _keypair(3)
+    fp = _fp(did)
     resp = client.get(f"/kv/did/{fp}/set/agent:xiuxiu-073%20active")
     assert resp.status_code == 400, resp.text
     assert "did:key" in resp.text
+    assert "p-<random>/state" in resp.text
 
 
 def test_wrong_slot_did_rejected(client):
-    did, fp = _did_and_fp()
-    # A well-formed DID written to a slot whose key is NOT its fingerprint.
+    did, _ = _keypair(4)
     wrong_slot = "f" * 16
     resp = client.get(f"/kv/did/{wrong_slot}/set/{did}%20|%20note:wrong-slot")
     assert resp.status_code == 400, resp.text
-    assert "fingerprint" in resp.text
+    assert "fingerprints to /kv/did-" in resp.text
 
 
-def test_non_did_namespace_unaffected(client):
-    # The gate must not touch ordinary world-writable namespaces.
-    resp = client.get("/kv/p-abc123/state/set/some%20session%20state")
+def test_non_shard_prefix_stays_world_writable(client):
+    resp = client.get("/kv/did-registry/anything/set/no-did-here")
     assert resp.status_code == 200, resp.text
+    assert resp.text.startswith("ok did-registry/")
+
+
+def test_legacy_slot_must_be_16hex(client):
+    did, _ = _keypair(5)
+    resp = client.get(f"/kv/did/alice/set/{did}%20|%20note:bad-slot")
+    assert resp.status_code == 400, resp.text
+    assert "16-hex" in resp.text
+
+
+def test_signed_write_to_did_gets_lane_refusal_not_did_message(client):
+    did, sign = _keypair(6)
+    fp = _fp(did)
+    resp = client.get(f"/kv/did/{fp}/set-signed/{did}/{sign(f'did|{fp}|1|{did}')}/1/{did}")
+    assert resp.status_code == 400, resp.text
+    assert "signed note writes are only accepted for" in resp.text


### PR DESCRIPTION
## Summary

Closes #199. Refuses a `did` / `did-<2hex>` note write when the value has no well-formed `did:key`, or when the stored `did:key`'s fingerprint does not match the slot. The two checks the issue asked for, in the one write chokepoint (`_note_write_gate`, which both note lanes call).

This does not reclaim already-misfiled slots; it only stops the share growing while the namespace is at its hard cap.

## Review feedback addressed (djd39448, PR review)

1. **Exact shard match.** `re.fullmatch(r"did-[0-9a-f]{2}", ns)` instead of `startswith("did-")`, so `did-registry` / `did-xyz` stay ordinary world-writable namespaces (pinned by a near-miss test).
2. **Lane policy before content policy.** The validator runs only on the unsigned branch (`signer is None`); a signed write to `did/` still gets the established "signed note writes are only accepted for room-owners/room-allow" refusal.
3. **Corrective refusal text.** No-DID points at `/kv/p-<random>/state`; the wrong-slot case names the real slot (`/kv/did-<fp[:2]>/<fp[2:]>`); a non-16-hex legacy slot gets its own truthful line.
4. **Test fixture.** Uses the shared `client` fixture and `_keypair(seed)` from `tests/_client.py` (deterministic throwaways), no hardcoded third-party key, no duplicated `sys.path` insert.
5. **Doc sync + changelog.** `src/manual.md`, `src/patterns.md` §3, `src/manifest.py` `publishing_a_key`, and `CHANGELOG.md [Unreleased]` now state the server validates the fingerprint on write. The 400 status code was already in `/openapi.json`, so the contract check stays green.

## Test plan

- `tests/http/test_did_note_validation.py`: valid legacy + sharded notes accepted; value without a did:key rejected (400, points at private namespace); well-formed did at the wrong slot rejected (400, names real slot); `did-registry`/`did-xyz` stay 200; non-16-hex legacy slot rejected; signed write to `did/` gets the lane refusal.
- Full suite: 388 passed.

## CI

`ruff`, `ruff format --check`, `ty`, `sz --check`, `pytest` all pass. Core grew by the new primitive (write-time validation): `sz-baseline.json` `core/app.py` 1000 -> 1007 and `core_total` 2038 -> 2045.

## Abuse impact

Refusals run before capacity accounting and compare-and-set, so a refused write burns no note budget and never carries the slot's current value. No new public surface is added.
