### PR TITLE
test(notes): pin HEAD on the shared note path to the read half

### DIFF
--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -353,6 +353,17 @@ def test_head_never_executes_a_get_write_lane(client):
     assert client.head("/r/head-signed").status_code == 200  # read-shaped GET keeps HEAD
 
 
+def test_head_on_the_shared_note_path_matches_the_read_half(client):
+    """/kv/<ns>/<key> carries two lanes — GET reader, POST writer — so HEAD has to match
+    the reader rather than fall through to the writer. A probe must neither overwrite a
+    stored value nor spend a write token failing as a bodiless POST."""
+    client.get("/kv/head-shared/state/set/keep-me")
+    assert client.head("/kv/head-shared/state").status_code == 200
+    assert client.get("/kv/head-shared/state").text.strip().endswith("keep-me")
+    # A missing key answers like a read too (404): no fall-through, nothing written.
+    assert client.head("/kv/head-shared/absent").status_code == 404
+
+
 def test_the_signature_covers_the_swept_text_not_the_raw_text(client):
     """Both directions, so the contract is unambiguous: what is stored is what was signed.
 


### PR DESCRIPTION
From the close-out of #258: #135 pins HEAD to the read half of /r/<room>, and this is the other dual-lane path, /kv/<ns>/<key>.

## Problem

/kv/<ns>/<key> carries two lanes — GET reader, POST writer — and nothing pinned which one a HEAD matches. Starlette's route order decides it today; if that ever changed (route reorder, an added methods= on the POST route), HEAD would fall through to the writer: overwriting a stored value as a bodiless probe.

## Fix

Test only. Pins the current contract: HEAD answers from the reader — 200 on a stored note with the value untouched, 404 on an absent key — never the writer. No product code changes.

Abuse impact: none; no new surface.

## Testing

- uv run coverage run -m pytest tests -q — 394 passed
- uv run coverage report — above the 96% floor
- uv run ruff check . && uv run ruff format --check . && uv run ty check — clean
- uv run sz.py --caps — at cap, unchanged

One judgment call: asserted the stored value survives rather than just the status codes, so a future fall-through to the POST lane fails the test even when it happens to return 200.
