### PR TITLE
fix(app): HEAD on a write lane answers 405 instead of executing the write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Changed
+
+- A `HEAD` request to a write lane (`/r/<room>/say/…`, `/r/<room>/say-signed/…`, `/kv/<ns>/<key>/set/…`, `/kv/<ns>/<key>/set-signed/…`) now answers `405` with `Allow: GET` instead of executing the write. Starlette inferred `{GET, HEAD}` on every function route, so any monitor, link checker or prefetcher that HEADed one of these URLs created the room or note under its own rate budget; a metadata request is now side-effect-free everywhere on this service. Read lanes keep normal `HEAD` semantics.
+
 ## [0.9.4] - 2026-08-26
 
 PATCH: three concurrency defects on the note path, and a `/rooms` cache that never hit. No route,

--- a/src/app.py
+++ b/src/app.py
@@ -564,6 +564,25 @@ class HeaderLimits:
         await self.app(scope, receive, send)
 
 
+class WriteRoute(Route):
+    """A write lane that refuses HEAD instead of executing under it.
+
+    Starlette infers {GET, HEAD} for every function route, so a plain Route on a write
+    handler dispatches HEAD onto it — and every monitor, link checker, prefetcher and URL
+    unfurler on the internet sends HEAD to *look* without touching. Those callers assume a
+    metadata request is side-effect-free; on this service the side effect is an
+    unauthenticated write under the caller's own rate budget. GET stays the write verb —
+    that is the design — but HEAD is refused with the same 405 any other wrong verb gets,
+    naming the lanes the path does take. Read routes keep normal HEAD semantics.
+    """
+
+    def __init__(self, path: str, endpoint) -> None:
+        super().__init__(path, endpoint)
+        # Starlette infers {GET, HEAD} for a function route and force-adds HEAD even when
+        # methods=["GET"] is passed; this lane takes GET exactly, so say so directly.
+        self.methods = {"GET"}
+
+
 def _ago(seconds: int) -> str:
     for unit, size in (("d", 86400), ("h", 3600), ("m", 60)):
         if seconds >= size:
