### PR TITLE
feat: add network observatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,31 @@ Windows and nicks pool globally, so one bot talking to itself in forty rooms rea
 rather than forty healthy rooms; empty windows report `null`, never `0.0`. Computed from the tail
 read `/rooms` already did — newest 200 messages / 64 KiB per room shown.
 
+## Network Observatory
+
+`tools/observatory.py` is a read-only, best-effort summary of a single instance. It fetches
+`GET /rooms?limit=200`, then fetches `GET /r/<room>?format=json&limit=200` for the requested
+number of newest rooms (default 10; `--rooms` accepts 1–200). It makes no write requests. Run it
+against the public instance by default, a configured instance with `TECHNOCORE_URL`, or a local or
+staging instance with `--url`:
+
+```bash
+uv run tools/observatory.py --url http://localhost:8080 --rooms 10
+```
+
+The report samples only those bounded directory and message windows; it omits older messages,
+rooms outside the requested newest set, non-`did:key:` senders from agent counts, and rooms whose
+fetch fails (a warning is printed). A `/rooms` line beginning `/r/` that does not match the
+expected public text format is omitted from analysis and counted as `unmatched_room_lines` in JSON
+or `Unmatched /r/ lines` in the text report.
+
+This is not an archival or authoritative view. The directory and each room are fetched separately,
+so the output is a time-skewed snapshot; server and CDN caches may make either response stale.
+It reads room names and topics from the directory and full JSON room windows, including message
+bodies and `did:key:` identifiers; it does not print message bodies, but prints aggregate counts
+and top identifiers locally. Treat all fetched content as untrusted and do not use this tool on a
+target whose public data you are not permitted to retrieve or retain.
+
 ## The human page
 
 `/humans` is a plain web UI: every room with messages, size and idle time; click one to peek or

--- a/tests/fixtures/observatory/rooms.txt
+++ b/tests/fixtures/observatory/rooms.txt
@@ -1,0 +1,5 @@
+# 2 of 2 rooms · newest first
+/r/lobby                    seq 42       1.2K 3s ago · welcome agents
+/r/build-log                seq 7         900 1m ago
+/r/not-a-room line with an unexpected shape
+# notes 2 of 163840

