### PR TITLE
perf(rooms): stamp topic writes, not every note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,25 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/rooms` still walked every room on 0.9.4, because `notes_written` replaced `messages`
+  as the thing ageing its cache out.** A topic is an ordinary note, so the stamp kept
+  `notes_written` to keep topic changes immediate — but that counter moves for *every*
+  note, and the listing renders exactly one namespace. Measured on technocore.chat:
+  1,281 note writes a minute, **3** of them topics, so the stamp turned over ~24 times per
+  3s window and the hit rate stayed at 0. `topics_written` is the same signal narrowed to
+  what is displayed; `notes_written` is unchanged and still keys the note gauge.
+
+  `rooms_cache_bench` gained the note-write axis it was missing — it drove messages only,
+  which is why it scored 0.9.4 as fixed. 512 rooms, 10s, 24 messages/s + 8 notes/s:
+
+  ```
+  0.9.3: messages + notes    29 walks / 29 requests   1.00 per request   5.91 ms median
+  0.9.4: notes_written       29 walks / 29 requests   1.00 per request   5.61 ms median
+  proposed: topics_written    4 walks / 29 requests   0.14 per request   0.31 ms median
+  ```
+
 ## [0.9.4] - 2026-08-26
 
 PATCH: three concurrency defects on the note path, and a `/rooms` cache that never hit. No route,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+## [0.9.5] - 2026-08-26
+
+The `/rooms` cache 0.9.4 was supposed to fix, actually hitting. 0.9.4 took `messages` out of
+the stamp and left `notes_written`, which moves for every note while the listing renders one
+namespace — so under a real write mix the hit rate stayed at 0 and nothing changed. No
+contract moves: structure, topics included, is still exact on the very next listing.
+
 ### Fixed
 
 - **`/rooms` still walked every room on 0.9.4, because `notes_written` replaced `messages`
@@ -741,7 +748,8 @@ this is the point it became a standalone, versioned, independently released proj
 - Per-IP token-bucket rate limiting with the retry delay in the 429 **body**, since agent harnesses
   show the page text and not the headers.
 
-[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.9.4...HEAD
+[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.9.5...HEAD
+[0.9.5]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.5
 [0.9.4]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.4
 [0.9.3]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.3
 [0.9.2]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.2

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.flop-labs/technocore-chat",
   "description": "Shared rooms and durable notes for agents over plain HTTP: rendezvous, hand-off, coordination.",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "status": "active",
   "websiteUrl": "https://technocore.chat",
   "repository": {
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "technocore-mcp",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -37,7 +37,7 @@ from . import protocol
 # here at build time, so the wheel, `initialize`'s serverInfo and the User-Agent cannot
 # disagree. `mcp/server.json` states it twice more, which a test and the release workflow
 # check against this constant.
-VERSION = "0.9.4"
+VERSION = "0.9.5"
 DEFAULT_URL = "https://technocore.chat"
 WAIT_CEILING = 10.0  # the service's own long-poll ceiling; asking for more just holds a socket
 TIMEOUT = 3 * WAIT_CEILING  # comfortably over it, so a held poll is never the thing that times out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "technocore-chat"
-version = "0.9.4"
+version = "0.9.5"
 description = "HTTP-native chat and notes for AI agents — over plain GETs or MCP"
 license = "Apache-2.0"
 # One Python, everywhere: `.python-version` pins what uv provisions locally and in CI, and

--- a/src/app.py
+++ b/src/app.py
@@ -592,7 +592,7 @@ MAX_ROOMS_CACHE = 64
 # /rooms is allowed to be stale about, so a counter added to the store later must be
 # considered here on purpose instead of silently joining a correctness-sensitive value.
 # `messages` is the one deliberately absent — see _rooms_stamp.
-ROOMS_STAMP_KEYS = ("rooms_created", "reaped_idle", "reaped_stillborn", "notes_written")
+ROOMS_STAMP_KEYS = ("rooms_created", "reaped_idle", "reaped_stillborn", "topics_written")
 
 
 def _rooms_stamp() -> tuple:
@@ -618,8 +618,9 @@ def _rooms_stamp() -> tuple:
     result up to EDGE_CACHE_SECONDS stale on top of it.
 
     So the split is structural-exact, recency-bounded. A room appearing (rooms_created),
-    a room disappearing (reaped_idle, reaped_stillborn) and a topic change — a topic is an
-    ordinary note, hence notes_written — are still reflected at once, from any worker, and
+    a room disappearing (reaped_idle, reaped_stillborn) and a topic change (topics_written,
+    bumped only by a write to the one namespace this listing shows) are still reflected at
+    once, from any worker, and
     so is `total`. Everything else the walk measures now lags by up to ROOMS_CACHE_SECONDS,
     with the clock as its bound rather than the stamp: `idle_seconds`, `last_seq`, the
     recency order, the engagement aggregates, and the byte figures — an append moves a

--- a/src/store.py
+++ b/src/store.py
@@ -205,7 +205,14 @@ EVENTS_NICK = "server"
 # files. Summing `last_seq` across rooms therefore *decreases* on a reap, which would make
 # a "messages since the last digest" delta negative. These four only ever go up.
 COUNTERS_FILE = ".counters"
-COUNTER_KEYS = ("messages", "rooms_created", "reaped_idle", "reaped_stillborn", "notes_written")
+COUNTER_KEYS = (
+    "messages",
+    "rooms_created",
+    "reaped_idle",
+    "reaped_stillborn",
+    "notes_written",
+    "topics_written",
+)
 # Periodic aggregate samples, so growth over a window is answerable at all: the counters
 # above say what the totals are *now*, and nothing but a stored history says what they were
 # a day ago. Kept here rather than in the reader because the service is the only thing that
@@ -743,7 +750,7 @@ def _cached_window(root: Path, name: str, stamp: tuple) -> tuple[int, list[str]]
     return view
 
 
-# Topic previews, valid while notes_written holds (a topic set is a note write); reaper
+# Topic previews, valid while topics_written holds (bumped only by a `topic` note); reaper
 # deletions age out with NOTE_STATS_CACHE_SECONDS, like the note gauge in app.py.
 _topics_memo: tuple = ((), 0.0, {})
 
@@ -788,7 +795,7 @@ def room_stats(root: Path, limit: int = 50) -> dict:
     entries.sort(reverse=True)
     shown = []
     windows = []
-    topics_stamp = (counters(root)["notes_written"], str(root))
+    topics_stamp = (counters(root)["topics_written"], str(root))
     mono = time.monotonic()
     for mtime, size, name, mtime_ns in entries[: max(1, min(int(limit), MAX_LIMIT))]:
         top, nicks = _cached_window(root, name, (mtime_ns, size))
@@ -1726,7 +1733,13 @@ def note_set(
         _replace(path, value.encode("utf-8"))
     # After the write is on disk, like append's bump: the counter invalidates the
     # note-derived caches, and being on disk every worker sees it.
-    _bump(root, notes_written=1)
+    #
+    # topics_written is the same signal narrowed to what /rooms actually displays. A topic
+    # IS an ordinary note, so notes_written still counts it and the note gauge still keys
+    # on that — but the listing shows only this one namespace, and keying it on every note
+    # meant a `did` or `kv` write aged out the room walk. Measured on technocore.chat
+    # 2026-08-26: 1,281 note writes a minute, 3 of them topics.
+    _bump(root, notes_written=1, **({"topics_written": 1} if ns == TOPIC_NS else {}))
     return {"ns": ns, "key": key, "bytes": len(value.encode()), "ts": _now()}
 
 

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,19 +1,19 @@
 {
-  "core_total": 2021,
+  "core_total": 2027,
   "caps": {
-    "core/app.py": 977,
+    "core/app.py": 976,
     "core/config.py": 57,
     "core/didkey.py": 57,
     "core/limit.py": 132,
-    "core/store.py": 798,
-    "core_total": 2021
+    "core/store.py": 805,
+    "core_total": 2027
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1735,
-      "code_lines": 977,
-      "comment_lines": 239,
-      "tokens_per_line": 7.89
+      "raw_lines": 1777,
+      "code_lines": 976,
+      "comment_lines": 256,
+      "tokens_per_line": 7.9
     },
     "core/config.py": {
       "raw_lines": 243,
@@ -34,10 +34,10 @@
       "tokens_per_line": 8.63
     },
     "core/store.py": {
-      "raw_lines": 1781,
-      "code_lines": 798,
-      "comment_lines": 368,
-      "tokens_per_line": 7.27
+      "raw_lines": 1801,
+      "code_lines": 805,
+      "comment_lines": 374,
+      "tokens_per_line": 7.24
     },
     "extra/manifest.py": {
       "raw_lines": 1590,

--- a/tests/capacity_bench.py
+++ b/tests/capacity_bench.py
@@ -326,11 +326,14 @@ def rooms_cache_bench(root: Path, seconds: float = 6.0) -> None:
     import app
     import config
 
-    messages_per_sec, rooms_per_sec = 24.0, 2.85  # technocore.chat, 0.9.3, under live load
+    # technocore.chat under live load. notes_per_sec is the axis this bench was missing:
+    # production writes ~8 notes/sec and ~0.05 of them are topics, so a stamp that keys on
+    # notes_written turns over ~24x per 3s window even with `messages` already out of it.
+    messages_per_sec, rooms_per_sec, notes_per_sec = 24.0, 2.85, 8.0
     pool = min(512, _drain((root / "rooms").glob("r*.jsonl"))) or 1
 
     def run(label: str, keys: tuple) -> None:
-        walks, latencies, sent, served = 0, [], 0, 0
+        walks, latencies, sent, served, noted = 0, [], 0, 0, 0
         last: dict | None = None
         app._rooms_cache.clear()
         app.ROOMS_STAMP_KEYS = keys
@@ -339,6 +342,11 @@ def rooms_cache_bench(root: Path, seconds: float = 6.0) -> None:
             if sent / messages_per_sec <= now:
                 store.append(root, f"r{sent % pool}", "bench", f"m{sent}")
                 sent += 1
+            if noted / notes_per_sec <= now:
+                # A non-topic namespace, which is what production's note traffic is:
+                # `did` and friends outnumber topic writes ~400:1.
+                store.note_set(root, "did", f"k{noted % 4096:04x}", f"v{noted}")
+                noted += 1
             if served / rooms_per_sec <= now:
                 at = time.perf_counter()
                 view = app._rooms_view(50)
@@ -372,8 +380,10 @@ def rooms_cache_bench(root: Path, seconds: float = 6.0) -> None:
         # config.ROOT is bound at import, and this script imports store (hence config) long
         # before it knows where the store is. Without this both halves walk /data.
         with config.override(ROOT=root):
-            run("messages in the stamp", ("messages", *stamped))
-            run("structural stamp only", stamped)
+            structural = ("rooms_created", "reaped_idle", "reaped_stillborn")
+            run("0.9.3: messages + notes", ("messages", *structural, "notes_written"))
+            run("0.9.4: notes_written", (*structural, "notes_written"))
+            run("proposed: topics_written", (*structural, "topics_written"))
     finally:
         app.ROOMS_STAMP_KEYS = stamped
     print(

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -109,7 +109,8 @@ def test_rooms_cache_is_exact_about_structure_and_only_lags_on_recency(client, t
         client.get("/r/second/say/bot/hi")
         assert "second" in client.get("/rooms").text, "a room created a moment ago must appear"
 
-        # So does a topic. A topic is an ordinary note, so it moves notes_written.
+        # So does a topic — it moves topics_written, which is stamped precisely because
+        # this is the one namespace the listing renders.
         client.get("/kv/topic/first/set/what%20first%20is%20for")
         assert "what first is for" in client.get("/rooms").text
         before = client.get("/rooms?format=json").json()  # the walk the next reads reuse
@@ -134,6 +135,44 @@ def test_rooms_cache_is_exact_about_structure_and_only_lags_on_recency(client, t
         (tmp_path / ".reaped").unlink(missing_ok=True)  # the reaper is throttled; let it run
         client.get("/r/first/say/bot/reap%20now")
         assert "second" not in client.get("/rooms").text, "a reaped room must disappear at once"
+
+
+def test_a_note_outside_the_topic_namespace_does_not_age_out_the_rooms_walk(client):
+    """Only the namespace /rooms renders may invalidate the walk that renders it.
+
+    A topic is an ordinary note, so `notes_written` counts it — but it counts every other
+    note too, and the listing shows none of them. Stamping it meant a `did` or `kv` write
+    aged out the room walk: measured on technocore.chat 2026-08-26, 1,281 note writes a
+    minute of which 3 were topics, so /rooms walked all 10,240 rooms on essentially every
+    request even with `messages` already out of the stamp. `topics_written` is the same
+    signal narrowed to what is actually displayed.
+
+    Asserted through recency rather than a hit counter: a message is deliberately served
+    stale, so if the note that follows it invalidated the walk the *message* would appear.
+    The window is pinned far above anything this test spends, so only the stamp can be the
+    thing invalidating.
+    """
+    import config
+
+    with config.override(ROOMS_CACHE_SECONDS=60):
+        client.get("/r/first/say/bot/hi")
+        assert "first" in client.get("/rooms").text  # populates the cache
+
+        client.get("/r/first/say/bot/again")  # bumps last_seq to 2; must stay stale
+        client.get("/kv/did/0123456789abcdef/set/did%3Akey%3Az6MkTest")  # not a topic
+
+        view = client.get("/rooms?format=json").json()
+        by_name = {r["room"]: r for r in view["rooms"]}
+        assert by_name["first"]["last_seq"] == 1, (
+            "a did note invalidated the /rooms walk — the listing does not render that "
+            "namespace, so it must not be stamped"
+        )
+
+        # The converse still holds: the namespace that IS rendered invalidates at once.
+        client.get("/kv/topic/first/set/now%20it%20has%20a%20topic")
+        after = client.get("/rooms?format=json").json()
+        assert {r["room"]: r for r in after["rooms"]}["first"]["last_seq"] == 2
+        assert "now it has a topic" in client.get("/rooms").text
 
 
 def test_a_message_reaches_rooms_within_the_cache_window(client):


### PR DESCRIPTION
## What

`/rooms` still walks every room on 0.9.4. #245 took `messages` out of the cache stamp and kept `notes_written`, because a topic is an ordinary note and topic changes have to stay immediate. But `notes_written` moves for **every** note, and the listing renders exactly **one** namespace.

Measured on technocore.chat 2026-08-26, in a 60-second window:

```
did      806        topic      3     <- the only namespace /rooms renders
lobby    368
style      7
                    1,281 note writes total
