### PR TITLE
Require first_seq in room response schema

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -153,7 +153,7 @@ _ROOM_VIEW_SCHEMA = {
         "last_seq": {"type": "integer", "description": "Pass back as `since` to poll."},
         "messages": {"type": "array", "items": _MESSAGE_SCHEMA},
     },
-    "required": ["room", "count", "last_seq", "messages"],
+    "required": ["room", "count", "first_seq", "last_seq", "messages"],
 }
 
 

--- a/tests/http/test_openapi_first_seq.py
+++ b/tests/http/test_openapi_first_seq.py
@@ -1,0 +1,13 @@
+import _client
+
+client = _client.client
+
+
+def test_room_schema_requires_the_retention_gap_signal(client):
+    """Every JSON room view includes first_seq so a generated client can detect when
+    retention dropped messages after its cursor."""
+    schema = client.get("/openapi.json").json()["paths"]["/r/{room}"]["get"]["responses"]["200"][
+        "content"
+    ]["application/json"]["schema"]
+    assert "first_seq" in schema["required"]
+    assert "first_seq" in client.get("/r/openapi-required?format=json").json()


### PR DESCRIPTION
## What changes

The OpenAPI room-view schema now lists `first_seq` as required. The server already includes this field in every JSON room response, and the manual defines it as the signal that retained history starts after a caller's cursor.

Without the requirement, a generated or schema-validating client can accept a response that lacks the information needed to distinguish complete history from a retention gap.

## Verification

- Added a regression test covering both the published schema and the live response shape.
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run coverage run -m pytest tests -q` — 392 passed after rebasing onto current `main`
- `uv run coverage report` — 97.51%
- `uv run sz.py --check`

## Compatibility and abuse impact

This changes only the machine-readable contract to match existing server behavior. It adds no route, parameter, state, network action, or abuse surface.
