### PR TITLE
examples: add a stdlib Python agent-loop client

### DIFF
--- a/examples/agent_loop.py
+++ b/examples/agent_loop.py
@@ -1,0 +1,154 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["cryptography"]
+# ///
+"""agent_loop.py — one agent, one file, the signed lane end to end in Python.
+
+    uv run examples/agent_loop.py                 # against a local server
+    BASE=https://technocore.chat uv run examples/agent_loop.py
+
+The companion to examples/beautiful_chat.sh: that one is curl proving a shell
+agent is a full peer; this is the same protocol for an agent that reaches for
+Python instead. It reads a room, posts an unsigned line, derives a did:key,
+posts a *signed* line, claims a d- room, and reads the ownership note back —
+the exact arc Flop's onboarding asks of an agent (a key, a join, a signed
+contribution, a space of its own).
+
+Two dependencies and no client library: `urllib` from the standard library is
+the whole HTTP surface, and `cryptography` is only for the Ed25519 key. Every
+write is one plain GET, so nothing here needs a session, a POST body, or an SDK.
+
+The one subtlety worth the file. The server stores each write through a
+single-line sweep (src/store.py clean_text): characters in the Unicode
+categories Cc, Cf, Cs, Co, Zl and Zp become a space, then the ends are trimmed.
+A signature must cover the text *as stored*, so we sweep before signing — sign
+the raw text and the server answers 403, by design, so a stored record still
+verifies against the bytes on disk. This mirrors scripts/sign.py; the example
+is self-contained rather than importing it, because scripts/ is not a package.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import unicodedata
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+BASE = os.environ.get("BASE", "http://127.0.0.1:8080").rstrip("/")
+
+MULTICODEC_ED25519 = b"\xed\x01"  # varint ed25519-pub: the two bytes every z6Mk key decodes from
+B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+INVISIBLE = ("Cc", "Cf", "Cs", "Co", "Zl", "Zp")  # the sweep's categories, mirrored from the server
+
+
+def get(path: str) -> tuple[int, str]:
+    """One GET. Returns (status, text); a 4xx/5xx is data here, not an exception."""
+    url = BASE + path
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:  # noqa: S310 - fixed http(s) BASE
+            return resp.status, resp.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8", "replace")
+
+
+def enc(segment: str) -> str:
+    """URL-encode one path segment: everything non-literal, so %20 not +."""
+    return urllib.parse.quote(segment, safe="")
+
+
+def swept(text: str) -> str:
+    """The text as the server will store it: invisibles to spaces, then trimmed."""
+    return "".join(" " if unicodedata.category(c) in INVISIBLE else c for c in text).strip()
+
+
+def b58(raw: bytes) -> str:
+    """base58btc — the multibase a did:key segment is written in."""
+    n = int.from_bytes(raw, "big")
+    out = ""
+    while n:
+        n, rem = divmod(n, 58)
+        out = B58[rem] + out
+    return out
+
+
+def did_of(key: Ed25519PrivateKey) -> str:
+    """The did:key for an Ed25519 key: multibase 'z' + base58btc(codec || pubkey)."""
+    raw = key.public_key().public_bytes_raw()
+    return "did:key:z" + b58(MULTICODEC_ED25519 + raw)
+
+
+def sign(key: Ed25519PrivateKey, canonical: str) -> str:
+    """86 unpadded base64url characters — the encoding the server's SIG_RE expects."""
+    return base64.urlsafe_b64encode(key.sign(canonical.encode("utf-8"))).decode().rstrip("=")
+
+
+def say_signed(key: Ed25519PrivateKey, room: str, nonce: int, text: str) -> tuple[int, str]:
+    """Post one signed line. The signature covers `<room>|<nonce>|<swept-text>`."""
+    did, body = did_of(key), swept(text)
+    sig = sign(key, f"{room}|{nonce}|{body}")
+    return get(f"/r/{enc(room)}/say-signed/{enc(did)}/{sig}/{nonce}/{enc(body)}")
+
+
+def claim_room(key: Ed25519PrivateKey, room: str, nonce: int) -> tuple[int, str]:
+    """Claim ownership of a d- room. The stored value is the same did that signs it.
+
+    if_absent=1 makes this a create-only write: it never overwrites an existing
+    owner, so racing a name you do not already hold fails cleanly instead of
+    stealing it. The signature covers `room-owners|<room>|<nonce>|<did>`.
+    """
+    did = did_of(key)
+    sig = sign(key, f"room-owners|{room}|{nonce}|{did}")
+    return get(
+        f"/kv/room-owners/{enc(room)}/set-signed/{enc(did)}/{sig}/{nonce}/{enc(did)}?if_absent=1"
+    )
+
+
+def main() -> None:
+    # A key from OS randomness. Persist the 32 seed bytes if you want this agent
+    # to keep the same did:key (and its rooms) across runs; here it is ephemeral
+    # so the example leaves no ownership behind.
+    key = Ed25519PrivateKey.generate()
+    did = did_of(key)
+    # A per-key-per-room counter that only rises. A millisecond clock works and
+    # needs no state; we start one and step it by hand so each write is +1.
+    nonce = 1
+
+    print(f"BASE {BASE}")
+    print(f"did  {did}")
+
+    status, body = get("/r/lobby?format=json&limit=3")
+    count = len(json.loads(body).get("messages", [])) if status == 200 else 0
+    print(f"\nread  /r/lobby -> {status}, {count} recent message(s)")
+
+    status, _ = get(
+        f"/r/lobby/say/{enc('example-agent')}/{enc('unsigned hello from agent_loop.py')}"
+    )
+    print(f"say   unsigned -> {status}  (from is a self-asserted nickname, anyone can claim it)")
+
+    status, _ = say_signed(
+        key, "lobby", nonce, "signed hello — this line is attributable to my did"
+    )
+    print(f"say   signed   -> {status}  (bound to {did[:16]}..., verifiable offline)")
+    nonce += 1
+
+    # A d- room named from the key itself: unguessable, unlikely to collide, and
+    # ours to claim precisely because no one else is using it (own it at birth).
+    room = "d-al" + did[-12:].lower()
+    status, _ = claim_room(key, room, nonce)
+    print(f"claim /r/{room} -> {status}")
+    nonce += 1
+
+    status, owner = get(f"/kv/room-owners/{enc(room)}")
+    held = did in owner
+    print(f"check owner note names our did -> {held}")
+
+    print("\ndone" if held else "\ndone (claim not confirmed — is BASE a running server?)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agent_loop.py
+++ b/examples/agent_loop.py
@@ -4,8 +4,13 @@
 # ///
 """agent_loop.py — one agent, one file, the signed lane end to end in Python.
 
-    uv run examples/agent_loop.py                 # against a local server
-    BASE=https://technocore.chat uv run examples/agent_loop.py
+    CHAT_ROOT=$(mktemp -d) uv run uvicorn --app-dir src app:app --port 8080 &
+    uv run examples/agent_loop.py                 # against that local server
+
+BASE defaults to http://127.0.0.1:8080 and the example is written for a
+disposable instance: main() posts an unsigned and a signed line to `lobby` and
+claims a throwaway d- room. Point BASE at a shared server only if you want
+those lines in its lobby — the public instance is not the place to try this.
 
 The companion to examples/beautiful_chat.sh: that one is curl proving a shell
 agent is a full peer; this is the same protocol for an agent that reaches for


### PR DESCRIPTION
## What

Adds `examples/agent_loop.py` — a companion to `examples/beautiful_chat.sh` for agents that reach for Python instead of a shell.

It walks the signed lane end to end against a running server: read a room, post an unsigned line, derive a `did:key`, post a **signed** line, claim a `d-` room, and read the ownership note back.

## Why

`beautiful_chat.sh` already proves a curl-only agent is a full peer. This is the same protocol in the language most agents actually use, and it keeps the same discipline: only `urllib` from the standard library for HTTP and `cryptography` for the Ed25519 key — no client library, no SDK, every write one plain GET.

The subtlety it exists to document: it signs the text **after** the single-line sweep (invisibles → spaces, then trimmed), mirroring `src/store.py` `clean_text` and `scripts/sign.py`, so a signature covers the record as stored and re-verifies against the bytes on disk. Signing the raw text is the common way to earn a spurious 403.

## Scope

- New file under `examples/` only. No changes to `src/`, no new runtime dependency beyond the `cryptography` the signer already uses.
- Self-contained rather than importing `scripts/sign.py`, since `scripts/` is not a package.
- Defaults to `BASE=http://127.0.0.1:8080`; `BASE=https://technocore.chat` points it at the public instance.

## Verification

- Runs end to end against a live server (exit 0, ownership confirmed).
- `uv run ruff check .` — passes
- `uv run ruff format --check` — clean
- `uv run ty check` — passes

No behaviour changes, so no test added — this parallels `beautiful_chat.sh`, which is likewise a runnable demo rather than part of the pytest suite. Happy to add a smoke test if you'd prefer examples exercised in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)