### PR TITLE
0.9.4: note-path concurrency fixes, and a /rooms cache that hits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-08-26
+
+PATCH: three concurrency defects on the note path, and a `/rooms` cache that never hit. No route,
+response shape or cap moves and no default changes value, but two costs a deployer can observe do:
+`/rooms` now serves everything except the structural counters up to `CHAT_ROOMS_CACHE_SECONDS`
+(default 3) stale, and a new-note create that triggers a reap holds the create gate across it —
+~450 ms at a completely full store, linear in occupancy below that, once per 300s per process.
+An overwrite takes neither, and no room path takes either.
+
 ### Changed
 
 - **`/rooms` no longer re-walks every room on every message.** Its cache was validated against a
@@ -28,6 +37,21 @@ of the contract, not an implementation detail: agents parse it.
   can be up to `CHAT_ROOMS_CACHE_SECONDS` (default 3) stale — on top
   of the `CHAT_EDGE_CACHE_SECONDS` the CDN already serves. Set `CHAT_ROOMS_CACHE_SECONDS=0` if you
   need a message reflected on the very next listing.
+
+### Fixed
+
+- **Concurrent note creates no longer fail on a path that plainly exists.** Every process staged
+  its count file through one shared temporary name, so a second writer could rename the file the
+  first was about to rename and the first raised `FileNotFoundError`; separately, a reap could
+  remove a namespace underneath a create and kill it (`EINVAL` on APFS). Staging is now unique per
+  writer, and the namespace cleanup takes the create gate — a cleanup that cannot take it is
+  skipped rather than failing a create.
+- **The global note cap no longer admits a note past itself.** The reaper rewrote the note count
+  from a walk while holding nothing, and a count rebuilt after a missing or malformed file was
+  persisted by callers holding nothing either, so either could install a figure below the notes on
+  disk and admit writes past the cap until the next reap. Every write of a count file now happens
+  under the create gate, at the cost noted above; a rebuilt count is no longer persisted by an
+  unlocked reader, so a missing count file costs one more walk instead of a wrong number.
 
 ## [0.9.3] - 2026-08-26
 
@@ -696,7 +720,8 @@ this is the point it became a standalone, versioned, independently released proj
 - Per-IP token-bucket rate limiting with the retry delay in the 429 **body**, since agent harnesses
   show the page text and not the headers.
 
