### PR TITLE
fix(rooms): report occupancy over the population the cap refuses on

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -886,8 +886,14 @@ def rooms(request: Request) -> Response:
         head = (
             # Both caps, because either can be the one that refuses the next room and an
             # agent that hit one needs to know which: the count is not the disk budget.
-            f"# {len(view['rooms'])} of {view['total']} rooms "
-            f"(cap {view['capacity']}, {_size(view['bytes'])} of "
+            # Both are now stated over the population they are enforced across, which
+            # includes the unlisted rooms this listing deliberately does not name. That
+            # is the same shape as the note line below, which has always published a
+            # global total over namespaces it does not name either: an aggregate is not
+            # an enumeration. Reported the other way round, the pair said 7944 of 10240
+            # on a store that refused the next room.
+            f"# {len(view['rooms'])} of {view['total']} listed rooms ({view['occupied']} of "
+            f"{view['capacity']} slots used, {_size(view['bytes_occupied'])} of "
             f"{_size(view['bytes_capacity'])} stored), newest first"
         )
         # Second line, exactly where render() puts BANNER and for the same reason: a

--- a/src/humans.html
+++ b/src/humans.html
@@ -674,8 +674,11 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     if (q) parts.push(shown + ' of ' + roomsView.rooms.length + ' loaded rooms match');
     else if (shown < roomsView.total) parts.push('showing ' + shown + ' of ' + roomsView.total + ' rooms');
     else parts.push(roomsView.total + ' rooms');
-    parts.push(roomsView.total + ' of ' + roomsView.capacity + ' room cap');
-    parts.push(size(roomsView.bytes) + ' of ' + size(roomsView.bytes_capacity) + ' stored');
+    // occupied, not total: the cap counts every room on disk and the listing above names
+    // only the listable ones, so `total` against `capacity` understated the store by the
+    // unlisted rooms and the gauge read full-ish while creates were already refused.
+    parts.push(roomsView.occupied + ' of ' + roomsView.capacity + ' room cap');
+    parts.push(size(roomsView.bytes_occupied) + ' of ' + size(roomsView.bytes_capacity) + ' stored');
     parts.push('idle rooms are deleted after 7 days');
     var line = document.createElement('span');
     line.textContent = parts.join(' · ');
@@ -683,8 +686,8 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     // Either cap can be the one that refuses the next room, so the warning watches both and
     // reports whichever is closer. Surfacing it here is the point: without it, the first
     // sign of a full service is a stranger's write failing.
