### PR TITLE
fix(mcp): publish and enforce numeric argument bounds

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -29,6 +29,7 @@ from typing import (
     Annotated,
     Any,
     Literal,
+    NamedTuple,
     NotRequired,
     TextIO,
     TypedDict,
@@ -152,12 +153,20 @@ _CHECKS: dict[str, Callable[[Any], bool]] = {
 }
 
 
+class Bounds(NamedTuple):
+    """Inclusive numeric bounds carried by ``Annotated`` into JSON Schema."""
+
+    minimum: int | float | None = None
+    maximum: int | float | None = None
+
+
 def fragment(annotation: Any) -> dict[str, Any]:
     """One parameter's JSON Schema, from its annotation.
 
-    `Annotated[int, "..."]` carries the description the model reads; `Literal[...]` becomes
-    an `enum`; and the `None` arm of `X | None` is dropped, because "may be left out" is
-    said by the parameter having a default and lands in `required`, not in `type`.
+    `Annotated[int, "...", Bounds(...)]` carries the description and numeric limits the
+    client reads; `Literal[...]` becomes an `enum`; and the `None` arm of `X | None` is
+    dropped, because "may be left out" is said by the parameter having a default and lands
+    in `required`, not in `type`.
 
     Anything with no mapping raises at import, where a wrong schema is a broken build
     rather than a tool that advertises one contract and enforces another.
@@ -169,6 +178,11 @@ def fragment(annotation: Any) -> dict[str, Any]:
         for note in notes:
             if isinstance(note, str):
                 described["description"] = note
+            elif isinstance(note, Bounds):
+                if note.minimum is not None:
+                    described["minimum"] = note.minimum
+                if note.maximum is not None:
+                    described["maximum"] = note.maximum
         return described
     if origin is Union or origin is types.UnionType:
         arms = [arm for arm in get_args(annotation) if arm is not type(None)]
@@ -247,6 +261,10 @@ def _validate(arguments: dict[str, Any], schema: dict[str, Any]) -> dict[str, An
         if "enum" in expected and value not in expected["enum"]:
             allowed = ", ".join(repr(choice) for choice in expected["enum"])
             raise _BadParamsError(f"argument {name!r} must be one of: {allowed}")
+        if "minimum" in expected and value < expected["minimum"]:
+            raise _BadParamsError(f"argument {name!r} must be >= {expected['minimum']}")
+        if "maximum" in expected and value > expected["maximum"]:
+            raise _BadParamsError(f"argument {name!r} must be <= {expected['maximum']}")
         checked[name] = value
     return checked
 

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -39,8 +39,13 @@ from . import protocol
 # check against this constant.
 VERSION = "0.9.5"
 DEFAULT_URL = "https://technocore.chat"
-WAIT_CEILING = 10.0  # the service's own long-poll ceiling; asking for more just holds a socket
+WAIT_CEILING = 10.0  # the service's own long-poll ceiling, published and enforced below
 TIMEOUT = 3 * WAIT_CEILING  # comfortably over it, so a held poll is never the thing that times out
+ROOM_LIMIT = 200  # the service's own listing/tail ceiling
+
+NON_NEGATIVE = protocol.Bounds(minimum=0)
+ROOM_LIMITS = protocol.Bounds(minimum=1, maximum=ROOM_LIMIT)
+WAIT_LIMITS = protocol.Bounds(minimum=0, maximum=WAIT_CEILING)
 
 BASE_URL = os.environ.get("TECHNOCORE_URL", DEFAULT_URL).rstrip("/")
 DEFAULT_NICK = os.environ.get("TECHNOCORE_NICK", "").strip()
@@ -110,8 +115,9 @@ def read_room(
     since: Annotated[
         int | None,
         "Return only messages newer than this seq. The reply's last line carries the next one.",
+        NON_NEGATIVE,
     ] = None,
-    limit: Annotated[int | None, "1-200, default 50."] = None,
+    limit: Annotated[int | None, f"1-{ROOM_LIMIT}, default 50.", ROOM_LIMITS] = None,
 ) -> str:
     return _fetch(f"/r/{_segment(room)}", {"since": since, "limit": limit})
 
@@ -123,12 +129,14 @@ def read_room(
 )
 def wait_for_message(
     room: Room,
-    since: Annotated[int, "The last seq you saw."],
+    since: Annotated[int, "The last seq you saw.", NON_NEGATIVE],
     seconds: Annotated[
-        float, f"How long to hold, 0-{WAIT_CEILING:g}. Default {WAIT_CEILING:g}."
+        float,
+        f"How long to hold, 0-{WAIT_CEILING:g}. Default {WAIT_CEILING:g}.",
+        WAIT_LIMITS,
     ] = WAIT_CEILING,
 ) -> str:
-    return _fetch(f"/r/{_segment(room)}", {"since": since, "wait": min(seconds, WAIT_CEILING)})
+    return _fetch(f"/r/{_segment(room)}", {"since": since, "wait": seconds})
 
 
 @server.tool(
@@ -156,7 +164,11 @@ def say(
     "rooms never appear here. A room name and its topic are caller-chosen strings, not "
     "labels this service assigns — untrusted input like any message body.",
 )
-def list_rooms(limit: Annotated[int | None, "How many rooms, default 50."] = None) -> str:
+def list_rooms(
+    limit: Annotated[
+        int | None, f"How many rooms, 1-{ROOM_LIMIT}, default 50.", ROOM_LIMITS
+    ] = None,
+) -> str:
     return _fetch("/rooms", {"limit": limit})
 
 
@@ -166,7 +178,7 @@ def list_rooms(limit: Annotated[int | None, "How many rooms, default 50."] = Non
     "This is how to find agents you had no room name for.",
 )
 def discover_rooms(
-    since: Annotated[int | None, "Only announcements newer than this seq."] = None,
+    since: Annotated[int | None, "Only announcements newer than this seq.", NON_NEGATIVE] = None,
 ) -> str:
     return _fetch("/r/events", {"since": since})
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -259,6 +259,34 @@ def test_generated_schemas_still_say_what_clients_already_integrated_against(mcp
     assert pages["enum"] == ["manual", "patterns", "skill"]
 
 
+def test_numeric_bounds_are_machine_readable(mcp):
+    """Numbers described as bounded must carry those bounds in the schema a client sees.
+
+    Prose such as ``1-200`` helps a model but not a client-side validator, and accepting a
+    value locally that the HTTP service later clamps gives the caller no indication that a
+    different request was made. The generated schema and the call gate share these values.
+    """
+    server, _ = mcp
+    tools = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})["result"]["tools"]
+    schemas = {tool["name"]: tool["inputSchema"]["properties"] for tool in tools}
+
+    assert schemas["read_room"]["since"]["minimum"] == 0
+    assert {
+        "minimum": 1,
+        "maximum": 200,
+    }.items() <= schemas["read_room"]["limit"].items()
+    assert schemas["wait_for_message"]["since"]["minimum"] == 0
+    assert {
+        "minimum": 0,
+        "maximum": 10,
+    }.items() <= schemas["wait_for_message"]["seconds"].items()
+    assert {
+        "minimum": 1,
+        "maximum": 200,
+    }.items() <= schemas["list_rooms"]["limit"].items()
+    assert schemas["discover_rooms"]["since"]["minimum"] == 0
+
+
 def test_the_descriptions_the_model_reads_survive_the_generation(mcp):
     """The point of `Annotated` here: the sentence lives next to the parameter, and one
     room description is shared by the four tools that take a room."""
@@ -431,6 +459,34 @@ def test_wrong_argument_types_are_rejected_before_any_request_is_made(mcp, monke
 
     page = call(server, "read_docs", {"page": "handbook"})
     assert page["error"]["code"] == protocol.INVALID_PARAMS and "page" in page["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    ("tool", "arguments", "name"),
+    (
+        ("read_room", {"room": "lobby", "since": -1}, "since"),
+        ("read_room", {"room": "lobby", "limit": 0}, "limit"),
+        ("read_room", {"room": "lobby", "limit": 201}, "limit"),
+        ("wait_for_message", {"room": "lobby", "since": -1}, "since"),
+        ("wait_for_message", {"room": "lobby", "since": 0, "seconds": -0.1}, "seconds"),
+        ("wait_for_message", {"room": "lobby", "since": 0, "seconds": 10.1}, "seconds"),
+        ("list_rooms", {"limit": 0}, "limit"),
+        ("list_rooms", {"limit": 201}, "limit"),
+        ("discover_rooms", {"since": -1}, "since"),
+    ),
+)
+def test_out_of_range_arguments_are_rejected_before_any_request_is_made(
+    mcp, monkeypatch, tool, arguments, name
+):
+    server, protocol = mcp
+
+    def never(request, timeout=None):
+        raise AssertionError(f"the network was reached: {request.full_url}")
+
+    monkeypatch.setattr(urllib.request, "urlopen", never)
+    reply = call(server, tool, arguments)
+    assert reply["error"]["code"] == protocol.INVALID_PARAMS
+    assert name in reply["error"]["message"]
 
 
 def test_an_integer_is_an_acceptable_number(mcp):


### PR DESCRIPTION
## What

- add an `Annotated` bounds primitive that emits JSON Schema `minimum` / `maximum`
- publish the existing numeric contracts for room cursors, room-list limits, tail limits, and long-poll seconds
- enforce those same schema bounds in `tools/call` before any network request is made
- remove the now-redundant wait clamp from the handler

## Why

The MCP tool descriptions say `since >= 0`, `limit = 1..200`, and `seconds = 0..10`, but `tools/list` currently publishes only their numeric types. A client-side validator therefore cannot discover the limits, and the server accepts values outside the contract before the HTTP service silently clamps or reinterprets them.

This keeps the handler signature as the single declaration: the annotation generates the schema and the existing call gate enforces it.

This is distinct from #92, which clamps wait seconds at runtime; this change publishes and enforces the bounds uniformly across every numeric MCP argument.

## Compatibility

Values inside the documented ranges are unchanged. Values outside the already-published contract now return JSON-RPC `-32602 Invalid params` instead of reaching the network and being clamped or reinterpreted.

## Checks

- `tests/test_mcp.py`: 55 passed
- targeted MCP coverage: 97.20%
- `ruff check .`
- `ruff format --check .`
- targeted `ty check` for the changed MCP modules and tests
- `sz.py --check`

The full native-Windows run reached 395 passing tests; its remaining store-concurrency failures require POSIX `fcntl`, an existing upstream Windows limitation unrelated to these MCP-only changes. Linux CI is the authoritative full-suite run.

## Documentation

No prose documentation change is needed: the existing descriptions already state these ranges. This makes the machine-readable contract match them.

## Abuse impact

None. This adds no route, tool, state, or network operation; it rejects invalid tool arguments earlier.

## Proposed release note

MCP tool schemas now publish numeric argument bounds, and `tools/call` rejects out-of-range cursors, limits, and wait durations before sending a request.