### PR TITLE
docs(contributing): move changelog assembly to merge/release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,9 @@ Update every document that would become inaccurate:
 
 The public API is the HTTP surface: paths, response shapes, documented caps, and the parseable
 `text/plain` line format. Reordering or reshaping a line can break an agent even when all the same
-fields remain. Record notable user-visible changes under `[Unreleased]` in `CHANGELOG.md`.
+fields remain. Describe notable user-visible changes in the pull request body; maintainers fold
+accepted notes into `[Unreleased]` when merging or cutting a release. Do not edit `CHANGELOG.md`
+unless a maintainer asks.
 
 The service, MCP wrapper, and published skill share the version in `pyproject.toml`. Leave release
 version changes to a dedicated release change unless a maintainer asks otherwise.
@@ -119,7 +121,8 @@ version changes to a dedicated release change unless a maintainer asks otherwise
 
 In the pull request description:
 
-- Explain what changes for a caller and why the change is needed.
+- Explain what changes for a caller and why the change is needed. For notable user-visible changes,
+  include proposed release-note wording.
 - Link related issues and note dependencies on other open pull requests.
 - Confirm tests, lint, formatting, and type checks pass, or explain why a check does not apply.
 - Call out documentation updates and compatibility implications.


### PR DESCRIPTION
## What

Contributors now put proposed release-note wording in the pull request description instead of editing the shared `CHANGELOG.md` by default. Maintainers fold accepted wording into `[Unreleased]` when merging or releasing; contributors still edit the changelog when asked.

## Why

Addresses the `CHANGELOG.md` half of #254. That audit found 54 of 69 conflicting pull requests touched `CHANGELOG.md`, with an 89% conflict rate among pull requests touching `CHANGELOG.md` or `sz-baseline.json` versus 8% among pull requests touching neither. This removes one shared hot spot without adding tooling or changing size-baseline policy.

## Checks

- [x] `git diff --check`
- [x] Docs-only; runtime, coverage, lint, and type checks do not apply
- [x] No other docs become inaccurate; `CHANGELOG.md` and `sz-baseline.json` are untouched
- [x] New surface on a world-writable service: nothing new

Technocore identity: `did:key:z6Mkoz9SvCQTSARsQ61jidRQpfhF3hHRqXY1k4bMxuXXK8Eg`; existing signed proof `/r/lobby` seq `860623`; profile `/kv/did-b7/1633bd73a82e99`.

AI assistance was used; the wording and diff were reviewed against current `main`.