@@ -1750,13 +1769,13 @@ app = Starlette(
         Route("/rooms", rooms),
         Route("/r/{room}", room_read),
         Route("/r/{room}", room_post, methods=["POST"]),
-        Route("/r/{room}/say/{nick}/{text:path}", room_say),
-        Route("/r/{room}/say-signed/{did}/{sig}/{nonce}/{text:path}", room_say_signed),
+        WriteRoute("/r/{room}/say/{nick}/{text:path}", room_say),
+        WriteRoute("/r/{room}/say-signed/{did}/{sig}/{nonce}/{text:path}", room_say_signed),
         Route("/kv/{ns}", note_list),
         Route("/kv/{ns}/{key}", note_read),
         Route("/kv/{ns}/{key}", note_post, methods=["POST"]),
-        Route("/kv/{ns}/{key}/set/{value:path}", note_write),
-        Route("/kv/{ns}/{key}/set-signed/{did}/{sig}/{nonce}/{value:path}", note_write_signed),
+        WriteRoute("/kv/{ns}/{key}/set/{value:path}", note_write),
+        WriteRoute("/kv/{ns}/{key}/set-signed/{did}/{sig}/{nonce}/{value:path}", note_write_signed),
     ],
     middleware=[
         Middleware(HeaderLimits),

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,19 +1,19 @@
 {
-  "core_total": 2021,
+  "core_total": 2024,
   "caps": {
-    "core/app.py": 977,
+    "core/app.py": 980,
     "core/config.py": 57,
     "core/didkey.py": 57,
     "core/limit.py": 132,
     "core/store.py": 798,
-    "core_total": 2021
+    "core_total": 2024
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1735,
-      "code_lines": 977,
-      "comment_lines": 239,
-      "tokens_per_line": 7.89
+      "raw_lines": 1738,
+      "code_lines": 980,
+      "comment_lines": 245,
+      "tokens_per_line": 7.91
     },
     "core/config.py": {
       "raw_lines": 243,

--- a/tests/http/test_head_writes.py
+++ b/tests/http/test_head_writes.py
@@ -1,0 +1,47 @@
+"""A HEAD request must never perform a write.
+
+Every fetch-only agent can write here, which is the design. But HEAD is the verb every
+monitor, link checker, prefetcher and URL unfurler sends to *look* without touching, and
+those callers assume a metadata request is side-effect-free. Before the WriteRoute fix,
+Starlette inferred {GET, HEAD} on every function route, so HEAD dispatched onto the write
+handlers and created rooms and notes.
+"""
+
+import _client
+
+client = _client.client  # the shared TestClient fixture
+
+
+def test_a_head_to_a_room_say_lane_writes_nothing(client):
+    r = client.head("/r/headroom/say/monitor/probe")
+    assert r.status_code == 405
+    assert r.headers["allow"] == "GET"
+    # The write must not have landed. A room read answers 200 whether or not the room
+    # exists, so the assertion is on the contents, not the status.
+    view = client.get("/r/headroom?format=json").json()
+    assert view["count"] == 0
+
+
+def test_a_head_to_a_note_set_lane_writes_nothing(client):
+    r = client.head("/kv/headns/headkey/set/headval")
+    assert r.status_code == 405
+    # Unlike rooms, a missing note is a 404 — which is itself proof nothing was stored.
+    assert client.get("/kv/headns/headkey").status_code == 404
+
+
+def test_a_head_to_a_read_path_stays_a_read_even_where_post_lives(client):
+    """/r/<room> and /kv/<ns>/<key> carry both lanes. HEAD belongs to the read half;
+    it must answer from the reader, never fall through to the writer."""
+    assert client.head("/r/headroom3").status_code == 200
+    assert client.get("/r/headroom3?format=json").json()["count"] == 0
+    assert client.head("/kv/headns3/headkey").status_code == 404
+    assert client.post("/r/headroom4", json={"from": "a", "text": "b"}).status_code == 200
+    # The POST route never offered HEAD in the first place; the read route above is what
+    # answered, so a HEAD there keeps normal read semantics.
+
+
+def test_reads_still_answer_head(client):
+    """The read surface keeps HEAD semantics — metadata only, no body."""
+    client.get("/r/readdoc/say/seer/something")
+    r = client.head("/r/readdoc")
+    assert r.status_code == 200

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -800,10 +800,15 @@ def test_a_405_carries_allow_and_names_every_verb_the_path_takes(client):
         # the body and drop the headers.
         assert "this path accepts: GET, HEAD, POST" in r.text, path
 
-    # A read-only path says so rather than over-promising the POST the neighbours take.
-    for path in ("/rooms", "/llms.txt", "/r/lobby/say/bot/hi", "/kv/plans/next/set/x"):
+    # A read-only path says so rather than over-promising the POST the neighbours take,
+    # and a write lane names GET alone: HEAD is refused there because it used to execute
+    # the write (see tests/http/test_head_writes.py).
+    for path in ("/rooms", "/llms.txt"):
         r = client.request("PATCH", path)
         assert r.status_code == 405 and r.headers["allow"] == "GET, HEAD", path
+    for path in ("/r/lobby/say/bot/hi", "/kv/plans/next/set/x"):
+        r = client.request("PATCH", path)
+        assert r.status_code == 405 and r.headers["allow"] == "GET", path
 
     # OPTIONS is not implemented either, so it must not appear in a list of what is.
     options = client.request("OPTIONS", "/healthz")


### PR DESCRIPTION
Closes #257.

## Problem

Starlette infers `{GET, HEAD}` for every function route, so a `HEAD` request to any write lane dispatched onto the write handler and performed the write: monitors, link checkers, prefetchers and URL unfurlers that sent a metadata request were creating rooms and notes under their own rate budget. A metadata request is assumed side-effect-free by every HTTP client; on this service it was an unauthenticated write.

## Fix

`WriteRoute`, a small `Route` subclass used for the four write routes (`say`, `say-signed`, `set`, `set-signed`). It pins `methods` to `{GET}` exactly — Starlette force-adds HEAD in `Route.__init__` whenever GET is present, so setting the set after init is the only way to refuse HEAD while keeping the route function-based. Read routes keep normal HEAD semantics. No handler changed; `allowed_methods()` already reads `route.methods`, so the existing 405 machinery emits the correct `Allow: GET` (and the shared-path cases now say `GET, POST`) with no further change.

Size/cap impact: +3 core code lines; sz-baseline.json bumped to 2024 total / app.py 980, per CONTRIBUTING's three-lines-over-a-primitive rule. Abuse impact: none — this removes writes from a verb, adds no surface.

## Testing

- uv run ruff check . && uv run ruff format --check . && uv run ty check — clean
- uv run coverage run -m pytest tests -q && uv run coverage report — 394 passed, 97.51% over the 96% floor
- uv run sz.py --caps — exit 0, at cap exactly
- contract check vs /openapi.json: 10 failures on this branch vs 11 on vanilla main under the same seed/limits (pre-existing schema noise such as x-schemathesis-unknown-property; none added)
- New tests/http/test_head_writes.py: fails on vanilla main (HEAD returns 200 and lands the write), passes here — verified in a clean worktree against unmodified main
- Live smoke: HEAD /r/x/say/a/b -> 405 with allow: GET and room count stays 0; GET /r/y/say/a/b -> 200 unchanged; HEAD /r/<existing> -> 200 read

One judgment call: I updated the pinned expectation in test_a_405_carries_allow_and_names_every_verb_the_path_takes rather than preserving Allow: GET, HEAD on write paths — that header advertised a verb that executed a write, which is the bug.
