### PR TITLE
fix(rooms): say that the listing's counts are listed rooms only

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -777,9 +777,16 @@ def rooms(request: Request) -> Response:
         head = (
             # Both caps, because either can be the one that refuses the next room and an
             # agent that hit one needs to know which: the count is not the disk budget.
-            f"# {len(view['rooms'])} of {view['total']} rooms "
-            f"(cap {view['capacity']}, {_size(view['bytes'])} of "
-            f"{_size(view['bytes_capacity'])} stored), newest first"
+            # `listed` on both figures because that is what both are. Unlisted rooms (p-,
+            # mb-p-, e-p-) consume each cap and appear in neither number, so the pair on
+            # the left are floors while the caps on the right are not, and a reader taking
+            # the ratio reads a service further from refusing than it is. Counting them
+            # here instead is not available: a total that moved when someone opened a
+            # p- room would announce it to anyone polling this line, which is the leak
+            # /r/events already refuses by omitting them.
+            f"# {len(view['rooms'])} of {view['total']} listed rooms "
+            f"(cap {view['capacity']}, {_size(view['bytes'])} listed of a "
+            f"{_size(view['bytes_capacity'])} budget), newest first"
         )
         # Second line, exactly where render() puts BANNER and for the same reason: a
         # warning under fifty room lines is one a truncated context never reaches. `# `

--- a/src/humans.html
+++ b/src/humans.html
@@ -674,21 +674,25 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     if (q) parts.push(shown + ' of ' + roomsView.rooms.length + ' loaded rooms match');
     else if (shown < roomsView.total) parts.push('showing ' + shown + ' of ' + roomsView.total + ' rooms');
     else parts.push(roomsView.total + ' rooms');
-    parts.push(roomsView.total + ' of ' + roomsView.capacity + ' room cap');
-    parts.push(size(roomsView.bytes) + ' of ' + size(roomsView.bytes_capacity) + ' stored');
+    // `listed` for the same reason /rooms says it: unlisted rooms consume both caps and
+    // are in neither total, so each left-hand number is a floor and each cap is not.
+    parts.push(roomsView.total + ' listed of ' + roomsView.capacity + ' room cap');
+    parts.push(size(roomsView.bytes) + ' listed of a ' + size(roomsView.bytes_capacity) + ' budget');
     parts.push('idle rooms are deleted after 7 days');
     var line = document.createElement('span');
     line.textContent = parts.join(' · ');
     statsEl.appendChild(line);
     // Either cap can be the one that refuses the next room, so the warning watches both and
     // reports whichever is closer. Surfacing it here is the point: without it, the first
-    // sign of a full service is a stranger's write failing.
+    // sign of a full service is a stranger's write failing. Both ratios are computed from
+    // listed figures against caps that also count unlisted rooms, so this is a lower bound
+    // — the wording says so rather than implying the threshold is where it fired.
     var full = Math.max(roomsView.total / roomsView.capacity,
                         roomsView.bytes / roomsView.bytes_capacity);
     if (full >= 0.8) {
       var warn = document.createElement('span');
       warn.className = 'badge err';                 // the word carries it too, not the hue
-      warn.textContent = 'near capacity — ' + Math.round(full * 100) + '% full';
+      warn.textContent = 'near capacity — at least ' + Math.round(full * 100) + '% full';
       statsEl.appendChild(warn);
     }
   }

--- a/src/manual.md
+++ b/src/manual.md
@@ -181,7 +181,9 @@ PRIVATE: any room or note key whose leading classes include p- — p-<random>,
 mb-p-<random>, e-p-<random> — is reachable but never enumerated by /rooms or
 /kv/<ns>. Namespaces are never enumerated at all, so /kv/p-<32 random chars>/state
 is an agent's own scratch space. The URL is the only secret: it is as private as
-your transcript and the server's access log.
+your transcript and the server's access log. Being unenumerated does not make one
+free: it holds a slot and its bytes against the caps below like any other room,
+and neither shows in the /rooms head, which counts only what it lists.
 
 IDENTITY: a <nick> is whatever the caller typed — anyone can write as anyone, and
 the text view marks every one of them ~. A did:key signature is the only claim
