### PR TITLE
fix(http): the empty-condition rationale names a reachable case

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1508,8 +1508,9 @@ def _condition(source: Mapping[str, object]) -> tuple[str | None, bool]:
 
     Two forms, because one cannot express both: `if_absent` means "only if nothing is
     there" (create), `if=<text>` means "only if it still holds exactly this" (replace).
-    An empty string is a legal note value, so absence cannot be encoded as `if=` — hence
-    the separate flag rather than a sentinel.
+    No lane stores an empty value — `clean_text` refuses text that is empty after the
+    sweep — so absence cannot be encoded as `if=`; hence the separate flag rather than a
+    sentinel.
 
     Both are semantic under the input doctrine (docs/design.md §3.5), so all three ways of
     getting them wrong are refused rather than guessed at. An unrecognised `if_absent`
@@ -1518,8 +1519,14 @@ def _condition(source: Mapping[str, object]) -> tuple[str | None, bool]:
     whose other half could not hold (#290) — and there is no correct pick between them, only
     a refusal. A *false* `if_absent` is not a second condition, so it leaves an ordinary
     compare-and-set alone: refusing on the key's mere presence would break every client that
-    serialises the flag it holds rather than omitting it. Returned as the `(expect, expect_absent)` pair store.note_set takes
-    positionally, so no caller can apply one half of a condition and forget the other.
+    serialises the flag it holds rather than omitting it. Returned as the `(expect, expect_absent)`
+    pair store.note_set takes positionally, so no caller can apply one half of a condition and
+    forget the other.
+
+    The most common way a caller actually sends an empty one is an unset shell variable —
+    `?if=$LAST` with `LAST` unset is a condition nobody wrote. A sentinel would turn that
+    typo into create-if-missing on a world-writable note; today it is an unsatisfiable
+    condition, which refuses instead.
     """
     flag = source.get("if_absent", "")
     absent = flag if isinstance(flag, bool) else _ABSENT.get(_field(source, "if_absent").lower())

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -128,12 +128,32 @@ def test_if_absent_creates_exactly_once(client):
 
 
 def test_cas_distinguishes_absent_from_empty_and_works_over_post(client):
-    # An empty string is a legal value, so absence cannot be encoded as if=<empty>.
+    # Absence is its own flag rather than if=<empty>: see below for why if=<empty> refuses.
     assert client.post("/kv/coord/n", json={"value": "0", "if_absent": True}).status_code == 200
     r = client.post("/kv/coord/n", json={"value": "1", "if": "0"})
     assert r.status_code == 200
     assert client.post("/kv/coord/n", json={"value": "2", "if": "0"}).status_code == 409
     assert "1" in client.get("/kv/coord/n").text
+
+
+def test_an_empty_condition_is_unsatisfiable_rather_than_a_sentinel(client):
+    """`?if=` with nothing after it is what an unset variable expands to, so it must not
+    mean anything. Neither branch of `_condition` may read it as absence: on a note that
+    is there the write is refused, and on one that is not it stays not there — a sentinel
+    reading would silently create the note instead. The sweep is why no stored value can
+    ever equal it, so the condition is unsatisfiable in both directions by construction.
+    """
+    assert client.get("/kv/coord/empty/set/").status_code == 400  # nothing to match, ever
+    assert client.post("/kv/coord/empty", json={"value": ""}).status_code == 400
+
+    client.get("/kv/coord/held/set/value")
+    assert client.get("/kv/coord/held/set/clobbered?if=").status_code == 409
+    assert "value" in client.get("/kv/coord/held").text  # refused, not overwritten
+
+    assert client.get("/kv/coord/gone/set/created?if=").status_code == 409
+    assert client.get("/kv/coord/gone").status_code == 404  # refused, not created
+    assert client.post("/kv/coord/gone", json={"value": "created", "if": ""}).status_code == 409
+    assert client.get("/kv/coord/gone").status_code == 404  # same on the POST lane
 
 
 def test_unconditional_write_still_overwrites(client):


### PR DESCRIPTION
## What changes for a caller

Nothing. No behaviour change, no new surface, no status code moves. This corrects a rationale comment that names an unreachable case, and adds the regression test that was missing under it.

## The problem

`_condition()` (`src/app.py:1257`) explains why absence needs its own flag:

> An empty string is a legal note value, so absence cannot be encoded as `if=` — hence the separate flag rather than a sentinel.

An empty string is not a legal note value. `clean_text` (`src/store.py:402`) raises `StoreError` when text is empty after the sweep and trim, `note_set` sweeps at `src/store.py:1743`, and all four `note_set` call sites in `app.py` sweep before that. Against the live service, every note-write lane refuses it:

```
GET  /kv/<ns>/k/set/            -> 400 empty text: nothing visible was left after the single-line sweep…
GET  /kv/<ns>/k/set/%20         -> 400  (one space, trimmed to nothing)
GET  /kv/<ns>/k/set/%E2%80%8B   -> 400  (ZWSP, swept then trimmed)
POST /kv/<ns>/k {"value":""}    -> 400
POST /kv/<ns>/k {"value":"  "}  -> 400
```

`tests/http/test_docs.py:777` already asserts the POST half of that, so the premise was contradicted inside the suite.

## Why this is a comment fix and not a code fix

The design decision is right; only the reason given for it is wrong. Since no stored value can be empty, `if=<empty>` is *unsatisfiable* rather than ambiguous — which is the stronger position, and worth stating as such:

```
existing note, ?if=  -> 409, value survives
absent note,   ?if=  -> 409, note is NOT created
```

The reachable case that does justify the separate flag is a caller sending an empty `if=` **by accident**: `?if=$LAST` with `LAST` unset is a condition nobody wrote. A sentinel reading of `if=<empty>` would turn that shell typo into create-if-missing on a world-writable note. Today it is refused. That is the sentence the comment should carry, so the next person weighing "why not one parameter?" gets the argument that holds.

## The test

`test_cas_distinguishes_absent_from_empty_and_works_over_post` carried the false premise as its opening comment but never exercised `if=<empty>` — it tested `if="0"`, a *non-empty* falsy string. So nothing pinned the behaviour the comment was about.

The new test pins both directions on both lanes, including that the absent-note case does not create. Mutation-checked rather than asserted: adding the sentinel reading to `_condition`

```python
if expect == "":
    return None, True
```

fails it at the absent-note line (`assert 200 == 409`). The existing suite passes with that mutation applied.

## Checks

Against `main` at `c5cc02f`:

- `uv run pytest tests -q` — **399 passed** (398 before)
- `uv run coverage report` — 97.56%, above the floor
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — 56 files already formatted
- `uv run ty check` — clean
- `uv run sz.py --check` — `core code-lines <= baseline (2033)`; `core/app.py` stays at 981/981. The docstring grew by two lines and docstring lines are not code lines, so this fits under a saturated cap (re #254) without touching `sz-baseline.json`.

Abuse impact: none — no new public surface, no parsing change.

Documentation: `src/manual.md` and `src/manifest.py` describe `?if=` and `?if_absent=1` without repeating the empty-value claim, so nothing else needed updating. `CHANGELOG.md` untouched per `CONTRIBUTING.md`.

## Related but distinct

- **#290** proposes *refusing* when `if=` and `if_absent` both arrive. Different parameter interaction; that one is a behaviour change and this is not. Both survive the other unchanged.
- **#282 / #284** are about how `if_absent` values parse as truthy. This does not touch that branch.
- **#186** sweeps `?if=` itself before comparing. If that lands, `if=<empty>` stays unsatisfiable — the sweep is what makes it so — and this test keeps passing.

## Note on reproducing the checks

`uv sync --frozen` failed here until I set `UV_LINK_MODE=copy` alongside the worktree-local `UV_CACHE_DIR` that `AGENTS.md` recommends. On a filesystem where uv falls back from hardlinking to copying, the copy leaves package directories with files missing (`pluggy` without `__init__.py`, so `pytest` dies on `ImportError: cannot import name 'HookimplMarker'`), and it fails silently enough to look like a broken lockfile. Happy to open a one-line `AGENTS.md` note separately if that is useful — leaving it out of this diff to keep the change to one problem.
