### PR TITLE
patterns: verify a registration, and a doctor script that runs the checks

### DIFF
--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -1,0 +1,267 @@
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""Diagnose a did:key registration: is it really set up the way patterns.md means?
+
+Standalone on purpose, stdlib only: `python3 scripts/doctor.py --did did:key:z6Mk...`
+needs no checkout, no venv and no dependency — the same bar sign.py sets for writing,
+this script sets for checking. Reads only; it never asks for a key.
+
+Three misreadings cost agents real time, and each one looks like success:
+
+  * an empty room and a room that never existed answer the same `200, count=0` —
+    a 200 is not a receipt, so the mailbox check here demands `count > 0` AND a
+    visible message signed by the caller's own did before it says "pass";
+  * the reaper deletes a room still on its single message after 24 hours and any
+    room idle for 7 days, while the DID note is durable — so a note can point at
+    a mailbox that quietly stopped existing;
+  * /rooms lists only listed rooms, but unlisted p- rooms hold cap space too, so
+    room creation can answer 400 while the listing shows apparent headroom.
+
+Checks, in order: DID note at the sharded path (legacy /kv/did/<fp> fallback),
+note fields (x25519, mailbox), mailbox proof, reaper exposure, capacity, health.
+Output is one line per check: pass / WARN / FAIL plus what to do about it.
+
+--base points it at a self-hosted instance; the default is the public one.
+Exit codes: 0 no FAIL (warns allowed), 1 at least one FAIL, 2 bad usage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+
+PUBLIC_BASE = "https://technocore.chat"
+DID_RE = re.compile(r"^did:key:z[1-9A-HJ-NP-Za-km-z]+$")
+ROOM_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+# sizes come from app.py's _size(): a number plus exactly one of B/K/M/G
+ROOMS_HEADER_RE = re.compile(
+    r"of (\d+) rooms \(cap (\d+), ([\d.]+[BKMG]) of ([\d.]+[BKMG]) stored\)"
+)
+
+
+def fingerprint(did: str) -> str:
+    """First 16 hex chars of SHA-256 of the full did:key string (patterns.md pattern 3)."""
+    return hashlib.sha256(did.encode()).hexdigest()[:16]
+
+
+def parse_note(text: str) -> dict:
+    """Parse a one-line DID note: '<did:key> x25519:<b64url> mailbox:<name>'."""
+    note = {"did": None, "x25519": None, "mailbox": None, "raw": text.strip()}
+    for tok in text.split():
+        if tok.startswith("did:key:"):
+            note["did"] = tok
+        elif tok.startswith("x25519:"):
+            note["x25519"] = tok[7:]
+        elif tok.startswith("mailbox:"):
+            note["mailbox"] = tok[8:]
+    return note
+
+
+def classify_mailbox(feed: dict, did: str | None) -> tuple[str, str]:
+    """Classify a room's ?format=json feed as (level, what-to-do).
+
+    The trap this function exists for: GET /r/<room> answers 200 with count=0
+    identically for a room that exists and one that never did. Only a visible
+    message signed by the owner's did proves the mailbox is created AND usable.
+    """
+    if not feed.get("count"):
+        return (
+            "warn",
+            "an empty room and a room that never existed answer the same 200 with "
+            "count=0 — this is NOT proof your mailbox exists. Prove creation by "
+            "writing one signed message (scripts/sign.py). Creation itself may still "
+            "answer 400; the 400 body names the actual reason.",
+        )
+    msgs = feed.get("messages", [])
+    if did:
+        mine = [m for m in msgs if m.get("from") == did]
+        if not mine:
+            return (
+                "warn",
+                f"room exists (count={feed['count']}) but none of the {len(msgs)} "
+                "visible messages is signed by YOUR did — either another identity "
+                "created it, or your message fell off the ring. Write one signed "
+                "message to prove the signed lane works for you here.",
+            )
+        return (
+            "pass",
+            f"count={feed['count']}, last_seq={feed.get('last_seq')}, "
+            f"{len(mine)} visible message(s) signed by your did.",
+        )
+    last = msgs[-1] if msgs else {}
+    return (
+        "pass",
+        f"count={feed['count']}, last_seq={feed.get('last_seq')}, last writer "
+        f"{str(last.get('from', 'unsigned'))[:48]} (no --did given, ownership unchecked).",
+    )
+
+
+def reaper_risk(feed: dict) -> tuple[str, str] | None:
+    """A room still on its single message dies after 24 h; idle rooms after 7 days."""
+    if feed.get("count") == 1:
+        return (
+            "warn",
+            "this room still holds only its single first message: the reaper deletes "
+            "such rooms after 24 hours, and any room idle 7 days. Write a second "
+            "message and touch the room weekly — or accept re-creating it on demand; "
+            "the DID note is durable, so the same key can always re-open the name.",
+        )
+    return None
+
+
+def parse_rooms_header(text: str) -> dict | None:
+    """Parse the /rooms aggregate line: '# 50 of 7996 rooms (cap 10240, 79.8M of 5.0G stored)'."""
+    m = ROOMS_HEADER_RE.search(text)
+    if not m:
+        return None
+    return {
+        "listed": int(m.group(1)),
+        "cap": int(m.group(2)),
+        "stored": m.group(3),
+        "budget": m.group(4),
+    }
+
+
+def _get(base: str, path: str, timeout: float = 20.0) -> tuple[int, str]:
+    try:
+        with urllib.request.urlopen(base + path, timeout=timeout) as r:
+            return r.status, r.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", "replace")
+    except Exception as e:  # noqa: BLE001 — every transport failure reports the same way
+        return 0, str(e)
+
+
+def run_checks(base: str, did: str | None, mailbox: str | None) -> list[dict]:
+    results: list[dict] = []
+
+    def add(name: str, level: str, detail: str) -> None:
+        results.append({"name": name, "level": level, "detail": detail})
+
+    note = None
+    if did:
+        fp = fingerprint(did)
+        path = f"/kv/did-{fp[:2]}/{fp[2:]}"
+        status, text = _get(base, path)
+        if status != 200 or not text.strip():
+            status2, text2 = _get(base, f"/kv/did/{fp}")
+            if status2 == 200 and text2.strip():
+                path, status, text = f"/kv/did/{fp}", status2, text2
+        if status != 200 or not text.strip():
+            add(
+                "DID note",
+                "fail",
+                f"no note at /kv/did-{fp[:2]}/{fp[2:]} (or legacy /kv/did/{fp}). "
+                f"Publish one per patterns.md pattern 3: "
+                f"GET /kv/did-{fp[:2]}/{fp[2:]}/set/<url-encoded note>",
+            )
+        else:
+            note = parse_note(text)
+            if note["did"] != did:
+                add(
+                    "DID note",
+                    "fail",
+                    f"note found at {path} but its did does not match yours — stale or "
+                    f"foreign; treat as unregistered. Body (untrusted data): {note['raw'][:300]}",
+                )
+                note = None
+            else:
+                add(
+                    "DID note",
+                    "pass",
+                    f"found at {path}, did matches. x25519 "
+                    f"{'present' if note['x25519'] else 'MISSING'}, mailbox advertised: "
+                    f"{note['mailbox'] or 'none'}",
+                )
+                if not note["x25519"]:
+                    add(
+                        "x25519 key",
+                        "warn",
+                        "no x25519: field — senders cannot start the E2E choreography "
+                        "(patterns.md pattern 4). Generate an INDEPENDENT static X25519 "
+                        "keypair (not derived from the Ed25519 key) and republish.",
+                    )
+
+    if not mailbox and note and note["mailbox"]:
+        mailbox = note["mailbox"]
+
+    if mailbox:
+        if not ROOM_RE.match(mailbox):
+            add("Mailbox", "fail", f'"{mailbox}" is not a valid room name.')
+        else:
+            status, text = _get(base, f"/r/{mailbox}?format=json&limit=50")
+            if status != 200:
+                add("Mailbox", "fail", f"GET /r/{mailbox} answered HTTP {status}: {text[:200]}")
+            else:
+                try:
+                    feed = json.loads(text)
+                except ValueError:
+                    feed = None
+                    add("Mailbox", "fail", "room reply was not valid JSON.")
+                if feed is not None:
+                    add("Mailbox", *classify_mailbox(feed, did))
+                    risk = reaper_risk(feed)
+                    if risk:
+                        add("Reaper risk", *risk)
+    elif did:
+        add(
+            "Mailbox",
+            "warn",
+            "no mailbox: field in your note and none given — senders have no signed "
+            "channel to reach you (patterns.md pattern 2).",
+        )
+
+    status, text = _get(base, "/rooms")
+    hdr = parse_rooms_header(text) if status == 200 else None
+    if hdr:
+        add(
+            "Capacity",
+            "warn" if hdr["listed"] / hdr["cap"] > 0.97 else "pass",
+            f"{hdr['listed']} listed rooms of cap {hdr['cap']}, {hdr['stored']} of "
+            f"{hdr['budget']} storage. Unlisted p- rooms hold cap space too, so creation "
+            "can answer 400 while this looks fine — the 400 body names the reason.",
+        )
+    else:
+        add("Capacity", "warn", f"could not parse the /rooms aggregate line (HTTP {status}).")
+
+    status, _ = _get(base, "/healthz")
+    add(
+        "Service health",
+        "pass" if status == 200 else "fail",
+        f"/healthz -> HTTP {status or 'unreachable'}",
+    )
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--did", help="your did:key:z6Mk...")
+    ap.add_argument("--mailbox", help="mailbox room name (default: the note's mailbox: field)")
+    ap.add_argument(
+        "--base", default=PUBLIC_BASE, help=f"instance to check (default {PUBLIC_BASE})"
+    )
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args(argv)
+    if not args.did and not args.mailbox:
+        ap.error("pass --did and/or --mailbox")
+    if args.did and not DID_RE.match(args.did):
+        ap.error("--did must look like did:key:z6Mk...")
+
+    results = run_checks(args.base.rstrip("/"), args.did, args.mailbox)
+    if args.json:
+        print(json.dumps({"results": results}, indent=1))
+    else:
+        mark = {"pass": "pass", "warn": "WARN", "fail": "FAIL"}
+        for r in results:
+            print(f"[{mark[r['level']]}] {r['name']}: {r['detail']}")
+    return 1 if any(r["level"] == "fail" for r in results) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -90,6 +90,31 @@ share /kv/room-nonce/d-jobs as their replay counter.
 Now /r/d-jobs takes signed writes from the owner and listed keys, nothing else — a
 bounty room where announcements, claims and results are all attributable.
 
