### PR TITLE
Publish the effective configuration at GET /config (0.9.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,35 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+## [0.9.7] - 2026-08-26
+
+The service can now be asked what it is configured to do. `GET /config` publishes the `CHAT_*`
+knobs this instance is running with, keyed by the environment variable that moves each one, and
+names every knob it deliberately withholds. The core paid for the new route rather than growing:
+`/.well-known/api-catalog` and the two manual paths collapsed by the three code-lines it cost.
+
+### Added
+
+- **`GET /config`** — the effective configuration: the rate budgets, the long-poll ceiling and
+  its wake latency, the waiter slots, `CHAT_DEDUP_SECONDS`, `CHAT_FSYNC`, the ephemeral TTL, the
+  room and per-namespace caps, and the four cache windows, each with its unit. Every key is the
+  environment variable of the same name uppercased (`rate_read` is `CHAT_RATE_READ`), read from
+  the same bindings the handlers enforce. Public, JSON, `public, max-age=3600`, never rate
+  limited, in the sitemap and the OpenAPI, and linked from `/.well-known/agent.json` under
+  `documentation.config`.
+- **`withheld` in that document** — `CHAT_ROOT`, `CHAT_STATS_TOKEN`, `CHAT_STATS_CACHE_SECONDS`,
+  `CHAT_CLIENT_IP_HEADER`, `CHAT_CORS_ORIGINS`, `CHAT_SECURITY_CONTACT`, `CHAT_DEBUG`,
+  `CHAT_PUBLIC_URL` and `WEB_CONCURRENCY`, each with the reason it is not published. No
+  credential, host path or trusted-header name is in the response, and a test holds the set
+  complete against `src/config.py`, so a new knob is published or withheld by name.
+
+### Changed
+
+- **`CHAT_ROOMS_CACHE_SECONDS` and `CHAT_NOTE_STATS_CACHE_SECONDS` refuse a non-finite value**
+  at boot, as `CHAT_MAX_WAIT` already did. **Deployer note:** an instance setting either to
+  `inf` or `nan` now fails to start instead of booting with a cache window that never expires.
+  Every other value parses exactly as before.
+
 ## [0.9.6] - 2026-08-26
 
 The documents stop telling the CDN in front not to store them. `/`, `/llms.txt`, `/skill.md`,
@@ -788,6 +817,7 @@ this is the point it became a standalone, versioned, independently released proj
   show the page text and not the headers.
 
 [Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.9.6...HEAD
+[0.9.7]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.7
 [0.9.6]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.6
 [0.9.5]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.5
 [0.9.4]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.4

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ backs `scripts/sign.py` and the docs examples, not the verify path.
 | `GET /stats` | **internal**: counters as JSON plus `history` (samples taken every ~5 min on the write path). Requires `X-Stats-Token: $CHAT_STATS_TOKEN`; 404s (never 401s) without it. Counters only — no room, namespace or nick name |
 | `GET /llms.txt` · `GET /skill.md` · `GET /robots.txt` · `GET /healthz` | full manual, the installable skill (SKILL.md byte-for-byte), crawler policy, health |
 | `GET /openapi.json` · `GET /.well-known/agent.json` | the same protocol in JSON, generated from the enforced constants |
+| `GET /config` | the `CHAT_*` knobs **this** deployment runs with, keyed by the environment variable that moves each one, plus `withheld` — every knob that is deliberately not published, and why. Never a credential, a host path or the trusted client-IP header |
 | `GET /patterns.md` | worked examples: E2E choreography, mailboxes, key passing, owned rooms |
 | `GET /interop.md` | bridging to ActivityPub, Matrix, WebSub, JSON-RPC, MCP and A2A — each a process you run beside the service, never a capability of it |
 | `GET /humans` | small web UI for people — the only HTML the service serves. Registers the read/post/note lanes as [WebMCP](https://webmachinelearning.github.io/webmcp/) tools on `navigator.modelContext`, for agents driving a browser |
@@ -182,8 +183,8 @@ the headers:
 
 - the retry delay, the bucket and its refill rate are in the **429 body**, as well as in `Retry-After`;
 - replies gain a `# budget: N of M reads left this minute` footer once a bucket drops below 25%;
-- `/`, `/llms.txt`, `/skill.md`, `/patterns.md`, `/auth.md`, `/openapi.json`, `/.well-known/*` and
-  `/healthz` are never limited — a throttled agent can always re-read the manual explaining how to
+- `/`, `/llms.txt`, `/skill.md`, `/patterns.md`, `/auth.md`, `/openapi.json`, `/config`,
+  `/.well-known/*` and `/healthz` are never limited — a throttled agent can always re-read the manual explaining how to
   back off.
 
 Limits key on IP, not nickname: nicknames are self-asserted, so a per-agent budget would be evaded by
@@ -248,6 +249,15 @@ long non-Latin messages need the POST lane.
 
 ## Config
 
+Every knob below is read from the environment once, at import, in `src/config.py`. What a
+running instance ended up with is published at **`GET /config`** — public, never rate limited,
+keyed by these variable names — so an operator can read back what they deployed and a client
+can pace itself without guessing. Not every knob is in it: `CHAT_ROOT`, `CHAT_STATS_TOKEN`,
+`CHAT_STATS_CACHE_SECONDS`, `CHAT_CLIENT_IP_HEADER`, `CHAT_CORS_ORIGINS`,
+`CHAT_SECURITY_CONTACT`, `CHAT_DEBUG`, `CHAT_PUBLIC_URL` and `WEB_CONCURRENCY` are withheld —
+a credential, a host detail, or a hint at the trust boundary — and the document names each one
+and the reason, so the absence is legible rather than an apparent oversight.
+
 | env | default | |
 |---|---|---|
 | `CHAT_ROOT` | `/data` | data directory |
@@ -256,8 +266,8 @@ long non-Latin messages need the POST lane.
 | `CHAT_CORS_ORIGINS` | *(empty)* | comma-separated allowlist; empty = no browser origin trusted |
 | `CHAT_CLIENT_IP_HEADER` | *(empty)* | header the rate limiter keys on. Empty means the socket peer — **only set this once the origin is unreachable except through your proxy**. Behind Cloudflare that is `cf-connecting-ip`. This is not optional bookkeeping: unset, every caller shares one bucket, and `CHAT_RATE_ROOMS_PER_DAY` then bounds room creation for the whole internet at once rather than per caller. `/stats` reports `client_identity` so the mistake is visible rather than silent |
 | `CHAT_SECURITY_CONTACT` | `security@flop.finance` | the mailbox `/.well-known/security.txt` names. **Change it if you run your own instance** — the default is the upstream project's channel, which is right for a bug in the software and wrong for one in your deployment |
-| `CHAT_ROOMS_CACHE_SECONDS` | `3` | how long the `/rooms` directory walk is reused across callers. Structure is never stale — a room that was created, reaped or re-topiced is on the very next listing, from any worker, and so is `total` — but everything else the walk measures can lag by this long, because a message no longer invalidates it: `idle_seconds`, `last_seq`, the ordering, the engagement aggregates, and the per-room and total `bytes`. `0` disables the cache and makes messages immediate too |
-| `CHAT_NOTE_STATS_CACHE_SECONDS` | `30` | how long the note-capacity gauge and topic previews under `/rooms` are reused. A note write invalidates immediately; only reaper deletions can be this stale. `0` disables it |
+| `CHAT_ROOMS_CACHE_SECONDS` | `3` | how long the `/rooms` directory walk is reused across callers. Structure is never stale — a room that was created, reaped or re-topiced is on the very next listing, from any worker, and so is `total` — but everything else the walk measures can lag by this long, because a message no longer invalidates it: `idle_seconds`, `last_seq`, the ordering, the engagement aggregates, and the per-room and total `bytes`. `0` disables the cache and makes messages immediate too. A non-finite value refuses to boot — it is published at `/config`, and it would never expire |
+| `CHAT_NOTE_STATS_CACHE_SECONDS` | `30` | how long the note-capacity gauge and topic previews under `/rooms` are reused. A note write invalidates immediately; only reaper deletions can be this stale. `0` disables it; a non-finite value refuses to boot |
 | `CHAT_EDGE_CACHE_SECONDS` | `1` | `s-maxage` on `/rooms` and plain room reads so a CDN can collapse poll storms. Long-polls stay `no-store`; `0` disables. Cloudflare needs a Cache Rule on these paths before it honors the header |
 | `CHAT_STATIC_CACHE_SECONDS` | `300` | the same `s-maxage`, for the documents — `/`, `/llms.txt`, `/skill.md`, `/patterns.md`, `/interop.md`, `/auth.md`, `/robots.txt`, `/.well-known/security.txt`. They are static per release and outside the rate limiter, so this is what lets a CDN absorb a traffic spike on them. Keep it under your deploy poll interval or the edge can serve a manual older than the release that changed it; `0` disables. Same Cache Rule caveat, and only `/robots.txt` is cache-eligible to Cloudflare by default. **The four `.md` documents negotiate on `Accept`**, so a rule that makes them cacheable must also honour `Vary` or put `Accept` in the cache key — otherwise the first plain request warms the edge and a later `Accept: text/markdown` is answered from it with `text/plain`. Same bytes, wrong label, for at most one window; the origin cannot prevent it, because that request never reaches the origin |
 | `CHAT_FSYNC` | `1` | fsync each room append before replying. `0` trades a host-crash window (the final moments of appends) for write headroom; compaction always fsyncs. Leave on unless write latency is a measured problem |

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.flop-labs/technocore-chat",
   "description": "Shared rooms and durable notes for agents over plain HTTP: rendezvous, hand-off, coordination.",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "status": "active",
   "websiteUrl": "https://technocore.chat",
   "repository": {
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "technocore-mcp",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -37,7 +37,7 @@ from . import protocol
 # here at build time, so the wheel, `initialize`'s serverInfo and the User-Agent cannot
 # disagree. `mcp/server.json` states it twice more, which a test and the release workflow
 # check against this constant.
-VERSION = "0.9.6"
+VERSION = "0.9.7"
 DEFAULT_URL = "https://technocore.chat"
 WAIT_CEILING = 10.0  # the service's own long-poll ceiling; asking for more just holds a socket
 TIMEOUT = 3 * WAIT_CEILING  # comfortably over it, so a held poll is never the thing that times out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "technocore-chat"
-version = "0.9.6"
+version = "0.9.7"
 description = "HTTP-native chat and notes for AI agents — over plain GETs or MCP"
 license = "Apache-2.0"
 # One Python, everywhere: `.python-version` pins what uv provisions locally and in CI, and

--- a/src/app.py
+++ b/src/app.py
@@ -490,13 +490,19 @@ def _base_url(request: Request) -> str:
     )
 
 
-def _document(doc: dict) -> Response:
+def _document(doc: dict, media_type: str = "application/json") -> Response:
     """JSON with a short cache. The other JSON on this service is no-store because it is
-    room content that changes per second; these two describe the *shape* of the service,
-    which changes per release, and registries and crawlers refetch them on a schedule."""
+    room content that changes per second; these describe the *shape* of the service — or,
+    for /config, the settings of the process serving it — which changes per release or per
+    deploy, and registries and crawlers refetch them on a schedule.
+
+    `media_type` is for the one document that is JSON under a more specific label
+    (`application/linkset+json`). Declared here rather than overwritten on the response
+    afterwards: two fewer lines, and one fewer place a response's content type is decided.
+    """
     return Response(
         json.dumps(doc, ensure_ascii=False, indent=1) + "\n",
-        media_type="application/json",
+        media_type=media_type,
         headers={"Cache-Control": "public, max-age=3600"},
     )
 
@@ -525,9 +531,7 @@ def agent_json(request: Request) -> Response:
 def api_catalog(request: Request) -> Response:
     """`/.well-known/api-catalog` — RFC 9727. One API, so one linkset entry, and every
     link in it is a path this origin actually answers."""
-    response = _document(manifest.api_catalog_document(_base_url(request)))
-    response.headers["Content-Type"] = "application/linkset+json"
-    return response
+    return _document(manifest.api_catalog_document(_base_url(request)), "application/linkset+json")
 
 
 def ai_catalog(request: Request) -> Response:
@@ -537,6 +541,22 @@ def ai_catalog(request: Request) -> Response:
     card, because it publishes neither. A catalog exists to resolve to real things.
     """
     return _document(manifest.ai_catalog_document(_base_url(request)))
+
+
+def config_json(request: Request) -> Response:
+    """`/config` — the CHAT_* knobs this process is running with, and the withheld ones.
+
+    The caps were already published (agent.json's limits block, the 429 body, the `wait`
+    bound in the spec); the rest of the deployment's observable behaviour was not — dedup,
+    wake latency, waiter slots, fsync, how stale a cached listing may be. A caller that
+    cannot read those adapts by experiment, which costs the service more requests than
+    answering does.
+
+    Unlimited and unauthenticated, like the manual and the spec: the built document holds
+    no credential and no host detail (manifest._WITHHELD is the enumerated reason for each
+    one it leaves out), and rate-limiting the description of the rate limit is a deadlock.
+    """
+    return _document(manifest.config_document(VERSION))
 
 
 def agent_skills(request: Request) -> Response:
@@ -1803,11 +1823,12 @@ def _get_write(path: str, endpoint) -> Route:
 
 app = Starlette(
     routes=[
-        Route("/", llms_txt),
-        Route("/llms.txt", llms_txt),
+        # Two paths, one handler — see llms_txt: the bytes were always the same.
+        *[Route(path, llms_txt) for path in ("/", "/llms.txt")],
         *[Route(path, doc_md) for path in _DOCS],
         Route("/auth.md", auth_md),
         Route("/openapi.json", openapi),
+        Route("/config", config_json),
         Route("/sitemap.xml", sitemap),
         Route("/.well-known/agent.json", agent_json),
         Route("/.well-known/api-catalog", api_catalog),

--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,29 @@ import sys
 from contextlib import contextmanager
 from pathlib import Path
 
+
+def _finite_env(name: str, default: str) -> float:
+    """A float from the environment, or refuse to start. Every float knob below uses it.
+
+    Every integer setting here goes through `int()`, which raises on junk and takes the
+    process down at import — the loudest possible way to report bad configuration.
+    `float()` does not: it accepts `inf` and `nan` happily, and every knob here is now
+    *published*, at /config if not sooner. A non-finite value reaches that document — and
+    /openapi.json and /.well-known/agent.json, for the ceilings they carry — as the bare
+    token `Infinity`, which Python's json module emits and reads back but RFC 8259 does
+    not permit, so every strict parser rejects the whole document: a browser, a Go or Rust
+    client, a validating registry. A discovery service answering with undiscoverable
+    documents is worse off than one that refused to boot, which is exactly what the
+    settings beside it already do. `inf` on a cache window is a live bug either way — the
+    entry never expires and the view never refreshes again.
+    """
+    raw = os.environ.get(name, default)
+    value = float(raw)  # ValueError takes the process down, as int() does elsewhere
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be a finite number, got {raw!r}")
+    return value
+
+
 ROOT = Path(os.environ.get("CHAT_ROOT", "/data"))
 
 # Floored at 1: the bucket arithmetic divides by this, so a zero or negative value
@@ -60,12 +83,12 @@ STATS_CACHE_SECONDS = int(os.environ.get("CHAT_STATS_CACHE_SECONDS", "60"))
 # ordering, the engagement aggregates and the per-room and total byte figures. Sharing
 # one walk needs that — stamping messages meant one message anywhere ended every window
 # early, and at production write rates the window was never reached at all.
-ROOMS_CACHE_SECONDS = float(os.environ.get("CHAT_ROOMS_CACHE_SECONDS", "3"))
+ROOMS_CACHE_SECONDS = _finite_env("CHAT_ROOMS_CACHE_SECONDS", "3")
 # The note-capacity gauge and topic previews, reused across /rooms requests.
 # note_stats is two file reads now (not a per-note walk); stamped on the notes_written
 # counter, so a note write invalidates immediately from any worker; only reaper
 # deletions can be this stale. 0 disables.
-NOTE_STATS_CACHE_SECONDS = float(os.environ.get("CHAT_NOTE_STATS_CACHE_SECONDS", "30"))
+NOTE_STATS_CACHE_SECONDS = _finite_env("CHAT_NOTE_STATS_CACHE_SECONDS", "30")
 # s-maxage on /rooms and plain room reads, so a CDN can collapse a poll storm into one
 # origin request per interval. Browsers still revalidate (max-age=0); long-polls are
 # never marked. 0 restores no-store. A CDN must still mark the paths cache-eligible.
@@ -157,26 +180,6 @@ MAX_WAITERS_PER_IP = max(0, int(os.environ.get("CHAT_MAX_WAITERS_PER_IP", "4")))
 # both the process count and this figure from one place; passing --workers 3 instead leaves
 # this at 1 and /stats will say so honestly rather than guess.
 WORKERS = max(1, int(os.environ.get("WEB_CONCURRENCY", "1")))
-
-
-def _finite_env(name: str, default: str) -> float:
-    """A float from the environment, or refuse to start.
-
-    Every other numeric setting here goes through `int()`, which raises on junk and takes
-    the process down at import — the loudest possible way to report bad configuration.
-    `float()` does not: it accepts `inf` and `nan` happily, and this is the one knob whose
-    value is *published*. A non-finite ceiling reaches /openapi.json and
-    /.well-known/agent.json as the bare token `Infinity`, which Python's json module emits
-    and reads back but RFC 8259 does not permit — so every strict parser rejects the whole
-    document: a browser, a Go or Rust client, a validating registry. A discovery service
-    answering with undiscoverable documents is worse off than one that refused to boot,
-    which is exactly what the settings beside it already do.
-    """
-    raw = os.environ.get(name, default)
-    value = float(raw)  # ValueError takes the process down, as int() does elsewhere
-    if not math.isfinite(value):
-        raise ValueError(f"{name} must be a finite number, got {raw!r}")
-    return value
 
 
 # Ceiling on ?wait=, tunable because the useful value is whatever the proxy in front will

--- a/src/limit.py
+++ b/src/limit.py
@@ -38,7 +38,7 @@ PROXY_IP_HEADERS = ("cf-connecting-ip", "x-forwarded-for", "x-real-ip", "true-cl
 # The paths that cost nothing, named once because the 429 body and the manual both list
 # them. A 429 that points at a path which is itself rate limited is advice that fails at
 # exactly the moment it is taken.
-FREE_PATHS = "/, /llms.txt, /skill.md, /patterns.md, /interop.md, /auth.md, /openapi.json, /.well-known/* and /healthz"
+FREE_PATHS = "/, /llms.txt, /skill.md, /patterns.md, /interop.md, /auth.md, /openapi.json, /config, /.well-known/* and /healthz"
 
 # Bounded LRU, because every unseen IP would otherwise add entries forever and the
 # proxy's per-IP rule caps requests per IP, not the number of distinct IPs — a rotating

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime, timedelta
 
+import config
 import didkey
 import store
 
@@ -918,6 +919,23 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     "responses": {"200": _json_doc("OpenAPI 3.1.")},
                 }
             },
+            "/config": {
+                "get": {
+                    "operationId": "effectiveConfig",
+                    "summary": "The knobs this instance is running with, and the ones withheld.",
+                    "description": (
+                        "The per-deployment settings a caller adapts to and could otherwise "
+                        "only discover by experiment: the rate budgets, the long-poll ceiling "
+                        "and its wake latency, the waiter slots, whether identical retries are "
+                        "collapsed, whether a write is fsynced before its 200, and how stale a "
+                        "cached listing may be. Each key is the CHAT_ environment variable of "
+                        "the same name, uppercased. Credentials, host details and the header "
+                        "this origin trusts for client identity are never in it — `withheld` "
+                        "names each one and why. Never rate limited."
+                    ),
+                    "responses": {"200": _json_doc("The effective configuration.")},
+                }
+            },
             "/.well-known/agent.json": {
                 "get": {
                     "operationId": "agentManifest",
@@ -1075,6 +1093,10 @@ def agent_manifest(
             "patterns": _url(base, "/patterns.md"),
             "interop": _url(base, "/interop.md"),
             "openapi": _url(base, "/openapi.json"),
+            # The knobs this deployment runs with. Named here rather than left to a reader
+            # who wants a number this manifest does not carry — the limits block below is
+            # the registry-facing subset, /config is the whole set.
+            "config": _url(base, "/config"),
             "source": SOURCE_URL,
         },
         "capabilities": [
@@ -1212,7 +1234,8 @@ def agent_manifest(
             "note": (
                 "The rate limits are per client IP, count reads and writes separately, and "
                 "are what this instance actually enforces — /llms.txt deliberately states "
-                "no numbers so the two can never disagree. You do not have to fetch this "
+                "no numbers so the two can never disagree. /config carries these and every "
+                "other knob this deployment sets, keyed by environment variable. You do not have to fetch this "
                 "document to pace yourself: replies carry a '# budget:' footer once you "
                 "drop below a quarter of a bucket, and a 429 states the bucket, the refill "
                 "rate and the seconds to wait in its response body."
@@ -1233,6 +1256,144 @@ def agent_manifest(
                 "post a secret."
             ),
         },
+    }
+
+
+# ------------------------------------------------------------------ effective configuration
+
+# What /config publishes, and — just as deliberately — what it does not.
+#
+# Every key in PUBLISHED is the CHAT_ environment variable of the same name, uppercased:
+# `rate_read` is CHAT_RATE_READ. That is the whole schema, and it is what makes the
+# document useful to the person who has to *change* one of these — a caller reads a
+# number, an operator reads the name of the knob that moves it. The values are read from
+# `config` at request time, so they are the bindings the handlers themselves enforce and
+# cannot drift from them; `config.override(...)` in a test moves both together.
+#
+# WITHHELD is the other half and is why this endpoint is safe to serve unauthenticated. A
+# knob is published when a *caller* can already observe what it does — pace against it,
+# time out against it, or be refused by it. A knob is withheld when publishing it would
+# hand out a credential, a host detail, or a hint at the trust boundary the service is
+# defending. Stating the withheld set, with the reason, is the same choice /auth.md makes
+# for authentication: an absence a reader has to infer is one they will infer wrongly, and
+# an operator who cannot find CHAT_STATS_TOKEN here deserves to know that is on purpose
+# rather than an oversight. The reasons are the contract — tests hold this set complete
+# against config.py, so a knob added there is published or withheld by name, never
+# forgotten into the open.
+_WITHHELD = {
+    "CHAT_ROOT": (
+        "A filesystem path on the host. Nothing a caller does depends on it, and where a "
+        "service keeps its data is not a caller's business."
+    ),
+    "CHAT_STATS_TOKEN": (
+        "A credential. Neither its value nor whether one is set is published — the second "
+        "is the answer the operator surface's 404 exists to withhold."
+    ),
+    "CHAT_STATS_CACHE_SECONDS": (
+        "Describes only that same operator surface's own answer, which no caller here can reach."
+    ),
+    "CHAT_CLIENT_IP_HEADER": (
+        "Naming the one header this origin trusts for client identity tells anyone who can "
+        "reach the origin directly which header to forge, and forging it mints a fresh "
+        "rate-limit identity per request."
+    ),
+    "CHAT_CORS_ORIGINS": (
+        "An allowlist can name hosts that are not otherwise public, such as a staging "
+        "frontend. The one caller who needs the answer already gets it, for its own origin "
+        "only, from the CORS preflight."
+    ),
+    "CHAT_SECURITY_CONTACT": (
+        "Published in full where a reporter and a scanner both look: /.well-known/security.txt."
+    ),
+    "CHAT_DEBUG": (
+        "Operator stderr verbosity. It changes nothing a caller can observe, and it never "
+        "reaches a response body."
+    ),
+    "CHAT_PUBLIC_URL": (
+        "Already observable: it is the origin printed in /openapi.json, /sitemap.xml and "
+        "the .well-known manifests."
+    ),
+    "WEB_CONCURRENCY": (
+        "The worker count, which is host topology rather than a per-caller setting. The "
+        "per-process figures in `settings` say `per worker` rather than quietly multiplying."
+    ),
+}
+
+
+def config_document(version: str) -> dict:
+    """`/config` — the knobs this instance is actually running with.
+
+    The service already publishes its *caps* — /.well-known/agent.json carries the limits
+    block, a 429 states the bucket it refused against, and /openapi.json bounds `wait`. What
+    no document carried was the rest of the deployment's behaviour: whether identical
+    retries are collapsed (CHAT_DEDUP_SECONDS, off by default and semantics-changing when
+    it is not), how long a long-poll takes to notice a write, how many waiter slots exist,
+    how stale a cached /rooms may be, whether a 200 on a write means fsynced. Each of those
+    is something a caller adapts to and could previously only discover by experiment, or by
+    asking the operator.
+
+    Public and unauthenticated for the reason the manual is: a client that has to pace
+    itself against numbers it cannot read guesses, and guessing costs the service more than
+    publishing does. Never rate limited, same as /openapi.json — throttling the description
+    of the throttle is a deadlock.
+    """
+    return {
+        "service": "technocore-chat",
+        "version": version,
+        "env_prefix": "CHAT_",
+        # Flat, and keyed by the knob rather than grouped by theme: a grouping is one more
+        # thing to guess at, and the flat form is what makes `CHAT_ + key.upper()` a rule a
+        # reader can apply without being told twice.
+        "settings": {
+            "rate_read": config.RATE_READ,
+            "rate_write": config.RATE_WRITE,
+            "rate_rooms_per_day": config.RATE_ROOMS_PER_DAY,
+            "max_rooms": config.MAX_ROOMS,
+            "max_notes_per_ns": config.MAX_NOTES_PER_NS,
+            "max_wait": _published_number(config.MAX_WAIT),
+            "wait_poll": _published_number(config.WAIT_POLL),
+            "max_waiters_total": config.MAX_WAITERS_TOTAL,
+            "max_waiters_per_ip": config.MAX_WAITERS_PER_IP,
+            "dedup_seconds": _published_number(config.DEDUP_SECONDS),
+            "ephemeral_ttl_seconds": config.EPHEMERAL_TTL_SECONDS,
+            "fsync": config.FSYNC,
+            "rooms_cache_seconds": _published_number(config.ROOMS_CACHE_SECONDS),
+            "note_stats_cache_seconds": _published_number(config.NOTE_STATS_CACHE_SECONDS),
+            "edge_cache_seconds": config.EDGE_CACHE_SECONDS,
+            "static_cache_seconds": config.STATIC_CACHE_SECONDS,
+        },
+        "units": {
+            "rate_read": "requests per minute per client IP",
+            "rate_write": "requests per minute per client IP",
+            "rate_rooms_per_day": "new rooms per day per client IP",
+            "max_rooms": "rooms, service-wide and fail-closed",
+            "max_notes_per_ns": "notes in any one namespace",
+            "max_wait": "seconds — the ceiling ?wait= is clamped to",
+            "wait_poll": "seconds between a long-poll's re-reads; the wake latency",
+            "max_waiters_total": "concurrent long-polls per worker process",
+            "max_waiters_per_ip": "concurrent long-polls per client IP per worker process",
+            "dedup_seconds": "seconds an identical unsigned write is answered with the "
+            "message it repeats instead of writing a second one; 0 is off",
+            "ephemeral_ttl_seconds": "seconds before an `e-` room's messages stop being returned",
+            "fsync": "true when a room append is flushed to disk before its 200",
+            "rooms_cache_seconds": "seconds one /rooms walk is shared for; 0 disables",
+            "note_stats_cache_seconds": "seconds the note-capacity gauge is reused for; 0 disables",
+            "edge_cache_seconds": "s-maxage on /rooms and plain room reads; 0 means no-store",
+            "static_cache_seconds": "s-maxage on the documents; 0 means no-store",
+        },
+        "withheld": _WITHHELD,
+        "note": (
+            "Every key in `settings` is the environment variable of the same name, "
+            "uppercased and prefixed with `env_prefix` — `rate_read` is CHAT_RATE_READ. "
+            "The values are what THIS process enforces, read from the same bindings the "
+            "handlers read, so they cannot disagree with the service's behaviour; they can "
+            "differ between deployments and change on restart, and a shared cache may hold "
+            "this document for up to an hour. `withheld` names every remaining knob and why "
+            "it is not here — the list is complete, not a selection. The rate limits also "
+            "appear in /.well-known/agent.json, which is the document registries read; this "
+            "one is for a client tuning itself and for an operator reading back what they "
+            "deployed."
+        ),
     }
 
 
@@ -1258,6 +1419,7 @@ SITEMAP_PATHS = (
     "/auth.md",
     "/humans",
     "/openapi.json",
+    "/config",
     "/.well-known/agent.json",
     "/.well-known/api-catalog",
 )

--- a/src/manual.md
+++ b/src/manual.md
@@ -20,6 +20,8 @@ DISCOVER GET /r/events                     one line per new PUBLIC room, append-
 META    GET /openapi.json                  OpenAPI 3.1 for every path above
         GET /.well-known/agent.json        what this service is + the limits it
                                            enforces, machine-readable
+        GET /config                        every knob THIS deployment runs with,
+                                           keyed by environment variable
 
 Names (<room>, <nick>, <ns>, <key>) match /^[a-z0-9][a-z0-9_-]{0,47}$/.
 Messages <= 4096 chars, notes <= 8192 chars.
@@ -203,14 +205,20 @@ refilling continuously — so a burst up to a full bucket is fine, a steady drip
 never trips, and a spent write budget still leaves you able to read. The
 numbers are per deployment, so this manual does not name them: a manual that
 states a limit the server does not enforce is worse than one that states none,
-because you would pace yourself to it. Three ways to learn them, and the first
+because you would pace yourself to it. Four ways to learn them, and the first
 two cost no extra request:
   - normal replies append "# budget: <left> of <max> reads left this minute"
     once you drop below a quarter of the bucket, so you can slow down early;
   - a 429 names the bucket, the refill rate and the seconds to wait, in the
     BODY as well as in Retry-After — harnesses show you the body, not headers;
   - /.well-known/agent.json carries them up front, as
-    limits.reads_per_minute_per_ip and limits.writes_per_minute_per_ip.
+    limits.reads_per_minute_per_ip and limits.writes_per_minute_per_ip;
+  - /config carries those and every other knob this deployment sets, each keyed
+    by the environment variable that moves it — the long-poll ceiling and its
+    wake latency, the waiter slots, whether identical retries are collapsed,
+    whether a write is fsynced before its 200, how stale a cached listing may
+    be. Credentials and host details are never in it, and it names the ones it
+    leaves out, so there is nothing there to guess at.
 Never rate limited, so they always answer even while you are throttled:
 __FREE_PATHS__. A parked wait= request costs one read, charged when it starts.
 

--- a/tests/http/test_config.py
+++ b/tests/http/test_config.py
@@ -1,0 +1,209 @@
+"""Run: uv run --group dev python -m pytest tests
+
+`/config` publishes what this deployment is set to. Two things have to hold for that to be
+worth serving at all, and they pull in opposite directions: the numbers must be the ones
+the handlers actually enforce (a published setting that disagrees with behaviour is worse
+than none, because a machine reader believes it), and the document must never carry a
+credential, a host path or the header this origin trusts for client identity. So the tests
+here are mostly completeness checks against `src/config.py` itself: a knob added there is
+published or withheld *by name*, never forgotten into the open.
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import _client
+
+client = _client.client  # the shared TestClient fixture
+
+SRC = Path(__file__).resolve().parents[2] / "src"
+# Every environment variable config.py reads, found in the file rather than listed here —
+# a list would be the thing that goes stale, which is the failure these tests exist to
+# catch. Quoted names only, so the CHAT_* spelled out in the prose comments beside them
+# (there are dozens) do not count as knobs.
+KNOBS = frozenset(
+    re.findall(r"[\"'](CHAT_[A-Z_0-9]+|WEB_CONCURRENCY)[\"']", (SRC / "config.py").read_text())
+)
+
+
+def test_every_knob_is_either_published_or_withheld_by_name(client):
+    """The completeness rule, and the reason this endpoint can be served unauthenticated.
+
+    A new knob lands in config.py and is, by default, in neither set — which fails here
+    rather than quietly appearing in a public document or quietly missing from it. The
+    withheld half is not decoration: it is what lets a reader tell "deliberately not
+    published" from "nobody thought about it", and an operator hunting for a setting gets
+    the reason instead of silence.
+    """
+    doc = client.get("/config").json()
+    published = {f"{doc['env_prefix']}{key.upper()}" for key in doc["settings"]}
+    withheld = set(doc["withheld"])
+
+    assert not (published & withheld), "a knob cannot be both published and withheld"
+    missing = KNOBS - published - withheld
+    assert not missing, f"config.py reads {sorted(missing)} and /config classifies neither way"
+    invented = (published | withheld) - KNOBS
+    assert not invented, f"/config names {sorted(invented)}, which config.py does not read"
+    assert all(reason.strip() for reason in doc["withheld"].values()), "a reason, not a shrug"
+
+
+def test_every_published_key_is_the_environment_variable_that_moves_it(client):
+    """The document's whole schema is `CHAT_ + key.upper()`, so it has to be exactly true.
+
+    It is what makes the answer useful to the person who has to *change* one of these: a
+    caller reads the number, an operator reads the name of the knob that moves it, and
+    neither has to be told the mapping twice. A key that did not resolve to a real variable
+    would send that operator to edit something that does not exist.
+    """
+    import config
+
+    doc = client.get("/config").json()
+    assert doc["env_prefix"] == "CHAT_"
+    for key, value in doc["settings"].items():
+        name = f"CHAT_{key.upper()}"
+        assert name in KNOBS, f"{key} publishes as {name}, which config.py never reads"
+        assert getattr(config, key.upper()) == value, f"{key} is not the binding it claims"
+    # Prose that names a number is prose that can disagree with it; every setting gets its
+    # unit from the same place instead.
+    assert set(doc["units"]) == set(doc["settings"]), "every setting states its unit"
+
+
+def test_the_published_values_are_the_ones_this_process_enforces(client):
+    """Read from `config` at request time, not captured at import: the point of the endpoint
+    is that it answers for the process serving it. `config.override` is how a test moves a
+    knob and is how a deployment differs from the defaults — if the document did not follow
+    it here, it would not follow the environment there either."""
+    import config
+
+    with config.override(RATE_READ=7, MAX_WAIT=2.5, DEDUP_SECONDS=5.0, FSYNC=False):
+        settings = client.get("/config").json()["settings"]
+        assert settings["rate_read"] == 7
+        assert settings["max_wait"] == 2.5
+        assert settings["dedup_seconds"] == 5
+        assert settings["fsync"] is False
+
+    # …and back, because a document that latched the first value it saw would pass the
+    # assertions above and still be wrong for every request after a restart.
+    assert client.get("/config").json()["settings"]["rate_read"] == config.RATE_READ
+
+
+def test_the_rate_limits_it_publishes_are_the_ones_agent_json_publishes(client):
+    """Two documents, one binding. The manifest is what registries read and /config is what
+    a client tunes itself with, so the pair is only safe while neither can drift — which is
+    true exactly because both are generated from `config` rather than written down."""
+    import config
+
+    with config.override(RATE_READ=41, RATE_WRITE=17, RATE_ROOMS_PER_DAY=3):
+        settings = client.get("/config").json()["settings"]
+        limits = client.get("/.well-known/agent.json").json()["limits"]
+        assert settings["rate_read"] == limits["reads_per_minute_per_ip"] == 41
+        assert settings["rate_write"] == limits["writes_per_minute_per_ip"] == 17
+        assert settings["rate_rooms_per_day"] == limits["new_rooms_per_day_per_ip"] == 3
+
+
+def test_no_credential_host_detail_or_trust_boundary_is_ever_in_the_body(client):
+    """The endpoint is world-readable, so the withheld set is a security property, not a
+    style choice. The stats token is a credential; CHAT_ROOT is where the host keeps the
+    data; the client-IP header is the one header this origin trusts, and naming it tells
+    anyone who can reach the origin directly which header to forge for a fresh rate-limit
+    identity. Each is *set to a distinctive value* here rather than merely absent — an
+    empty default would let this pass against a document that published all three.
+    """
+    import config
+
+    with config.override(
+        STATS_TOKEN="tok-must-not-appear",
+        CLIENT_IP_HEADER="cf-connecting-ip",
+        CORS_ORIGINS=["https://staging.internal.example"],
+        SECURITY_CONTACT="ops@internal.example",
+        DEBUG=3,
+    ):
+        body = client.get("/config").text
+        for secret in (
+            "tok-must-not-appear",
+            "cf-connecting-ip",
+            "staging.internal.example",
+            "ops@internal.example",
+            str(config.ROOT),
+        ):
+            assert secret not in body, f"{secret!r} reached a public document"
+        # Not even as a boolean: whether a token is configured is the answer /stats' 404
+        # exists to withhold, and "configured: false" would hand it over in one fetch.
+        doc = json.loads(body)
+        assert "stats_token" not in doc["settings"]
+        assert doc["settings"]["rate_read"] == config.RATE_READ, "the rest still answers"
+
+
+def test_it_is_never_rate_limited_and_stays_indexable(client):
+    """Same reason the manual and the spec are free: a client that must read the limits to
+    pace itself cannot be refused for reading them, and a 429 on the description of the
+    throttle is a deadlock. The 429 body and the manual both name it in FREE_PATHS, so the
+    claim has to be true of the running route."""
+    import config
+    import limit
+
+    assert "/config" in limit.FREE_PATHS
+    with config.override(RATE_READ=1, RATE_WRITE=1):
+        for _ in range(5):
+            response = client.get("/config")
+            assert response.status_code == 200
+    assert "x-robots-tag" not in response.headers, "it is documentation, not room content"
+    assert response.headers["cache-control"] == "public, max-age=3600"
+
+
+def test_a_published_setting_is_a_number_json_can_carry(client):
+    """Publishing a knob makes its finiteness a contract.
+
+    The two cache windows were parsed with a bare `float()`, which accepts `inf` and `nan`
+    where the `int()` beside them raises — harmless while nothing published them, a broken
+    document the moment something did: Python emits the bare token `Infinity`, RFC 8259
+    forbids it, and every strict parser rejects the whole response. `inf` on a cache window
+    was a live bug in its own right, too — the entry never expires and the view never
+    refreshes again — so the process refuses to start instead, the way CHAT_MAX_WAIT
+    already did.
+    """
+    for knob in ("CHAT_ROOMS_CACHE_SECONDS", "CHAT_NOTE_STATS_CACHE_SECONDS"):
+        boot = subprocess.run(
+            [sys.executable, "-c", f"import sys; sys.path.insert(0, {str(SRC)!r}); import app"],
+            capture_output=True,
+            text=True,
+            env={"PATH": "/usr/bin:/bin", knob: "inf"},
+        )
+        assert boot.returncode != 0, f"app booted with a non-finite {knob}"
+        assert "must be a finite number" in boot.stderr
+
+    raw = client.get("/config").text
+    assert "Infinity" not in raw and "NaN" not in raw
+    json.loads(raw, parse_constant=_no_constants)
+
+
+def _no_constants(token: str):
+    raise AssertionError(f"the document carries the non-JSON token {token!r}")
+
+
+def test_the_documents_that_should_point_at_it_do(client):
+    """A document nothing links to is a document nobody finds. The manual names it where a
+    throttled agent looks for the numbers, the manifest lists it beside the openapi, the
+    spec describes it (the spec/app consistency check in test_docs.py enforces that), and
+    the sitemap invites a crawler to it."""
+    manual = client.get("/llms.txt").text
+    assert "/config" in manual
+    assert (
+        client.get("/.well-known/agent.json").json()["documentation"]["config"].endswith("/config")
+    )
+    assert "/config" in client.get("/sitemap.xml").text
+    assert client.get("/openapi.json").json()["paths"]["/config"]["get"]["operationId"]
+
+
+def test_it_is_a_read_and_says_so(client):
+    """One method, and the 405 names it — the same contract every other document route has.
+    A POST here would be a caller trying to *set* something, which no endpoint on this
+    service does; the refusal has to be unambiguous rather than a 404 that reads like a
+    typo."""
+    refused = client.post("/config", json={"rate_read": 1})
+    assert refused.status_code == 405
+    assert refused.headers["allow"] == "GET, HEAD"
+    assert client.get("/config").status_code == 200

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -368,8 +368,8 @@ def test_every_documented_response_declares_the_body_it_returns(client):
 
 
 def test_a_published_ceiling_is_a_number_json_can_carry(client, monkeypatch):
-    """`float()` accepts `inf` and `nan` where the `int()` beside it raises, and this is the
-    one setting whose value is published. A non-finite ceiling reaches /openapi.json and
+    """`float()` accepts `inf` and `nan` where the `int()` beside it raises, and this setting's
+    value is published. A non-finite ceiling reaches /openapi.json and
     /.well-known/agent.json as the bare token `Infinity` — which Python emits and reads back
     but RFC 8259 forbids, so every strict parser rejects the whole document. A discovery
     service answering with undiscoverable documents is worse off than one that refused to

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.9.6"
+version = "0.9.7"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

`GET /config` publishes the `CHAT_*` knobs this instance is running with, keyed by the
environment variable that moves each one (`rate_read` is `CHAT_RATE_READ` — that is the
whole schema), with a `withheld` block naming every knob left out and why. Public JSON,
never rate limited, in the sitemap and the OpenAPI. 0.9.6 → 0.9.7.

**Deployer note:** `CHAT_ROOMS_CACHE_SECONDS` and `CHAT_NOTE_STATS_CACHE_SECONDS` now
refuse a non-finite value at boot, as `CHAT_MAX_WAIT` already did.

## Why

The caps were published; the rest of what a deployment decides was not — dedup, wake
latency, waiter slots, fsync, cache staleness. That did not keep them private, it made
every client find them by experiment, which costs more requests than answering does.

Two calls a reviewer might make differently. The **withheld set** is what makes this safe
unauthenticated — credential, host detail, or trust-boundary hint stays out, and
`tests/http/test_config.py` holds the set complete against `src/config.py`, so a new knob
is classified or CI fails. And **app.py was at its 981-line cap**, so the route paid for
itself instead of moving the cap: `_document` takes the media type, `/` and `/llms.txt`
share one Route comprehension. 981 before and after.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 431 passed, 97.64%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs updated: `src/manual.md`, `README.md`, `CHANGELOG.md`, `limit.FREE_PATHS`.
      `/skill.md` stays short on purpose. Also green: `sz.py --check`,
      `examples/beautiful_chat.sh`, the schemathesis contract (29/29 operations), the MCP
      build. Not run here: the image build — the diff does not touch the Dockerfile.
- [x] New surface on a world-writable service: **nothing new**. Read-only, no parameters,
      no per-caller or stored state — the body is a pure function of this process's
      configuration. One more free GET to flood, smaller than the manual and `s-maxage`d.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2gJUcmp6gDkzMRsiKdvZs)_