### PR TITLE
fix: point the did-namespace capacity refusal at its sharded escape hatch

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1357,15 +1357,30 @@ def _count_new_note(root: Path, ns_dir: Path, size: int, delta: int) -> None:
         _write_note_count(ns_dir, max(0, ns_count + delta), max(0, ns_used + size * delta))
 
 
-def _at_capacity(cap: int, what: str) -> StoreError:
+def _at_capacity(cap: int, what: str, ns: str | None = None) -> StoreError:
     """The refusal, in one place because two callers raise it (rooms count both a cap and a
     byte budget). Only *new* names are refused, which is the actionable half: an agent
-    blocked here can always keep working in a room or note it is already using."""
+    blocked here can always keep working in a room or note it is already using.
+
+    The flat `did` namespace gets one more line: it has a sharded escape hatch
+    (`did-<first 2>/<remaining 14>`, already documented in patterns.md and served in
+    /llms.txt) that a caller hitting this refusal has no way to discover from the refusal
+    itself. Field reports (#269) show agents reading "reuse one you already have" too
+    literally and overwriting a stranger's note instead — the sharded path was always the
+    actionable fix, just not stated where the refusal happens.
+    """
+    hint = (
+        " The did:key convention has a sharded slot for exactly this — publish at "
+        "/kv/did-<first 2 hex>/<remaining 14 hex> instead of the flat namespace; see "
+        "/patterns.md."
+        if ns == "did"
+        else ""
+    )
     return StoreError(
         f"{what} limit reached ({cap} is the cap, and this would be a new one). "
         f"Existing {what}s still accept writes, so reuse one you already have — "
         f"GET /rooms shows what exists. Idle {what}s are reclaimed after 7 days "
-        "(a room still on its first message goes after 24 hours)."
+        f"(a room still on its first message goes after 24 hours).{hint}"
     )
 
 
@@ -1457,7 +1472,7 @@ def _check_note_capacity(root: Path, path: Path) -> None:
     if path.exists():
         return
     if _note_totals(path.parent, _ns_totals, persist=True)[0] >= MAX_NOTES_PER_NS:
-        raise _at_capacity(MAX_NOTES_PER_NS, "note")
+        raise _at_capacity(MAX_NOTES_PER_NS, "note", ns=path.parent.name)
     _check_note_total(root)
 
 

--- a/src/store.py
+++ b/src/store.py
@@ -1362,25 +1362,25 @@ def _at_capacity(cap: int, what: str, ns: str | None = None) -> StoreError:
     byte budget). Only *new* names are refused, which is the actionable half: an agent
     blocked here can always keep working in a room or note it is already using.
 
-    The flat `did` namespace gets one more line: it has a sharded escape hatch
+    The flat `did` namespace gets one more line, stated *before* "reuse one you already
+    have": that sentence is what a caller with no note of its own yet was reading too
+    literally (#269, and PR review on the same). Leading with the sharded escape hatch
     (`did-<first 2>/<remaining 14>`, already documented in patterns.md and served in
-    /llms.txt) that a caller hitting this refusal has no way to discover from the refusal
-    itself. Field reports (#269) show agents reading "reuse one you already have" too
-    literally and overwriting a stranger's note instead — the sharded path was always the
-    actionable fix, just not stated where the refusal happens.
+    /llms.txt) means the actionable fix is the first thing read, not a trailing clause
+    after the sentence that caused the confusion.
     """
     hint = (
-        " The did:key convention has a sharded slot for exactly this — publish at "
+        "The did:key convention has a sharded slot for exactly this — publish at "
         "/kv/did-<first 2 hex>/<remaining 14 hex> instead of the flat namespace; see "
-        "/patterns.md."
+        "/patterns.md. "
         if ns == "did"
         else ""
     )
     return StoreError(
-        f"{what} limit reached ({cap} is the cap, and this would be a new one). "
+        f"{what} limit reached ({cap} is the cap, and this would be a new one). {hint}"
         f"Existing {what}s still accept writes, so reuse one you already have — "
         f"GET /rooms shows what exists. Idle {what}s are reclaimed after 7 days "
-        f"(a room still on its first message goes after 24 hours).{hint}"
+        "(a room still on its first message goes after 24 hours)."
     )
 
 

--- a/tests/unit/test_did_capacity_shard_hint.py
+++ b/tests/unit/test_did_capacity_shard_hint.py
@@ -1,0 +1,38 @@
+"""Run: uv run --group dev python -m pytest tests
+
+Regression test: the "note limit reached" refusal for the flat `did` namespace must
+point callers at the sharded escape hatch (`did-<2>/<14>`, documented in patterns.md
+and served in /llms.txt) rather than the generic "reuse one you already have" advice.
+
+Field reports (issue #269, two independent third-party observers) found agents hitting
+this cap and reading the generic refusal literally: since they have no note of their own
+yet, "reuse one you already have" led some to overwrite a stranger's did note instead of
+switching to the sharded namespace that was the actual fix. The sharded convention
+already exists and is already documented elsewhere in the repo (patterns.md, manual.md,
+manifest.py) — this only surfaces it at the point where the refusal actually happens.
+
+A namespace other than `did` (which has no sharded alternative) must keep the original,
+generic wording unchanged.
+"""
+
+import pytest
+
+import store
+
+
+def test_did_namespace_at_capacity_points_at_the_sharded_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 1)
+    store.note_set(tmp_path, "did", "existing", "hi")
+    with pytest.raises(store.StoreError, match=r"note limit reached \(1 is the cap") as exc:
+        store.note_set(tmp_path, "did", "second", "hi")
+    assert "/kv/did-<first 2 hex>/<remaining 14 hex>" in str(exc.value)
+    assert "/patterns.md" in str(exc.value)
+
+
+def test_other_namespaces_at_capacity_get_no_shard_hint(tmp_path, monkeypatch):
+    monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 1)
+    store.note_set(tmp_path, "plans", "existing", "hi")
+    with pytest.raises(store.StoreError, match=r"note limit reached \(1 is the cap") as exc:
+        store.note_set(tmp_path, "plans", "second", "hi")
+    assert "sharded" not in str(exc.value)
+    assert "/patterns.md" not in str(exc.value)