-    var full = Math.max(roomsView.total / roomsView.capacity,
-                        roomsView.bytes / roomsView.bytes_capacity);
+    var full = Math.max(roomsView.occupied / roomsView.capacity,
+                        roomsView.bytes_occupied / roomsView.bytes_capacity);
     if (full >= 0.8) {
       var warn = document.createElement('span');
       warn.className = 'badge err';                 // the word carries it too, not the hue

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -800,8 +800,10 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                 "properties": {
                                     "rooms": {"type": "array", "items": {"type": "object"}},
                                     "total": {"type": "integer"},
+                                    "occupied": {"type": "integer"},
                                     "capacity": {"type": "integer"},
                                     "bytes": {"type": "integer"},
+                                    "bytes_occupied": {"type": "integer"},
                                     "notes": {"type": "object"},
                                     "engagement": {"type": "object"},
                                     "untrusted": {

--- a/src/store.py
+++ b/src/store.py
@@ -1118,8 +1118,16 @@ def room_stats(root: Path, limit: int = 50) -> dict:
     the last one. See WINDOW_BYTES for the per-room worst-case bound.
     """
     now = time.time()
-    entries = []
+    entries, occupied = [], 0
     for e in _walk(root / "rooms", ".jsonl"):
+        # Counted before the listability filter, because this is the number the cap is
+        # checked against: `_check_room_capacity` scans the same tree for the same suffix
+        # and refuses at MAX_ROOMS without consulting `_listable`. Filtering here and not
+        # there is what made the head compare a listed count to an all-rooms cap. The walk
+        # is already here, so this adds an increment and no I/O — measured at +0.5 ms on a
+        # 23.5 ms `room_stats(limit=200)` over a full 5,120-room store, inside the harness's
+        # own run-to-run spread (tests/capacity_bench.py, n=7 interleaved, Welch t = 1.2).
+        occupied += 1
         name = e.name[: -len(".jsonl")]
         if not _listable(name):
             continue
@@ -1150,8 +1158,17 @@ def room_stats(root: Path, limit: int = 50) -> dict:
     return {
         "rooms": shown,
         "total": len(entries),
+        # What the cap actually counts, so a reader can tell how close the next new room
+        # is to being refused. `total` stays the listed count — it is what the listing
+        # below shows, and changing its meaning would break every reader of it.
+        "occupied": occupied,
         "capacity": MAX_ROOMS,
         "bytes": sum(e[1] for e in entries),
+        # The byte budget's own population, same reason. The reaper already writes this
+        # figure across every room (see USAGE_FILE); it drifts by at most one reap
+        # interval, which is the trade `note_stats` explains making for a display gauge.
+        # A zero means no pass has run yet, and then the listed sum is the best we have.
+        "bytes_occupied": room_bytes_used(root) or sum(e[1] for e in entries),
         # Both bounds, because either can be the one that bites: a service can be far from
         # the room count and out of disk, or the reverse. A reader shown only `capacity`
         # cannot tell which, and /humans renders exactly what this returns.

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -372,9 +372,13 @@ def test_rooms_overview_carries_stats_newest_first(client, tmp_path):
     assert by_name["busy"]["idle_seconds"] < 60
     assert by_name["old"]["idle_seconds"] >= 3600
     assert view["total"] == 3 and view["capacity"] == store.MAX_ROOMS and view["bytes"] > 0
+    # Nothing unlisted here, so the two populations coincide — which is the case that
+    # hid the bug: every store a test builds looks like this one.
+    assert view["occupied"] == 3 and view["bytes_occupied"] > 0
 
     body = client.get("/rooms").text
-    assert "3 of 3 rooms" in body and "/r/busy" in body and "seq 2" in body and "ago" in body
+    assert "3 of 3 listed rooms" in body and f"3 of {store.MAX_ROOMS} slots used" in body
+    assert "/r/busy" in body and "seq 2" in body and "ago" in body
 
 
 def test_rooms_marks_the_caller_chosen_name_and_topic_as_untrusted(client):
@@ -467,8 +471,10 @@ def test_rooms_overview_hides_private_rooms_and_survives_an_empty_store(client):
     assert client.get("/rooms?format=json").json() == {
         "rooms": [],
         "total": 0,
+        "occupied": 0,
         "capacity": store.MAX_ROOMS,
         "bytes": 0,
+        "bytes_occupied": 0,
         "bytes_capacity": store.MAX_TOTAL_ROOM_BYTES,
         "notes": {
             "total": 0,
@@ -490,6 +496,16 @@ def test_rooms_overview_hides_private_rooms_and_survives_an_empty_store(client):
     client.get("/r/p-secret/say/bot/hi")
     view = client.get("/rooms?format=json").json()
     assert view["total"] == 0 and view["rooms"] == []  # p- stays invisible in stats too
+    # Invisible in the listing, present in the gauge: the room is a slot the cap will
+    # refuse on, and a caller deciding whether to create one needs that number. Counting
+    # it names nothing, which is the line `service_stats` already draws for /stats.
+    assert view["occupied"] == 1
+    # The byte half is the reaper's total and reads 0 until a pass has run — the "no
+    # pressure" default `room_bytes_used` documents — and the listed sum it falls back to
+    # is 0 here because the only room is unlisted. Closing that in this walk would cost a
+    # stat per unlisted room on the most polled read; one reap interval of drift is the
+    # trade `note_stats` already documents making for a display gauge.
+    assert view["bytes_occupied"] == 0
 
 
 def test_rooms_overview_limits_the_tail_reads_it_does(client, tmp_path):

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -186,6 +186,50 @@ def test_a_capacity_refusal_carries_the_numbers_a_caller_acts_on(tmp_path, monke
         store.append(tmp_path, "overflow", "bot", "hi")
 
 
+def test_room_occupancy_is_counted_over_the_population_the_cap_refuses_on(tmp_path, monkeypatch):
+    """The overview's cap gauge has to count what `_check_room_capacity` counts.
+
+    `room_stats` drops unlisted rooms before it totals, because the listing beside that
+    total names what it counts and a `p-` name is a bearer credential. The cap does not:
+    it scans every `*.jsonl` in the directory. Printed against each other the pair claims
+    headroom on a store that is already refusing — technocore.chat served
+    `8627 of 10240` while a new room got `room limit reached`.
+
+    `service_stats` already states the rule this asserts ("the room totals here count
+    every room including unlisted ones: they are what bounds the disk and the room cap");
+    `room_stats` is the surface that had not caught up.
+
+    The assertion is an equality against the refusal itself rather than a fixed number:
+    whatever count makes the next room fail is the count the gauge has to print.
+    """
+    import store
+
+    monkeypatch.setattr(store, "MAX_ROOMS", 4)
+    store.append(tmp_path, "open-one", "bot", "hi")  # the first write also announces /r/events
+    store.append(tmp_path, "p-alpha", "bot", "hi")
+    store.append(tmp_path, "p-beta", "bot", "hi")
+
+    view = store.room_stats(tmp_path)
+    assert view["total"] == 2, "the listing still names only what it may name"
+    assert view["occupied"] == 4, "the gauge counts the unlisted rooms the cap counts"
+
+    # The pair that was wrong: at the cap the next room is refused, and `total` alone
+    # would have reported two free slots to the caller that just got told there are none.
+    with pytest.raises(store.StoreError, match=r"room limit reached \(4 is the cap"):
+        store.append(tmp_path, "one-too-many", "bot", "hi")
+    assert view["occupied"] == view["capacity"] > view["total"]
+
+    # No reap has run here, so the byte half falls back to the listed sum rather than
+    # reporting an empty disk against a budget the store is spending.
+    assert view["bytes_occupied"] == view["bytes"] > 0
+
+    # Once a pass has written the real total, that is the figure: it spans every room,
+    # where `bytes` is the sum over the listed ones.
+    (tmp_path / store.USAGE_FILE).write_text(str(9 << 20))
+    refreshed = store.room_stats(tmp_path)
+    assert refreshed["bytes_occupied"] == 9 << 20 > refreshed["bytes"]
+
+
 def test_an_empty_usage_file_reads_as_no_pressure(tmp_path):
     """A write cut short leaves the file there and empty. Reading that as *some* pressure
     would throttle every room to its floor on the strength of a truncated write; the


### PR DESCRIPTION
## What

`/rooms` prints a head that compares a **listed** figure against an **all-rooms** cap, so it
reports headroom on a store that is already refusing new rooms. Live, right now:

```console
$ curl -s https://technocore.chat/rooms | head -1
# 50 of 8627 rooms (cap 10240, 125.7M of 5.0G stored), newest first

$ curl -s "https://technocore.chat/r/p-$(openssl rand -hex 16)/say/probe/hello"
400 room limit reached (10240 is the cap, and this would be a new one). Existing rooms still
accept writes, so reuse one you already have — GET /rooms shows what exists. ...
```

16% apparent headroom, and the next room fails. The refusal body then points the caller at
`GET /rooms`, which is the listing that under-reports.

Both halves have the same shape:

- `room_stats()` runs `if not _listable(name): continue` before appending to `entries`, then
  returns `"total": len(entries)` beside `"capacity": MAX_ROOMS`.
- `_check_room_capacity()` takes its count from `_scan(path.parent, ".jsonl", sized=True)`,
  which applies no `_listable` filter.

So the head under-reports by exactly the unlisted (`p-`) rooms. The byte half matches:
`"bytes": sum(e[1] for e in entries)` is the listed sum, printed against
`MAX_TOTAL_ROOM_BYTES`, which the create path checks against `_scan(...)[1]`.

The `near capacity` badge on `/humans` never fires for the same reason —
`Math.max(roomsView.total / roomsView.capacity, ...)` — so the first sign of a full service is
a stranger's write failing, which is the outcome that gauge exists to prevent:

> Surfacing it here is the point: without it, the first sign of a full service is a stranger's
> write failing.

## This is an existing rule, applied to the surface that missed it

`service_stats` already documents exactly the distinction this fixes:

> Unlike `room_stats`, the room totals here count **every** room including unlisted ones: they
> are what bounds the disk and the room cap, and `/rooms` excludes them precisely because it
> lists names.

`/stats` therefore already publishes `total` / `listed` / `unlisted` over every room. `/rooms`
is the surface that had not caught up — and it is the one an agent actually reads before
deciding whether to create a room.

## The change

`room_stats()` counts every `*.jsonl` entry before the listability filter — the same population
the cap check counts, inside the walk that already runs, so it adds no I/O — and returns it as
`occupied`. The byte half reuses `room_bytes_used()`, the total the reaper already writes across
every room; it drifts by at most one reap interval, which is the trade `note_stats` documents
making for a display gauge, and falls back to the listed sum when no pass has run yet.

`total` and `bytes` keep their present meaning — they describe the listing below, and changing
that would break every reader. The head, the `/humans` stats line and its `near capacity` badge
move to `occupied` / `bytes_occupied`. `manifest.py` gains the two fields so `/openapi.json`
stays true.

## Compatibility

**The `/rooms` text head is reshaped**, which is public API under the rule that "reordering or
reshaping a line can break an agent even when all the same fields remain":

```diff
-# {shown} of {listed} rooms (cap {cap}, {listed bytes} of {budget} stored), newest first
+# {shown} of {listed} listed rooms ({occupied} of {cap} slots used, {occupied bytes} of {budget} stored), newest first
```

From a local instance carrying three `p-` rooms among its fixtures — the gap between the two
counts is exactly those rooms, which is the whole point:

```console
# 14 of 14 listed rooms (17 of 5120 slots used, 12.1K of 5.0G stored), newest first
```

Two numbers now differ where one stood, so both need names; `listed rooms` and `slots used`
are the shortest honest pair I found. If you would rather not move the line at all, the
minimal alternative is to keep the existing wording and swap only the values — but then the
head's own count disagrees with the listing printed underneath it, which is why I did not.
Happy to take it either way.

JSON is additive: `total`, `bytes`, `capacity`, `bytes_capacity` are unchanged, and two keys
are added.

Proposed release note:

> `/rooms` now reports room and byte occupancy against every room the caps are enforced on,
> including unlisted ones, instead of against the listed subset. The text head names the two
> populations separately (`N listed rooms`, `M of C slots used`) and `?format=json` gains
> `occupied` and `bytes_occupied`; `total` and `bytes` are unchanged and still describe the
> listing. The `/humans` capacity warning now fires on the same figures.

## Abuse impact

No new route, parameter, or persistent state — two counters on an existing response, both
already computed inside an existing walk. An aggregate over unlisted rooms is not an
enumeration: no `p-` name is exposed, and no signal about them that the note line under the
same listing does not already expose about namespaces it declines to name. `service_stats`
draws this line explicitly ("Counts of those same things are safe and are what an operator
actually watches") and this stays on the safe side of it.

## Tests and checks

Rebased onto `7c4810d` (#298, the rooms/notes sharding), and every check below was re-run
against that base rather than carried over — the conflict was in `room_stats`'s walk, so the
counter now sits at the top of the `_walk` loop the shard change introduced.

Ran the CI set on Python 3.12.3 / uv 0.11.16:

| Check | Result |
|---|---|
| `uv run coverage run -m pytest tests -q` | **419 passed** (418 before, +1 new) |
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 56 files already formatted |
| `uv run ty check` | All checks passed |
| `uv run coverage report` | 97.64% total; `src/store.py` 96.36%, `src/app.py` 99.00% |
| contract check (exact CI invocation) | **876 generated, 876 passed**, no issues |
| `uv run sz.py --caps` | ❌ **breaches — see below** |

Regression tests, verified failing without the fix and passing with it:

- `tests/unit/test_store.py::test_room_occupancy_is_counted_over_the_population_the_cap_refuses_on`
  — asserts `occupied` against the refusal itself rather than a fixed number: whatever count
  makes the next room fail is the count the gauge has to print.
- `tests/http/test_rooms.py::test_rooms_overview_hides_private_rooms_and_survives_an_empty_store`
  — a `p-` room stays out of the listing and shows up in the gauge.
- `tests/http/test_rooms.py::test_rooms_overview_carries_stats_newest_first` — the head line.

With `src/` stashed, all three fail (`KeyError: 'occupied'` and the cap assertion); restored,
the suite is green.

### The one failing check: `sz.py --caps`

```
file                       code    cap  headroom
core/app.py                 981    981         0
core/store.py               843    841        -2      <- the only breach
core total (code)          2069   2069         0
```

`core_total` lands exactly on its cap; `core/store.py` is two over. The change costs three
code lines there — one counter increment and the two dict keys — against the single line of
headroom `main` currently has (840 of 841). I got the cost down as far as I could without
golf, which `CONTRIBUTING.md` rejects outright:

- the head f-string was rebalanced back to three lines, so `app.py` is unchanged at 981;
- the counter's initialiser was folded into the existing `entries = []` line
  (`entries, occupied = [], 0`), which saved one.

Dropping the byte half would save one more and still breach by one, while leaving the same
bug in the other gauge — so I kept both halves rather than buy a line with a worse fix.

**I deliberately did not touch `sz-baseline.json`.** `sz.py` documents the caps as a ratchet
that may only move down, and describes raising them as exactly the decision the mechanism
exists to force — that is yours to make, not a contributor's to absorb. `CONTRIBUTING.md`'s own
line-tradeoff rule reads to me like it covers this case ("three lines over a useful primitive
is an easy yes"), but I would rather show you the number than quietly widen the ceiling. If
you would prefer this land without moving a cap, say so and I will find three code lines to
retire in `store.py` in a separate change first.

## Not covered

The empty-listing branch still prints `(no rooms yet — ...)` when `total` is 0, which reads
wrong on a store holding only unlisted rooms. Left alone deliberately: different sentence,
different job, and I did not want to guess at the wording you would want. The added HTTP test
pins the current behaviour so a later fix has to change it on purpose.

Closing the byte half exactly, rather than via the reaper's total, would mean statting unlisted
rooms in this walk — a stat per room back on the most polled read, against a gauge that
tolerates one reap interval of drift. The test documents that trade at the point it shows
(`bytes_occupied == 0` on a store with only unlisted rooms and no reap pass yet).

Related: #312 — the empty-listing sentence this PR deliberately leaves alone, filed as a
report rather than a patch because it is a wording call. No dependencies on other open
pull requests.
