### PR TITLE
fix(tooling): a mutation run that judged nothing stops reading as a clean sweep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,8 +98,11 @@ source_paths = ["src"]
 only_mutate = ["src/app.py", "src/store.py", "src/didkey.py", "src/limit.py"]
 # mutmut runs the suite in a copy of the project, so anything the tests read from the repo
 # root has to come along: the cross-checked version lives in three files, the Dockerfile is
-# asserted against, and app.py reads SKILL.md at import.
-also_copy = ["SKILL.md", "docker", "mcp"]
+# asserted against, and app.py reads SKILL.md at import. Two more the selected suite reads:
+# test_rooms.py cross-checks the ownership claim against README.md, and test_signer.py runs
+# scripts/sign.py as a subprocess. Without them the baseline fails inside mutants/ and the
+# run never reaches a verdict.
+also_copy = ["README.md", "SKILL.md", "docker", "mcp", "scripts"]
 # test_mcp.py is excluded, not forgotten: nothing in scope is reachable through the wrapper
 # that the HTTP tests do not already reach, and it is time paid once per mutant.
 # test_app.py was split into tests/http/ and tests/unit/; every shard selects the same
@@ -108,6 +111,16 @@ pytest_add_cli_args_test_selection = [
     "tests/http",
     "tests/unit",
     "tests/test_store_stateful.py",
+    # Deselected for the same reason test_mcp.py is excluded — it cannot say anything
+    # about a mutant. Both tests assert docs/store.md against the *module*, and the
+    # store.py mutmut runs is the rewritten one: the regenerated page never matches, and
+    # every `x_…__mutmut_N` wrapper is a public function the doc does not list. So it
+    # fails identically for every store mutant — the baseline never gets off the ground,
+    # and a mutant that did run would be scored killed by a doc-staleness assertion that
+    # never saw it. The page is still guarded on every pull request, where src/store.py
+    # is the real one; this only stands it down where it has nothing to measure.
+    "--deselect",
+    "tests/unit/test_store_doc.py",
 ]
 
 # Not an installable package: src/ is copied into the image and imported by path.

--- a/tests/mutation_scope.py
+++ b/tests/mutation_scope.py
@@ -116,10 +116,24 @@ def report() -> int:
     checked = stats["killed"] + stats["survived"]
     score = (100 * stats["killed"] / checked) if checked else 0.0
     broken = {name: stats[name] for name in BROKEN if stats.get(name)}
+    # Mutants generated and none of them judged: the runner died before the first verdict,
+    # which every counter in BROKEN reports as zero. Without this the run renders as a
+    # clean sweep and exits 0, and the workflow promises the opposite — "exits non-zero
+    # only when the harness broke — mutants generated and never judged". The usual cause
+    # is the selected suite failing inside `mutants/`, over a path the tests read from the
+    # repo root that `also_copy` does not carry.
+    if stats.get("total") and not checked:
+        broken["never_judged"] = stats["total"]
     survivors = _survivors()
 
     # Rendered first because it can add to `broken`, then spliced in below it.
-    if not stats["survived"]:
+    if not checked:
+        body = [
+            "No mutant was judged, so this run says nothing about the suite — read it as "
+            "a broken harness, never as a clean sweep.",
+            "",
+        ]
+    elif not stats["survived"]:
         body = ["Nothing survived: every mutant in scope was caught by a test.", ""]
     elif survivors is None:
         broken["survivors_unreadable"] = stats["survived"]

