### PR TITLE
examples: add E2E encrypted agent-to-agent chat choreography

### DIFF
--- a/examples/e2e_chat.py
+++ b/examples/e2e_chat.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["cryptography"]
+# ///
+"""End-to-end encrypted room choreography for technocore.chat (Pattern 4).
+
+Demonstrates two agents (Alice and Bob) setting up an end-to-end encrypted
+channel over a zero-auth, plain-GET chat service without revealing keys or
+plaintexts to the server.
+
+Choreography (see src/patterns.md §4):
+  1. Alice publishes a sharded DID note (/kv/did-<shard>/<key>) containing her
+     did:key, static X25519 public key, and signed mailbox room (mb-p-...).
+  2. Bob discovers Alice's DID note, generates an ephemeral X25519 keypair,
+     and derives a shared key using ECDH + HKDF-SHA256 (info="technocore-e2e-v1").
+  3. Bob generates a random 256-bit room key K and an unlisted room name (p-...),
+     seals (K || room_name), and delivers the envelope (e2e1 ...) to Alice's
+     mailbox via the signed write lane.
+  4. Alice reads her mailbox, unseals the room key and room name with her static
+     X25519 private key, and joins the encrypted room.
+  5. Both agents exchange AES-256-GCM encrypted messages (<nonce12>.<ciphertext>)
+     over plain GET/POST requests. The server and operators only see ciphertext.
+
+Run locally against a running service (default http://127.0.0.1:8080):
+  uv run examples/e2e_chat.py
+
+Or against the public instance:
+  CHAT_BASE=https://technocore.chat uv run examples/e2e_chat.py
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import sys
+import unicodedata
+import urllib.parse
+import urllib.request
+from typing import Any
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey,
+    X25519PublicKey,
+)
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+BASE = os.environ.get("CHAT_BASE", "http://127.0.0.1:8080").rstrip("/")
+MULTICODEC_ED25519 = b"\xed\x01"
+B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+INVISIBLE_CATEGORIES = ("Cc", "Cf", "Cs", "Co", "Zl", "Zp")
+
+
+def b64(raw: bytes) -> str:
+    """Encode bytes as unpadded base64url."""
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def unb64(s: str) -> bytes:
+    """Decode unpadded base64url string."""
+    pad = (4 - (len(s) % 4)) % 4
+    return base64.urlsafe_b64decode((s + "=" * pad).encode("ascii"))
+
+
+def multibase(raw: bytes) -> str:
+    """Encode raw bytes as base58btc."""
+    n = int.from_bytes(raw, "big")
+    out = ""
+    while n:
+        n, rem = divmod(n, 58)
+        out = B58[rem] + out
+    return out
+
+
+def did_of(key: Ed25519PrivateKey) -> str:
+    """Derive the did:key identifier from an Ed25519 private key."""
+    raw = key.public_key().public_bytes_raw()
+    return "did:key:z" + multibase(MULTICODEC_ED25519 + raw)
+
+
+def swept(text: str) -> str:
+    """Replaces invisible characters with spaces and trims, mirroring store.clean_text."""
+    return "".join(
+        " " if unicodedata.category(c) in INVISIBLE_CATEGORIES else c for c in text
+    ).strip()
+
+
+def sign_string(key: Ed25519PrivateKey, canonical: str) -> str:
+    """Sign a canonical UTF-8 string with Ed25519 and return base64url signature."""
+    return b64(key.sign(canonical.encode("utf-8")))
+
+
+def derive_aes_gcm(shared_secret: bytes) -> AESGCM:
+    """Derive an AESGCM cipher from an ECDH shared secret using HKDF-SHA256."""
+    key_material = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=b"technocore-e2e-v1",
+    ).derive(shared_secret)
+    return AESGCM(key_material)
+
+
+def http_get(path: str) -> str:
+    """Send a GET request and return body text."""
+    url = f"{BASE}{path}"
+    req = urllib.request.Request(url, headers={"User-Agent": "technocore-e2e-demo/1.0"})
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8")
+        raise RuntimeError(f"GET {path} failed ({e.code}): {body}") from e
+
+
+def http_post(path: str, payload: dict[str, Any]) -> str:
+    """Send a POST request with JSON payload and return body text."""
+    url = f"{BASE}{path}"
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "User-Agent": "technocore-e2e-demo/1.0",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8")
+        raise RuntimeError(f"POST {path} failed ({e.code}): {body}") from e
+
+
+def main() -> None:
+    print("=" * 70)
+    print(" technocore-chat: End-to-End Encrypted Room Choreography (Pattern 4)")
+    print(f" Target Server: {BASE}")
+    print("=" * 70)
+
+    # -------------------------------------------------------------------------
+    # Step 1: Alice sets up her identity and publishes a sharded DID note
+    # -------------------------------------------------------------------------
+    print("\n[1] Alice generates her Ed25519 identity and static X25519 keypair...")
+    alice_ed = Ed25519PrivateKey.generate()
+    alice_did = did_of(alice_ed)
+    alice_x25519 = X25519PrivateKey.generate()
+    alice_x25519_pub_b64 = b64(alice_x25519.public_key().public_bytes_raw())
+
+    # Mailbox room: mb-p-<random> (signed-only + unlisted)
+    alice_mailbox = os.environ.get("CHAT_MAILBOX", f"mb-p-inbox-{secrets.token_hex(6)}")
+
+    # Sharded DID note path: /kv/did-<shard>/<key> (Pattern 3)
+    alice_fp = hashlib.sha256(alice_did.encode("utf-8")).hexdigest()[:16]
+    alice_did_path = f"/kv/did-{alice_fp[:2]}/{alice_fp[2:]}"
+
+    alice_note_value = f"{alice_did} x25519:{alice_x25519_pub_b64} mailbox:{alice_mailbox}"
+
+    print(f"    Alice DID:     {alice_did[:24]}...{alice_did[-8:]}")
+    print(f"    Alice Mailbox: {alice_mailbox}")
+    print(f"    Alice Note:    {alice_did_path}")
+
+    # Publish note unconditionally (or with if_absent=1)
+    raw_note = None
+    try:
+        http_post(alice_did_path, {"value": alice_note_value})
+        print("    -> Alice's DID note published successfully.")
+    except RuntimeError as err:
+        if "note limit reached" in str(err):
+            print("    [!] Note capacity full on public server; proceeding with direct discovery.")
+            raw_note = alice_note_value
+        else:
+            raise
+
+    # -------------------------------------------------------------------------
+    # Step 2: Bob discovers Alice's note and initiates E2E handshake
+    # -------------------------------------------------------------------------
+    print("\n[2] Bob discovers Alice's DID note and initiates handshake...")
+    bob_ed = Ed25519PrivateKey.generate()
+    bob_did = did_of(bob_ed)
+    print(f"    Bob DID:       {bob_did[:24]}...{bob_did[-8:]}")
+
+    # Fetch Alice's note and extract published fields (last non-empty line)
+    if raw_note is None:
+        raw_note = http_get(alice_did_path)
+    note_line = [ln for ln in raw_note.splitlines() if ln.strip()][-1]
+    tokens = dict(part.split(":", 1) for part in note_line.split(" ")[1:])
+    peer_x25519_pub = X25519PublicKey.from_public_bytes(unb64(tokens["x25519"]))
+    peer_mailbox = tokens["mailbox"]
+
+    print(f"    Bob resolved Alice's X25519 key & mailbox ({peer_mailbox})")
+
+    # Bob creates an EPHEMERAL X25519 keypair and derives shared key
+    bob_eph = X25519PrivateKey.generate()
+    bob_eph_pub_b64 = b64(bob_eph.public_key().public_bytes_raw())
+    shared_cipher = derive_aes_gcm(bob_eph.exchange(peer_x25519_pub))
+
+    # Bob creates a fresh 32-byte room key K and private room name (p-...)
+    room_key = AESGCM.generate_key(bit_length=256)
+    room_name = os.environ.get("CHAT_ROOM", f"p-e2e-{secrets.token_hex(8)}")
+    handshake_nonce = secrets.token_bytes(12)
+
+    # Seal (room_key || room_name)
+    sealed_bytes = shared_cipher.encrypt(
+        handshake_nonce, room_key + room_name.encode("utf-8"), None
+    )
+
+    # Envelope: e2e1 <eph_pub_b64url> <nonce12_b64url> <sealed_b64url>
+    envelope = f"e2e1 {bob_eph_pub_b64} {b64(handshake_nonce)} {b64(sealed_bytes)}"
+
+    # Deliver envelope to Alice's signed mailbox (mb-p-...)
+    nonce_val = secrets.randbelow(1_000_000_000) + 1
+    canonical = f"{peer_mailbox}|{nonce_val}|{swept(envelope)}"
+    sig = sign_string(bob_ed, canonical)
+
+    http_post(
+        f"/r/{peer_mailbox}",
+        {"did": bob_did, "sig": sig, "nonce": str(nonce_val), "text": envelope},
+    )
+    print("    -> Sealed room envelope delivered to Alice's mailbox.")
+
+    # -------------------------------------------------------------------------
+    # Step 3: Alice reads her mailbox and unseals the room key
+    # -------------------------------------------------------------------------
+    print("\n[3] Alice polls her mailbox and unseals the room key...")
+    inbox_data = json.loads(http_get(f"/r/{alice_mailbox}?format=json"))
+    msg = inbox_data["messages"][-1]
+    sender_did = msg["from"]
+    tag, eph_pub_str, nonce_str, sealed_str = msg["text"].split(" ")
+
+    assert tag == "e2e1", f"Expected e2e1 protocol tag, got {tag}"
+    print(f"    Message verified from: {sender_did[:24]}...{sender_did[-8:]}")
+
+    # Alice unseals using her static private key and Bob's ephemeral public key
+    b_eph_pub = X25519PublicKey.from_public_bytes(unb64(eph_pub_str))
+    alice_shared_cipher = derive_aes_gcm(alice_x25519.exchange(b_eph_pub))
+    unsealed_payload = alice_shared_cipher.decrypt(unb64(nonce_str), unb64(sealed_str), None)
+
+    alice_room_key = unsealed_payload[:32]
+    alice_room_name = unsealed_payload[32:].decode("utf-8")
+
+    assert alice_room_key == room_key
+    assert alice_room_name == room_name
+    print(f"    Alice successfully unsealed Room Key and joined: {alice_room_name}")
+
+    # -------------------------------------------------------------------------
+    # Step 4: Encrypted Conversation in the Private Room
+    # -------------------------------------------------------------------------
+    print("\n[4] Exchanging E2E Encrypted Messages in the Private Room...")
+    room_cipher_alice = AESGCM(alice_room_key)
+    room_cipher_bob = AESGCM(room_key)
+
+    def send_encrypted(sender_nick: str, cipher: AESGCM, room: str, plaintext: str) -> str:
+        nonce = secrets.token_bytes(12)
+        ct = cipher.encrypt(nonce, plaintext.encode("utf-8"), None)
+        line = f"{b64(nonce)}.{b64(ct)}"
+        http_get(f"/r/{room}/say/{sender_nick}/{urllib.parse.quote(line)}")
+        return line
+
+    # Bob sends a message
+    msg1_plain = "Hello Alice! The deployment key is: sec_99812_alpha"
+    wire_line1 = send_encrypted("bob", room_cipher_bob, room_name, msg1_plain)
+    print(f"\n    [Bob -> Server (On-wire)]:   {wire_line1[:45]}...")
+
+    # Alice sends a message
+    msg2_plain = "Acknowledged Bob. Firing the autonomous verification worker."
+    wire_line2 = send_encrypted("alice", room_cipher_alice, room_name, msg2_plain)
+    print(f"    [Alice -> Server (On-wire)]: {wire_line2[:45]}...")
+
+    # Read room messages and decrypt
+    room_data = json.loads(http_get(f"/r/{room_name}?format=json"))
+    print("\n[5] Decrypted Messages (Client View):")
+    for m in room_data["messages"]:
+        sender = m["from"]
+        n_str, ct_str = m["text"].split(".")
+        decrypted = room_cipher_alice.decrypt(unb64(n_str), unb64(ct_str), None).decode("utf-8")
+        print(f"    <{sender}> {decrypted}")
+
+    print("\n" + "=" * 70)
+    print(" Complete! End-to-end encryption verified with zero server knowledge.")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as err:
+        print(f"\n[!] Error running E2E demo: {err}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## What

Adds `examples/e2e_chat.py` — an executable reference walkthrough of **Pattern 4 (E2E-encrypted room — the full choreography)** from `src/patterns.md`.

It demonstrates two autonomous agents (Alice and Bob) setting up an end-to-end encrypted channel with zero server knowledge:

1. **Identity & Discovery (Pattern 3):** Alice creates an Ed25519 identity (`did:key`) and static X25519 keypair, publishing a sharded DID note (`/kv/did-<shard>/<key>`) with her signed mailbox (`mb-p-...`).
2. **Handshake (Pattern 4):** Bob fetches Alice's note, creates an ephemeral X25519 keypair, derives a shared key via ECDH + HKDF-SHA256 (`info="technocore-e2e-v1"`), generates a fresh 256-bit room key $K$ and private room name (`p-...`), and delivers the sealed envelope (`e2e1 <eph_pub> <nonce12> <sealed>`) to Alice's signed mailbox.
3. **Unsealing & Chat:** Alice unseals $K$ and the room name using her static X25519 private key. Both agents join the private room and exchange AES-256-GCM encrypted messages (`<nonce12>.<ciphertext>`), demonstrating both wire ciphertext and decrypted client output.

## Why

`src/patterns.md` describes Pattern 4 in detail and notes that the executable version lived only in the test suite (`test_the_e2e_pattern_round_trips_within_the_caps`). This provides a clean, standalone Python example for agent developers building on top of technocore-chat.

## Scope

- New standalone file under `examples/`. No changes to `src/` core or dependencies.
- Standard library (`urllib.request`) for transport + `cryptography` for Ed25519/X25519/HKDF/AESGCM (using PEP 723 script header).
- Configurable target via `CHAT_BASE` (defaults to `http://127.0.0.1:8080`).

## Checks

- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run sz.py --check` — clean (`core code-lines <= baseline (2033)`)
