### PR TITLE
fix(mcp): close the advertised schema that tools/call already closes

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -193,6 +193,14 @@ def schema_of(handler: Callable[..., str]) -> dict[str, Any]:
     saying anything else would advertise a call that cannot happen. `required` is omitted
     entirely when nothing is required, which is what a client expects to see for a tool
     whose arguments are all optional.
+
+    `additionalProperties: false` is the same rule in the other direction. A JSON Schema
+    object admits every property it does not name, so without it the document says a
+    property this signature has no parameter for is fine, and `_validate` then answers
+    `-32602 unexpected arguments` for exactly that call — a client that validated locally
+    against our own document pays a round trip to learn it. `src/humans.html` already
+    publishes these nine tools that way to `navigator.modelContext`; this is the same
+    statement, read off the signature instead of written by hand.
     """
     called = getattr(handler, "__name__", "handler")
     hints = get_type_hints(handler, include_extras=True)
@@ -206,7 +214,11 @@ def schema_of(handler: Callable[..., str]) -> dict[str, Any]:
         properties[name] = fragment(hints[name])
         if parameter.default is inspect.Parameter.empty:
             required.append(name)
-    schema: dict[str, Any] = {"type": "object", "properties": properties}
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
     if required:
         schema["required"] = required
     return schema

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -285,6 +285,23 @@ def test_a_schema_cannot_drift_from_the_function_it_describes(mcp):
         assert tool.schema.get("required", []) == expected
 
 
+def test_the_advertised_schema_closes_the_door_tools_call_already_closes(mcp):
+    """`tools/call` answers `-32602` for a property no tool declares. Without
+    `additionalProperties: false` the document handed out by `tools/list` says that same
+    property is admissible, so a client validating locally against it reaches *valid* and
+    pays a round trip to learn otherwise. Both halves are asserted together here: a schema
+    that stopped closing the door would still pass if only the refusal were checked."""
+    server, protocol = mcp
+    tools = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})["result"]["tools"]
+    assert tools
+    for tool in tools:
+        assert tool["inputSchema"]["additionalProperties"] is False
+
+    reply = call(server, "read_room", {"room": "lobby", "colour": "blue"})
+    assert reply["error"]["code"] == protocol.INVALID_PARAMS
+    assert "colour" in reply["error"]["message"]
+
+
 def test_an_undescribable_parameter_fails_at_registration(mcp):
     """A handler the schema cannot describe must break the build, not ship a tool whose
     advertised contract is a guess."""


### PR DESCRIPTION
Closes #105.

## What changes for a caller

`tools/list` now returns `"additionalProperties": false` on all nine tool schemas. A client that validates a call locally against the document this server hands it now reaches the same verdict the server does, instead of reaching *valid* and being answered `-32602 unexpected arguments` a round trip later.

Before / after, for `read_room`:

```diff
 {"type": "object",
  "properties": {"room": {...}, "since": {...}, "limit": {...}},
+ "additionalProperties": false,
  "required": ["room"]}
```

Nothing that was accepted before is refused now, and nothing refused before is accepted. The enforcement in `_validate` is unchanged — only the document catches up to it.

## Why

`schema_of` exists so this cannot happen. Its module docstring:

> a tool's `inputSchema` is read off its handler's signature: the function *is* the schema, so what `tools/list` advertises and what `tools/call` enforces cannot disagree with what the handler accepts.

A JSON Schema object admits every property it does not name until `additionalProperties` says otherwise, so on the unknown-argument branch they did disagree. `_validate`'s own docstring names this failure mode one branch below the one that caused it:

> Rejecting it would fail a client that validated locally against our own document — the exact disagreement generating these schemas was meant to end

There is also an in-repo precedent: `src/humans.html` registers these same nine tools with `navigator.modelContext` and already sets `additionalProperties: false` on every one of them. Two frontends of one service were describing the same contract differently; this is the Python side saying what the browser side already says, read off the signature rather than written by hand.

## Tests

`test_the_advertised_schema_closes_the_door_tools_call_already_closes` asserts both halves in one test: every advertised schema closes the door, **and** `tools/call` refuses the same property. Asserting only the refusal would still pass if the document reopened, which is the bug.

It fails without the fix (`KeyError: 'additionalProperties'`) and passes with it.

## Checks

All CI checks run locally and pass:

| | |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 56 files already formatted |
| `uv run ty check` | All checks passed |
| `uv run coverage run -m pytest tests -q` | 399 passed |
| `uv run coverage report` | 97.56% |
| `uv run sz.py --check` | core code-lines <= baseline (2033) |
| `uv build --project mcp` + `tests/verify_mcp_dist.py`, `tests/test_mcp_package.py` | built, 4 passed |

`mcp/` is extra rather than core, so the core caps in `sz-baseline.json` are untouched.

## Documentation and compatibility

No documentation change is needed. `src/manifest.py` generates `/openapi.json` and `/.well-known/agent.json` from the HTTP surface and does not publish MCP tool schemas, so the contract check is unaffected; `mcp/README.md` does not print a schema. `CHANGELOG.md` is left alone per CONTRIBUTING.

Proposed release note, if it is worth one:

> `tools/list` now declares `additionalProperties: false`, matching the unknown-argument rule `tools/call` already enforced.

Compatibility: this is a strictly more accurate description of unchanged behaviour. A client that ignores the keyword sees no difference. A client that honours it stops sending calls this server was already refusing.

## Abuse impact

None. No new route, parameter, or persistent state; no change to what reaches the network or the store. The keyword is descriptive and is enforced by the same `_validate` that ran before.

Technocore identity: `did:key:z6MktragusbhDriqLoB7ohcxca1uhrQE2ZoN8Vpn4FEDuhJA`; signed proof https://gist.github.com/k3nt0w/3fa6d59cc459b8ea121b644aa3eff1c8 — the statement names this GitHub account and is signed by the key, so neither half stands without the other. It is an identity assertion only, not a claim about this pull request; the attribution here is GitHub's.

AI assistance was used; the wording and diff were reviewed against current `main`.
