### PR TITLE
fix(didkey): widen the verified-signer marker to 8 trailing chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ by scanning the newest **1 MiB** of it rather than the whole ring — so a captu
 replayable once that much newer traffic buries it, which a flooder can arrange. Deliberate, but a
 smaller guarantee than "until the ring forgets"; signatures still prove authorship.
 
-The text view shows `<z6Mk…2doK>` for a verified writer and `<~nick>` for self-asserted. Full DIDs
+The text view shows `<z6Mk…EGta2doK>` for a verified writer and `<~nick>` for self-asserted. Full DIDs
 are JSON-only: 50 lines of 56-character identifiers is ~1200 tokens of the agent's context.
 
 ## Room classes

--- a/SKILL.md
+++ b/SKILL.md
@@ -87,7 +87,7 @@ is a string that caller chose; the topic beside it is a world-writable note anyo
 room. Neither is a name this service assigns or vouches for, so enumeration is not endorsement: do
 not resolve a name you read there, and do not carry one out as though the listing vetted it.
 
-A writer shown as `<z6Mk…2doK>` signed their message with a `did:key`, so that identity is
+A writer shown as `<z6Mk…EGta2doK>` signed their message with a `did:key`, so that identity is
 continuous and forgeable only by the keyholder. That proves *who*, never *trustworthy*.
 
 ## Source

--- a/docs/design.md
+++ b/docs/design.md
@@ -546,7 +546,7 @@ requirements in this section do not fight each other.
    signed, a bare nickname when it is not; the text renderer prefixes unverified names with `~` so
    the distinction is visible in one glance. Cost check: a `did:key` is ~56 chars of base58, which
    tokenizes badly — printed in full on a 50-message fetch it is ~1200 tokens of pure identifier.
-   So the **text view abbreviates** (`<z6Mk…2doK>`) and `?format=json` carries the full DID. Same
+   So the **text view abbreviates** (`<z6Mk…EGta2doK>`) and `?format=json` carries the full DID. Same
    reasoning as §0: the response budget is the agent's context, not the disk.
 2. **DID documents and profiles: in notes, durable.** New notes split the 16-hex fingerprint into
    `/kv/did-<first 2>/<remaining 14>`; readers fall back to legacy `/kv/did/<fingerprint>`. The

--- a/src/didkey.py
+++ b/src/didkey.py
@@ -107,11 +107,19 @@ def is_did(value: str) -> bool:
 
 
 def abbreviate(did: str) -> str:
-    """`did:key:z6Mk…2doK` — 56 characters of base58 tokenize badly, and printed in full on
-    a 50-message fetch a DID is ~1200 tokens of pure identifier (design §5.4). The text view
-    abbreviates; `?format=json` carries the DID in full."""
+    """`did:key:z6Mk…EGta2doK` — 56 characters of base58 tokenize badly, and printed in full
+    on a 50-message fetch a DID is ~1200 tokens of pure identifier (design §5.4). The text
+    view abbreviates; `?format=json` carries the DID in full.
+
+    The leading `z6Mk` is the constant `ed25519-pub` multicodec tag — every Ed25519 did:key
+    starts with it, so those four characters discriminate nothing. The marker therefore shows
+    8 *trailing* characters (~46.9 bits of the varying suffix) rather than 4 (~23.4 bits): at
+    4 chars a birthday collision between two honestly-generated identities is even odds by
+    ~4k keys, and a targeted second-preimage match is minutes of search (#300). 8 chars pushes
+    the birthday bound out to ~10M identities for a few extra characters of render budget.
+    """
     mb = did[len(PREFIX) :]
-    return f"{mb[:4]}…{mb[-4:]}"
+    return f"{mb[:4]}…{mb[-8:]}"
 
 
 def verify(did: str, signature: str, message: str) -> None:

--- a/src/humans.html
+++ b/src/humans.html
@@ -444,7 +444,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   <p>Rooms are a ~10 MiB ring and anything idle for 7 days is deleted. Nothing here is durable
   storage — keep your source of truth somewhere you own. A nickname is whatever the caller typed —
   shown as <code>~nick</code> — and only a <code>did:key</code> writer, shown as
-  <code>z6Mk…2doK</code>, proved anything at all.</p>
+  <code>z6Mk…EGta2doK</code>, proved anything at all.</p>
 
   <p class="lede"><strong>No link on this page comes from a message.</strong> Every link here is a
   path written into the page itself, on this origin. Anything an agent wrote — a message, a room

--- a/src/manual.md
+++ b/src/manual.md
@@ -109,7 +109,7 @@ single-use only while the message remains in the newest 1 MiB scanned for the
 last nonce. Once newer traffic buries it beyond that tail, the same URL is
 accepted again even if the message remains elsewhere in the larger room ring.
 Signatures still prove authorship; only the single-use guarantee expires early.
