### PR TITLE
Validate scripts/sign.py names before signing

### DIFF
--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -60,6 +60,10 @@ signature — ready for:
 Nonces are yours to choose (1-19 digits) and must count up per key per room;
 a millisecond clock works, and so does a plain counter.
 
+The room, namespace and key arguments must match the same public name grammar
+the server enforces: lowercase ASCII, digits, underscore and hyphen, beginning
+with a lowercase ASCII letter or digit, up to 48 characters.
+
 'note' prints the note path a DID's identity note lives at, which is where a
 delegation is published: the first 16 lowercase hex characters of
 SHA-256(did:key string), split as /kv/did-<first 2>/<remaining 14>.
@@ -118,6 +122,7 @@ MAX_VALUE_CHARS = 8192  # notes
 # The room/namespace halves are store.py's NAME_RE, so a scope names something that can
 # exist.
 NAME = r"[a-z0-9][a-z0-9_-]{0,47}"
+NAME_RE = re.compile(NAME)
 SCOPE_RE = re.compile(rf"\*|r:{NAME}|kv:{NAME}")
 DIGITS_RE = re.compile(r"[0-9]{1,19}")
 # `mailbox: <room>` already lives in this note (see the manual's IDENTITY section), so a
@@ -152,6 +157,16 @@ def swept(text: str, limit: int) -> str:
             f"{len(cleaned)} characters after the sweep, over the {limit}-character cap — split it"
         )
     return cleaned
+
+
+def name(value: str, label: str) -> str:
+    """A server-storable room/ns/key name, checked before signing."""
+    if not NAME_RE.fullmatch(value):
+        raise SystemExit(
+            f"bad {label} {value!r}: expected /^{NAME}$/ — lowercase letters, digits, - "
+            "and _, 1-48 characters, starting with a letter or digit"
+        )
+    return value
 
 
 def multibase(raw: bytes) -> str:
@@ -423,9 +438,12 @@ def main() -> None:
     if not re.fullmatch(r"[0-9]{1,19}", args.nonce):
         raise SystemExit(f"nonce must be 1-19 ASCII digits, got {args.nonce!r}")
     if args.cmd == "say":
-        canonical = f"{args.room}|{args.nonce}|{swept(args.text, MAX_TEXT_CHARS)}"
+        canonical = f"{name(args.room, 'room')}|{args.nonce}|{swept(args.text, MAX_TEXT_CHARS)}"
     else:
-        canonical = f"{args.ns}|{args.key}|{args.nonce}|{swept(args.value, MAX_VALUE_CHARS)}"
+        canonical = (
+            f"{name(args.ns, 'namespace')}|{name(args.key, 'key')}|"
+            f"{args.nonce}|{swept(args.value, MAX_VALUE_CHARS)}"
+        )
     key, _ = load_key(seed)
     print(did_of(key))
     print(signature(key, canonical))

--- a/tests/http/test_signer.py
+++ b/tests/http/test_signer.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import _client  # noqa: F401 (imported for the fixture alias below)
 
 import didkey
+import store
 
 client = _client.client  # the shared TestClient fixture
 
@@ -72,6 +73,23 @@ def test_nonces_are_rejected_exactly_where_the_server_would_reject() -> None:
     assert re.fullmatch(didkey.SIG_PATTERN, sig)
 
 
+def test_names_are_rejected_exactly_where_the_server_would_reject() -> None:
+    cases = [
+        ("say", ("UPPER", "7", "hi"), "room"),
+        ("say", ("mb-FOO", "7", "hi"), "room"),
+        ("set", ("Room", "d-owned", "7", "value"), "namespace"),
+        ("set", ("room-owners", "D-owned", "7", "value"), "key"),
+        ("set", ("room-owners", "x" * 49, "7", "value"), "key"),
+    ]
+    for cmd, args, label in cases:
+        out = run(cmd, "--seed", SEED, *args)
+        combined = out.stdout + out.stderr
+        assert out.returncode != 0, f"{cmd} accepted {args!r}"
+        assert f"bad {label}" in combined and store.NAME_RE.pattern in combined
+        assert "did:key:" not in out.stdout
+        assert not any(re.fullmatch(didkey.SIG_PATTERN, line) for line in out.stdout.splitlines())
+
+
 def test_a_script_signature_is_accepted_by_the_real_server(client) -> None:
     text = "hello from the signer"
     out = run("say", "--seed", SEED, "signerroom", "3", text)
@@ -81,6 +99,17 @@ def test_a_script_signature_is_accepted_by_the_real_server(client) -> None:
     assert r.status_code == 200, r.text
     assert text in r.text
     assert "<z6Mk" in r.text  # a verified writer renders as the key, not a nickname
+
+
+def test_a_script_note_signature_is_accepted_by_the_real_server(client) -> None:
+    did = run("did", "--seed", SEED).stdout.strip()
+    out = run("set", "--seed", SEED, "room-owners", "d-signer", "1", did)
+    assert out.returncode == 0
+    signed_did, sig = out.stdout.splitlines()
+    assert signed_did == did
+    r = client.get(f"/kv/room-owners/d-signer/set-signed/{did}/{sig}/1/{did}?if_absent=1")
+    assert r.status_code == 200, r.text
+    assert client.get("/kv/room-owners/d-signer").text.strip().endswith(did)
 
 
 def test_a_stored_signed_record_keeps_its_signature(client) -> None:


### PR DESCRIPTION
## What

- Validate `scripts/sign.py` room, namespace, and key arguments against the server's public name grammar before signing.
- Document that grammar in the signer docstring.
- Add signer tests for invalid names and for the documented `set` subcommand against the signed ownership-note lane.

## Why

The signer already refuses nonces and text values the server would reject, but it still emitted signatures for invalid room/ns/key names. That leaves users with a valid-looking signature and a server-side `400`. Failing before signing keeps the standalone helper aligned with the HTTP contract it demonstrates.

## Testing

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/ty check`
- `.venv/bin/coverage run -m pytest tests -q`
- `.venv/bin/coverage report`
- `.venv/bin/python sz.py --check`
- `bash examples/beautiful_chat.sh`
- `uv build --project mcp --out-dir dist/mcp`
- `.venv/bin/python tests/verify_mcp_dist.py dist/mcp/technocore_mcp-0.9.5-py3-none-any.whl dist/mcp/technocore_mcp-0.9.5.tar.gz`
