### PR TITLE
docs: an allow-list is replaced, never emptied

### DIFF
--- a/src/manual.md
+++ b/src/manual.md
@@ -139,6 +139,11 @@ the owner can write:
         signature covers `room-allow|d-<room>|<greater_nonce>|<value>`
 The allow-list nonce must be greater than claim_nonce: both signed ownership
 namespaces share /kv/room-nonce/<room> as their replay counter.
+An allow-list can be replaced but never emptied: a note with nothing visible left
+after the sweep is refused, and so is any entry that is not a did:key, because a
+list fails closed and an unparseable one would let nobody in. To revoke every
+guest, write the owner's own key as the whole list — the owner may write anyway,
+so that list grants nothing to anyone else.
 Handing the room over is the same signed write against room-owners. Signed note
 writes exist for those two namespaces and nowhere else — every other note is
 world-writable, as before. /kv/room-nonce/<room> is the server's replay counter

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -87,6 +87,10 @@ must be signed by the same did:key being stored, proving the claimant holds that
 The allow-list nonce must be greater than the claim nonce: room-owners and room-allow
 share /kv/room-nonce/d-jobs as their replay counter.
 
+To revoke everyone you replace the list, you do not clear it: an empty value is
+refused by the sweep and a non-did:key entry is refused as junk, so write the
+owner's own key as the whole list.
+
 Now /r/d-jobs takes signed writes from the owner and listed keys, nothing else — a
 bounty room where announcements, claims and results are all attributable.
 

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -846,6 +846,47 @@ def test_an_allow_list_needs_an_owner_and_fails_closed_on_junk(client):
     assert client.get("/kv/room-allow/d-orphan").status_code == 404
 
 
+def test_an_allow_list_is_replaced_never_emptied(client):
+    """Revoking every guest means writing the owner's own key.
+
+    The list has no empty state to clear it to: the sweep refuses a value with
+    nothing visible left, and the allow-list gate refuses anything that is not a
+    did:key. Both are deliberate — a list that failed open, or one an owner
+    believed they had cleared, would keep letting a revoked guest write.
+    """
+    owner, owner_sign = _keypair()
+    guest, guest_sign = _keypair(seed=2)
+    _claim(client, "d-revoke", owner, owner_sign)
+    assert (
+        _set_signed(client, "room-allow", "d-revoke", owner, owner_sign, guest, nonce=2).status_code
+        == 200
+    )
+    assert _say_signed(client, "d-revoke", guest, guest_sign, "listed", nonce=1).status_code == 200
+
+    # Refused, and deliberately not pinned to *which* gate refuses it: an empty
+    # value trips the sweep, and the allow-list gate rejects it independently, so
+    # asserting one message would pin gate ordering rather than the behaviour.
+    empty = _set_signed(client, "room-allow", "d-revoke", owner, owner_sign, "", nonce=3)
+    assert empty.status_code == 400
+    assert client.get("/kv/room-allow/d-revoke").text.strip().endswith(guest)
+    # A refused write leaves the list exactly as it was: the guest still writes.
+    # nonce=2: a message nonce must strictly increase per key per room, so reusing
+    # 1 here would fail for that reason and prove nothing about the allow-list.
+    assert (
+        _say_signed(client, "d-revoke", guest, guest_sign, "still listed", nonce=2).status_code
+        == 200
+    )
+
+    # The documented revocation: replace the list with the owner's own key.
+    assert (
+        _set_signed(client, "room-allow", "d-revoke", owner, owner_sign, owner, nonce=4).status_code
+        == 200
+    )
+    revoked = _say_signed(client, "d-revoke", guest, guest_sign, "no longer", nonce=3)
+    assert revoked.status_code == 403
+    assert _say_signed(client, "d-revoke", owner, owner_sign, "owner writes").status_code == 200
+
+
 def test_signed_note_writes_are_scoped_to_the_two_ownership_namespaces(client):
     did, sign = _keypair()
     r = _set_signed(client, "plans", "next", did, sign, "ship")


### PR DESCRIPTION
## What

Documents how an owner revokes every guest from a claimed `d-` room, in the manual
and `patterns.md`, and pins the behaviour with a regression test. No source change.

## Why

Nothing said how to revoke, and the two obvious moves both fail: an empty value is
refused by the sweep (`store.py`), and a placeholder is refused because every entry
must parse as a `did:key` (`app.py`, "a list with an unparseable entry lets nobody
in"). Both gates are deliberate and fail closed, so the only revocation is to
replace the list with the owner's own key — which grants nothing, since the owner
may write regardless.

`test_an_allow_list_needs_an_owner_and_fails_closed_on_junk` already covers a
non-`did:key` entry, but not the empty one, which a different gate answers. The new
test asserts the refusal and that the list is unchanged, deliberately *not* which
gate answers: that ordering is an implementation detail. Verified meaningful by
removing both gates, under which it fails.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 391 passed, 97.43%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — all pass
- [x] Docs that would now be wrong are updated: `src/manual.md`, `src/patterns.md`
- [x] New surface on a world-writable service: nothing new — docs and a test only

Run on Linux; the suite cannot run on Windows (`fcntl`), which is what #232 is about.