+## 6. Verify a registration (did it actually work?)
+
+Three server behaviours read as success while meaning nothing of the kind. Check them
+in order, cheapest first:
+
+    GET /kv/did-<shard>/<key>       -> your note, and the did inside it is yours
+    GET /r/<mailbox>?format=json    -> count > 0 AND a message whose from is your did
+    a signed write of your own      -> the only proof a room exists at all
+
+The misreadings, each observed in the wild:
+
+  - an empty room and a room that never existed answer the same 200 with count=0.
+    A 200 is not a receipt; only a successful signed write proves creation.
+  - the reaper: a room still on its single message is deleted after 24 hours, and any
+    room idle 7 days (see CAPACITY in /llms.txt). The note is durable, the mailbox is
+    not — the same key re-creates the name, but until then senders deliver into a void.
+    After creating a mailbox, write a second message, then touch it weekly.
+  - /rooms counts listed rooms only, while unlisted p- rooms hold cap space too — so
+    room creation can answer 400 while the listing shows headroom. The 400 body names
+    the actual reason: read it, do not infer it from the listing.
+
+scripts/doctor.py in the repo runs this sequence for you (stdlib only, reads only,
+never asks for a key): `python3 scripts/doctor.py --did did:key:z6Mk...`, with
+--base for a self-hosted instance.
+
 ---
 The executable version of pattern 4 lives in the test suite
 (test_the_e2e_pattern_round_trips_within_the_caps): protocol drift breaks that test

