### PR TITLE
fix(http): refuse when both if and if_absent are present (#290)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1128,8 +1128,7 @@ def room_say(request: Request) -> Response:
     if retry:
         return limit.limited("write", RATE_WRITE, retry, text=text, max_wait=MAX_WAIT)
     room = request.path_params["room"]
-    denied = _room_write_gate(request, room, None)
-    if denied:
+    if denied := _room_write_gate(request, room, None):
         return denied
     nick, body = request.path_params["nick"], request.path_params["text"]
     with _dupe_slot(room, body) as refused:
@@ -1160,8 +1159,7 @@ def room_say_signed(request: Request) -> Response:
     signer = _signer(p["did"], p["sig"], nonce, f"{room}|{nonce}|{body}")
     if isinstance(signer, Response):
         return signer
-    denied = _room_write_gate(request, room, signer)
-    if denied:
+    if denied := _room_write_gate(request, room, signer):
         return denied
     with _dupe_slot(room, body) as refused:
         if refused:
@@ -1313,10 +1311,14 @@ def _condition(source: dict) -> tuple[str | None, bool]:
     An empty string is a legal note value, so absence cannot be encoded as `if=` — hence
     the separate flag rather than a sentinel.
     """
-    if source.get("if_absent") not in (None, "", False, "0", "false"):
-        return None, True
+    absent = source.get("if_absent") not in (None, "", False, "0", "false")
     expect = source.get("if")
-    return (str(expect) if expect is not None else None), False
+    if absent and expect is not None:
+        raise store.StoreError(
+            "if and if_absent cannot both apply: if_absent means the note is not there, "
+            "if= means it is there holding exactly that value. Send one."
+        )
+    return None if absent else (str(expect) if expect is not None else None), absent
 
 
 def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Response | None:
@@ -1420,8 +1422,7 @@ def note_write(request: Request) -> Response:
         return limit.limited("write", RATE_WRITE, retry, text=text, max_wait=MAX_WAIT)
     p = request.path_params
     value = store.clean_text(p["value"], store.MAX_VALUE_CHARS)
-    denied = _note_write_gate(p["ns"], p["key"], value, None)
-    if denied:
+    if denied := _note_write_gate(p["ns"], p["key"], value, None):
         return denied
     expect, expect_absent = _condition(dict(request.query_params))
     meta = store.note_set(
@@ -1474,11 +1475,9 @@ def note_write_signed(request: Request) -> Response:
     signer = _signer(p["did"], p["sig"], nonce, f"{ns}|{key}|{nonce}|{value}")
     if isinstance(signer, Response):
         return signer
-    denied = _note_write_gate(ns, key, value, signer)
-    if denied:
+    if denied := _note_write_gate(ns, key, value, signer):
         return denied
-    denied = _burn_nonce(key, nonce)
-    if denied:
+    if denied := _burn_nonce(key, nonce):
         return denied
     expect, expect_absent = _condition(dict(request.query_params))
     meta = store.note_set(config.ROOT, ns, key, value, expect=expect, expect_absent=expect_absent)
@@ -1517,13 +1516,10 @@ async def note_post(request: Request) -> Response:
     # note, the nonce burn is a compare-and-swap on disk, and note_set walks the notes tree
     # to enforce the global cap. None of that may run on the loop from an `async def`.
     def write() -> Response:
-        denied = _note_write_gate(ns, key, value, signer)
-        if denied:
+        if denied := _note_write_gate(ns, key, value, signer):
             return denied
-        if signer is not None:
-            burned = _burn_nonce(key, nonce)
-            if burned:
-                return burned
+        if signer is not None and (burned := _burn_nonce(key, nonce)):
+            return burned
         meta = store.note_set(
             config.ROOT, ns, key, value, expect=expect, expect_absent=expect_absent
         )

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -130,23 +130,25 @@ def test_if_absent_creates_exactly_once(client):
 def test_if_and_if_absent_together_are_refused_on_both_lanes(client):
     """`if_absent` (create-if-missing) and `if=` (replace-if-matching) cannot both apply:
     one requires the note not to exist, the other requires it to exist and hold that value.
-    Refuse with 400 rather than dropping one silently.
+    Refuse with 400 rather than dropping one silently, including when if= is empty.
     """
-    # GET lane: query parameters
-    r_get = client.get("/kv/coord/conflict/set/v?if=old&if_absent=1")
-    assert r_get.status_code == 400
-    assert "if and if_absent cannot both apply" in r_get.text
-    assert client.get("/kv/coord/conflict").status_code == 404
-
-    # POST lane: JSON payload with boolean and string if_absent
-    for absent_val in (True, "1"):
-        r_post = client.post(
-            "/kv/coord/conflict",
-            json={"value": "v", "if": "old", "if_absent": absent_val},
-        )
-        assert r_post.status_code == 400
-        assert "if and if_absent cannot both apply" in r_post.text
+    # GET lane: query parameters with non-empty and empty if=
+    for if_param in ("old", ""):
+        r_get = client.get(f"/kv/coord/conflict/set/v?if={if_param}&if_absent=1")
+        assert r_get.status_code == 400
+        assert "if and if_absent cannot both apply" in r_get.text
         assert client.get("/kv/coord/conflict").status_code == 404
+
+    # POST lane: JSON payload with boolean, string if_absent, and empty if
+    for if_val in ("old", ""):
+        for absent_val in (True, "1"):
+            r_post = client.post(
+                "/kv/coord/conflict",
+                json={"value": "v", "if": if_val, "if_absent": absent_val},
+            )
+            assert r_post.status_code == 400
+            assert "if and if_absent cannot both apply" in r_post.text
+            assert client.get("/kv/coord/conflict").status_code == 404
 
 
 def test_cas_distinguishes_absent_from_empty_and_works_over_post(client):

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -127,6 +127,28 @@ def test_if_absent_creates_exactly_once(client):
     assert "agent-a" in client.get("/kv/coord/claim").text
 
 
+def test_if_and_if_absent_together_are_refused_on_both_lanes(client):
+    """`if_absent` (create-if-missing) and `if=` (replace-if-matching) cannot both apply:
+    one requires the note not to exist, the other requires it to exist and hold that value.
+    Refuse with 400 rather than dropping one silently.
+    """
+    # GET lane: query parameters
+    r_get = client.get("/kv/coord/conflict/set/v?if=old&if_absent=1")
+    assert r_get.status_code == 400
+    assert "if and if_absent cannot both apply" in r_get.text
+    assert client.get("/kv/coord/conflict").status_code == 404
+
+    # POST lane: JSON payload with boolean and string if_absent
+    for absent_val in (True, "1"):
+        r_post = client.post(
+            "/kv/coord/conflict",
+            json={"value": "v", "if": "old", "if_absent": absent_val},
+        )
+        assert r_post.status_code == 400
+        assert "if and if_absent cannot both apply" in r_post.text
+        assert client.get("/kv/coord/conflict").status_code == 404
+
+
 def test_cas_distinguishes_absent_from_empty_and_works_over_post(client):
     # An empty string is a legal value, so absence cannot be encoded as if=<empty>.
     assert client.post("/kv/coord/n", json={"value": "0", "if_absent": True}).status_code == 200


### PR DESCRIPTION
## What changes for a caller

When both `if=` (replace-if-matching) and `if_absent` (create-if-missing) are supplied in the same request, the service now refuses with `400 Bad Request` explaining that the two conditions cannot both apply, instead of silently dropping `if=` and evaluating only `if_absent`.

Fixes #290

## The problem

`_condition()` previously returned `None, True` on the first branch whenever `if_absent` was truthy, completely ignoring `if=`:

```bash
# absent note: if=X cannot match, but note was created and returned 200
GET /kv/$NS/k/set/v?if=X&if_absent=1
```

Because `if_absent` and `if=` are mutually exclusive (a note cannot be absent and simultaneously hold an expected value), accepting this request and dropping one condition gave callers false guarantees on the conditional write lane.

## The fix

- In `_condition()`, check if both `absent` is truthy and `expect is not None`. If so, raise `StoreError` with a clear message explaining that the two conditions cannot both apply.
- Added comprehensive regression tests in `tests/http/test_notes.py` covering both GET query parameters and POST JSON bodies (with boolean and string `if_absent` values).

## Checks

- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run sz.py --check` — clean (`core code-lines <= baseline (2029 <= 2033)`, `core/app.py` is at 977/981).
