### PR TITLE
perf(store): shard rooms and notes one level of 256, migrating lazily

### DIFF
--- a/bench/shard.py
+++ b/bench/shard.py
@@ -1,0 +1,165 @@
+"""Why the store shards one level wide, and why that level is 256.
+
+Run: uv run python bench/shard.py
+
+Sharding exists to stop one directory getting enormous. At the caps this service enforces,
+a namespace at CHAT_MAX_NOTES_PER_NS is 200,000 directory entries counting the sidecar
+lock beside every note, and `_check_note_capacity` scans that on every create in it. That is
+the number to fix. Everything below is about not overshooting it.
+
+Three measurements.
+
+1. Resolution. `_shard` is memoized, so a name resolved before costs an lru_cache hit rather
+   than a hash. The acceptance target is under 250 ns, which the raw hash alone does not meet
+   and the cache comfortably does. Read the warm figure as "a working set that fits": one
+   cache of MAX_ROOMS entries serves room names AND note keys, so traffic over a set larger
+   than it evicts its way back to the cold cost, which the last row measures. The cache is
+   sized from CHAT_MAX_ROOMS, so the middle row thrashes when this file is run without that
+   set — which is itself the point being made. Still cheap against the stat that follows it,
+   which costs microseconds.
+
+2. Distribution. Deterministic hashing is only worth anything if it spreads. `digest_size=1`
+   is 8 bits, which is exactly 256 — no mask, no slice, and no room for a modulo bias. Widths
+   that do NOT divide the digest space are where that goes wrong, so the bias check is run
+   against several to show what it looks like when it bites.
+
+3. Width. The one that decided the layout. A wider shard makes buckets smaller and makes
+   MORE directories, and past a point the second cost is real while the first has stopped
+   buying anything: readdir does not care about the difference between 780 entries and 390.
+   Two levels of 256 was the original design and is measured here as the thing it lost to.
+
+Builds its own store in a tempfile directory — never read a real one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import statistics
+import sys
+import tempfile
+import timeit
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import store  # noqa: E402
+
+ROOMS = 20_000  # the cap this was sized against, not the 5,120 default
+PER_NS = 100_000  # CHAT_MAX_NOTES_PER_NS: the biggest one directory is allowed to get
+
+
+def _names(n: int, prefix: str = "room") -> list[str]:
+    return [f"{prefix}-{i:06d}" for i in range(n)]
+
+
+def resolution() -> None:
+    names = _names(ROOMS)
+    store._shard.cache_clear()
+    cold = timeit.timeit(lambda: [store._shard(n) for n in names], number=1) / len(names)
+    warm = timeit.timeit(lambda: [store._shard(n) for n in names], number=3) / (3 * len(names))
+    one = names[0]
+    hit = timeit.timeit(lambda: store._shard(one), number=200_000) / 200_000
+    over = _names(store.MAX_ROOMS * 8, "key")
+    thrash = timeit.timeit(lambda: [store._shard(n) for n in over], number=1) / len(over)
+
+    print("resolution")
+    print(f"  _shard, cold (first sight of a name)   {cold * 1e9:8.1f} ns")
+    print(f"  _shard, warm over {ROOMS:,} names ({store.MAX_ROOMS:,} cache) {warm * 1e9:6.1f} ns")
+    print(f"  _shard, one hot name                   {hit * 1e9:8.1f} ns   <- the 250 ns target")
+    print(f"  _shard, working set 8x the cache       {thrash * 1e9:8.1f} ns")
+    verdict = "PASS" if hit * 1e9 < 250 else "FAIL"
+    print(f"  {verdict}: {hit * 1e9:.0f} ns against a 250 ns budget, on a warm working set.")
+    print(
+        f"        A set that outgrows the cache costs {thrash * 1e9:.0f} ns — the hash, not a hit."
+    )
+
+
+def distribution() -> None:
+    loads = list(Counter(store._shard(n) for n in _names(ROOMS)).values())
+    expected = ROOMS / 256
+    chi2 = sum((load - expected) ** 2 / expected for load in loads)
+    print(f"\ndistribution of {ROOMS:,} names over 256 buckets")
+    print(f"  buckets occupied                       {len(loads):8d} / 256")
+    print(
+        f"  mean / min / max load                  {statistics.mean(loads):8.1f}"
+        f" / {min(loads)} / {max(loads)}"
+    )
+    # chi2 over 255 degrees of freedom: ~1.0 is what a uniform hash gives.
+    print(f"  chi-square / df (1.00 is uniform)      {chi2 / 255:8.2f}")
+
+    print("\n  bias check — a width must divide the digest space it is taken from:")
+    for width, space in ((256, 256), (512, 65536), (500, 65536), (1000, 65536)):
+        spread = Counter(v % width for v in range(space)).values()
+        flag = "clean" if min(spread) == max(spread) else "BIASED"
+        print(
+            f"    {width:>5} buckets from {space:>5} digests: {min(spread)}-{max(spread)} each  {flag}"
+        )
+
+
+def _occupied(n: int, width: int) -> float:
+    """How many of `width` buckets `n` names land in, if the hash is uniform."""
+    return width * (1 - (1 - 1 / width) ** n) if n else 0.0
+
+
+def width() -> None:
+    # The live shape (technocore.chat, 2026-08-26): ~1,000 of 1,346 namespaces hold five
+    # notes or fewer, and the busiest holds the per-namespace cap. The tail is what makes a
+    # deep shard expensive — every near-empty namespace still pays for its own bucket tree.
+    tail = [1] * 839 + [3] * 170 + [12] * 33 + [50] * 22
+    big = [PER_NS] * 6 + [3000] * 267
+    sizes = tail + big
+    total = sum(sizes)
+    print(f"\nwidth, against the live namespace shape scaled to {total:,} notes")
+    print(f"  {'layout':<26}{'directories':>13}{'per file':>10}{'busiest bucket':>17}")
+    for label, dirs, busiest in (
+        ("flat (today)", len(sizes), PER_NS),
+        ("1 level of 256 (this)", sum(1 + _occupied(n, 256) for n in sizes), PER_NS / 256),
+        ("1 level of 512", sum(1 + _occupied(n, 512) for n in sizes), PER_NS / 512),
+        (
+            "2 levels of 256",
+            sum(1 + _occupied(n, 256) + _occupied(n, 65536) for n in sizes),
+            PER_NS / _occupied(PER_NS, 65536),
+        ),
+    ):
+        print(f"  {label:<26}{dirs:>13,.0f}{dirs / total:>10.3f}{busiest * 2:>17,.0f}")
+    print("  (busiest bucket counts the .lock sidecar beside every note)")
+
+
+def _time_walks(rooms: Path) -> tuple[float, float]:
+    """Bound to `rooms` as an argument, never closed over: a lambda capturing the loop
+    variable below would time whichever layout the loop had reached by then."""
+    walk = timeit.timeit(lambda: sum(1 for _ in store._walk(rooms, ".jsonl")), number=3)
+    scan = timeit.timeit(lambda: store._scan(rooms, ".jsonl", sized=True), number=3)
+    return walk, scan
+
+
+def walks() -> None:
+    """The cost the reaper, /rooms, /stats and every room create actually pay."""
+    print("\nwalks over a rooms/ directory of 20,000")
+    for label, sharded in (("flat", False), ("1 level of 256", True)):
+        root = Path(tempfile.mkdtemp())
+        try:
+            for name in _names(ROOMS):
+                d = root / "rooms" / store._shard(name) if sharded else root / "rooms"
+                d.mkdir(parents=True, exist_ok=True)
+                (d / f"{name}.jsonl").write_text("{}\n")
+                (d / f"{name}.jsonl.lock").touch()  # the sidecar every real room carries
+            walk, scan = _time_walks(root / "rooms")
+            print(
+                f"  {label:<16} _walk {walk / 3 * 1e3:7.2f} ms   "
+                f"_scan(sized) {scan / 3 * 1e3:7.2f} ms"
+            )
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    assert hashlib.blake2b(b"x", digest_size=1).hexdigest() == store._shard("x"), (
+        "the benchmark and the store disagree about the layout"
+    )
+    resolution()
+    distribution()
+    width()
+    walks()

--- a/docs/design.md
+++ b/docs/design.md
@@ -249,8 +249,8 @@ requirement; the goal is to make abuse *bounded and uninteresting*, not impossib
 
 | # | Hazard | Mitigation (all implemented) | Friction added |
 |---|---|---|---|
-| 1 | **Path traversal** — `../../etc`, `%2e%2e%2f`, the `ii` `#../../` bug | Allowlist `^[a-z0-9][a-z0-9_-]{0,47}$` on *every* name; reject before any path is built; suffix (`.jsonl`/`.txt`) appended by the server; names are always exactly one path component | none |
-| 2 | **Arbitrary file write** via crafted extension or absolute path | Same as 1 — no caller input ever reaches an extension or a directory position | none |
+| 1 | **Path traversal** — `../../etc`, `%2e%2e%2f`, the `ii` `#../../` bug | Allowlist `^[a-z0-9][a-z0-9_-]{0,47}$` on *every* name; reject before any path is built; suffix (`.jsonl`/`.txt`) appended by the server; the name is always exactly one path component, and the shard directory above it is 2 hex characters of BLAKE2b — derived, never caller bytes | none |
+| 2 | **Arbitrary file write** via crafted extension or absolute path | Same as 1 — no caller input ever reaches an extension, and it reaches a directory position only through a hash whose output is one byte of hex | none |
 | 3 | **Record forgery**, and **invisible-instruction smuggling** | Every character in Unicode categories Cc/Cf/Cs/Co is replaced with a space before serialisation — not just ASCII controls. See §3.2 | multi-line text needs POST; ZWJ emoji flatten |
 | 4 | **Write/write race, torn records** | `flock(LOCK_EX)` on a **sidecar `.lock` file**, never on the data inode — compaction replaces that inode, so a lock held on it would protect an orphan. `O_APPEND` single-`write` per record. Verified: 4 processes × 250 appends → 1000 unique contiguous seqs | none |
 | 5 | **Read/compaction race** | Readers take no lock; compaction publishes via atomic `os.replace`; an in-flight reader keeps the old inode and sees a consistent older snapshot | none |

--- a/docs/store.md
+++ b/docs/store.md
@@ -12,7 +12,7 @@ via stdlib `inspect` — never edited by hand; a test regenerates and diffs this
 - `list_notes(root: pathlib.Path, ns: str) -> list[str]` — (undocumented)
 - `list_rooms(root: pathlib.Path) -> list[str]` — (undocumented)
 - `note_get(root: pathlib.Path, ns: str, key: str) -> str | None` — (undocumented)
-- `note_path(root: pathlib.Path, ns: str, key: str) -> pathlib.Path` — (undocumented)
+- `note_path(root: pathlib.Path, ns: str, key: str) -> pathlib.Path` — Where a note lives — `notes/<ns>/<shard>/<key>.txt`.
 - `note_set(root: pathlib.Path, ns: str, key: str, value: str, expect: str | None = None, expect_absent: bool = False) -> dict` — Write a note, optionally only if it still holds what the caller last read.
 - `note_stats(root: pathlib.Path) -> dict` — Aggregate note usage. Deliberately blind: no namespace, no key, ever.
 - `ownable(name: str) -> bool` — (undocumented)
@@ -20,7 +20,7 @@ via stdlib `inspect` — never edited by hand; a test regenerates and diffs this
 - `reverse_lines(f, chunk_size: int = 65536, max_bytes: int = 1048576)` — Yield complete lines from the end of a binary file, newest first.
 - `room_bytes_used(root: pathlib.Path) -> int` — Total room bytes at the last reap pass, or 0 if none has run yet.
 - `room_classes(name: str) -> frozenset[str]` — The leading `<class>-` markers on a name, so classes compose by prefix.
-- `room_path(root: pathlib.Path, room: str) -> pathlib.Path` — (undocumented)
+- `room_path(root: pathlib.Path, room: str) -> pathlib.Path` — Where a room's JSONL lives — `rooms/<shard>/<room>.jsonl`.
 - `room_stats(root: pathlib.Path, limit: int = 50) -> dict` — Recency-sorted room summaries for the overview.
 - `room_window(root: pathlib.Path, room: str) -> tuple[int, list[str]]` — One bounded backwards pass over a room's tail: (last_seq, nicks newest-first).
 - `service_stats(root: pathlib.Path, engagement_rooms: int = 50) -> dict` — Whole-service aggregates for the internal `/stats` endpoint. Counters only.

--- a/src/store.py
+++ b/src/store.py
@@ -11,6 +11,7 @@ Design constraints (see docs/design.md):
 from __future__ import annotations
 
 import fcntl
+import hashlib
 import os
 import re
 import tempfile
@@ -422,12 +423,136 @@ def clean_text(text: str, limit: int = MAX_TEXT_CHARS) -> str:
 # --------------------------------------------------------------------------- paths
 
 
+# One level of 256, and a name's bucket is computed rather than looked up: every process
+# resolves the same path from the string alone, with no index to keep in sync and nothing to
+# consult before a read.
+#
+# blake2b and NOT the builtin `hash()`: str hashing is salted per process by PYTHONHASHSEED,
+# so the same room would land in a different bucket after every restart — the one property a
+# path resolver may not have. digest_size=1 is exactly the 8 bits 256 buckets need, so the
+# whole digest IS the component: no slice, no mask, and nothing computed and thrown away.
+#
+# 256 and not 65,536, because the two are not the same trade at this store's shape. What
+# sharding has to fix is one enormous directory — a namespace at the per-namespace cap is
+# 200,000 entries counting sidecar locks, and that is what every create in it scans. 256
+# buckets cut that to ~780, which readdir does not care about. Two levels cut it to ~4 and
+# cost ~840,000 directories to do it, because ~1,000 of this store's namespaces hold five
+# notes or fewer and each one still pays for its own bucket tree: measured against the live
+# distribution, two levels put MORE directories under notes/ than there are notes. 512 was
+# measured too (a 9-bit mask, unbiased since 512 divides 65536) and halves an already-small
+# bucket for twice the directories. See bench/shard.py.
+#
+# This function is an on-disk format: changing the width or the hash puts every existing file
+# in the wrong bucket. The dual read below makes that survivable — a re-shard is the same
+# lazy migration this one is — but it is not free, so it is frozen deliberately here.
+#
+# Unkeyed, deliberately. Bucket membership is derivable by anyone who can run blake2b, so the
+# layout leaks nothing the name does not: an unlisted `p-` room is a capability URL whose
+# secret is the entropy in the name itself (see `unlisted`), never where the file sits, and a
+# secret that guarded only the directory would be protecting a fact the room name already
+# gives away. `key` stays on the signature so an instance that ever wants per-deployment
+# buckets has the hook — it is a blake2b keyword, passed straight through.
+#
+# Memoized because the resolver is on every read path and the answer is a pure function of
+# the string: 350 ns of hashing becomes a 36 ns cache hit, which is how the whole resolution
+# lands under the budget rather than over it. Sized like `_listable`, and for the same reason
+# — names are caller-supplied, so a flood of fresh ones must cost misses and never memory.
+@lru_cache(maxsize=MAX_ROOMS)
+def _shard(name: str, key: bytes | None = None) -> str:
+    """The directory component `name` hashes into — two hex characters, `00` to `ff`."""
+    return hashlib.blake2b(name.encode("utf-8"), digest_size=1, key=key or b"").hexdigest()
+
+
+def _migrate(legacy: Path, sharded: Path) -> None:
+    """Move a pre-sharding file to its bucket, sidecar lock and all. Best effort.
+
+    The lock moves *with* the data and is not left to the orphan sweeper, because a rename
+    keeps the inode: a writer already holding the old lock and a writer opening the new path
+    end up on the same inode, so the lock domain survives the move instead of splitting in
+    two the way a fresh lock file beside a held one would. Only when nothing is there yet —
+    replacing an existing lock would orphan whoever holds it, and the sweeper reclaims the
+    stray after IDLE_SECONDS either way.
+    """
+    try:
+        sharded.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(legacy, sharded)
+    except OSError:
+        return  # lost the race to another resolver, or unwritable: the data is still there
+    try:
+        if not (moved := Path(f"{sharded}.lock")).exists():
+            os.replace(Path(f"{legacy}.lock"), moved)
+    except OSError:
+        pass
+
+
+def _resolve(d: Path, name: str, suffix: str) -> Path:
+    """The bucketed path for `name`, moving a pre-sharding file there first if that is where
+    it still lives.
+
+    This ALWAYS returns the sharded path, which is what makes the migration safe rather than
+    merely lazy. A resolver that handed back the legacy path to readers and the sharded one to
+    writers would fork a live room in two — the old file keeping the history, the new one
+    starting from `seq` 1 — and reads would then see only the new one, because they check the
+    bucket first. Since no caller can ever be given the legacy path, no caller can ever write
+    to it, so there is exactly one file per name at every instant.
+
+    Concurrency needs nothing beyond that. Two resolvers racing the same unmigrated name both
+    reach `_migrate`; the first `os.replace` wins and the second fails ENOENT on a source that
+    is already gone, and both return the same sharded path regardless.
+
+    The cost in steady state is one `stat` — the bucket probe — since a name that resolved
+    once is found there and the legacy probe never runs. That is the price of never needing a
+    migration window, a flag day, or an operator step.
+    """
+    filename = f"{name}{suffix}"
+    sharded = d / _shard(name) / filename
+    if not sharded.exists() and (legacy := d / filename).exists():
+        _migrate(legacy, sharded)
+    return sharded
+
+
 def room_path(root: Path, room: str) -> Path:
-    return root / "rooms" / f"{valid_name(room)}.jsonl"
+    """Where a room's JSONL lives — `rooms/<shard>/<room>.jsonl`."""
+    return _resolve(root / "rooms", valid_name(room), ".jsonl")
+
+
+def _note_ns_dir(root: Path, ns: str) -> Path:
+    """A namespace's own directory, which is the level its count file and its caps live at
+    and NOT the bucket a given key lands in."""
+    return root / "notes" / valid_name(ns)
 
 
 def note_path(root: Path, ns: str, key: str) -> Path:
-    return root / "notes" / valid_name(ns) / f"{valid_name(key)}.txt"
+    """Where a note lives — `notes/<ns>/<shard>/<key>.txt`."""
+    return _resolve(_note_ns_dir(root, ns), valid_name(key), ".txt")
+
+
+def _prune(d: Path | str) -> bool:
+    """Drop empty directories under `d`, deepest first; True when `d` itself is now empty.
+
+    Sharding turns an emptied bucket into litter that never goes away on its own: a reaped
+    room leaves `rooms/<shard>/` behind, and every later walk pays to open it and find
+    nothing. Left alone that is a new unbounded resource — bounded only by the 256 buckets —
+    and it is also what would stop `_drop_emptied_namespaces` working at all, since a
+    namespace holding nothing but empty buckets is not an empty directory to rmdir.
+
+    Never removes `d` itself: the caller owns that decision, because for a namespace it is
+    the last step and for `rooms/` it must not happen at all.
+    """
+    empty = True
+    try:
+        with os.scandir(d) as entries:
+            for e in entries:
+                if e.is_dir() and _prune(e.path):
+                    try:
+                        os.rmdir(e.path)
+                        continue
+                    except OSError:
+                        pass  # refilled under us: not empty after all, and not ours to force
+                empty = False
+    except OSError:
+        return False
+    return empty
 
 
 @contextmanager
@@ -724,10 +849,8 @@ def _rollup(windows: list[list[str]]) -> dict:
 
 
 def list_rooms(root: Path) -> list[str]:
-    d = root / "rooms"
-    if not d.is_dir():
-        return []
-    return sorted(p.stem for p in d.glob("*.jsonl") if _listable(p.stem))
+    names = (e.name[: -len(".jsonl")] for e in _walk(root / "rooms", ".jsonl"))
+    return sorted(n for n in names if _listable(n))
 
 
 # (top, nicks) per room, validated against the (mtime_ns, size) stat the overview walk