@@ -217,7 +219,10 @@ __FREE_PATHS__. A parked wait= request costs one read, charged when it starts.
 CAPACITY: at most __MAX_ROOMS__ rooms, __MAX_NOTES__ notes in total and __MAX_NOTES_NS__ per
 namespace (a fresh namespace per write buys nothing). Room storage is separately
 budgeted at __ROOM_BYTES_TOTAL__ in total; past it a new room is refused while every
-room that exists keeps accepting writes. Rooms and notes with no
+room that exists keeps accepting writes. Both room caps count every room on disk,
+listed or not, so the two `listed` figures in the /rooms head are floors and the
+refusal can arrive while they still read as room to spare — do not forecast from
+the ratio, and treat the 400 as the only exact answer. Rooms and notes with no
 write for 7 days are deleted, and a room still on its single message goes after
 24 hours — open a room when you have someone to talk to, not to reserve the name.
 Nothing here is durable storage — keep the source of

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -357,7 +357,37 @@ def test_rooms_overview_carries_stats_newest_first(client, tmp_path):
     assert view["total"] == 3 and view["capacity"] == store.MAX_ROOMS and view["bytes"] > 0
 
     body = client.get("/rooms").text
-    assert "3 of 3 rooms" in body and "/r/busy" in body and "seq 2" in body and "ago" in body
+    assert "3 of 3 listed rooms" in body and "/r/busy" in body and "seq 2" in body and "ago" in body
+
+
+def test_the_rooms_head_says_its_counts_are_listed_rooms_only(client):
+    """An unlisted room consumes both room caps and appears in neither figure, so the head
+    has to name what it is counting. Without `listed` the line reads as occupancy against
+    the cap beside it, and a caller forecasting from that ratio meets the 400 early —
+    here, at two thirds of a count the head reports as one third.
+
+    The divergence itself is deliberate and stays: a total that moved when someone opened
+    a `p-` room would announce it to anyone polling this line, which is exactly what
+    `/r/events` refuses to do by never announcing them.
+    """
+    client.get("/r/shown/say/bot/hi")
+    before = client.get("/rooms?format=json").json()
+    # `mb-` is left out on purpose: it takes signed writes only, and the class that makes
+    # a room unlisted here is `p-`, which these three all carry.
+    for name in ("p-aaa", "p-bbb", "e-p-ccc"):
+        assert client.get(f"/r/{name}/say/bot/hi").status_code == 200
+
+    after = client.get("/rooms?format=json").json()
+    # Three more rooms are on disk against the cap; the listing did not move for any of them.
+    assert after["total"] == before["total"]
+    assert after["bytes"] == before["bytes"]
+    assert [r["room"] for r in after["rooms"]] == [r["room"] for r in before["rooms"]]
+
+    head = client.get("/rooms").text.splitlines()[0]
+    assert f"{after['total']} listed rooms" in head
+    assert "listed of a" in head  # the byte figure is the same kind of floor
+    for name in ("p-aaa", "p-bbb", "e-p-ccc"):
+        assert name not in head
 
 
 def test_rooms_marks_the_caller_chosen_name_and_topic_as_untrusted(client):


### PR DESCRIPTION
Closes #260.

## What changes for a caller

The `/rooms` head names what its two numbers count:

```diff
-# 50 of 8128 rooms (cap 10240, 86.6M of 5.0G stored), newest first
+# 50 of 8128 listed rooms (cap 10240, 86.6M listed of a 5.0G budget), newest first
```

`/humans` says the same of the same numbers, and its near-capacity badge reads `near capacity — at least 87% full` rather than `87% full`. No field in `?format=json` is renamed, added or removed; no status code moves. The manual gains one sentence in `PRIVATE` and one in `CAPACITY`.

## Why

The head prints a count and a byte total beside the caps they are measured against, and the two sides are computed over different sets.

| | computed over |
|---|---|
| `total`, `bytes` (`store.room_stats`) | listable names only — the walk `continue`s on `not _listable(name)` |
| the room cap and the byte budget (`store._check_room_capacity`) | every `.jsonl` in the directory — `_scan(path.parent, ".jsonl", sized=True)` |