--- a/tests/unit/test_mutation_scope.py
+++ b/tests/unit/test_mutation_scope.py
@@ -1,0 +1,78 @@
+"""The mutation report's own failure mode: a run that judged nothing.
+
+`report()` renders the weekly job's summary and picks its exit code. Both readings come
+from counters that a runner which died before its first verdict leaves at zero — so
+"every mutant was caught" and "no mutant was ever judged" arrive as the same numbers, and
+only `total` tells them apart. `_survivors()` already refuses that confusion one level
+down ("nothing survived" versus "the tool that lists survivors did not run"); these pin
+the same distinction one level up, where the summary a human actually reads is written.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load():
+    # By path, like the store-doc generator: tests/ is not a package, and a bare pytest
+    # invocation should not need it on the module search path.
+    spec = importlib.util.spec_from_file_location(
+        "mutation_scope", ROOT / "tests" / "mutation_scope.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _report(monkeypatch, tmp_path, capsys, **counters) -> tuple[int, str]:
+    """Run `report()` over one stats file and return (exit code, rendered markdown)."""
+    module = _load()
+    stats = {
+        "killed": 0,
+        "survived": 0,
+        "total": 0,
+        "no_tests": 0,
+        "skipped": 0,
+        "suspicious": 0,
+        "timeout": 0,
+        "check_was_interrupted_by_user": 0,
+        "segfault": 0,
+        **counters,
+    }
+    path = tmp_path / "mutmut-cicd-stats.json"
+    path.write_text(json.dumps(stats), encoding="utf-8")
+    monkeypatch.setattr(module, "STATS", path)
+    # Stubbed: the real one shells out to `mutmut results`, which needs a run on disk.
+    monkeypatch.setattr(module, "_survivors", lambda: [])
+    code = module.report()
+    return code, capsys.readouterr().out
+
+
+def test_a_run_that_judged_nothing_is_broken_not_a_clean_sweep(monkeypatch, tmp_path, capsys):
+    """mutmut generating mutants and judging none is the harness breaking.
+
+    It is what a baseline failing inside `mutants/` produces — a path the tests read from
+    the repo root that `also_copy` does not carry — and it leaves every counter in BROKEN
+    at zero. The workflow's contract is that this exits non-zero ("mutants generated and
+    never judged"), and the summary must not claim the suite caught anything.
+    """
+    code, out = _report(monkeypatch, tmp_path, capsys, total=4139)
+
+    assert code == 1, "a run that judged nothing must fail the job"
+    assert "every mutant in scope was caught" not in out
+    assert "The run itself is broken" in out
+    assert "never_judged" in out
+
+
+def test_a_real_clean_sweep_still_reads_as_one(monkeypatch, tmp_path, capsys):
+    """The other side of the same boundary, so the fix cannot swallow a genuine pass."""
+    code, out = _report(monkeypatch, tmp_path, capsys, killed=970, total=4139)
+
+    assert code == 0
+    assert "Nothing survived: every mutant in scope was caught by a test." in out
+    assert "The run itself is broken" not in out


### PR DESCRIPTION
## What

The weekly mutation run has never judged a mutant, and reports the opposite. `also_copy` is
missing two paths the selected suite reads from the repo root, so mutmut's baseline fails
inside `mutants/`; `report()` renders the resulting zeroes as a clean sweep and exits 0.

## Why

The one scheduled run so far ([#1](https://github.com/flop-labs/technocore-chat/actions/runs/32619000029))
died on `mutants/README.md` — and the summary it wrote to `$GITHUB_STEP_SUMMARY` said:

> **0 killed, 0 survived** of 0 mutants checked — 0% caught.
>
> Nothing survived: every mutant in scope was caught by a test.

Locally that is 4,139 mutants generated and none judged. Every name in `BROKEN` is zero when
the runner dies before its first verdict, and the exported `total` alone separates the two
readings. mutation.yml already states the rule this makes true — "exits non-zero only when
the harness broke — mutants generated and never judged" — and `_survivors()` refuses the
same conflation one level down.

Two halves of one problem: the run works again, and the next breakage says so.
`test_store_doc.py` is deselected rather than carried — under mutation it asserts a
generated page against a rewritten module, so it fails for every store mutant and would
score them killed without seeing them. No changelog entry; nothing deployer-visible moves.
**Baseline** left alone: it runs in the original tree, so the report is what catches the
next gap.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 392 passed, 97.51%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: none — CI tooling only
- [x] New surface on a world-writable service: nothing new

Rebased on `fe50623`. Verified after the fix: the baseline passes inside `mutants/` and the
run reaches its verdicts.