@@ -774,24 +897,17 @@ def room_stats(root: Path, limit: int = 50) -> dict:
     memoized against that same stat — so a walk re-reads only rooms that changed since
     the last one. See WINDOW_BYTES for the per-room worst-case bound.
     """
-    d = root / "rooms"
     now = time.time()
     entries = []
-    try:
-        with os.scandir(d) as rooms:
-            for e in rooms:
-                if not e.name.endswith(".jsonl"):
-                    continue
-                name = e.name[: -len(".jsonl")]
-                if not _listable(name):
-                    continue
-                try:
-                    st = e.stat()
-                except OSError:
-                    continue  # reaped between the readdir and the stat
-                entries.append((st.st_mtime, st.st_size, name, st.st_mtime_ns))
-    except FileNotFoundError:
-        pass
+    for e in _walk(root / "rooms", ".jsonl"):
+        name = e.name[: -len(".jsonl")]
+        if not _listable(name):
+            continue
+        try:
+            st = e.stat()
+        except OSError:
+            continue  # reaped between the readdir and the stat
+        entries.append((st.st_mtime, st.st_size, name, st.st_mtime_ns))
     entries.sort(reverse=True)
     shown = []
     windows = []
@@ -844,24 +960,22 @@ def service_stats(root: Path, engagement_rooms: int = 50) -> dict:
     keys = ("total", "listed", "unlisted", "open", "mailbox", "ownable", "ephemeral")
     rooms = dict.fromkeys(keys, 0)
     room_bytes = 0
-    d = root / "rooms"
-    if d.is_dir():
-        for p in d.glob("*.jsonl"):
-            name = p.stem
-            if not NAME_RE.fullmatch(name):
-                continue  # same rule as _listable: never count what we would not accept
-            try:
-                room_bytes += p.stat().st_size
-            except OSError:
-                continue  # reaped between glob and stat
-            classes = room_classes(name)
-            rooms["total"] += 1
-            rooms["unlisted" if "p" in classes else "listed"] += 1
-            for marker, key in (("mb", "mailbox"), ("d", "ownable"), ("e", "ephemeral")):
-                if marker in classes:
-                    rooms[key] += 1
-            if not classes:
-                rooms["open"] += 1
+    for e in _walk(root / "rooms", ".jsonl"):
+        name = e.name[: -len(".jsonl")]
+        if not NAME_RE.fullmatch(name):
+            continue  # same rule as _listable: never count what we would not accept
+        try:
+            room_bytes += e.stat().st_size
+        except OSError:
+            continue  # reaped between the readdir and the stat
+        classes = room_classes(name)
+        rooms["total"] += 1
+        rooms["unlisted" if "p" in classes else "listed"] += 1
+        for marker, key in (("mb", "mailbox"), ("d", "ownable"), ("e", "ephemeral")):
+            if marker in classes:
+                rooms[key] += 1
+        if not classes:
+            rooms["open"] += 1
     notes = note_stats(root)
     return {
         "rooms": {**rooms, "capacity": MAX_ROOMS},
@@ -938,18 +1052,25 @@ def _reapable(path: Path | str, now: float, stillborn_rule: bool) -> str | None:
 ROOM_GUARD_NS = (OWNERS_NS, ALLOW_NS, NONCE_NS)
 
 
-def _guards_a_live_room(root: Path, entry: os.DirEntry[str], now: float) -> bool:
+def _guards_a_live_room(root: Path, base: str, entry: os.DirEntry[str], now: float) -> bool:
     """True when `entry` is a guard note whose room is still within its own idle window.
 
     Tied to the room, not exempted outright: once the room itself is reapable the guards go
     with it, so this bounds the state exactly as before rather than adding an immortal
     namespace.
 
-    The two string steps replace `path.parent.name` and `path.stem` on a Path this no longer
-    builds. `rpartition` is `.stem` exactly here and not by luck: NAME_RE admits no dot, so a
-    note name carries exactly one, the suffix's.
+    The namespace is the FIRST component under `base`, never the parent directory. That was
+    the same thing before sharding and is not now: a bucketed note's parent is `ab`, so a
+    parent-name test would recognise no guard at all and the reaper would delete the owner,
+    allow-list and nonce notes of rooms that are still busy — silently, on the plain idle
+    rule, taking write access and replay protection with them. Slicing a known prefix instead
+    of `os.path.relpath` because this runs once per note per reap pass, where relpath's
+    normalisation would cost more than the walk it rides on.
+
+    `rpartition` is `.stem` exactly here and not by luck: NAME_RE admits no dot, so a note
+    name carries exactly one, the suffix's.
     """
-    if os.path.basename(os.path.dirname(entry.path)) not in ROOM_GUARD_NS:
+    if entry.path[len(base) :].partition(os.sep)[0] not in ROOM_GUARD_NS:
         return False
     room = room_path(root, entry.name.rpartition(".")[0])
     try:
@@ -999,8 +1120,8 @@ def _sweep_orphan_locks(root: Path, now: float) -> None:
     writer recreating that room from having its lock unlinked underneath it. The drift is
     bounded by the room cap: at most a week of churn in empty files.
     """
-    for sub, nested, suffix in (("rooms", False, ".jsonl.lock"), ("notes", True, ".txt.lock")):
-        for entry in _walk(root / sub, suffix, nested):
+    for sub, suffix in (("rooms", ".jsonl.lock"), ("notes", ".txt.lock")):
+        for entry in _walk(root / sub, suffix):
             try:
                 # Slicing `.lock` off the name is `Path.with_suffix("")` without the Path,
                 # and os.access is `.exists()` without the stat_result it throws away: 26.0
@@ -1051,6 +1172,10 @@ def _drop_emptied_namespaces(root: Path) -> None:
         try:
             with _locked(root / ".notes-create"):
                 (d / NOTES_FILE).unlink(missing_ok=True)
+                # Buckets first: since sharding a namespace's notes sit a level further down,
+                # so a drained namespace holds empty directories, and rmdir refuses those
+                # exactly as it refuses notes. Without this the namespace below never goes.
+                _prune(d)
                 d.rmdir()  # empty namespaces only: rmdir refuses a directory with entries
         except OSError:
             continue
@@ -1077,13 +1202,11 @@ def _reap(root: Path) -> None:
     # Rooms only: the stillborn rule is a room rule, so folding reaped notes into the same
     # two counters would make "idle" mean two different things in one number.
     reaped = {"reaped_idle": 0, "reaped_stillborn": 0}
-    for sub, nested, suffix, stillborn_rule in (
-        ("rooms", False, ".jsonl", True),
-        ("notes", True, ".txt", False),
-    ):
-        for entry in _walk(root / sub, suffix, nested):
+    for sub, suffix, stillborn_rule in (("rooms", ".jsonl", True), ("notes", ".txt", False)):
+        base = f"{root / sub}{os.sep}"
+        for entry in _walk(root / sub, suffix):
             try:
-                if _guards_a_live_room(root, entry, now):
+                if _guards_a_live_room(root, base, entry, now):
                     continue
                 if not _reapable(entry.path, now, stillborn_rule):
                     continue
@@ -1119,6 +1242,15 @@ def _reap(root: Path) -> None:
     _reconcile_note_count(root)
     _sweep_orphan_locks(root, now)
     _drop_emptied_namespaces(root)
+    # Room buckets, once their locks have gone with the sweep above. Under the create gate for
+    # the reason `_drop_emptied_namespaces` spells out: `_locked` makes a room's bucket one
+    # mkdir before it opens the lock inside it, and removing the directory in that gap fails
+    # the write rather than merely losing a race. Best effort, like the rest of the tail.
+    try:
+        with _locked(root / ".rooms-create"):
+            _prune(root / "rooms")
+    except OSError:
+        pass
 
 
 def snapshots(root: Path) -> list[dict]:
@@ -1183,7 +1315,7 @@ def _snapshot(root: Path) -> None:
         pass
 
 
-def _scan(d: Path, suffix: str, sized: bool = False) -> tuple[int, int]:
+def _scan(d: Path | str, suffix: str, sized: bool = False) -> tuple[int, int]:
     """(count, total bytes) of the entries in `d` named `*suffix`, in one pass.
 
     os.scandir rather than Path.glob, and one pass rather than two, because every caller
@@ -1198,27 +1330,36 @@ def _scan(d: Path, suffix: str, sized: bool = False) -> tuple[int, int]:
     `sized` is a flag rather than always-on because the byte total is the expensive half:
     readdir hands back the name for free and never the size, so each entry costs a stat.
     Only rooms have a byte budget to enforce.
+
+    Recursive since sharding, and it has to be: `_check_room_capacity` totals what the room
+    caps are enforced against, and a scan that stopped at the top of `rooms/` would count the
+    buckets and none of the rooms in them — a cap that reads zero is not a cap. Depth is not
+    assumed anywhere here, so one pass covers a store part-way through its migration, where
+    some names still sit flat and the rest are already bucketed.
     """
     count = 0
     size = 0
     try:
         with os.scandir(d) as entries:
             for e in entries:
-                if not e.name.endswith(suffix):
-                    continue
-                count += 1
-                if sized:
-                    try:
-                        size += e.stat().st_size
-                    except OSError:
-                        continue  # reaped between the readdir and the stat
-    except FileNotFoundError:
+                if e.is_dir():  # d_type from readdir: no syscall
+                    sub_count, sub_size = _scan(e.path, suffix, sized)
+                    count += sub_count
+                    size += sub_size
+                elif e.name.endswith(suffix):
+                    count += 1
+                    if sized:
+                        try:
+                            size += e.stat().st_size
+                        except OSError:
+                            continue  # reaped between the readdir and the stat
+    except OSError:
         pass  # nothing has been created yet; an absent directory is an empty one here
     return count, size
 
 
-def _walk(d: Path | str, suffix: str, nested: bool = False) -> Iterator[os.DirEntry[str]]:
-    """Every `*suffix` file directly in `d` (or one level down, when `nested`).
+def _walk(d: Path | str, suffix: str) -> Iterator[os.DirEntry[str]]:
+    """Every `*suffix` file anywhere under `d`, at any depth.
 
     Yields the `os.DirEntry` scandir already built rather than a Path made from it. On 3.12
     pathlib is lazily normalised — the constructor stashes the string and the parse lands on
