### PR TITLE
refactor(store): drop list_rooms, which had no caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Removed
+
+- **`store.list_rooms()`**, which had no caller outside two tests: `room_stats()` already walks
+  the same directory through the same `_listable` filter and returns the rows with it. No HTTP
+  surface changes; the MCP and WebMCP tools named `list_rooms` are a different thing and are
+  untouched.
+
 ### Added
 
 - **`GET /interop.md`** — bridging this service to ActivityPub, Matrix, WebSub, JSON-RPC, MCP and

--- a/docs/store.md
+++ b/docs/store.md
@@ -10,7 +10,6 @@ via stdlib `inspect` — never edited by hand; a test regenerates and diffs this
 - `is_mailbox(name: str) -> bool` — `mb-` rooms take signed writes only, so spam is attributable and ignorable by key.
 - `last_seq(root: pathlib.Path, room: str) -> int` — (undocumented)
 - `list_notes(root: pathlib.Path, ns: str) -> list[str]` — (undocumented)
-- `list_rooms(root: pathlib.Path) -> list[str]` — (undocumented)
 - `note_get(root: pathlib.Path, ns: str, key: str) -> str | None` — (undocumented)
 - `note_path(root: pathlib.Path, ns: str, key: str) -> pathlib.Path` — (undocumented)
 - `note_set(root: pathlib.Path, ns: str, key: str, value: str, expect: str | None = None, expect_absent: bool = False) -> dict` — Write a note, optionally only if it still holds what the caller last read.

--- a/src/store.py
+++ b/src/store.py
@@ -723,13 +723,6 @@ def _rollup(windows: list[list[str]]) -> dict:
     }
 
 
-def list_rooms(root: Path) -> list[str]:
-    d = root / "rooms"
-    if not d.is_dir():
-        return []
-    return sorted(p.stem for p in d.glob("*.jsonl") if _listable(p.stem))
-
-
 # (top, nicks) per room, validated against the (mtime_ns, size) stat the overview walk
 # already does — so a walk re-reads only the rooms a write actually changed. LRU-bounded.
 _WINDOW_MEMO_MAX = 512

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,5 +1,5 @@
 {
-  "core_total": 2028,
+  "core_total": 2023,
   "caps": {
     "core/app.py": 979,
     "core/config.py": 57,
@@ -34,10 +34,10 @@
       "tokens_per_line": 8.75
     },
     "core/store.py": {
-      "raw_lines": 1801,
-      "code_lines": 805,
+      "raw_lines": 1794,
+      "code_lines": 800,
       "comment_lines": 374,
-      "tokens_per_line": 7.24
+      "tokens_per_line": 7.22
     },
     "extra/manifest.py": {
       "raw_lines": 1604,

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -245,7 +245,7 @@ def test_listing_notes_does_not_evict_the_room_names(tmp_path):
 
     for i in range(20):
         store.append(tmp_path, f"room{i}", "bot", "hi")
-    store.list_rooms(tmp_path)  # warms the cache with room names
+    store.room_stats(tmp_path)  # warms the cache with room names
     warm = store._listable.cache_info().currsize
     assert warm >= 20
 
@@ -735,7 +735,6 @@ def test_listings_never_echo_a_name_the_validator_would_reject(tmp_path):
     (tmp_path / "rooms" / "ok.jsonl").write_bytes(b'{"seq":1,"ts":"t","from":"b","text":"x"}\n')
     (tmp_path / "rooms" / "bad\nname.jsonl").write_bytes(b'{"seq":1}\n')
     (tmp_path / "rooms" / "UPPER.jsonl").write_bytes(b'{"seq":1}\n')
-    assert store.list_rooms(tmp_path) == ["ok"]
     assert [r["room"] for r in store.room_stats(tmp_path)["rooms"]] == ["ok"]
 
 


### PR DESCRIPTION
## What changes for a caller

Nothing. `store.list_rooms()` is not reachable from any route; the HTTP surface, the MCP tools
and the WebMCP tools are untouched. `core/store.py` goes 805 → 800 code-lines, `core_total`
2028 → 2023.

## Why

`CONTRIBUTING.md`: *"Removing dead code from core is a win on its own; open a pull request for
it."* This is that, and `core/store.py` is at its cap, so the five lines are worth having back.

Every call site was a test:

```
tests/unit/test_store.py:248   store.list_rooms(tmp_path)  # warms the cache with room names
tests/unit/test_store.py:738   assert store.list_rooms(tmp_path) == ["ok"]
```

and line 739 is `assert [r["room"] for r in store.room_stats(tmp_path)["rooms"]] == ["ok"]` —
the same property, through the path that actually serves it. `room_stats` walks the same
directory through the same `_listable` filter and returns the rows with it, so `list_rooms`
was the filter without its result.

The two tests, minimally:

- **248** now warms `_listable` through `room_stats(tmp_path)`. It is the same walk over the same
  names, which is what the assertion two lines down (`cache_info().currsize >= 20`) is measuring.
- **738** is dropped rather than rewritten. The line under it already covers the `bad\nname` and
  `UPPER` cases it was there for.

`grep list_rooms` is noisy in this repo — most hits are the **MCP and WebMCP tools of that name**,
which are a different thing entirely. Only `store.list_rooms(` matters here:

```bash
git grep -n -E 'store\.list_rooms\(|import.*\blist_rooms\b' -- 'src/*.py' 'tests/**/*.py' 'mcp/**/*.py'
```

## Generated artifacts

`docs/store.md` regenerated with `scripts/gen_store_doc.py`, and `sz-baseline.json` rewritten with
`sz.py --update-baseline` (which carries the caps forward untouched, as documented).

## Checks

`uv sync --frozen`, then:

| check | result |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 55 files already formatted |
| `uv run ty check` | All checks passed |
| `uv run coverage run -m pytest tests -q` | 393 passed |
| `uv run sz.py --check` | check ok: core code-lines <= baseline (2023) |

The contract job was not run: `manifest.py` is untouched and no route or response shape moves.

One thing I left alone, since `CONTRIBUTING.md` puts release versions with the maintainers:
`uv.lock` still carries `version = "0.9.4"` for `technocore-chat` while `pyproject.toml` is at
`0.9.5`, so `uv sync` rewrites it. I reverted that hunk rather than carry it here.

## Abuse impact

None. No new surface; strictly less code.
