### PR TITLE
fix(docs): render the retention floor through _size, not a whole-MiB shift (#242)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1775,7 +1775,11 @@ MANUAL = (
     .replace("__ROOM_BYTES_TOTAL__", f"{store.MAX_TOTAL_ROOM_BYTES >> 30} GiB")
     .replace("__MAX_WAIT__", f"{MAX_WAIT:g}")
     .replace("__ROOM_RING__", f"{store.MAX_ROOM_BYTES >> 20} MiB")
-    .replace("__ROOM_FLOOR__", f"{store.RESERVED_ROOM_BYTES >> 20} MiB")
+    # The floor is the one derived value here (budget // rooms), so unlike the stated caps
+    # it can land between whole units: at CHAT_MAX_ROOMS=10240 it is 512 KiB, which a
+    # whole-MiB `>> 20` rendered as "a guaranteed 0 MiB" — the opposite of the guarantee
+    # (#242). _size tiers down to bytes, so no knob setting can print the floor as nothing.
+    .replace("__ROOM_FLOOR__", _size(store.RESERVED_ROOM_BYTES))
 )
 
 

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -87,6 +87,24 @@ def test_the_served_manual_states_the_caps_it_actually_enforces(client):
     assert "at most 512 rooms" not in manual and "4096 notes" not in manual
 
 
+def test_the_manual_can_state_a_retention_floor_smaller_than_a_whole_mib(client):
+    """The bug this closes (#242): __ROOM_FLOOR__ rendered through `>> 20`, which floors
+    to whole MiB. The floor is the one derived number in the manual (budget // rooms), and
+    the production config (CHAT_MAX_ROOMS=10240) puts it at 512 KiB — below that
+    granularity — so the live manual printed "down to a guaranteed 0 MiB per room": the
+    opposite of the guarantee store.py enforces and test_store pins. At the source-default
+    5120 rooms the floor is exactly 1 MiB, so no default-config assertion could catch it;
+    this pins the formatter's sub-MiB behaviour directly instead."""
+    import app as app_module
+    import store
+
+    manual = client.get("/llms.txt").text
+    assert f"guaranteed\n{app_module._size(store.RESERVED_ROOM_BYTES)} per room" in manual
+    # The production shape: a sub-MiB floor states its size rather than vanishing.
+    assert app_module._size((5 << 30) // 10240) == "512.0K"
+    assert "guaranteed\n0" not in manual
+
+
 def test_the_room_budget_is_published_where_agents_look(client):
     import app as app_module
     import store


### PR DESCRIPTION
## What

`__ROOM_FLOOR__` in the served manual now renders through `_size()` — the byte-aware
formatter `/rooms` already uses — instead of `>> 20`, which floors to whole MiB. On the
production config (`CHAT_MAX_ROOMS=10240`, floor = 5 GiB // 10240 = 512 KiB) the manual
printed *"down to a guaranteed 0 MiB per room"*; it now prints `512.0K`. Rendering only:
nothing enforced changes, and the floor itself (`store.RESERVED_ROOM_BYTES`) is untouched.

The cost is a style change at configs that were rendering correctly: the source default
(5120 rooms, a floor of exactly 1 MiB) now prints `1.0M` where it printed `1 MiB`.

## Why

#242 — the floor is the manual's one *derived* number (budget // room cap), so a supported
knob can put it between the whole units the stated caps sit on, and the whole-MiB formatter
then renders the guarantee as its opposite. The generator exists to stop prose disagreeing
with the enforced constants (the comment above the substitution block says exactly that),
and this was it doing the disagreeing itself.

The source default is also why no existing test caught it: at exactly 1 MiB the truncation
is invisible, and `test_the_served_manual_states_the_caps_it_actually_enforces` asserts
every substituted number except the floor. The new test pins the sub-MiB shape directly
(512 KiB renders as `512.0K`, not `0`) and adds the floor to what the served manual must
state, at whatever config the suite runs under.

## Proposed release note

Per #259, wording for `[Unreleased]` → `Fixed`, for the maintainer to fold in at merge:

> **The manual states the per-room retention floor at its actual size.** On deployments
> whose derived floor (room budget // room cap) is under 1 MiB, `/llms.txt` printed
> "down to a guaranteed 0 MiB per room" — the opposite of the enforced guarantee. It now
> renders through the byte-aware formatter (`512.0K` on such a config; `1.0M` at the
> source default, previously `1 MiB`). Rendering only; the enforced floor is unchanged.
> ([#242](https://github.com/flop-labs/technocore-chat/issues/242))

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 399 passed,
      97.56%; the new test fails without the fix (verified by stashing the `app.py` change)
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] `sz.py --check` and `sz.py --caps` — the replace stays one code line, so core
      code-lines are unchanged and no cap moves
- [x] Docs: the manual is the artifact being fixed; `CHANGELOG.md` untouched per #259
      (wording above). No path, response shape, or documented cap changes — `/llms.txt`
      prose only — so `/openapi.json` and `/.well-known/agent.json` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
