### PR TITLE
fix(store): unique tmp name per writer in _write_note_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A concurrent reap could crash an in-flight note create with an uncaught `FileNotFoundError`
+  instead of a clean response.** The global note-count file's replace used one fixed tmp name for
+  every writer, so a reap's unlocked rewrite could delete the tmp file a locked create was about
+  to publish. The tmp name is now unique per writer (its pid); the accepted best-effort count
+  drift between a reap and a concurrent create is unchanged.
+
 ## [0.9.3] - 2026-08-26
 
 PATCH: signed writes stop parsing a read window they are about to discard, plus documentation

--- a/src/store.py
+++ b/src/store.py
@@ -1141,10 +1141,17 @@ def _write_note_count(root: Path, total: int, size: int) -> None:
     two files could be read either side of a reap and report a count and a byte total that
     never coexisted. The format gained a second field, so a file written by an older build
     parses as untrusted and rebuilds by walking: a slow first read, never a wrong one.
+
+    The tmp name carries this writer's pid: not every caller takes the count lock (a
+    reap's post-deletion rewrite and a rebuild-on-read both write unlocked, on purpose —
+    see their own docstrings), so a fixed tmp name let an unlocked writer's os.replace
+    consume a locked writer's tmp file out from under it, turning a legitimate, cap-checked
+    create into an uncaught FileNotFoundError instead of the accepted count drift both
+    unlocked paths already tolerate.
     """
     path = root / NOTES_FILE
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.parent / f"{path.name}.tmp"
+    tmp = path.parent / f"{path.name}.{os.getpid()}.tmp"
     tmp.write_text(f"{total} {size}", encoding="utf-8")
     os.replace(tmp, path)  # atomic: readers never see a half-written file
 

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -186,6 +186,14 @@ def test_the_global_cap_binds_exactly_under_concurrent_processes(tmp_path) -> No
     }
     root = tmp_path / "shared"
     root.mkdir()
+    # Stamp the reap marker before racing, same reasoning as
+    # test_racers_on_one_key_count_one_note: on a fresh store several workers pass the reap
+    # throttle before the marker exists, and a reap rebuilds the global count from a walk
+    # without the count lock, so an in-flight reap can shave the published count by one
+    # against these very workers. That drift is real, bounded by REAP_EVERY and
+    # self-healing (see _write_note_count and _count_new_note) — it is not what "binds
+    # exactly" is about here, and no reap is due on a store this fresh.
+    (root / ".reaped").touch()
 
     workers = [
         subprocess.Popen(


### PR DESCRIPTION
## The bug

`_write_note_count`'s atomic replace used one fixed tmp path (`.notes-count.tmp`) for every
writer. Not every caller takes the count lock by design — a reap's post-deletion rewrite and
the rebuild-on-read path both write unlocked. So an unlocked writer's `os.replace` could
consume the tmp file a locked, cap-checked note create was about to publish, crashing that
create with an uncaught `FileNotFoundError` instead of the accepted count drift both unlocked
paths already tolerate.

## The fix

Give the tmp file's name each writer's pid, so a locked and an unlocked writer can never
collide on it.

Also stamps `.reaped` before racing in
`test_the_global_cap_binds_exactly_under_concurrent_processes`, mirroring
`test_racers_on_one_key_count_one_note`: without it, a reap can shave the published count by
one against the very workers the test measures — accepted drift the test isn't about.

## Test

Reproduced the crash on unmodified `main` (e6114b3): 30 runs of the target test gave
`pass=28 fail=2`, both with the exact `FileNotFoundError` from the issue. With the fix,
40/40 runs passed.

Fixes #237

## Checks

```
ruff check              All checks passed!
ruff format --check     2 files already formatted
ty check                All checks passed!
pytest tests -q         381 passed
coverage report         97.50% total
sz.py --check           core code-lines <= baseline (2015), store.py unchanged at 792
```

Run on WSL2 (Ubuntu 24.04) since `src/store.py` imports `fcntl` unconditionally and does not
yet run on native Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