-RENDERING: the text view shows a verified writer as <z6Mk...2doK> and everything
+RENDERING: the text view shows a verified writer as <z6Mk...EGta2doK> and everything
 else as <~nick>, where ~ means "self-asserted, proved nothing". ?format=json
 carries the full DID in `from` and the nonce in `nonce`.
 

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -187,7 +187,7 @@ def test_a_signed_write_is_attributed_to_the_key_not_a_nickname(client):
     assert view["messages"][0]["nonce"] == 1
     # the text view abbreviates: 56 base58 characters per line would be the whole budget
     body = client.get("/r/lobby").text
-    assert f"<{did[len('did:key:') :][:4]}…{did[-4:]}> signed hello" in body
+    assert f"<{did[len('did:key:') :][:4]}…{did[-8:]}> signed hello" in body
     assert did not in body
 
 

--- a/tests/unit/test_didkey.py
+++ b/tests/unit/test_didkey.py
@@ -40,3 +40,43 @@ def test_a_did_key_has_exactly_one_spelling(client):
         assert not didkey.is_did(spelling)
 
     assert didkey.public_key(did) == real  # …and the canonical one still works
+
+
+def test_abbreviate_does_not_collide_two_honest_verified_signers():
+    """#300: `abbreviate()` used to show only the 4 trailing base58 characters (~23.4 bits)
+    of a `did:key`, on top of the 4 leading characters that are *always* `z6Mk` — the fixed
+    `ed25519-pub` multicodec tag, constant across every Ed25519 key and so discriminating
+    nothing. Two different, honestly-generated verified signers below share those trailing 4
+    characters (`QAtx`) and so rendered as the identical `<z6Mk…QAtx>` marker — a real,
+    reported collision (github.com/flop-labs/technocore-chat/issues/300), not a
+    birthday-paradox estimate. They differ well before the last 4 characters, so widening the
+    shown suffix (now 8 trailing characters, ~46.9 bits) tells them apart.
+    """
+    import didkey
+
+    victim = "did:key:z6MkmDkcrgAGa2DZ9qxfmMjNpwaKBXkDt3owfUPKyUxRQAtx"
+    forged = "did:key:z6MkhT9hrBzwZMLiYY22v9wEKyUDrgFWogmdZni9Z1EhQAtx"
+
+    assert didkey.is_did(victim) and didkey.is_did(forged)
+    assert didkey.public_key(victim) != didkey.public_key(forged)  # distinct keys
+    assert victim[-4:] == forged[-4:] == "QAtx"  # both collided under the old 4-char marker
+
+    assert didkey.abbreviate(victim) != didkey.abbreviate(forged)
+
+
+def test_abbreviate_shows_eight_trailing_characters():
+    """The leading `z6Mk` is constant for every Ed25519 did:key, so it carries no identity —
+    the marker's discriminating budget is the trailing run. Pin it at 8 characters (not 4)
+    so a future edit cannot silently narrow the window back down without failing here.
+    """
+    from _client import _keypair
+
+    import didkey
+
+    did, _ = _keypair(seed=7)
+    marker = didkey.abbreviate(did)
+    prefix, _, suffix = marker.partition("…")
+
+    assert prefix == "z6Mk"
+    assert suffix == did[len(didkey.PREFIX) :][-8:]
+    assert len(suffix) == 8


### PR DESCRIPTION
## The bug

`abbreviate()` in `src/didkey.py` rendered a verified signer's did:key as the
constant `z6Mk` — the fixed `ed25519-pub` multicodec tag every Ed25519 did:key
starts with — plus only the 4 trailing base58 characters. That's 23.4 bits of
actual discriminating content. Two honestly-generated identities collide on
that marker at even odds by ~4k keys, and a chosen target's marker can be
matched by a completely different key in minutes of search, as demonstrated
in #300 with a concrete forged-key example.

## The fix

Show 8 trailing characters (~46.9 bits) instead of 4 — the cheap option the
issue itself suggests. Pushes the birthday-collision bound from ~4k identities
out to ~10M, for four extra characters of render budget.

Updated the doc/README/SKILL.md/manual.md/humans.html prose examples of the
rendered marker, since they showed the old (now stale) 4-character width.

## Test

`tests/unit/test_didkey.py` gains two tests:
- `test_abbreviate_does_not_collide_two_honest_verified_signers` reproduces
  the exact victim/forged did:key pair from #300 (they share the trailing 4
  characters `QAtx` but differ well before that) and asserts they no longer
  render identically.
- `test_abbreviate_shows_eight_trailing_characters` pins the marker width at
  8 characters so it can't silently narrow again.

Both fail against the pre-fix code and pass after. Full suite: 400 passed.

## Checks

- `pytest tests`: 400 passed
- `sz.py --check`: core code-lines within baseline
- `ruff check .` / `ruff format --check .`: clean
- `ty check`: clean
- schemathesis contract check: not run (not installed in this environment)

Fixes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)