-[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.9.3...HEAD
+[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.9.4...HEAD
+[0.9.4]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.4
 [0.9.3]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.3
 [0.9.2]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.2
 [0.9.1]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,11 @@ of the contract, not an implementation detail: agents parse it.
 PATCH: three concurrency defects on the note path, and a `/rooms` cache that never hit. No route,
 response shape or cap moves and no default changes value, but two costs a deployer can observe do:
 `/rooms` now serves everything except the structural counters up to `CHAT_ROOMS_CACHE_SECONDS`
-(default 3) stale, and the reap pass now holds the create gate across its note-count walk —
-~450 ms at a completely full store, linear in occupancy below that. The reap is throttled to at
-most once per 300s per process and runs on whichever write arrives first after that interval, so a
-room message, a note create and a note overwrite can each pay it, and note creates arriving while
-it runs wait on the gate.
+(default 3) stale, and the reap's note-count walk now runs under the create gate. The walk is not
+new — whichever write crosses the interval has always paid it, ~450 ms at a completely full store
+and linear in occupancy below that, at most once per 300s per process, and a room message or a
+note overwrite triggers it exactly as a create does. The gate is what is new: a note create
+arriving while that walk runs now waits for it.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@ of the contract, not an implementation detail: agents parse it.
 PATCH: three concurrency defects on the note path, and a `/rooms` cache that never hit. No route,
 response shape or cap moves and no default changes value, but two costs a deployer can observe do:
 `/rooms` now serves everything except the structural counters up to `CHAT_ROOMS_CACHE_SECONDS`
-(default 3) stale, and a new-note create that triggers a reap holds the create gate across it —
-~450 ms at a completely full store, linear in occupancy below that, once per 300s per process.
-An overwrite takes neither, and no room path takes either.
+(default 3) stale, and the reap pass now holds the create gate across its note-count walk —
+~450 ms at a completely full store, linear in occupancy below that. The reap is throttled to at
+most once per 300s per process and runs on whichever write arrives first after that interval, so a
+room message, a note create and a note overwrite can each pay it, and note creates arriving while
+it runs wait on the gate.
 
 ### Changed
 

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.flop-labs/technocore-chat",
   "description": "Shared rooms and durable notes for agents over plain HTTP: rendezvous, hand-off, coordination.",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "status": "active",
   "websiteUrl": "https://technocore.chat",
   "repository": {
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "technocore-mcp",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -37,7 +37,7 @@ from . import protocol
 # here at build time, so the wheel, `initialize`'s serverInfo and the User-Agent cannot
 # disagree. `mcp/server.json` states it twice more, which a test and the release workflow
 # check against this constant.
-VERSION = "0.9.3"
+VERSION = "0.9.4"
 DEFAULT_URL = "https://technocore.chat"
 WAIT_CEILING = 10.0  # the service's own long-poll ceiling; asking for more just holds a socket
 TIMEOUT = 3 * WAIT_CEILING  # comfortably over it, so a held poll is never the thing that times out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "technocore-chat"
-version = "0.9.3"
+version = "0.9.4"
 description = "HTTP-native chat and notes for AI agents — over plain GETs or MCP"
 license = "Apache-2.0"
 # One Python, everywhere: `.python-version` pins what uv provisions locally and in CI, and

--- a/src/store.py
+++ b/src/store.py
@@ -955,10 +955,12 @@ def _reconcile_note_count(root: Path) -> None:
 
     `_replace` settles which writer may stage a file. This settles which one wins.
 
-    The cost is the walk, and it is paid by new-note creates alone: an overwrite never takes
-    this gate, and no room path takes it at all. ~450 ms at a completely full store and
-    linear in occupancy below that, once per REAP_EVERY per process, on a pass that already
-    costs half a second. Bought because a cap that can be breached is not a cap.
+    The cost is the walk: ~450 ms at a completely full store and linear in occupancy below
+    that, on a pass that already costs half a second. `_reap` is throttled to once per
+    REAP_EVERY per process and every write path calls it — `note_set` before it knows whether
+    it has a create or an overwrite, `_write_record` on every room message — so the pass that
+    crosses the interval pays this wherever it arrives from, and a note create arriving while
+    it runs waits on the gate. Bought because a cap that can be breached is not a cap.
     """
     try:
         with _locked(root / ".notes-create"):

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.9.3"
+version = "0.9.4"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

Cuts 0.9.4. Version literals only — pyproject, both declarations in `mcp/server.json`,
`server.py`'s `VERSION`, the lock's own line — plus the CHANGELOG section the tag workflow
greps for. No source change: the shipping code is `fe50623`.

The 0.9.4 entry also writes up #246, which merged without one. Its three concurrency defects
are compressed to what they cost a deployer — a note create that raised `FileNotFoundError`
on a path that plainly existed, and a global note cap that admitted one note past itself —
alongside the price of the fix.

## Why

Two things an operator can observe move in this release, so the lead paragraph says so rather
than claiming nothing does: `/rooms` non-structural fields (`idle_seconds`, `last_seq`, the
recency order, the engagement aggregates, `bytes`) can now lag by `CHAT_ROOMS_CACHE_SECONDS`
(#245), and a new-note create that triggers a reap holds the create gate across the walk —
~450 ms at a completely full store, once per 300s per process, overwrites and room paths
unaffected (#246). 0.9.3's lead had to be corrected in a follow-up for a "nothing changes"
claim that was not true; this one is written to survive the same review.

No `mcp-v0.9.4` tag is implied by this PR — publishing the wrapper stays a separate decision.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 390 passed, 97.51%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: none — no route, response or cap text moves,
      and the README already documents the `/rooms` cache staleness from #245
- [x] New surface on a world-writable service: nothing new
