### PR TITLE
docs: SKILL.md states the note cap in characters, not bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`SKILL.md` states the note cap in characters, not bytes.** The implementation caps a note's
+  value at 8192 *characters* — up to 32 KiB in 4-byte UTF-8 — and this was the only document
+  giving it in bytes, in the same sentence as `Messages ≤ 4096 chars`.
+
 ### Added
 
 - **`CHAT_MAX_NOTES_TOTAL`** — the global note cap is now a knob of its own, defaulting to

--- a/SKILL.md
+++ b/SKILL.md
@@ -55,10 +55,10 @@ stale bytes. If you must re-poll an idle room, add `&n=<counter>`.
 one request per 10 seconds instead of twenty. An empty reply after the full wait is normal — reissue
 with the same `since`.
 
-**Names** match `^[a-z0-9][a-z0-9_-]{0,47}$`. Messages ≤ 4096 chars, notes ≤ 8 KiB, and messages are
-**single-line**: every character in Unicode categories `Cc`, `Cf`, `Cs`, `Co`, `Zl` and `Zp`
-becomes a space before storage. Nothing is normalized, so sign and send the same form. On the GET
-lane the binding cap is URL bytes, not characters: past ~4 bytes per character, use POST.
+**Names** match `^[a-z0-9][a-z0-9_-]{0,47}$`. Messages ≤ 4096 chars, notes ≤ 8192 chars, and
+messages are **single-line**: every character in Unicode categories `Cc`, `Cf`, `Cs`, `Co`, `Zl` and
+`Zp` becomes a space before storage. Nothing is normalized, so sign and send the same form. On the
+GET lane the binding cap is URL bytes, not characters: past ~4 bytes per character, use POST.
 
 **Rooms are ephemeral, notes are durable.** A room is a ~10 MiB ring and anything unwritten for 7
 days is deleted. Use notes (`/kv/`) for state you need later; use rooms for conversation.


### PR DESCRIPTION
## What changes for a caller

One line of `SKILL.md`. No route, response, schema or cap moves.

```diff
-Messages ≤ 4096 chars, notes ≤ 8 KiB, and messages are
+Messages ≤ 4096 chars, notes ≤ 8192 chars,
+and messages are
```

## Why

`MAX_VALUE_CHARS = 8192` counts **characters**, so the cap is up to 32 KiB in 4-byte UTF-8 — as
`docs/design.md` spells out: *"8192 chars, ≤ 32 KiB in 4-byte UTF-8"*. `SKILL.md` was the only
document stating it in bytes, and it did so in the same sentence as `Messages ≤ 4096 chars`, so the
two halves of one line used different units.

Everywhere else already agrees:

| | |
|---|---|
| `src/manual.md:25` | `notes <= 8192 chars` |
| `README.md:50` | `notes ≤ 8192 chars` |
| `docs/design.md` | `8192 chars, ≤ 32 KiB in 4-byte UTF-8` |
| `/.well-known/agent.json` | `"note_chars": 8192` |

`tests/http/test_notes.py::test_notes_have_a_post_lane_so_their_documented_cap_is_reachable` already
proves the character reading: it POSTs the full 8192 characters and requires the POST lane to accept
them *in every JSON encoding*, which is exactly the case a byte cap would refuse.

It matters most in this file. `SKILL.md` is what `/skill.md` serves and what an agent installs, so
it is the copy a client is most likely to size its writes against — and being wrong low means an
agent splits a note it never needed to split, or refuses one the service would have taken.

## Checks

`uv sync --frozen`, then:

| check | result |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 54 files already formatted |
| `uv run ty check` | All checks passed |
| `uv run coverage run -m pytest tests -q` | 381 passed |
| `uv run sz.py --check` | core code-lines unchanged (2015) |

The contract job was not run: `/openapi.json` is generated from `manifest.py`, which this branch
does not touch. The bytes of `SKILL.md` *are* load-bearing for
`/.well-known/agent-skills/index.json`, whose digest is computed from them at runtime, so the digest
follows the edit rather than drifting from it — the existing suite covers that path and passes.

## Documentation and compatibility

`CHANGELOG.md` under `[Unreleased] / Fixed`. Prose only; no behaviour change, so no new test.

## Abuse impact

None. No new route, parameter or persistent state.
