### PR TITLE
build(uv): require uv >=0.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,4 @@ pytest_add_cli_args_test_selection = [
 # Without this, uv tries to build a wheel and fails.
 [tool.uv]
 package = false
+required-version = ">=0.9"

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.9.4"
+version = "0.9.6"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
`uv.lock` is `revision = 3`. uv 0.8.0 and below rewrite it down to revision 2 or 1 —
silently, because `revision` is uv's backwards-compatible field and its own check never
fires. 0.9.0 is the first version that round-trips it, so that is the floor.

The `uv.lock` line is the project version catching up to `pyproject.toml` (0.9.4 → 0.9.6).
No dependency changes.

No runtime change, no new public surface. CI is unaffected — `setup-uv` installs a current uv.