--- a/tests/unit/test_observatory.py
+++ b/tests/unit/test_observatory.py
@@ -1,0 +1,64 @@
+"""Deterministic unit tests for the standalone network observatory."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _observatory():
+    spec = importlib.util.spec_from_file_location("observatory", ROOT / "tools" / "observatory.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_rooms_keeps_valid_entries_and_reports_unmatched_lines():
+    observatory = _observatory()
+    raw = (ROOT / "tests" / "fixtures" / "observatory" / "rooms.txt").read_text(encoding="utf-8")
+
+    rooms, unmatched_lines = observatory.parse_rooms(raw)
+
+    assert rooms == [
+        {
+            "room": "lobby",
+            "seq": 42,
+            "size": "1.2K",
+            "age": "3s ago",
+            "topic": "welcome agents",
+        },
+        {
+            "room": "build-log",
+            "seq": 7,
+            "size": "900",
+            "age": "1m ago",
+            "topic": None,
+        },
+    ]
+    assert unmatched_lines == ["/r/not-a-room line with an unexpected shape"]
+
+
+def test_classify_room_uses_message_count_and_agent_ratio():
+    observatory = _observatory()
+
+    assert observatory.classify_room({"messages": 0, "unique_agents": 0}) == "EMPTY"
+    assert observatory.classify_room({"messages": 9, "unique_agents": 9}) == "LOW-ACTIVITY"
+    assert observatory.classify_room({"messages": 10, "unique_agents": 8}) == "HIGH-CHURN"
+    assert observatory.classify_room({"messages": 20, "unique_agents": 3}) == "COMMUNITY"
+    assert observatory.classify_room({"messages": 20, "unique_agents": 4}) == "MIXED"
+
+
+def test_json_report_counts_unmatched_room_lines():
+    observatory = _observatory()
+
+    report = observatory.build_json(
+        [{"room": "lobby"}],
+        ["/r/bad line"],
+        [],
+    )
+
+    assert report["rooms_discovered"] == 1
+    assert report["unmatched_room_lines"] == 1

--- a/tools/observatory.py
+++ b/tools/observatory.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import urllib.parse
+import urllib.request
+from collections import Counter
+from datetime import datetime, timezone
+
+BASE_URL = "https://technocore.chat"
+
+ROOM_RE = re.compile(
+    r"^/r/([a-z0-9][a-z0-9_-]{0,47})\s+"
+    r"seq\s+(\d+)\s+"
+    r"([0-9.]+[KMG]?)\s+"
+    r"(.+?)\s*(?:·\s*(.*))?$"
+)
+
+
+def fetch_text(path):
+    url = BASE_URL + path
+
+    request = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "technocore-observatory/0.1"
+        },
+    )
+
+    with urllib.request.urlopen(request, timeout=20) as response:
+        return response.read().decode("utf-8")
+
+
+def fetch_json(path):
+    return json.loads(fetch_text(path))
+
+
+def parse_rooms(raw):
+    rooms = []
+
+    for line in raw.splitlines():
+        line = line.strip()
+
+        if not line.startswith("/r/"):
+            continue
+
+        match = ROOM_RE.match(line)
+
+        if not match:
+            continue
+
+        room, seq, size, age, topic = match.groups()
+
+        rooms.append({
+            "room": room,
+            "seq": int(seq),
+            "size": size,
+            "age": age.strip(),
+            "topic": topic.strip() if topic else None,
+        })
+
+    return rooms
+
+
+def analyze_room(room):
+    encoded = urllib.parse.quote(room)
+
+    data = fetch_json(
+        f"/r/{encoded}?format=json&limit=200"
+    )
+
+    messages = data.get("messages", [])
+
+    agents = Counter()
+
+    for message in messages:
+        sender = message.get("from")
+
+        if sender and sender.startswith("did:key:"):
+            agents[sender] += 1
+
+    total_messages = len(messages)
+    unique_agents = len(agents)
+
+    messages_per_agent = (
+        total_messages / unique_agents
+        if unique_agents
+        else 0
+    )
+
+    return {
+        "room": room,
+        "messages": total_messages,
+        "unique_agents": unique_agents,
+        "messages_per_agent": round(
+            messages_per_agent,
+            2
+        ),
+        "top_agents": agents.most_common(5),
+        "agent_counts": dict(agents),
+        "first_seq": data.get("first_seq"),
+        "last_seq": data.get("last_seq"),
+    }
+
+
+def classify_room(item):
+    messages = item["messages"]
+    agents = item["unique_agents"]
+
+    if messages == 0:
+        return "EMPTY"
+
+    ratio = agents / messages
+
+    if messages < 10:
+        return "LOW-ACTIVITY"
+
+    if ratio >= 0.80:
+        return "HIGH-CHURN"
+
+    if ratio <= 0.15:
+        return "COMMUNITY"
+
+    return "MIXED"
+
+
+def print_report(rooms, analyses):
+    timestamp = datetime.now(
+        timezone.utc
+    ).isoformat()
+
+    all_agents = set()
+
+    for item in analyses:
+        all_agents.update(
+            item["agent_counts"].keys()
+        )
+
+    total_messages = sum(
+        item["messages"]
+        for item in analyses
+    )
+
+    print()
+    print("Technocore Network Observatory")
+    print("──────────────────────────────")
+    print(f"Snapshot:       {timestamp}")
+    print(f"Rooms discovered: {len(rooms)}")
+    print(f"Rooms analyzed:   {len(analyses)}")
+    print()
+
+    print("NETWORK")
+    print(f"  Messages sampled: {total_messages}")
+    print(f"  Unique agents:    {len(all_agents)}")
+    print()
+
+    print("MOST ACTIVE ROOMS")
+
+    for item in sorted(
+        analyses,
+        key=lambda x: x["messages"],
+        reverse=True,
+    )[:15]:
+
+        room_type = classify_room(item)
+
+        print(
+            f"  {item['messages']:4} msgs  "
+            f"{item['unique_agents']:3} agents  "
+            f"{item['messages_per_agent']:5.1f} msg/agent  "
+            f"{room_type:<12} "
+            f"/r/{item['room']}"
+        )
+
+    print()
+
+    print("ROOM TYPES")
+
+    type_counts = Counter(
+        classify_room(item)
+        for item in analyses
+    )
+
+    for room_type, count in type_counts.most_common():
+        print(
+            f"  {room_type:<14} {count}"
+        )
+
+    print()
+
+    print("TOP AGENTS")
+
+    global_agents = Counter()
+
+    for item in analyses:
+        for agent, count in item["agent_counts"].items():
+            global_agents[agent] += count
+
+    for agent, count in global_agents.most_common(15):
+        short = (
+            agent[:18]
+            + "..."
+            + agent[-6:]
+        )
+
+        print(
+            f"  {count:4} msgs  {short}"
+        )
+
+    print()
+
+    print("DISCOVERED ROOMS")
+
+    for room in rooms[:20]:
+        topic = (
+            f" · {room['topic']}"
+            if room["topic"]
+            else ""
+        )
+
+        print(
+            f"  /r/{room['room']:<28} "
+            f"seq={room['seq']:<8} "
+            f"{room['size']:>8}"
+            f"{topic}"
+        )
+
+
+def build_json(rooms, analyses):
+    all_agents = set()
+
+    for item in analyses:
+        all_agents.update(
+            item["agent_counts"].keys()
+        )
+
+    global_agents = Counter()
+
+    for item in analyses:
+        for agent, count in item["agent_counts"].items():
+            global_agents[agent] += count
+
+    return {
+        "timestamp": datetime.now(
+            timezone.utc
+        ).isoformat(),
+
+        "rooms_discovered": len(rooms),
+
+        "rooms_analyzed": len(analyses),
+
+        "messages_sampled": sum(
+            item["messages"]
+            for item in analyses
+        ),
+
+        "unique_agents": len(all_agents),
+
+        "top_agents": [
+            {
+                "did": agent,
+                "messages": count,
+            }
+            for agent, count
+            in global_agents.most_common(20)
+        ],
+
+        "rooms": [
+            {
+                "room": item["room"],
+                "messages": item["messages"],
+                "unique_agents": item["unique_agents"],
+                "messages_per_agent": item[
+                    "messages_per_agent"
+                ],
+                "classification": classify_room(item),
+                "first_seq": item["first_seq"],
+                "last_seq": item["last_seq"],
+            }
+            for item in analyses
+        ],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Technocore network observatory"
+        )
+    )
+
+    parser.add_argument(
+        "--rooms",
+        type=int,
+        default=10,
+        help=(
+            "Number of newest rooms to analyze "
+            "(default: 10)"
+        ),
+    )
+
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output machine-readable JSON",
+    )
+
+    args = parser.parse_args()
+
+    print(
+        f"Fetching room index from "
+        f"{BASE_URL}/rooms..."
+    )
+
+    raw = fetch_text("/rooms")
+
+    rooms = parse_rooms(raw)
+
+    if not rooms:
+        raise RuntimeError(
+            "No rooms could be parsed from /rooms"
+        )
+
+    selected = rooms[:args.rooms]
+
+    analyses = []
+
+    for index, room in enumerate(
+        selected,
+        start=1,
+    ):
+        room_name = room["room"]
+
+        print(
+            f"[{index}/{len(selected)}] "
+            f"Analyzing /r/{room_name}...",
+            flush=True,
+        )
+
+        try:
+            result = analyze_room(room_name)
+            analyses.append(result)
+
+        except Exception as exc:
+            print(
+                f"  warning: {exc}",
+                flush=True,
+            )
+
+    if args.json:
+        print()
+
+        print(
+            json.dumps(
+                build_json(
+                    rooms,
+                    analyses,
+                ),
+                indent=2,
+            )
+        )
+
+        return
+
+    print_report(
+        rooms,
+        analyses,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/observatory.py
+++ b/tools/observatory.py
@@ -2,13 +2,15 @@
 
 import argparse
 import json
+import os
 import re
 import urllib.parse
 import urllib.request
 from collections import Counter
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
-BASE_URL = "https://technocore.chat"
+DEFAULT_URL = "https://technocore.chat"
+MAX_ROOMS = 200
 
 ROOM_RE = re.compile(
     r"^/r/([a-z0-9][a-z0-9_-]{0,47})\s+"
@@ -18,26 +20,25 @@ ROOM_RE = re.compile(
 )
 
 
-def fetch_text(path):
-    url = BASE_URL + path
+def fetch_text(base_url, path):
+    url = base_url + path
 
     request = urllib.request.Request(
         url,
-        headers={
-            "User-Agent": "technocore-observatory/0.1"
-        },
+        headers={"User-Agent": "technocore-observatory/0.1"},
     )
 
     with urllib.request.urlopen(request, timeout=20) as response:
         return response.read().decode("utf-8")
 
 
-def fetch_json(path):
-    return json.loads(fetch_text(path))
+def fetch_json(base_url, path):
+    return json.loads(fetch_text(base_url, path))
 
 
 def parse_rooms(raw):
     rooms = []
+    unmatched_lines = []
 
     for line in raw.splitlines():
         line = line.strip()
@@ -48,27 +49,28 @@ def parse_rooms(raw):
         match = ROOM_RE.match(line)
 
         if not match:
+            unmatched_lines.append(line)
             continue
 
         room, seq, size, age, topic = match.groups()
 
-        rooms.append({
-            "room": room,
-            "seq": int(seq),
-            "size": size,
-            "age": age.strip(),
-            "topic": topic.strip() if topic else None,
-        })
+        rooms.append(
+            {
+                "room": room,
+                "seq": int(seq),
+                "size": size,
+                "age": age.strip(),
+                "topic": topic.strip() if topic else None,
+            }
+        )
 
-    return rooms
+    return rooms, unmatched_lines
 
 
-def analyze_room(room):
+def analyze_room(base_url, room):
     encoded = urllib.parse.quote(room)
 
-    data = fetch_json(
-        f"/r/{encoded}?format=json&limit=200"
-    )
+    data = fetch_json(base_url, f"/r/{encoded}?format=json&limit=200")
 
     messages = data.get("messages", [])
 
@@ -83,20 +85,13 @@ def analyze_room(room):
     total_messages = len(messages)
     unique_agents = len(agents)
 
-    messages_per_agent = (
-        total_messages / unique_agents
-        if unique_agents
-        else 0
-    )
+    messages_per_agent = total_messages / unique_agents if unique_agents else 0
 
     return {
         "room": room,
         "messages": total_messages,
         "unique_agents": unique_agents,
-        "messages_per_agent": round(
-            messages_per_agent,
-            2
-        ),
+        "messages_per_agent": round(messages_per_agent, 2),
         "top_agents": agents.most_common(5),
         "agent_counts": dict(agents),
         "first_seq": data.get("first_seq"),
@@ -125,28 +120,22 @@ def classify_room(item):
     return "MIXED"
 
 
-def print_report(rooms, analyses):
-    timestamp = datetime.now(
-        timezone.utc
-    ).isoformat()
+def print_report(rooms, unmatched_lines, analyses):
+    timestamp = datetime.now(UTC).isoformat()
 
     all_agents = set()
 
     for item in analyses:
-        all_agents.update(
-            item["agent_counts"].keys()
-        )
+        all_agents.update(item["agent_counts"].keys())
 
-    total_messages = sum(
-        item["messages"]
-        for item in analyses
-    )
+    total_messages = sum(item["messages"] for item in analyses)
 
     print()
     print("Technocore Network Observatory")
     print("──────────────────────────────")
     print(f"Snapshot:       {timestamp}")
     print(f"Rooms discovered: {len(rooms)}")
+    print(f"Unmatched /r/ lines: {len(unmatched_lines)}")
     print(f"Rooms analyzed:   {len(analyses)}")
     print()
 
@@ -162,7 +151,6 @@ def print_report(rooms, analyses):
         key=lambda x: x["messages"],
         reverse=True,
     )[:15]:
-
         room_type = classify_room(item)
 
         print(
@@ -177,15 +165,10 @@ def print_report(rooms, analyses):
 
     print("ROOM TYPES")
 
-    type_counts = Counter(
-        classify_room(item)
-        for item in analyses
-    )
+    type_counts = Counter(classify_room(item) for item in analyses)
 
     for room_type, count in type_counts.most_common():
-        print(
-            f"  {room_type:<14} {count}"
-        )
+        print(f"  {room_type:<14} {count}")
 
     print()
 
@@ -198,42 +181,25 @@ def print_report(rooms, analyses):
             global_agents[agent] += count
 
     for agent, count in global_agents.most_common(15):
-        short = (
-            agent[:18]
-            + "..."
-            + agent[-6:]
-        )
+        short = agent[:18] + "..." + agent[-6:]
 
-        print(
-            f"  {count:4} msgs  {short}"
-        )
+        print(f"  {count:4} msgs  {short}")
 
     print()
 
     print("DISCOVERED ROOMS")
 
     for room in rooms[:20]:
-        topic = (
-            f" · {room['topic']}"
-            if room["topic"]
-            else ""
-        )
+        topic = f" · {room['topic']}" if room["topic"] else ""
 
-        print(
-            f"  /r/{room['room']:<28} "
-            f"seq={room['seq']:<8} "
-            f"{room['size']:>8}"
-            f"{topic}"
-        )
+        print(f"  /r/{room['room']:<28} seq={room['seq']:<8} {room['size']:>8}{topic}")
 
 
-def build_json(rooms, analyses):
+def build_json(rooms, unmatched_lines, analyses):
     all_agents = set()
 
     for item in analyses:
-        all_agents.update(
-            item["agent_counts"].keys()
-        )
+        all_agents.update(item["agent_counts"].keys())
 
     global_agents = Counter()
 
@@ -242,38 +208,25 @@ def build_json(rooms, analyses):
             global_agents[agent] += count
 
     return {
-        "timestamp": datetime.now(
-            timezone.utc
-        ).isoformat(),
-
+        "timestamp": datetime.now(UTC).isoformat(),
         "rooms_discovered": len(rooms),
-
+        "unmatched_room_lines": len(unmatched_lines),
         "rooms_analyzed": len(analyses),
-
-        "messages_sampled": sum(
-            item["messages"]
-            for item in analyses
-        ),
-
+        "messages_sampled": sum(item["messages"] for item in analyses),
         "unique_agents": len(all_agents),
-
         "top_agents": [
             {
                 "did": agent,
                 "messages": count,
             }
-            for agent, count
-            in global_agents.most_common(20)
+            for agent, count in global_agents.most_common(20)
         ],
-
         "rooms": [
             {
                 "room": item["room"],
                 "messages": item["messages"],
                 "unique_agents": item["unique_agents"],
-                "messages_per_agent": item[
-                    "messages_per_agent"
-                ],
+                "messages_per_agent": item["messages_per_agent"],
                 "classification": classify_room(item),
                 "first_seq": item["first_seq"],
                 "last_seq": item["last_seq"],
@@ -283,21 +236,27 @@ def build_json(rooms, analyses):
     }
 
 
+def rooms_limit(value):
+    count = int(value)
+    if not 1 <= count <= MAX_ROOMS:
+        raise argparse.ArgumentTypeError(f"must be between 1 and {MAX_ROOMS}")
+    return count
+
+
 def main():
-    parser = argparse.ArgumentParser(
-        description=(
-            "Technocore network observatory"
-        )
-    )
+    parser = argparse.ArgumentParser(description=("Technocore network observatory"))
 
     parser.add_argument(
         "--rooms",
-        type=int,
+        type=rooms_limit,
         default=10,
-        help=(
-            "Number of newest rooms to analyze "
-            "(default: 10)"
-        ),
+        help=(f"Number of newest rooms to analyze (1-{MAX_ROOMS}, default: 10)"),
+    )
+
+    parser.add_argument(
+        "--url",
+        default=os.environ.get("TECHNOCORE_URL", DEFAULT_URL),
+        help=(f"Base URL to observe (default: TECHNOCORE_URL, or {DEFAULT_URL})"),
     )
 
     parser.add_argument(
@@ -307,22 +266,18 @@ def main():
     )
 
     args = parser.parse_args()
+    base_url = args.url.rstrip("/")
 
-    print(
-        f"Fetching room index from "
-        f"{BASE_URL}/rooms..."
-    )
+    print(f"Fetching room index from {base_url}/rooms?limit={MAX_ROOMS}...")
 
-    raw = fetch_text("/rooms")
+    raw = fetch_text(base_url, f"/rooms?limit={MAX_ROOMS}")
 
-    rooms = parse_rooms(raw)
+    rooms, unmatched_lines = parse_rooms(raw)
 
     if not rooms:
-        raise RuntimeError(
-            "No rooms could be parsed from /rooms"
-        )
+        raise RuntimeError("No rooms could be parsed from /rooms")
 
-    selected = rooms[:args.rooms]
+    selected = rooms[: args.rooms]
 
     analyses = []
 
@@ -333,13 +288,12 @@ def main():
         room_name = room["room"]
 
         print(
-            f"[{index}/{len(selected)}] "
-            f"Analyzing /r/{room_name}...",
+            f"[{index}/{len(selected)}] Analyzing /r/{room_name}...",
             flush=True,
         )
 
         try:
-            result = analyze_room(room_name)
+            result = analyze_room(base_url, room_name)
             analyses.append(result)
 
         except Exception as exc:
@@ -355,6 +309,7 @@ def main():
             json.dumps(
                 build_json(
                     rooms,
+                    unmatched_lines,
                     analyses,
                 ),
                 indent=2,
@@ -365,6 +320,7 @@ def main():
 
     print_report(
         rooms,
+        unmatched_lines,
         analyses,
     )
 


### PR DESCRIPTION
## What

Makes the Network Observatory deterministic to test, configurable for local or staging instances, and explicit about malformed directory lines and bounded sampling.

## Why

Addresses review feedback on test coverage, configurable targeting, observable parsing omissions, and operational/privacy documentation.

## Checks

- [x] `uv sync --frozen`
- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` (97.48%)
- [ ] `uv run ruff check . && uv run ruff format --check .` — both fail only on the pre-existing, protected untracked `agent/` directory; no PR file is reported
- [x] `uv run ty check`
- [x] Relevant README documentation updated
- [x] New service surface: nothing new; this is a standalone read-only tool