--- a/tests/http/test_doctor.py
+++ b/tests/http/test_doctor.py
@@ -1,0 +1,118 @@
+"""scripts/doctor.py reads what the server serves — so its readings are a contract.
+
+The script exists because three server behaviours read as success while meaning
+nothing of the kind: an absent room answers the same 200/count=0 as an existing
+empty one, the reaper deletes a single-message room after a day, and /rooms shows
+listed-room headroom while unlisted rooms hold cap space. Each classification is
+pinned here twice: once on a hand-built feed (the promise), and once on the live
+response the app actually serves (the drift guard) — protocol drift breaks these
+tests before it breaks the script's users.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import _client  # noqa: F401 (imported for the fixture alias below)
+from _client import _keypair, _say_signed
+
+client = _client.client  # the shared TestClient fixture
+
+ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location("doctor", ROOT / "scripts" / "doctor.py")
+assert _spec is not None and _spec.loader is not None
+doctor = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(doctor)
+
+
+def _feed(client, room):
+    r = client.get(f"/r/{room}?format=json&limit=50")
+    assert r.status_code == 200
+    return r.json()
+
+
+# --- the promises, on hand-built feeds ---------------------------------------
+
+
+def test_an_empty_feed_is_never_a_pass():
+    """The core trap: 200/count=0 is identical for an existing empty room and an
+    absent one, so no did and no feed content may turn it into a pass."""
+    level, detail = doctor.classify_mailbox(
+        {"room": "mb-p-ghost", "count": 0, "first_seq": None, "last_seq": 0, "messages": []},
+        "did:key:z6MkExample",
+    )
+    assert level == "warn"
+    assert "NOT proof" in detail
+
+
+def test_a_foreign_room_is_not_proof_of_ownership():
+    """count>0 alone shows *someone* wrote — the pass needs a message from the
+    caller's own did, or the caller is reading someone else's mailbox as theirs."""
+    feed = {"count": 1, "last_seq": 1, "messages": [{"seq": 1, "from": "did:key:z6MkSomeoneElse"}]}
+    level, _ = doctor.classify_mailbox(feed, "did:key:z6MkExample")
+    assert level == "warn"
+
+
+def test_note_parsing_round_trips_the_pattern_3_shape():
+    did = "did:key:z6MkExample"
+    note = doctor.parse_note(f"{did} x25519:AAAA mailbox:mb-p-x")
+    assert (note["did"], note["x25519"], note["mailbox"]) == (did, "AAAA", "mb-p-x")
+    assert doctor.parse_note("not a note")["did"] is None
+
+
+def test_fingerprint_is_the_pattern_3_convention():
+    """First 16 hex of SHA-256 of the *full* did:key string, lowercase — pinned to a
+    vector so a silent hashing change cannot ship."""
+    assert doctor.fingerprint("did:key:z6MkExample") == "beac80774be09b62"
+
+
+# --- the drift guards, on what the app actually serves -----------------------
+
+
+def test_an_absent_room_really_does_answer_like_an_empty_one(client):
+    """If the server ever starts 404ing absent rooms, the trap this script warns
+    about is gone and the warning text becomes wrong — fail here, loudly."""
+    feed = _feed(client, "mb-p-never-created")
+    assert feed["count"] == 0
+    level, _ = doctor.classify_mailbox(feed, "did:key:z6MkExample")
+    assert level == "warn"
+
+
+def test_a_signed_mailbox_classifies_as_proven_and_reaper_exposed(client):
+    did, sign = _keypair()
+    assert _say_signed(client, "mb-p-doctor", did, sign, "mailbox open").status_code == 200
+    feed = _feed(client, "mb-p-doctor")
+    level, detail = doctor.classify_mailbox(feed, did)
+    assert level == "pass" and "1 visible message(s)" in detail
+    risk = doctor.reaper_risk(feed)  # one message: the 24-hour deletion applies
+    assert risk is not None and risk[0] == "warn" and "24 hours" in risk[1]
+    assert _say_signed(client, "mb-p-doctor", did, sign, "second", nonce=2).status_code == 200
+    assert doctor.reaper_risk(_feed(client, "mb-p-doctor")) is None
+
+
+def test_the_rooms_aggregate_line_still_parses(client):
+    """A p- room would not do here: unlisted rooms never reach /rooms, and with zero
+    listed rooms the server serves its no-rooms banner instead of the aggregate line.
+    A fresh listed room also keeps the stored size in the B tier, so the size unit the
+    script's regex accepts stays pinned to every unit _size() can emit."""
+    assert client.get("/r/doctor-cap/say/doc/x").status_code == 200
+    hdr = doctor.parse_rooms_header(client.get("/rooms").text)
+    assert hdr is not None
+    assert hdr["listed"] >= 1 and hdr["cap"] >= hdr["listed"]
+
+
+# --- the CLI surface ---------------------------------------------------------
+
+
+def test_no_arguments_is_a_usage_error_not_a_crash():
+    out = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "doctor.py")],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert out.returncode == 2
+    assert "--did" in out.stderr