--- a/tests/unit/test_did_capacity_shard_hint.py
+++ b/tests/unit/test_did_capacity_shard_hint.py
@@ -13,6 +13,10 @@ manifest.py) — this only surfaces it at the point where the refusal actually h
 
 A namespace other than `did` (which has no sharded alternative) must keep the original,
 generic wording unchanged.
+
+The sharded hint must come *before* "reuse one you already have" — that sentence is
+what agents were reading too literally (per PR review feedback from #269's reporter), so
+a caller reading only the opening of the refusal still sees the actionable fix first.
 """
 
 import pytest
@@ -25,8 +29,13 @@ def test_did_namespace_at_capacity_points_at_the_sharded_path(tmp_path, monkeypa
     store.note_set(tmp_path, "did", "existing", "hi")
     with pytest.raises(store.StoreError, match=r"note limit reached \(1 is the cap") as exc:
         store.note_set(tmp_path, "did", "second", "hi")
-    assert "/kv/did-<first 2 hex>/<remaining 14 hex>" in str(exc.value)
-    assert "/patterns.md" in str(exc.value)
+    message = str(exc.value)
+    assert "/kv/did-<first 2 hex>/<remaining 14 hex>" in message
+    assert "/patterns.md" in message
+    assert message.index("did-<first 2 hex>") < message.index("reuse one you already have"), (
+        "the sharded hint must come before 'reuse one you already have', the sentence "
+        "agents were reading too literally"
+    )
 
 
 def test_other_namespaces_at_capacity_get_no_shard_hint(tmp_path, monkeypatch):


### PR DESCRIPTION
Addresses one item from #269 (field reports by @jjmobile and @loopjockey) —
not a fix for that whole issue, which covers much more (capacity data,
room-cap timing, methodology notes). This PR only fixes the one concrete,
actionable bug buried in it.

## What changes for a caller
When the flat `/kv/did` namespace is at its per-namespace cap, the refusal
told callers to "reuse one you already have" — advice that doesn't apply
to an agent writing its first DID note there. #269 reports agents reading
that literally and overwriting a stranger's note, when the actual fix (the
already-implemented, already-documented `/kv/did-<first 2 hex>/<remaining
14 hex>` sharded namespace) was never mentioned at the point of refusal.

## Fix
`_at_capacity()` gets an optional `ns` parameter and appends one line
pointing at the sharded path only when the namespace hit is exactly `did`.
Every other namespace (rooms, all other note namespaces) keeps the
original wording, unchanged.

## Tests
Added a regression test covering both the did-namespace hint and the
unchanged behavior for other namespaces. Full suite: 400 passed. `ruff
check`, `ruff format --check`, and `ty check` all pass.

## Abuse impact
None — this only changes refusal text on an existing, already-enforced
cap. No new surface, no behavior change for any namespace other than
`did`.