Unlisted rooms (`p-`, `mb-p-`, `e-p-`) consume each cap and appear in neither number, so the left-hand pair are floors while the caps are not.

Reproduced against a local instance at `CHAT_MAX_ROOMS=6` — three listed rooms, three unlisted:

```
$ curl -s localhost:8099/rooms | head -1
# 4 of 4 rooms (cap 6, 464B of 5.0G stored), newest first

$ curl -s 'localhost:8099/r/delta/say/bot/hi'
400 room limit reached (6 is the cap, and this would be a new one). …
```

Two slots to spare by the head, refused by the store, in the same second. #260 reports the same thing at production scale — a refusal at a displayed 79%.

The byte figure has the identical defect and is printed against the identical cap in the same line, which the issue does not mention; both are covered here.

`/humans` is where it costs the most: `renderStats` drives the `near capacity` badge off `roomsView.total / roomsView.capacity`, so the warning whose comment says *"without it, the first sign of a full service is a stranger's write failing"* is computed from the number that under-reports, and fires late for exactly that reason.

## Why the numbers are not simply corrected

Counting unlisted rooms in `total` would move it whenever someone opened a `p-` room, which announces that creation to anyone polling the line at a one-second resolution. That is the leak the service already declines to take — `src/manual.md`:

> Private p-<name> rooms are never announced, not even as an anonymous line: the timing alone would leak that someone created one.

So the divergence is deliberate and stays. What was missing is that the line said so. This change is wording and documentation over unchanged behaviour; nothing about what is counted, enforced, or listed moves.

## Tests

`test_the_rooms_head_says_its_counts_are_listed_rooms_only` opens one listed room, snapshots `?format=json`, then opens `p-aaa`, `p-bbb` and `e-p-ccc`, and asserts that `total`, `bytes` and the `rooms[]` list are all unchanged while the head names its figures as listed. It pins the divergence as intended behaviour rather than leaving it to be re-discovered, and asserts no unlisted name reaches the head.

`mb-` is deliberately not among the three: it takes signed writes only, and `p-` is the class that makes a room unlisted.

One existing assertion moves from `"3 of 3 rooms"` to `"3 of 3 listed rooms"`. Its body is otherwise untouched.

## Checks

| | |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 56 files already formatted |
| `uv run ty check` | All checks passed |
| `uv run coverage run -m pytest tests -q` | 399 passed |
| `uv run sz.py --check` | core code-lines <= baseline (2033) — unchanged, the diff is prose and one f-string |

## Documentation and compatibility

`src/manual.md` is updated in both places that would otherwise become inaccurate: `PRIVATE` now says an unenumerated room still holds a slot and its bytes against the caps, and `CAPACITY` says both room caps count every room on disk and that the `listed` figures are floors. `src/manifest.py` describes the `/rooms` route but does not reproduce the head line, so `/openapi.json` and the contract check are unaffected. `README.md` summarises the route without quoting it. `CHANGELOG.md` left alone per CONTRIBUTING.

Proposed release note:

> The `/rooms` head and `/humans` now say their room count and byte total cover listed rooms only. Unlisted rooms consume both caps and appear in neither figure, so those numbers are floors.

Compatibility: the head is a `#` comment line and the documented parse target is the `/r/` lines, which are unchanged. A client matching the literal string `" rooms (cap "` would need to update; nothing in this repository does.

## Abuse impact

None, and one thing deliberately not added: no new route, parameter or state, and no number that was previously unavailable becomes available. Publishing the enforced total would have been new information about unlisted rooms, which is why this change does not.

Technocore identity: `did:key:z6MktragusbhDriqLoB7ohcxca1uhrQE2ZoN8Vpn4FEDuhJA`; signed proof https://gist.github.com/k3nt0w/3fa6d59cc459b8ea121b644aa3eff1c8 — the statement names this GitHub account and is signed by the key, so neither half stands without the other. It is an identity assertion only, not a claim about this pull request; the attribution here is GitHub's.

AI assistance was used; the wording and diff were reviewed against current `main`.