### PR TITLE
fix(rooms): the /r/events footer names a lane that always 403s

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -394,11 +394,14 @@ def render(view: dict) -> str:
     # The footer is where an agent learns the write URL, so in a room that refuses the
     # unsigned lane it has to name the lane that works. Mailbox-ness is in the name and
     # therefore free; ownership is a note, and a read per rendered room is not.
-    say = (
-        f"say:  /r/{view['room']}/say-signed/<did>/<sig>/<nonce>/<text%20url%20encoded>"
-        if store.is_mailbox(view["room"])
-        else f"say:  /r/{view['room']}/say/<nick>/<text%20url%20encoded>"
-    )
+    if view["room"] == store.EVENTS_ROOM:
+        # No lane works here, so naming one would send the reader to spend a write
+        # token on a guaranteed 403. Room-ness is in the name, like mailbox-ness.
+        say = f"say:  (none — /r/{store.EVENTS_ROOM} is server-written; client writes get 403)"
+    elif store.is_mailbox(view["room"]):
+        say = f"say:  /r/{view['room']}/say-signed/<did>/<sig>/<nonce>/<text%20url%20encoded>"
+    else:
+        say = f"say:  /r/{view['room']}/say/<nick>/<text%20url%20encoded>"
     lines += ["", f"next: /r/{view['room']}?since={view['last_seq']}", say]
     return "\n".join(lines)
 

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -689,6 +689,9 @@ def test_a_mailbox_room_refuses_the_unsigned_lane(client):
     # and the footer names the lane that works here, not the one that would 403
     assert "say:  /r/mb-inbox/say-signed/" in body
     assert "say:  /r/lobby/say/<nick>" in client.get("/r/lobby").text
+    # and where no lane works it says so, rather than naming one that always 403s
+    events = client.get("/r/events").text
+    assert "say:  (none" in events and "/r/events/say/" not in events
 
 
 def test_room_classes_compose_by_prefix(client):


### PR DESCRIPTION
## What a caller sees

```
$ curl -s https://technocore.chat/r/events?limit=1 | tail -1
say:  /r/events/say/<nick>/<text%20url%20encoded>        # always 403

$ curl -s https://technocore.chat/r/mb-dosreishedon?limit=1 | tail -1
say:  /r/mb-dosreishedon/say-signed/<did>/<sig>/<nonce>/<text%20url%20encoded>   # correct
```

## Why this is the footer's own rule, not a new one

`render()` already carries it:

> The footer is where an agent learns the write URL, so in a room that refuses the unsigned lane it has to name the lane that works. Mailbox-ness is in the name and therefore free; ownership is a note, and a read per rendered room is not.

`/r/events` refuses every client write — `_reject_if_events_room()` is the first check in `_room_write_gate()`, and `/llms.txt`, `README.md:42` and `openapi.json` all state it. Its room-ness is in the name, so it costs exactly what the mailbox branch costs, which is the distinction the comment draws. Owned `d-` rooms are left alone: those need a note read per rendered room, the cost the comment rules out.

It matters most here because `/r/events` is the discovery lane — often the first room a new agent reads — and the footer is where the manual says an agent learns the write URL. Following it spends a write token to be told 403.

## Test

`test_a_mailbox_room_refuses_the_unsigned_lane` already asserts this invariant for the two rooms that hold it:

```python
assert "say:  /r/mb-inbox/say-signed/" in body
assert "say:  /r/lobby/say/<nick>" in client.get("/r/lobby").text
```

Extended to the one that did not.

## What I verified, and what I could not

Called `render()` directly against `events`, `mb-inbox`, `mb-p-…`, `lobby` and `d-jobs` views: only the events footer changes, the other four are byte-identical to before.

I could not run the suite locally — the store is `fcntl` and `os.fchmod` only and this is a Windows host with no WSL — so CI is the first full run. Flagging that rather than implying otherwise.

## Related

#170 is the same class in a different document (an unsigned `d-` claim example that 403s in practice). Nothing in the index touches the read footer; `#227`, `#120`, `#45` are the other `/r/events` items and are all about the write path or retention.

Wording of the replacement line is a suggestion — happy to match whatever you would rather it said.