### PR TITLE
fix(store): fall back to path chmod when fd chmod is unavailable

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -696,7 +696,7 @@ def _replace(path: Path, data: bytes, fsync: bool = False) -> None:
     fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=f"{path.name}.", suffix=".tmp")
     try:
         with os.fdopen(fd, "wb") as f:
-            os.fchmod(f.fileno(), 0o644)
+            os.chmod(f.fileno() if os.chmod in os.supports_fd else tmp, 0o644)
             f.write(data)
             if fsync:  # compaction only: see the knob, which never applied to this one
                 f.flush()

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -226,6 +226,30 @@ def test_a_second_writer_cannot_consume_the_first_writers_staging_file(
     assert store._note_totals(tmp_path) == (3, 30), "and must leave the old totals alone"
 
 
+def test_atomic_replace_falls_back_to_path_chmod_when_fd_chmod_is_unavailable(
+    tmp_path, monkeypatch
+) -> None:
+    """Platforms without descriptor chmod still replace through the unique staging path."""
+    import store
+
+    real_chmod = os.chmod
+    calls = []
+
+    def path_only(path, mode):
+        assert isinstance(path, (str, bytes, os.PathLike))
+        calls.append(path)
+        real_chmod(path, mode)
+
+    monkeypatch.setattr(store.os, "supports_fd", set())
+    monkeypatch.setattr(store.os, "chmod", path_only)
+    target = tmp_path / "count"
+
+    store._replace(target, b"7")
+
+    assert calls
+    assert target.read_bytes() == b"7"
+
+
 # --------------------------------------------------------------------------- the cap
 
 # A worker: create notes as fast as it can into one shared root, and report how many the


### PR DESCRIPTION
## What

Preserve descriptor-based chmod where supported, otherwise chmod the unique staging path before atomic replacement. Rebased onto `main` `45921c3`; head `2a37753`.

## Why

The unmodified write helper still calls `os.fchmod`, which is absent on native Windows Python 3.12. The fallback addresses this write path, not the separate Unix-only locking import or complete Windows service support.

## Checks

- [x] [Native Windows GitHub run](https://github.com/zakazaka95/technocore-chat/actions/runs/34121690255): four cases pass with real filesystem APIs and unmodified capability detection; the unfixed baseline fails as expected. Exact function source is isolated only to avoid the unrelated `fcntl` import.
- [x] [Current Linux CI](https://github.com/zakazaka95/technocore-chat/actions/runs/34121835732): 771 passed, 1 skipped; 97.90% coverage. Lint/types/size, example, packaging, Docker smoke, Worker bundling and OpenAPI contract all passed.
- [x] Local unchanged browser probe: 138 checks pass, using only a locking adapter; no chmod/fchmod shim. Native WebMCP was not exercised.
- [x] Documentation compatibility reviewed; no protocol or response-shape change.
- [x] New world-writable surface: nothing new. Windows chmod is read-only-attribute handling, not POSIX ACL enforcement.
- [ ] Upstream required workflows still need maintainer approval.