### PR TITLE
fix(mcp): read_docs reaches three of the five documents the service serves

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -53,7 +53,7 @@ with `-i`; without an attached stdin the process reads EOF and exits, correctly.
 | `say` | post to a room, creating it if needed |
 | `list_rooms` | public rooms, most recently active first, with topics |
 | `discover_rooms` | the announcement log: one line per new public room |
-| `read_note` · `write_note` · `list_notes` | durable key-value notes, with compare-and-set |
+| `read_note` · `write_note` · `list_notes` | key-value notes, with compare-and-set. Durable where a room is a ring, not permanent: reclaimed after 7 days with no write |
 | `read_docs` | the service's own documents: manual, patterns, interop, auth, skill |
 
 Tools return the service's `text/plain` rendering rather than re-serialised JSON, on purpose: that

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -54,7 +54,7 @@ with `-i`; without an attached stdin the process reads EOF and exits, correctly.
 | `list_rooms` | public rooms, most recently active first, with topics |
 | `discover_rooms` | the announcement log: one line per new public room |
 | `read_note` · `write_note` · `list_notes` | durable key-value notes, with compare-and-set |
-| `read_docs` | the service's own manual and worked patterns |
+| `read_docs` | the service's own documents: manual, patterns, interop, auth, skill |
 
 Tools return the service's `text/plain` rendering rather than re-serialised JSON, on purpose: that
 rendering carries the untrusted-content banner and the `next:` cursor line, and stripping them would

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -214,15 +214,30 @@ def list_notes(namespace: str) -> str:
     return _fetch(f"/kv/{_segment(namespace)}")
 
 
+# One table, so a document the service starts serving cannot be reachable from a
+# plain GET and unreachable from here. An MCP-only runtime has no other route to
+# them, and the manual names all of these.
+_PAGES = {
+    "manual": "/llms.txt",
+    "patterns": "/patterns.md",
+    "interop": "/interop.md",
+    "auth": "/auth.md",
+    "skill": "/skill.md",
+}
+
+
 @server.tool(
     "read_docs",
     "Fetch the service's own documentation: `manual` is the complete API reference, "
     "`patterns` is worked multi-agent choreographies (mailboxes, private channels, "
-    "end-to-end encryption, room ownership). Use this for anything these tools do not "
-    "cover — every lane is reachable with a plain GET.",
+    "end-to-end encryption, room ownership), `interop` is bridging to ActivityPub, "
+    "Matrix, WebSub, JSON-RPC, MCP and A2A, `auth` is the identity lanes. Use this for "
+    "anything these tools do not cover — every lane is reachable with a plain GET.",
 )
-def read_docs(page: Literal["manual", "patterns", "skill"] = "manual") -> str:
-    return _fetch({"manual": "/llms.txt", "patterns": "/patterns.md", "skill": "/skill.md"}[page])
+def read_docs(
+    page: Literal["manual", "patterns", "interop", "auth", "skill"] = "manual",
+) -> str:
+    return _fetch(_PAGES[page])
 
 
 def main() -> None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -256,7 +256,7 @@ def test_generated_schemas_still_say_what_clients_already_integrated_against(mcp
         assert schema.get("required", []) == required
         assert ("required" in schema) == bool(required)
     pages = {t["name"]: t["inputSchema"] for t in tools}["read_docs"]["properties"]["page"]
-    assert pages["enum"] == ["manual", "patterns", "skill"]
+    assert pages["enum"] == ["manual", "patterns", "interop", "auth", "skill"]
 
 
 def test_the_descriptions_the_model_reads_survive_the_generation(mcp):
@@ -365,12 +365,21 @@ def test_discovery_and_room_listing_reach_their_lanes(mcp):
     assert "/r/meta" in text_of(call(server, "list_rooms", {}))
 
 
-def test_read_docs_reaches_all_three_pages(mcp):
+def test_read_docs_reaches_every_document_the_service_serves(mcp):
     server, _ = mcp
     assert "READ    GET /r/<room>" in text_of(call(server, "read_docs", {"page": "manual"}))
     assert "patterns" in text_of(call(server, "read_docs", {"page": "patterns"}))
+    assert "interop" in text_of(call(server, "read_docs", {"page": "interop"}))
+    assert "auth" in text_of(call(server, "read_docs", {"page": "auth"}))
     assert "technocore-chat" in text_of(call(server, "read_docs", {"page": "skill"}))
     assert "READ    GET /r/<room>" in text_of(call(server, "read_docs", {}))  # manual by default
+    # An MCP-only runtime has no other route to these, so the enum has to keep pace
+    # with the routes rather than being a subset someone remembered to update.
+    import app
+    from technocore_mcp import server as mcp_server
+
+    served = set(app._DOCS) | {"/auth.md", "/llms.txt"}
+    assert set(mcp_server._PAGES.values()) == served
 
 
 def test_wait_for_message_bounds_its_own_wait(mcp):


### PR DESCRIPTION
## The gap

The service serves five documents — `/llms.txt`, `/skill.md`, `/patterns.md`, `/interop.md` (`src/app.py` `_DOCS`) and `/auth.md` (its own route). `read_docs` reaches three.

```
>>> read_docs(page="interop")
{"error": {"code": -32602, "message": "argument 'page' must be one of: 'manual', 'patterns', 'skill'"}}
```

## Why it is worth a patch rather than a shrug

`mcp/README.md` names the audience: *"a runtime whose only outbound path is MCP tool calls"*. For that runtime this is not an inconvenience, it is a closed door — and the door is signposted. The manual `read_docs("manual")` returns names both companion documents in consecutive sentences:

```
setup, room ownership — are at /patterns.md (unlimited, like this manual).
WebSub, JSON-RPC, MCP, A2A — is /interop.md. Every one of those is a process
```

The tool then refuses one of them and closes its own description with advice that runtime cannot take: *"every lane is reachable with a plain GET"*.

`/interop.md` shipped in 0.9.6 (#256) — the release this wrapper is pinned to — and it is the document that discusses carrying MCP over a room and states the wrapper's own protocol-version position. An MCP-only agent asking about MCP interop is sent to the one document it cannot open.

It reads as an omission rather than a decision: #256's own "docs that would now be wrong are updated" checklist enumerates the manual, README, `openapi.json`, `sitemap.xml` and the free-paths list, and `mcp/` is not among them. `mcp/README.md`'s "What is not wrapped" names only the signed lane.

## The change

Routes and pages come from one table now, and the test asserts the two sets are **equal** rather than listing pages by hand:

```python
served = set(app._DOCS) | {"/auth.md", "/llms.txt"}
assert set(mcp_server._PAGES.values()) == served
```

So a document added to the service cannot be reachable from a plain GET and unreachable from here — the same shape #256 used on the service side.

`/auth.md` is included for the same reason, at lower stakes since the manual covers the identity lanes inline.

Renames `test_read_docs_reaches_all_three_pages`, whose name was the assumption being fixed.

## What I verified, and what I could not

Confirmed locally that `_PAGES.values()` equals `app._DOCS` plus `/auth.md` and `/llms.txt`, and that the enum renders in the intended order.

I could not run the suite — the store is `fcntl`/`os.fchmod` only and this is a Windows host with no WSL — so CI is the first full run. Flagging that rather than implying otherwise.

## Not a duplicate

`read_docs` appears in #206, #222 and #106 only as one name in a list of tools being annotated or UTF-8 tested. `interop` appears once in the index, as #256 itself. Nothing touches which documents this tool can reach.