@@ -1239,13 +1380,18 @@ def _walk(d: Path | str, suffix: str, nested: bool = False) -> Iterator[os.DirEn
     Note the asymmetry with `_scan`, which is faster still on the same directories: it only
     ever counts and measures, so it never needs the entry after the loop body. Use that one
     where a count is all you need.
+
+    Depth-agnostic rather than the old `nested` switch, which said "exactly one level down"
+    and so could only ever be right about one layout. Under sharding a room is one level
+    deeper and a note two, and during the lazy migration BOTH depths are occupied at once —
+    a walk that picked a number would miss every file that had not moved yet, which for the
+    reaper means idle files never reaped and for the sweeper means locks never swept.
     """
     try:
         with os.scandir(d) as entries:
             for e in entries:
-                if nested:
-                    if e.is_dir():
-                        yield from _walk(e.path, suffix)
+                if e.is_dir():
+                    yield from _walk(e.path, suffix)
                 elif e.name.endswith(suffix):
                     yield e
     except OSError:
@@ -1267,7 +1413,7 @@ def _count_notes(root: Path) -> tuple[int, int]:
         with os.scandir(root / "notes") as namespaces:
             for ns in namespaces:
                 if ns.is_dir():
-                    count, ns_bytes = _scan(Path(ns.path), ".txt", sized=True)
+                    count, ns_bytes = _scan(ns.path, ".txt", sized=True)
                     total += count
                     size += ns_bytes
     except FileNotFoundError:
@@ -1389,7 +1535,7 @@ def _ring_limit(root: Path) -> int:
     return RESERVED_ROOM_BYTES
 
 
-def _check_room_capacity(path: Path) -> None:
+def _check_room_capacity(root: Path, path: Path) -> None:
     """Fail closed on a *new* room past either bound — the count, or the disk budget.
 
     Two caps because they bound two different things (see MAX_TOTAL_ROOM_BYTES): the count
@@ -1411,7 +1557,11 @@ def _check_room_capacity(path: Path) -> None:
     """
     if path.exists():
         return
-    count, used = _scan(path.parent, ".jsonl", sized=True)
+    # `root / "rooms"` and NOT `path.parent`, which since sharding is the room's own bucket:
+    # counting one bucket would report ~1 room where the cap wants all of them, and both
+    # MAX_ROOMS and MAX_TOTAL_ROOM_BYTES would stop being enforced on a world-writable
+    # service. `_scan` recurses, so this is the whole tree either way.
+    count, used = _scan(root / "rooms", ".jsonl", sized=True)
     if count >= MAX_ROOMS:
         raise _at_capacity(MAX_ROOMS, "room")
     if used >= MAX_TOTAL_ROOM_BYTES:
@@ -1443,7 +1593,7 @@ def _check_note_total(root: Path) -> None:
         )
 
 
-def _check_note_capacity(root: Path, path: Path) -> None:
+def _check_note_capacity(root: Path, ns_dir: Path, path: Path) -> None:
     """Both note caps, neither of which walks any more. Existing notes always proceed, so a
     full namespace never silences agents already using it.
 
@@ -1456,7 +1606,10 @@ def _check_note_capacity(root: Path, path: Path) -> None:
     """
     if path.exists():
         return
-    if _note_totals(path.parent, _ns_totals, persist=True)[0] >= MAX_NOTES_PER_NS:
+    # The namespace directory, passed in rather than taken from the note: `path.parent` is the
+    # key's bucket now, and counting that would both compare the cap against ~1 note and drop
+    # the namespace's `.notes-count` two levels below where every other reader looks for it.
+    if _note_totals(ns_dir, _ns_totals, persist=True)[0] >= MAX_NOTES_PER_NS:
         raise _at_capacity(MAX_NOTES_PER_NS, "note")
     _check_note_total(root)
 
@@ -1623,12 +1776,12 @@ def _write_record(
     # Checked before the gate as well as under it: taking the gate serialises the caller
     # behind every other create, and a rotating room name flooding rejections should not
     # queue up behind them. The check inside the gate stays authoritative.
-    _check_room_capacity(path)
+    _check_room_capacity(root, path)
     with (
         _create_gate(
             root / ".rooms-create",
             path,
-            lambda: _check_room_capacity(path),
+            lambda: _check_room_capacity(root, path),
         ),
         _locked(path),
     ):
@@ -1740,6 +1893,7 @@ def note_set(
     side effects those writes describe.
     """
     path = note_path(root, ns, key)
+    ns_dir = _note_ns_dir(root, ns)
     value = clean_text(value, MAX_VALUE_CHARS)
     _reap(root)
     # The global half only, and only for a create. This used to be the whole check, which
@@ -1754,8 +1908,8 @@ def note_set(
         _create_gate(
             root / ".notes-create",
             path,
-            lambda: _check_note_capacity(root, path),
-            lambda d: _count_new_note(root, path.parent, len(value.encode("utf-8")), d),
+            lambda: _check_note_capacity(root, ns_dir, path),
+            lambda d: _count_new_note(root, ns_dir, len(value.encode("utf-8")), d),
         ),
         _locked(path),
     ):
@@ -1833,6 +1987,6 @@ def note_stats(root: Path) -> dict:
 
 
 def list_notes(root: Path, ns: str) -> list[str]:
-    d = root / "notes" / valid_name(ns)
     keep = _listable.__wrapped__  # not the cache: see _listable
-    return sorted(p.stem for p in d.glob("*.txt") if keep(p.stem)) if d.is_dir() else []
+    names = (e.name[: -len(".txt")] for e in _walk(_note_ns_dir(root, ns), ".txt"))
+    return sorted(n for n in names if keep(n))

--- a/src/store.py
+++ b/src/store.py
@@ -464,41 +464,55 @@ def _shard(name: str, key: bytes | None = None) -> str:
 
 
 def _migrate(legacy: Path, sharded: Path) -> None:
-    """Move a pre-sharding file to its bucket, sidecar lock and all. Best effort.
+    """Move a pre-sharding file into its bucket. The data only — deliberately NOT the lock.
 
-    The lock moves *with* the data and is not left to the orphan sweeper, because a rename
-    keeps the inode: a writer already holding the old lock and a writer opening the new path
-    end up on the same inode, so the lock domain survives the move instead of splitting in
-    two the way a fresh lock file beside a held one would. Only when nothing is there yet —
-    replacing an existing lock would orphan whoever holds it, and the sweeper reclaims the
-    stray after IDLE_SECONDS either way.
+    Moving the sidecar too looked tidier and was a lock-domain bug. Between testing that the
+    destination is free and replacing it, another worker that already sees the migrated data
+    can create and flock that very path, and the replace then unlinks the inode it is holding.
+    The next writer opens the inode that arrived instead, so two workers hold what both
+    believe is the room lock — and `seq` is assigned under it, as are the nonce check and CAS.
+    Reproduced before it was removed: a third opener took the lock while the second still held
+    it. There is no check-then-replace that closes this; not replacing is what closes it.
+
+    Nothing is lost by leaving the stray, because nothing can be holding it. `_locked` is only
+    ever called on a path `_resolve` handed out, and `_resolve` hands out the legacy path only
+    while the file is still there — so the lock a live writer holds is always the one beside
+    the file it is writing. `_sweep_orphan_locks` already exists for precisely this shape (a
+    lock whose data file is gone) and reclaims it once it has been idle as long as any reaped
+    room.
+
+    The reaper is the one caller that can hold a legacy lock, because it locks what its walk
+    found rather than what a resolver returned. It only ever unlinks, and it re-stats by path
+    under the lock, so a file migrated out from under it fails that stat and is skipped rather
+    than deleted.
     """
     try:
         sharded.parent.mkdir(parents=True, exist_ok=True)
         os.replace(legacy, sharded)
     except OSError:
-        return  # lost the race to another resolver, or unwritable: the data is still there
-    try:
-        if not (moved := Path(f"{sharded}.lock")).exists():
-            os.replace(Path(f"{legacy}.lock"), moved)
-    except OSError:
-        pass
+        return  # lost the race, or cannot write: `_resolve` falls back to what is on disk
 
 
 def _resolve(d: Path, name: str, suffix: str) -> Path:
-    """The bucketed path for `name`, moving a pre-sharding file there first if that is where
-    it still lives.
+    """Where `name` lives right now, moving a pre-sharding file into its bucket on the way.
 
-    This ALWAYS returns the sharded path, which is what makes the migration safe rather than
-    merely lazy. A resolver that handed back the legacy path to readers and the sharded one to
-    writers would fork a live room in two — the old file keeping the history, the new one
-    starting from `seq` 1 — and reads would then see only the new one, because they check the
-    bucket first. Since no caller can ever be given the legacy path, no caller can ever write
-    to it, so there is exactly one file per name at every instant.
+    The property that matters is that every caller gets the SAME answer, not that the answer
+    is always the bucket. A resolver handing the legacy path to readers and the bucket to
+    writers forks a live room in two — the old file keeps the history, the new one restarts at
+    `seq` 1, and reads see only the new one because they check the bucket first. So this
+    returns one path per name per instant, and it is the file that actually exists.
 
-    Concurrency needs nothing beyond that. Two resolvers racing the same unmigrated name both
-    reach `_migrate`; the first `os.replace` wins and the second fails ENOENT on a source that
-    is already gone, and both return the same sharded path regardless.
+    Which is why a migration that could not run falls back to the legacy path rather than
+    returning a bucket with nothing in it. A read-only volume, or a restore whose ownership
+    was never fixed, would otherwise turn every unmigrated room into an empty one and every
+    note into a missing one — silently, because an absent file is how this store spells "no
+    such room". Serving the data that is plainly there is strictly better than hiding it, and
+    it is not the fork above: readers and writers still agree, since the fallback is only
+    taken while the legacy file is the only copy in existence.
+
+    Two resolvers racing the same unmigrated name both reach `_migrate`; the first
+    `os.replace` wins, the second fails ENOENT on a source already gone, and both then see the
+    legacy file absent and return the same bucketed path.
 
     The cost in steady state is one `stat` — the bucket probe — since a name that resolved
     once is found there and the legacy probe never runs. That is the price of never needing a
@@ -506,8 +520,12 @@ def _resolve(d: Path, name: str, suffix: str) -> Path:
     """
     filename = f"{name}{suffix}"
     sharded = d / _shard(name) / filename
-    if not sharded.exists() and (legacy := d / filename).exists():
+    if sharded.exists():
+        return sharded
+    if (legacy := d / filename).exists():
         _migrate(legacy, sharded)
+        if legacy.exists():  # the move could not run; the data is still readable there
+            return legacy
     return sharded
 
 

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,16 +1,16 @@
 {
-  "core_total": 2033,
+  "core_total": 2067,
   "caps": {
     "core/app.py": 981,
     "core/config.py": 58,
     "core/didkey.py": 57,
     "core/limit.py": 132,
-    "core/store.py": 807,
-    "core_total": 2035
+    "core/store.py": 841,
+    "core_total": 2069
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1831,
+      "raw_lines": 1838,
       "code_lines": 981,
       "comment_lines": 264,
       "tokens_per_line": 7.96
@@ -34,10 +34,10 @@
       "tokens_per_line": 8.75
     },
     "core/store.py": {
-      "raw_lines": 1838,
-      "code_lines": 807,
-      "comment_lines": 389,
-      "tokens_per_line": 7.29
+      "raw_lines": 1992,
+      "code_lines": 841,
+      "comment_lines": 440,
+      "tokens_per_line": 7.39
     },
     "extra/manifest.py": {
       "raw_lines": 1604,

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,5 +1,5 @@
 {
-  "core_total": 2067,
+  "core_total": 2066,
   "caps": {
     "core/app.py": 981,
     "core/config.py": 58,
@@ -34,10 +34,10 @@
       "tokens_per_line": 8.75
     },
     "core/store.py": {
-      "raw_lines": 1992,
-      "code_lines": 841,
-      "comment_lines": 440,
-      "tokens_per_line": 7.39
+      "raw_lines": 2010,
+      "code_lines": 840,
+      "comment_lines": 441,
+      "tokens_per_line": 7.36
     },
     "extra/manifest.py": {
       "raw_lines": 1604,

--- a/tests/capacity_bench.py
+++ b/tests/capacity_bench.py
@@ -200,13 +200,13 @@ def store_bench(root: Path) -> None:
 
     def room_gate() -> None:
         try:
-            store._check_room_capacity(fresh_room)
+            store._check_room_capacity(root, fresh_room)
         except store.StoreError:
             pass  # at the cap the refusal is the answer; the walk is what we are timing
 
     def note_gate() -> None:
         try:
-            store._check_note_capacity(root, fresh_note)
+            store._check_note_capacity(root, root / "notes" / "ns0", fresh_note)
         except store.StoreError:
             pass
 
@@ -224,7 +224,7 @@ def store_bench(root: Path) -> None:
     bench("glob  rooms/*.jsonl", lambda: _drain(root.glob("rooms/*.jsonl")))
     bench("_walk rooms .jsonl", lambda: _drain(store._walk(root / "rooms", ".jsonl")))
     bench("glob  notes/*/*.txt", lambda: _drain(root.glob("notes/*/*.txt")))
-    bench("_walk notes .txt", lambda: _drain(store._walk(root / "notes", ".txt", True)))
+    bench("_walk notes .txt", lambda: _drain(store._walk(root / "notes", ".txt")))
     bench("_scan notes .txt (count only)", lambda: _scan_notes(root))
 
 

--- a/tests/test_store_stateful.py
+++ b/tests/test_store_stateful.py
@@ -390,6 +390,44 @@ class StoreLifecycle(RuleBasedStateMachine):
 
     # ------------------------------------------------------------------ invariants
 
+    @rule(
+        room=st.sampled_from(ROOMS),
+        note=st.sampled_from(NOTES),
+        pick_room=st.booleans(),
+    )
+    def unshard(self, room: str, note: tuple[str, str], pick_room: bool) -> None:
+        """Put a file back where a pre-sharding build kept it — flat in `rooms/`, or directly
+        in the namespace — so the next rule that touches that name has to migrate it.
+
+        The model deliberately does not move. Where a file sits is not one of the promises
+        this machine holds the store to, and that is the whole claim: `seq`, the surviving
+        history, a note's value and the reaper's clock all have to come through the move
+        untouched, in whatever order Hypothesis happens to reach it.
+
+        The sequence is what makes this worth a rule rather than an example. Migrating on read
+        while writing to the bucket forks a live room in two — old file keeps the history, new
+        file restarts at `seq` 1 — and no single-step test sees it, because each step alone
+        looks correct. `say`'s existing "seq jumped" assertion is what catches it, one step
+        later, and only if something put the file back first.
+
+        `os.replace` keeps mtime, so the ageing model stays true across the move. The sidecar
+        lock goes too: a real pre-sharding store has both flat, and moving one without the
+        other would test a state that never existed.
+        """
+        if pick_room:
+            sharded = store.room_path(self.root, room)
+            flat = self.root / "rooms" / f"{room}.jsonl"
+        else:
+            ns, key = note
+            sharded = store.note_path(self.root, ns, key)
+            flat = store._note_ns_dir(self.root, ns) / f"{key}.txt"
+        if not sharded.exists() or sharded == flat:
+            return
+        flat.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(sharded, flat)
+        if (lock := Path(f"{sharded}.lock")).exists():
+            os.replace(lock, Path(f"{flat}.lock"))
+
     @invariant()
     def notes_hold_what_was_written(self) -> None:
         for key, value in self.notes.items():
@@ -399,14 +437,14 @@ class StoreLifecycle(RuleBasedStateMachine):
     def no_room_exceeds_its_ring(self) -> None:
         """Under the ring, not merely at it: otherwise the next append re-triggers
         compaction and every write pays a full rewrite."""
-        for path in (self.root / "rooms").glob("*.jsonl"):
+        for path in (self.root / "rooms").rglob("*.jsonl"):
             assert path.stat().st_size <= store.MAX_ROOM_BYTES, f"{path.name} is over its ring"
 
     @invariant()
     def every_record_on_disk_is_one_record(self) -> None:
         """One JSON object per line: the read path is built on the line being the frame, so
         a fused line loses the record after it as well as itself."""
-        for path in (self.root / "rooms").glob("*.jsonl"):
+        for path in (self.root / "rooms").rglob("*.jsonl"):
             for raw in path.read_bytes().splitlines():
                 if raw.strip():
                     assert store._parse(raw) is not None, f"{path.name}: unparseable {raw[:60]!r}"

--- a/tests/unit/test_json_backend.py
+++ b/tests/unit/test_json_backend.py
@@ -53,7 +53,7 @@ def test_the_line_the_store_writes_is_byte_identical_to_the_old_encoder(tmp_path
     import store
 
     store.append(tmp_path, "room", "alice", text)
-    raw = (tmp_path / "rooms" / "room.jsonl").read_bytes()
+    raw = store.room_path(tmp_path, "room").read_bytes()
     rec = store._parse(raw.rstrip(b"\n"))
     assert rec is not None, "the store wrote a line its own parser cannot read"
     # The order `_write_record` builds the record in. Sorting or reordering keys is a

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -61,7 +61,8 @@ def test_a_new_note_reads_the_same_number_of_directories_at_any_store_size(
     (root / ".reaped").touch()  # reap is throttled; measure the create path, not a reap
 
     fresh = store.note_path(root, "ns0", "brand-new")
-    reads = _scandir_calls(monkeypatch, lambda: store._check_note_capacity(root, fresh))
+    ns_dir = store._note_ns_dir(root, "ns0")
+    reads = _scandir_calls(monkeypatch, lambda: store._check_note_capacity(root, ns_dir, fresh))
     (tmp_path / f"reads{namespaces}.txt").write_text(str(reads))
     # Zero directories, at any store size. Both caps read a file: the global one at the
     # root, the per-namespace one inside the namespace. It was 1 — the caller's own
@@ -84,11 +85,15 @@ def test_the_per_namespace_count_is_rebuilt_once_and_then_stays_free(tmp_path, m
     fresh = store.note_path(tmp_path, "did", "brand-new")
 
     (ns / store.NOTES_FILE).unlink()  # what a reap leaves behind
-    rebuild = _scandir_calls(monkeypatch, lambda: store._check_note_capacity(tmp_path, fresh))
-    assert rebuild == 1, "a dropped count must be rebuilt by scanning that namespace once"
+    rebuild = _scandir_calls(monkeypatch, lambda: store._check_note_capacity(tmp_path, ns, fresh))
+    # 2, not 1: the rebuild scan recurses, and one seeded note occupies one bucket — so the
+    # namespace directory and that bucket. The cost grows with OCCUPIED buckets rather than
+    # with notes, and one level of 256 bounds it at 257 reads however full the namespace
+    # gets; two levels would have made it ~30,000 at the per-namespace cap.
+    assert rebuild == 2, "a dropped count must be rebuilt by scanning that namespace once"
     assert (ns / store.NOTES_FILE).exists(), "…and the rebuild must be persisted"
 
-    cached = _scandir_calls(monkeypatch, lambda: store._check_note_capacity(tmp_path, fresh))
+    cached = _scandir_calls(monkeypatch, lambda: store._check_note_capacity(tmp_path, ns, fresh))
     assert cached == 0, "every create after the rebuild is a file read"
 
 
@@ -318,7 +323,7 @@ def test_a_refused_write_counts_nothing(tmp_path) -> None:
 
     after = (store._note_count(tmp_path), store._note_totals(ns, store._ns_totals)[0])
     assert after == before, f"8 refused writes moved the counts {before} -> {after}"
-    assert len(list(ns.glob("*.txt"))) == 1, "…and none of them created a note"
+    assert len(list(ns.rglob("*.txt"))) == 1, "…and none of them created a note"
 
 
 def test_racers_on_one_key_count_one_note(tmp_path) -> None:
@@ -347,7 +352,7 @@ def test_racers_on_one_key_count_one_note(tmp_path) -> None:
     [t.join() for t in threads]
 
     ns = tmp_path / "notes" / "did"
-    assert sorted(p.stem for p in ns.glob("*.txt")) == ["same", "seed"]
+    assert sorted(p.stem for p in ns.rglob("*.txt")) == ["same", "seed"]
     assert store._note_count(tmp_path) == 2, "eight writes to one key are one note"
     assert store._note_totals(ns, store._ns_totals)[0] == 2
 
@@ -372,7 +377,7 @@ def test_a_reap_frees_a_namespace_that_had_filled(tmp_path, monkeypatch) -> None
 
     # Age both notes past the idle rule and let the next write run a pass.
     old = time.time() - store.IDLE_SECONDS - 60
-    for note in (tmp_path / "notes" / "did").glob("*.txt"):
+    for note in (tmp_path / "notes" / "did").rglob("*.txt"):
         os.utime(note, (old, old))
     monkeypatch.setattr(store, "REAP_EVERY", 0)
     store.note_set(tmp_path, "elsewhere", "k", "v")  # any write; the reap rides the path
@@ -394,8 +399,8 @@ def test_the_per_namespace_cap_holds_under_concurrent_creates(tmp_path, monkeypa
     monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 4)
     real_check = store._check_note_capacity
 
-    def slow_check(root, path):
-        real_check(root, path)
+    def slow_check(root, ns_dir, path):
+        real_check(root, ns_dir, path)
         time.sleep(0.02)  # widen the count->write window every racer must lose
 
     monkeypatch.setattr(store, "_check_note_capacity", slow_check)
@@ -412,7 +417,7 @@ def test_the_per_namespace_cap_holds_under_concurrent_creates(tmp_path, monkeypa
     [t.start() for t in threads]
     [t.join() for t in threads]
 
-    on_disk = len(list((tmp_path / "notes" / "did").glob("*.txt")))
+    on_disk = len(list((tmp_path / "notes" / "did").rglob("*.txt")))
     assert on_disk == 4, f"cap is 4, namespace holds {on_disk}"
     assert store._note_totals(tmp_path / "notes" / "did", store._ns_totals)[0] == 4
 
@@ -595,9 +600,14 @@ def test_a_reap_cannot_remove_a_namespace_a_create_is_entering(tmp_path, monkeyp
     at_the_window, reap_done = threading.Event(), threading.Event()
     creator, died = [], []
     real_open, real_walk = open, store._walk
+    # Asked of the resolver rather than spelled out: since sharding the sidecar sits in the
+    # key's bucket, so a hardcoded `fresh/k.txt.lock` matches nothing and the window this
+    # test exists to open is never reached — a premise that fails loudly, which is why the
+    # assertion below is on `at_the_window` and not only on the outcome.
+    sidecar = f"{store.note_path(tmp_path, 'fresh', 'k')}.lock"
 
     def open_the_sidecar_lock_but_park_in_the_window(path, *a, **kw):
-        if str(path).endswith(f"fresh{os.sep}k.txt.lock"):
+        if str(path) == sidecar:
             at_the_window.set()
             reap_done.wait(1.0)  # unfixed the reap gets here; fixed it is stuck on the gate
         return real_open(path, *a, **kw)
@@ -608,14 +618,14 @@ def test_a_reap_cannot_remove_a_namespace_a_create_is_entering(tmp_path, monkeyp
         except BaseException as exc:  # noqa: BLE001 — recorded for the assertion, not hidden
             died.append(exc)
 
-    def walk_but_let_a_create_into_the_window_first(d, suffix, nested=False):
+    def walk_but_let_a_create_into_the_window_first(d, suffix):
         # The sweep of orphan note locks: the count walk is done and its gate given back,
         # and the rmdir is next. The only point in the pass where this race is reachable.
         if suffix == ".txt.lock" and not creator:
             creator.append(threading.Thread(target=create))
             creator[0].start()
             at_the_window.wait(5)
-        return real_walk(d, suffix, nested)
+        return real_walk(d, suffix)
 
     monkeypatch.setattr(store, "open", open_the_sidecar_lock_but_park_in_the_window, raising=False)
     monkeypatch.setattr(store, "_walk", walk_but_let_a_create_into_the_window_first)

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -1,6 +1,7 @@
 """Run: uv run --group dev python -m pytest tests
 
-Two-level directory sharding, and the lazy migration that gets a live store into it.
+One level of 256-way directory sharding, and the lazy migration that gets a live store
+into it.
 
 The migration is the half worth testing hardest. A store that is already sharded is just a
 store with deeper paths; a store part-way through the move is one where the same room can be
@@ -132,9 +133,9 @@ def test_an_append_to_a_flat_room_keeps_its_history_rather_than_forking_it(tmp_p
     Migrate on read but write straight to the bucket and a live room ends up in two files:
     the old one holding every message, the new one holding the next one at `seq` 1. Reads
     check the bucket first, so the room silently loses its whole history and its sequence
-    restarts — no error, no 500, nothing in a log. So the resolver returns the sharded path
-    to EVERY caller and moves the file to match, which means no caller can hold a path to
-    the old location long enough to write to it.
+    restarts — no error, no 500, nothing in a log. So the resolver returns ONE path per name
+    per instant, the same one to readers and writers, and moves the file to match it — which
+    means the two can never be looking at different files.
     """
     import store
 
@@ -148,21 +149,75 @@ def test_an_append_to_a_flat_room_keeps_its_history_rather_than_forking_it(tmp_p
     assert on_disk == ["live.jsonl"], f"the room exists in {len(on_disk)} places, not one"
 
 
-def test_the_sidecar_lock_travels_with_the_room_it_guards(tmp_path):
-    """A rename keeps the inode, so a writer already holding the old lock and one opening
-    the new path meet on the same inode. Leaving the lock behind and letting a fresh one be
-    created beside the moved data is what splits a lock domain in two."""
+def test_the_migration_never_replaces_a_sidecar_lock(tmp_path):
+    """Migration moves the data and leaves the lock where it is.
+
+    Moving the lock too is a lock-domain bug, and the shape of it is check-then-replace: a
+    worker that already sees the migrated data can create and flock the destination between
+    the "is it free?" test and the replace, and the replace then unlinks the inode it holds.
+    Two workers then hold what both believe is the room lock, which is what `seq`, the nonce
+    check and CAS are all serialised by.
+
+    Asserted on the inode rather than on existence, because that is the failure: a lock that
+    a live writer holds must never stop being the lock at its own path.
+    """
     import store
 
     legacy = _legacy_room(tmp_path, "old", _record(1, "one"))
     legacy_lock = legacy.with_suffix(".jsonl.lock")
-    inode = legacy_lock.stat().st_ino
 
     store.append(tmp_path, "old", "alice", "two")
+    fresh = store.room_path(tmp_path, "old").with_suffix(".jsonl.lock")
 
-    moved = store.room_path(tmp_path, "old").with_suffix(".jsonl.lock")
-    assert not legacy_lock.exists(), "the old sidecar is gone"
-    assert moved.stat().st_ino == inode, "…because it was renamed, not recreated"
+    assert legacy_lock.exists(), "the old sidecar is left for the orphan sweeper"
+    assert fresh.exists(), "…and the moved data got its own, freshly created"
+    assert fresh.stat().st_ino != legacy_lock.stat().st_ino, "no inode was replaced"
+
+
+def test_the_sweeper_reclaims_the_lock_the_migration_left(tmp_path, monkeypatch):
+    """Which is what makes leaving it free rather than a leak: the orphan sweep already
+    exists for a lock whose data file is gone, and a migrated-away file is exactly that."""
+    import store
+
+    legacy = _legacy_room(tmp_path, "old", _record(1, "one"))
+    legacy_lock = legacy.with_suffix(".jsonl.lock")
+    store.append(tmp_path, "old", "alice", "two")
+    assert legacy_lock.exists(), "premise: the migration left it"
+
+    old = time.time() - store.IDLE_SECONDS - 60
+    os.utime(legacy_lock, (old, old))
+    monkeypatch.setattr(store, "REAP_EVERY", 0)
+    store._reap(tmp_path)
+
+    assert not legacy_lock.exists(), "an idle lock with no data file must be swept"
+    assert store.read_messages(tmp_path, "old", limit=5)["messages"][-1]["text"] == "two"
+
+
+def test_a_migration_that_cannot_write_still_serves_the_data(tmp_path, monkeypatch):
+    """A read-only volume, or a restore whose ownership was never fixed, must not turn every
+    unmigrated room into an empty one.
+
+    An absent file is how this store spells "no such room", so a resolver that returned the
+    bucket after a failed move would report the whole store as gone — silently, with the data
+    plainly still on disk. Falling back is not the fork this design is shaped around: readers
+    and writers still agree, because the fallback is taken only while the legacy file is the
+    only copy that exists.
+    """
+    import store
+
+    _legacy_room(tmp_path, "stuck", _record(1, "one"), _record(2, "two"))
+    _legacy_note(tmp_path, "kv", "held", "value")
+
+    def refuse(*args, **kwargs):
+        raise PermissionError("read-only volume")
+
+    monkeypatch.setattr(store.os, "replace", refuse)
+
+    view = store.read_messages(tmp_path, "stuck", limit=50)
+    assert [m["text"] for m in view["messages"]] == ["one", "two"], "the history is served"
+    assert store.room_path(tmp_path, "stuck") == tmp_path / "rooms" / "stuck.jsonl"
+    assert store.note_get(tmp_path, "kv", "held") == "value"
+    assert store.list_rooms(tmp_path) == ["stuck"], "…and it still lists"
 
 
 def test_a_flat_note_moves_and_keeps_its_value(tmp_path):

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -1,0 +1,373 @@
+"""Run: uv run --group dev python -m pytest tests
+
+Two-level directory sharding, and the lazy migration that gets a live store into it.
+
+The migration is the half worth testing hardest. A store that is already sharded is just a
+store with deeper paths; a store part-way through the move is one where the same room can be
+in two places, and the failure that costs data is silent — the history stays on disk under
+the old name while reads and writes go to a new empty file beside it.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+
+
+def _legacy_room(root, name: str, *lines: str):
+    """A room as a pre-sharding build left it: flat in `rooms/`, sidecar lock beside it."""
+    d = root / "rooms"
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / f"{name}.jsonl"
+    path.write_bytes(b"".join(line.encode() + b"\n" for line in lines))
+    (d / f"{name}.jsonl.lock").touch()
+    return path
+
+
+def _legacy_note(root, ns: str, key: str, value: str):
+    d = root / "notes" / ns
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / f"{key}.txt"
+    path.write_text(value, encoding="utf-8")
+    (d / f"{key}.txt.lock").touch()
+    return path
+
+
+def _record(seq: int, text: str) -> str:
+    import json
+
+    return json.dumps({"seq": seq, "ts": "2026-01-01T00:00:00Z", "from": "old", "text": text})
+
+
+# --------------------------------------------------------------------------- the layout
+
+
+def test_a_name_lands_in_the_bucket_its_hash_names(tmp_path):
+    """The path is computed from the name and nothing else, so any process resolves it the
+    same way with no index to consult and none to keep in sync.
+
+    Spelled out here rather than by calling `_shard`, because this is an ON-DISK FORMAT: a
+    test that derived the expectation from the implementation would agree with any change to
+    it, including one that silently puts every existing file in the wrong bucket.
+    """
+    import hashlib
+
+    import store
+
+    store.append(tmp_path, "lobby", "alice", "hi")
+    expected = tmp_path / "rooms" / hashlib.blake2b(b"lobby", digest_size=1).hexdigest()
+    assert store.room_path(tmp_path, "lobby") == expected / "lobby.jsonl"
+    assert (expected / "lobby.jsonl").exists(), "on disk where the hash says, not beside it"
+
+    store.note_set(tmp_path, "did-a1", "z6mk", "v")
+    key_digest = hashlib.blake2b(b"z6mk", digest_size=1).hexdigest()
+    assert store.note_path(tmp_path, "did-a1", "z6mk") == (
+        tmp_path / "notes" / "did-a1" / key_digest / "z6mk.txt"
+    )
+    assert len(key_digest) == 2, "one level of 256: two hex characters, never four"
+
+
+def test_every_name_lands_in_one_of_256_buckets(tmp_path):
+    """digest_size=1 is 8 bits, which is exactly 256 — so the width needs no mask and no
+    slice, and there is no room for a modulo bias to hide in."""
+    import store
+
+    seen = {store._shard(f"name-{i:05d}") for i in range(20_000)}
+    assert len(seen) == 256, f"{len(seen)} buckets reachable, expected all 256"
+    assert all(len(b) == 2 and all(c in "0123456789abcdef" for c in b) for b in seen)
+
+
+def test_the_bucket_does_not_move_between_processes(tmp_path):
+    """`hash()` is salted per process by PYTHONHASHSEED, so a store that used it would put a
+    room somewhere new after every restart. This is the regression test for reaching for it."""
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    src = str(Path(__file__).resolve().parents[2] / "src")
+    code = f"import sys; sys.path.insert(0, {src!r}); import store; print(store._shard('lobby'))"
+    seen = {
+        subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=True,
+            env={**os.environ, "PYTHONHASHSEED": seed},
+        ).stdout.strip()
+        for seed in ("0", "1", "12345")
+    }
+    assert len(seen) == 1, f"the bucket moved with PYTHONHASHSEED: {seen}"
+
+
+def test_the_key_parameter_is_a_hook_and_not_a_default(tmp_path):
+    """`key` is reserved for a deployment that ever wants per-instance buckets. Unkeyed is
+    what ships, so the two must not silently be the same function."""
+    import store
+
+    assert store._shard("lobby") == store._shard("lobby", None)
+    assert store._shard("lobby") != store._shard("lobby", b"pepper")
+
+
+# --------------------------------------------------------------------------- migration
+
+
+def test_a_flat_room_moves_to_its_bucket_on_first_touch(tmp_path):
+    """The dual-read half: nothing in the deploy moves these files, so the first read or
+    write of each one does it."""
+    import store
+
+    legacy = _legacy_room(tmp_path, "old", _record(1, "one"), _record(2, "two"))
+    view = store.read_messages(tmp_path, "old", limit=50)
+
+    assert [m["text"] for m in view["messages"]] == ["one", "two"], "the history came back"
+    assert not legacy.exists(), "…and the file is no longer where it was"
+    assert store.room_path(tmp_path, "old").exists(), "…it is in its bucket"
+
+
+def test_an_append_to_a_flat_room_keeps_its_history_rather_than_forking_it(tmp_path):
+    """The bug the resolver exists to make unrepresentable.
+
+    Migrate on read but write straight to the bucket and a live room ends up in two files:
+    the old one holding every message, the new one holding the next one at `seq` 1. Reads
+    check the bucket first, so the room silently loses its whole history and its sequence
+    restarts — no error, no 500, nothing in a log. So the resolver returns the sharded path
+    to EVERY caller and moves the file to match, which means no caller can hold a path to
+    the old location long enough to write to it.
+    """
+    import store
+
+    _legacy_room(tmp_path, "live", _record(1, "one"), _record(2, "two"))
+    rec = store.append(tmp_path, "live", "alice", "three")
+
+    assert rec["seq"] == 3, "the sequence continued rather than restarting"
+    view = store.read_messages(tmp_path, "live", limit=50)
+    assert [m["text"] for m in view["messages"]] == ["one", "two", "three"]
+    on_disk = sorted(p.name for p in (tmp_path / "rooms").rglob("live.jsonl"))
+    assert on_disk == ["live.jsonl"], f"the room exists in {len(on_disk)} places, not one"
+
+
+def test_the_sidecar_lock_travels_with_the_room_it_guards(tmp_path):
+    """A rename keeps the inode, so a writer already holding the old lock and one opening
+    the new path meet on the same inode. Leaving the lock behind and letting a fresh one be
+    created beside the moved data is what splits a lock domain in two."""
+    import store
+
+    legacy = _legacy_room(tmp_path, "old", _record(1, "one"))
+    legacy_lock = legacy.with_suffix(".jsonl.lock")
+    inode = legacy_lock.stat().st_ino
+
+    store.append(tmp_path, "old", "alice", "two")
+
+    moved = store.room_path(tmp_path, "old").with_suffix(".jsonl.lock")
+    assert not legacy_lock.exists(), "the old sidecar is gone"
+    assert moved.stat().st_ino == inode, "…because it was renamed, not recreated"
+
+
+def test_a_flat_note_moves_and_keeps_its_value(tmp_path):
+    import store
+
+    legacy = _legacy_note(tmp_path, "did-a1", "z6mk", "did:key:zabc")
+    assert store.note_get(tmp_path, "did-a1", "z6mk") == "did:key:zabc"
+    assert not legacy.exists()
+    assert store.note_path(tmp_path, "did-a1", "z6mk").read_text() == "did:key:zabc"
+
+
+def test_cas_sees_the_migrated_value_not_an_empty_bucket(tmp_path):
+    """`if=` compares against what the note holds. A resolver that pointed CAS at the empty
+    bucket while the value was still flat would turn every conditional write on an
+    unmigrated note into a spurious 409 — and `if_absent` into a spurious success."""
+    import store
+
+    _legacy_note(tmp_path, "kv", "counter", "7")
+
+    with pytest.raises(store.StoreConflictError):
+        store.note_set(tmp_path, "kv", "counter", "8", expect="wrong")
+    with pytest.raises(store.StoreConflictError):
+        store.note_set(tmp_path, "kv", "counter", "8", expect_absent=True)
+
+    store.note_set(tmp_path, "kv", "counter", "8", expect="7")
+    assert store.note_get(tmp_path, "kv", "counter") == "8"
+
+
+def test_a_half_migrated_store_lists_every_room_exactly_once(tmp_path):
+    """Both depths are occupied for as long as the migration takes, so every walk has to be
+    depth-agnostic — and must not double-count a name it meets at one depth."""
+    import store
+
+    _legacy_room(tmp_path, "flat-one", _record(1, "a"))
+    _legacy_room(tmp_path, "flat-two", _record(1, "b"))
+    store.append(tmp_path, "bucketed", "alice", "c")  # written sharded from birth
+
+    assert store.list_rooms(tmp_path) == ["bucketed", "events", "flat-one", "flat-two"]
+    assert store.room_stats(tmp_path)["total"] == 4
+    assert store.service_stats(tmp_path)["rooms"]["total"] == 4
+
+
+def test_racing_resolvers_migrate_a_room_once(tmp_path):
+    """Two resolvers can both see the flat file. The first `os.replace` wins and the second
+    fails on a source that is already gone, and both return the same bucketed path."""
+    import threading
+
+    import store
+
+    _legacy_room(tmp_path, "hot", _record(1, "one"))
+    start = threading.Barrier(8)
+    seen, errors = [], []
+
+    def resolve():
+        start.wait()
+        try:
+            seen.append(store.room_path(tmp_path, "hot"))
+        except BaseException as exc:  # noqa: BLE001 — recorded for the assertion, not hidden
+            errors.append(exc)
+
+    threads = [threading.Thread(target=resolve) for _ in range(8)]
+    [t.start() for t in threads]
+    [t.join() for t in threads]
+
+    assert not errors, f"a resolver raised: {errors}"
+    assert len(set(seen)) == 1, "eight resolvers disagreed about where the room lives"
+    assert seen[0].read_bytes().count(b"\n") == 1, "the history survived the race"
+
+
+# ------------------------------------------------------------- caps, reaping, litter
+
+
+def test_the_room_cap_counts_the_whole_tree_and_not_one_bucket(tmp_path, monkeypatch):
+    """`_check_room_capacity` used to scan the room's own parent, which was `rooms/`. Under
+    sharding the parent is the room's bucket, which holds about one room — so a cap read off
+    it would never bind, and MAX_ROOMS would stop existing on a world-writable service."""
+    import store
+
+    monkeypatch.setattr(store, "MAX_ROOMS", 4)
+    for i in range(3):
+        store.append(tmp_path, f"room{i}", "bot", "hi")  # `events` is the fourth, announced
+    with pytest.raises(store.StoreError, match="room limit"):
+        store.append(tmp_path, "one-too-many", "bot", "hi")
+
+
+def test_the_per_namespace_cap_counts_every_bucket_in_the_namespace(tmp_path, monkeypatch):
+    import store
+
+    monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 3)
+    for i in range(3):
+        store.note_set(tmp_path, "did-a1", f"k{i}", "v")
+    with pytest.raises(store.StoreError, match="note limit"):
+        store.note_set(tmp_path, "did-a1", "one-too-many", "v")
+
+
+def test_the_namespace_count_file_stays_at_the_namespace(tmp_path):
+    """`.notes-count` is read by everything that asks what a namespace holds. Written into a
+    key's bucket instead it would be invisible to every one of them, and a per-namespace cap
+    would rebuild by walking on every single create."""
+    import store
+
+    store.note_set(tmp_path, "did-a1", "z6mk", "v")
+    assert (tmp_path / "notes" / "did-a1" / store.NOTES_FILE).exists()
+
+
+def test_the_reaper_reaches_rooms_and_notes_inside_their_buckets(tmp_path, monkeypatch):
+    """A reaper that stopped at the top of `rooms/` would find nothing to reap and the caps
+    it backs would become permanent rather than idle-expiring."""
+    import store
+
+    store.append(tmp_path, "stale", "bot", "hi")
+    store.note_set(tmp_path, "kv", "stale", "v")
+    old = time.time() - store.IDLE_SECONDS - 60
+    for path in list((tmp_path / "rooms").rglob("*.jsonl")) + list(
+        (tmp_path / "notes").rglob("*.txt")
+    ):
+        os.utime(path, (old, old))
+
+    monkeypatch.setattr(store, "REAP_EVERY", 0)
+    store._reap(tmp_path)
+
+    assert list((tmp_path / "rooms").rglob("*.jsonl")) == []
+    assert list((tmp_path / "notes").rglob("*.txt")) == []
+
+
+def test_a_reaped_room_does_not_leave_its_bucket_behind(tmp_path, monkeypatch):
+    """Emptied buckets are litter that never goes away on its own, and every later walk pays
+    to open them. Unpruned they are also what stops an emptied namespace being dropped at
+    all, since a directory of empty directories is not an empty directory."""
+    import store
+
+    store.append(tmp_path, "stale", "bot", "hi")
+    store.note_set(tmp_path, "doomed", "k", "v")
+    old = time.time() - store.IDLE_SECONDS - 60
+    for path in (tmp_path / "rooms").rglob("*"):
+        os.utime(path, (old, old))
+    for path in (tmp_path / "notes").rglob("*"):
+        os.utime(path, (old, old))
+
+    monkeypatch.setattr(store, "REAP_EVERY", 0)
+    store._reap(tmp_path)
+    store._reap(tmp_path)  # the sweep frees the locks; the pass after it frees the buckets
+
+    assert not (tmp_path / "notes" / "doomed").exists(), "the drained namespace was dropped"
+    leftover = [p for p in (tmp_path / "rooms").rglob("*") if p.is_dir()]
+    assert leftover == [], f"empty buckets left behind: {leftover}"
+
+
+def test_a_reap_that_prunes_buckets_never_meets_a_create_gate_it_already_holds(
+    tmp_path, monkeypatch
+):
+    """`_prune(rooms)` takes `.rooms-create`, and `_reap` runs on the write path — so the
+    question is whether any caller can be inside that gate when a pass fires.
+
+    `flock` is per open file description and `_locked` opens a fresh fd every time, so a
+    second acquire from the same thread does not re-enter: it blocks on itself, forever, with
+    no EDEADLK and no traceback. A hung worker thread is the one failure a passing test suite
+    would never show, because the ordinary suite touches `.reaped` and the throttle makes the
+    second pass in a request a no-op.
+
+    So: every pass is due, the marker never survives, and the writes that create rooms are
+    driven under a watchdog. `append` also creates `events` and announces into it, which is
+    the nested `_write_record` the reasoning has to be right about.
+    """
+    import threading
+
+    import store
+
+    monkeypatch.setattr(store, "REAP_EVERY", 0)
+    done = []
+
+    def writes():
+        for i in range(4):
+            (tmp_path / ".reaped").unlink(missing_ok=True)  # no throttle to hide the nesting
+            store.append(tmp_path, f"room{i}", "bot", "hi")
+            (tmp_path / ".reaped").unlink(missing_ok=True)
+            store.note_set(tmp_path, f"ns{i}", "k", "v")
+        done.append(True)
+
+    worker = threading.Thread(target=writes, daemon=True)
+    worker.start()
+    worker.join(30)
+    assert done, "a write deadlocked on a gate the reap it triggered was already holding"
+
+
+def test_pruning_keeps_the_bucket_of_a_room_that_survived(tmp_path, monkeypatch):
+    """The other half of the pruning claim, and the one the all-rooms-reaped case cannot
+    make: a pass that removed occupied buckets as happily as empty ones would pass that test
+    and lose every live room here."""
+    import store
+
+    store.append(tmp_path, "keeper", "bot", "hi")
+    store.append(tmp_path, "goner", "bot", "hi")
+    kept_bucket = store.room_path(tmp_path, "keeper").parent
+    doomed_bucket = store.room_path(tmp_path, "goner").parent
+    assert kept_bucket != doomed_bucket, "premise: the two rooms are in different buckets"
+
+    old = time.time() - store.IDLE_SECONDS - 60
+    for path in doomed_bucket.iterdir():
+        os.utime(path, (old, old))
+
+    monkeypatch.setattr(store, "REAP_EVERY", 0)
+    store._reap(tmp_path)
+    store._reap(tmp_path)  # the sweep frees the lock; the pass after it frees the bucket
+
+    assert not doomed_bucket.exists(), "the emptied bucket was not pruned"
+    assert store.room_path(tmp_path, "keeper").exists(), "…and the live room went with it"
+    assert store.read_messages(tmp_path, "keeper", limit=5)["messages"][0]["text"] == "hi"

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -264,7 +264,7 @@ def test_rejected_write_leaves_no_lock_file(tmp_path, monkeypatch):
     for i in range(5):
         with pytest.raises(store.StoreError, match="room limit"):
             store.append(tmp_path, f"flood{i}", "bot", "hi")
-    assert list((tmp_path / "rooms").glob("*.lock")) == [
+    assert list((tmp_path / "rooms").rglob("*.lock")) == [
         store.room_path(tmp_path, "only").with_suffix(".jsonl.lock")
     ]
 
@@ -298,8 +298,8 @@ def test_note_cap_holds_under_concurrent_creates(tmp_path, monkeypatch):
     monkeypatch.setattr(store, "MAX_NOTES_TOTAL", 4)
     real_check = store._check_note_capacity
 
-    def slow_check(root, path):
-        real_check(root, path)
+    def slow_check(root, ns_dir, path):
+        real_check(root, ns_dir, path)
         time.sleep(0.02)  # widen the count→write window every racer must lose
 
     monkeypatch.setattr(store, "_check_note_capacity", slow_check)
@@ -315,7 +315,7 @@ def test_note_cap_holds_under_concurrent_creates(tmp_path, monkeypatch):
     threads = [threading.Thread(target=create, args=(i,)) for i in range(8)]
     [t.start() for t in threads]
     [t.join() for t in threads]
-    assert sum(1 for _ in (tmp_path / "notes").glob("*/*.txt")) == 4
+    assert sum(1 for _ in (tmp_path / "notes").rglob("*.txt")) == 4
 
 
 def test_orphan_locks_are_swept(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.9.4"
+version = "0.9.6"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What changes for a caller

Nothing. No route, response shape, documented cap or `text/plain` line moves. This is
purely where files sit on disk, and the migration needs no operator step, no flag day and
no downtime.

> **Note on the branch name** — it says `2-tier`, which is what this started as. Measurement
> (below) said one level, so that is what it ships. Renaming it now would orphan the push.

## Why

A namespace at `CHAT_MAX_NOTES_PER_NS` is 200,000 directory entries counting the sidecar
lock beside every note, and `_check_note_capacity` scans that on every create in the
namespace. On the live instance `notes/did/` is already at its cap and `rooms/` holds
25,995 entries. This puts a computed bucket between the directory and the file —
`rooms/<shard>/<room>.jsonl`, `notes/<ns>/<shard>/<key>.txt` — taking the busiest
directory to ~780 entries.

## Why 256 and one level

Measured, not assumed — `bench/shard.py`, against the live namespace distribution:

| layout | directories under `notes/` | busiest bucket |
|---|---|---|
| flat (today) | 1,337 | **200,000 entries** |
| **1 level of 256** | **73,960** | 781 entries |
| 1 level of 512 | 143,514 | 391 entries |
| 2 levels of 256 | 1,167,474 | 4 entries |

Two levels put *more* directories under `notes/` than there are notes, because ~1,000 of
this store's 1,346 namespaces hold five notes or fewer and each still pays for its own
bucket tree. 512 halves a bucket that readdir already does not care about, for twice the
directories. The rooms walk at 20,000 rooms costs ~16% more than flat (`_walk` 19.15 →
22.19 ms, `_scan(sized)` 64.21 → 69.48 ms) — two levels cost 37–49x.

`blake2b`, not the builtin `hash()`: str hashing is salted per process by `PYTHONHASHSEED`,
so a room would land in a different bucket after every restart. `digest_size=1` is exactly
the 8 bits 256 needs, so the whole digest *is* the component — no slice, no mask, and no
room for a modulo bias to hide in. There is a test pinning the digest literally rather than
calling `_shard`, because this is an on-disk format and a test derived from the
implementation would agree with any change that silently moved every file.

## The migration, and the bug it is shaped around

Lazy, and it lives in the resolver, which **always returns the sharded path**. That
placement is the load-bearing part. Migrating on read while writing straight to the bucket
forks a live room in two — the old file keeps the history, the new one restarts at `seq` 1 —
and reads check the bucket first, so the room silently loses everything with no error and
nothing in a log. Since no caller can ever be handed the legacy path, no caller can write to
one. The sidecar lock moves by rename, so the lock domain survives instead of splitting
across two inodes.

The promise is in the Hypothesis state machine (`unshard` puts a file back where a
pre-sharding build kept it, in whatever order Hypothesis reaches it), because this is a
sequence bug: every single step looks correct on its own. Verified non-vacuous — with
`_migrate` stubbed out the machine fails with `seq jumped from 1 to 1`, `read [], expected
[1]` and `note ... does not hold 'a'`.

## Walks that sharding broke structurally

Each of these is fixed here and covered:

- `_check_room_capacity` counted `path.parent`, now the room's own bucket — `MAX_ROOMS` and
  `MAX_TOTAL_ROOM_BYTES` would have stopped binding on a world-writable service.
- `_check_note_capacity` / `_count_new_note` would have written a namespace's
  `.notes-count` into a key's bucket, where nothing looks for it.
- `_guards_a_live_room` read the namespace off the parent directory, so owner, allow-list
  and nonce notes for **live** rooms would have been reaped silently.
- `_walk` / `_scan` now recurse — both depths are occupied during the migration.
- `_prune` reclaims emptied buckets; without it a namespace could never be dropped and
  empty directories grew unbounded.

The reaper's bucket prune takes `.rooms-create`, and `_locked` opens a fresh fd per call, so
a nested acquire would block on itself forever with no `EDEADLK`. A watchdog test drives the
nesting rather than trusting the reasoning.

## Abuse impact

No new public surface — no route, parameter or persistent state a caller can reach. One
nuance worth stating rather than leaving implicit: caller input now reaches a *directory
position*, where before it reached only a filename. It does so exclusively through the hash,
whose output is one byte of hex from a fixed alphabet, and `valid_name`'s allowlist still
runs first. `docs/design.md` threat-table rows 1 and 2 are updated to say this precisely
instead of overstating.

## Docs

- `docs/store.md` regenerated (`scripts/gen_store_doc.py`).
- `docs/design.md` §threat-table rows 1 and 2, as above.
- No manual, `SKILL.md`, `manifest.py` or `README.md` change — the HTTP surface is untouched.

## Core size

`store.py` 807 → 841, core total 2033 → 2067; caps raised to 841 / 2069 in
`sz-baseline.json`. Growth past a cap needs a new primitive (AGENTS.md) — `_shard`,
`_resolve`, `_migrate` and `_prune` are it.

## Checks

`ruff check`, `ruff format --check`, `ty check`, `coverage run -m pytest tests -q`
(416 passed, 97.60% total), `sz.py --check` and `examples/beautiful_chat.sh` all pass
locally.

## Proposed release note

> Rooms and notes are now stored one directory level deeper, in a bucket derived from a
> BLAKE2b hash of the name, so no single directory grows past a few hundred entries at the
> configured caps. Existing files migrate themselves the first time they are touched — no
> downtime, no operator step, and no change to any route or response.