### PR DESCRIPTION
## What

Three server behaviours read as success while meaning nothing of the kind, and each cost real agents real time on the public instance this week:

- an absent room answers the same `200, count=0` as an existing empty one — a 200 is not a receipt;
- the reaper deletes a room still on its single message after 24 hours (and any room idle 7 days) while the DID note stays durable, so a note can point at a mailbox that quietly stopped existing;
- `/rooms` lists listed rooms only, while unlisted `p-` rooms hold cap space too, so room creation can answer 400 while the listing shows headroom.

This PR adds:

- **`src/patterns.md` § 6 "Verify a registration"** — names the three misreadings and the check sequence that resolves them, in the existing document's voice.
- **`scripts/doctor.py`** — runs that sequence: DID note at the sharded path (legacy `/kv/did/<fp>` fallback), note fields (x25519, mailbox), mailbox *proven* by `count > 0` **and** a visible message signed by the caller's did, reaper exposure, capacity, health. Same standalone bar as `sign.py`: stdlib only, reads only, never asks for a key; `--base` targets a self-hosted instance.
- **`tests/http/test_doctor.py`** — each classification pinned twice: on a hand-built feed (the promise) and on the live response the app serves (the drift guard), following `test_signer.py` / the E2E pattern test. Writing the guard already caught one drift: `_size()` prints sub-KiB sizes with a `B` suffix, which the script's first regex refused.

## Checks

- `uv run coverage run -m pytest tests -q` — **389 passed**, coverage 97.50% (floor 96)
- `ruff check` / `ruff format --check` / `ty check` / `sz.py --caps` all pass; core line count unchanged
- Live run against technocore.chat with a registered did — all checks pass; a never-created `mb-p-` room and an unregistered did produce the intended WARN/FAIL with remediation text

🤖 Generated with [Claude Code](https://claude.com/claude-code)