```

At 8.02 notes/sec the stamp turns over **~24 times per 3-second window**, so the hit rate is still 0 and every `/rooms` request stats the whole store. On the box, before and after 0.9.4:

| | 0.9.3 | 0.9.4 |
|---|---|---|
| `newfstatat`/sec | 29,193 | 20,952 |
| **stats per `/rooms` request** | ~8,300 | **~7,857** |

The other three stamped counters are effectively static by comparison — `rooms_created` and `reaped_stillborn` are 0.03/sec, `reaped_idle` is 0.

`topics_written` is that signal narrowed to what is displayed. `notes_written` is untouched and still keys the note gauge, which legitimately depends on all of them.

## The benchmark scored 0.9.4 as fixed, and shouldn't have

`rooms_cache_bench` drove **messages only** — it never wrote a note, so `notes_written` never moved and the structural stamp looked stable. That is why #245 measured 4 walks / 29 requests and production got none of it.

It now drives production's mix. 512 rooms, 10s, 24 messages/s **+ 8 notes/s**:

```
0.9.3: messages + notes    29 walks / 29 requests   1.00 per request   5.91 ms median
0.9.4: notes_written       29 walks / 29 requests   1.00 per request   5.61 ms median
proposed: topics_written    4 walks / 29 requests   0.14 per request   0.31 ms median
```

**0.9.4 is indistinguishable from 0.9.3 under a realistic write mix.** Four walks in ten seconds is `ceil(10 / ROOMS_CACHE_SECONDS)` — the clock bound, as intended.

## Contract

Unchanged from #245, and the reason this is a fix rather than a further relaxation: structure stays exact. A room created, a room reaped, **and a topic changed** are all still on the very next listing from any worker. Only recency lags, bounded by `ROOMS_CACHE_SECONDS`. `CHAT_ROOMS_CACHE_SECONDS=0` remains the escape hatch.

## Verification

`test_a_note_outside_the_topic_namespace_does_not_age_out_the_rooms_walk` asserts it through recency rather than a hit counter: a message is deliberately served stale, so if the note after it invalidated the walk the *message* would appear. **Reverting only the stamp key fails it** with `assert 2 == 1`, and the converse (a topic write invalidating at once) is asserted in the same test.

`test_rooms_cache_is_exact_about_structure_and_only_lags_on_recency` had a comment saying a topic moves `notes_written`; updated rather than left stale.

Full AGENTS.md sequence on `944c918`:

```
ruff check .          All checks passed!
ruff format --check   54 files already formatted
ty check              All checks passed!
pytest tests -q       391 passed
sz.py --check         exit 0
```

## Size

`core/store.py` 798 → 805. **Seven of those eight lines are ruff exploding `COUNTER_KEYS`** — its contents were already 79 of the 83 characters the line budget allows, so any sixth key forces it multi-line whatever the name. The behaviour is one line: `_bump(root, notes_written=1, **({"topics_written": 1} if ns == TOPIC_NS else {}))`.

Caps and baseline set to exactly current with no headroom, per #246's precedent. `core/app.py` ratchets down 977 → 976.

Happy to drop the counter and stamp `stat(notes/topic).st_mtime_ns` instead if you would rather not spend the lines — every note write is an `os.replace`, so the directory mtime moves on exactly the same events. It trades a counter for a stat and a `FileNotFoundError` branch, which is why I did not lead with it.


## Release

This PR also **cuts 0.9.5**, so merging it is the whole release: push `v0.9.5` afterwards and
`release.yml` builds and publishes. Both of its guards are simulated green on this branch —

```
tag=0.9.5 pyproject=0.9.5          guard 1 PASS
## [0.9.5] in CHANGELOG.md         guard 2 PASS
```

Version moved in the four places a release moves it: `pyproject.toml`, `mcp/server.json` (x2),
the MCP wrapper's `VERSION`, and the CHANGELOG compare links. No README change — 0.9.4's was
the config-table prose from #245, not a version.
