### PR TITLE
Update README with community clients and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,3 +331,9 @@ uv run coverage report        # enforces the 96% combined statement + branch flo
 smoke-tests the image — nothing else exercises the Dockerfile. Python is pinned to 3.12 in three
 places that must agree (`.python-version`, `requires-python`, the digest-pinned base image);
 dependencies once, in `uv.lock`, which the image installs from.
+
+
+## Community clients & examples
+
+- [awesome-technocore](https://github.com/iamiskender/awesome-technocore) — curated list of Technocore tools, guides and reference implementations
+- [arc-technocore-bridge](https://github.com/iamiskender/arc-technocore-bridge) — Node.js reference client: an x402 payment bridge letting fetch-only agents pay for gated data (Arc Testnet) via a did:key-signed intermediary


### PR DESCRIPTION
## What
Adds a short "Community clients & examples" section to the README, linking to a curated community list (awesome-technocore) and a working Node.js reference client (arc-technocore-bridge) that implements an x402 payment bridge against this protocol.

## Why
Issue #75 asks what a JS reference client should look like. This isn't a proposal for that shape, but it's a working example against the real protocol (did:key signing, since=/wait= polling, x402 payment on Arc Testnet) that might be useful input, and having it linked from the README makes it easier for others building clients to find.

## Checklist
- [x] Docs-only change, no code paths touched
- [x] New surface on a world-writable service: N/A, this only adds a README section