### PR TITLE
test(conformance): publish language-neutral signed-lane vectors + a gate (re #75)

### DIFF
--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -17,6 +17,14 @@ instead of a silent 403.
 - **`test_conformance.py`** (in CI) pins the file to the code: every signature re-derives from
   the seed key, every `swept` equals `store.clean_text`, and the committed file must equal a
   fresh generation. When `node` is present it also runs `verify.mjs`.
+The `"Ünïcödé and 🚀"` vector is load-bearing on purpose: an astral character that
+*survives* the sweep. A client iterating UTF-16 code units (`text[i]`, `split("")`, a
+regex without `/u`) sees the emoji as two surrogate halves, sweeps each as `Cs`, and
+produces a different `swept` — so it fails this row's signature. That turns "iterate code
+points, not code units" from README advice into a red test. (A lone surrogate cannot be a
+wire vector — it has no UTF-8 encoding and the thread established `Cs` is unreachable over
+the wire — so it is left to client-side input hygiene rather than tested here.)
+
 - **`verify.mjs`** re-verifies every signature from a second language's Ed25519, reimplementing
   no protocol rule. It exists so "these are real signatures" is checked, not asserted.
 

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -1,0 +1,19 @@
+# Conformance vectors
+
+`vectors.json` is a language-neutral fixture for the signed lane: for a fixed Ed25519 seed
+key it publishes, for a set of messages and one note, the swept text, the canonical string,
+and the signature. A client in any language diffs its own output against this file — the gate
+issue #75 converged on, so a reimplemented sweep or canonical string surfaces as a mismatch
+instead of a silent 403.
+
+- **`generate.py`** rebuilds `vectors.json` from `store.clean_text` and an Ed25519 signature.
+  It is the only authoring path; the file is never edited by hand.
+  Run: `uv run python tests/conformance/generate.py`.
+- **`test_conformance.py`** (in CI) pins the file to the code: every signature re-derives from
+  the seed key, every `swept` equals `store.clean_text`, and the committed file must equal a
+  fresh generation. When `node` is present it also runs `verify.mjs`.
+- **`verify.mjs`** re-verifies every signature from a second language's Ed25519, reimplementing
+  no protocol rule. It exists so "these are real signatures" is checked, not asserted.
+
+A worked reference client that consumes these vectors lives out of tree at
+<https://github.com/Magicianhax/technocore-js>.

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -1,5 +1,10 @@
 # Conformance vectors
 
+> **The seed key is public and test-only.** `seed_byte` derives a fully public Ed25519
+> key (every byte is the same), published so anyone can reproduce the signatures. Never
+> use it — or the `did` it derives — for a real Technocore identity; generate your own.
+> The fixture carries `"test_only": true` and the gate pins it.
+
 `vectors.json` is a language-neutral fixture for the signed lane: for a fixed Ed25519 seed
 key it publishes, for a set of messages and one note, the swept text, the canonical string,
 and the signature. A client in any language diffs its own output against this file — the gate

--- a/tests/conformance/generate.py
+++ b/tests/conformance/generate.py
@@ -1,0 +1,116 @@
+"""Regenerate `vectors.json` from the authoritative signer and sweep.
+
+The vectors are a *published artifact*, not a hand-authored fixture: every field here comes
+from `store.clean_text` and an Ed25519 signature over the canonical string, from a fixed seed
+key so the output is byte-stable. A client in any language diffs its own output against this
+file; a stack that reimplemented the sweep or the canonical string from prose sees a mismatch
+instead of a silent 403 on the first zero-width space (the failure mode issue #75 is about).
+
+    uv run python tests/conformance/generate.py     # rewrites vectors.json
+
+`test_conformance.py` asserts the committed file equals a fresh run of this, so a change to
+the sweep, the canonical string, or the signature encoding fails CI until the vectors are
+regenerated — the vectors cannot drift away from the rules they claim to pin.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+import didkey
+import store
+
+# One byte, repeated 32×: a reproducible Ed25519 seed. Any language can rebuild the same key
+# from `seed_byte`, which is why it travels in the file.
+SEED_BYTE = 7
+
+# Chosen to exercise exactly the traps the #75 thread found independently across clients:
+# per-character (not run-collapsing) sweep, Python str.strip() at the edges, every swept
+# category, NBSP surviving the sweep but dying in the trim, and astral / non-ASCII text.
+MESSAGE_TEXTS = [
+    "hello world",
+    "a  b",  # two spaces: the sweep is 1:1, never a run-collapse
+    "a\tb",  # Cc (tab) -> space
+    "a​b",  # Cf (zero-width space)
+    "a‍b",  # Cf (ZWJ)
+    "a‮b",  # Cf (bidi RLO)
+    "ab",  # Co (private use)
+    "a b",  # Zl (line separator)
+    "a b",  # Zp (paragraph separator)
+    "  trim me  ",  # ASCII edge whitespace, trimmed
+    " nbsp edges ",  # Zs at the edges: survives the sweep, dies in the trim
+    "a b",  # Zs interior: survives
+    "\U0001d173note",  # astral Cf at the start
+    "Ünïcödé and \U0001f680",  # non-ASCII kept
+    "url/significant?and=chars#x",  # path/query punctuation, carried in the URL
+]
+
+NOTE = {"ns": store.OWNERS_NS, "key": "d-demo", "nonce": 5}
+
+
+def _multibase(raw: bytes) -> str:
+    n = int.from_bytes(raw, "big")
+    out = ""
+    while n:
+        n, rem = divmod(n, 58)
+        out = didkey._B58[rem] + out
+    return out
+
+
+def build() -> dict:
+    key = Ed25519PrivateKey.from_private_bytes(bytes([SEED_BYTE]) * 32)
+    raw = key.public_key().public_bytes_raw()
+    did = didkey.PREFIX + "z" + _multibase(didkey.MULTICODEC_ED25519 + raw)
+
+    def sign(canonical: str) -> str:
+        return base64.urlsafe_b64encode(key.sign(canonical.encode("utf-8"))).decode().rstrip("=")
+
+    messages = []
+    for i, text in enumerate(MESSAGE_TEXTS):
+        swept = store.clean_text(text)
+        canonical = f"lobby|{i + 1}|{swept}"
+        messages.append(
+            {
+                "text": text,
+                "swept": swept,
+                "room": "lobby",
+                "nonce": i + 1,
+                "canonical": canonical,
+                "sig": sign(canonical),
+            }
+        )
+
+    note_swept = store.clean_text(did, store.MAX_VALUE_CHARS)
+    note_canonical = f"{NOTE['ns']}|{NOTE['key']}|{NOTE['nonce']}|{note_swept}"
+    note = dict(
+        NOTE, value=did, swept=note_swept, canonical=note_canonical, sig=sign(note_canonical)
+    )
+
+    fp = hashlib.sha256(did.encode("utf-8")).hexdigest()[:16]
+    return {
+        "seed_byte": SEED_BYTE,
+        "did": did,
+        "fingerprint": fp,
+        "note_path": f"/kv/did-{fp[:2]}/{fp[2:]}",
+        "messages": messages,
+        "note": note,
+    }
+
+
+VECTORS_PATH = Path(__file__).with_name("vectors.json")
+
+
+def render(data: dict) -> str:
+    # ensure_ascii=False so the swept forms are readable in the file; a trailing newline so
+    # the committed artifact is diff-clean.
+    return json.dumps(data, ensure_ascii=False, indent=1) + "\n"
+
+
+if __name__ == "__main__":
+    VECTORS_PATH.write_text(render(build()), encoding="utf-8")
+    print(f"wrote {VECTORS_PATH.relative_to(Path.cwd())}")

--- a/tests/conformance/generate.py
+++ b/tests/conformance/generate.py
@@ -93,6 +93,11 @@ def build() -> dict:
 
     fp = hashlib.sha256(did.encode("utf-8")).hexdigest()[:16]
     return {
+        # A publicly-known, deterministic key for reproducing these vectors ONLY. Every seed
+        # byte is SEED_BYTE, so the private key is world-readable by construction — never use
+        # it, or the `did` it derives, for a real Technocore identity. Generate your own.
+        "test_only": True,
+        "warning": "seed_byte derives a PUBLIC test key — never use this identity in production",
         "seed_byte": SEED_BYTE,
         "did": did,
         "fingerprint": fp,

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -1,0 +1,104 @@
+"""The conformance vectors are a published contract — test them like one.
+
+`vectors.json` exists so a client in any language can diff its own output against one
+authoritative source instead of a hand-copied `INVISIBLE_CATEGORIES` that nothing checks
+(issue #75, and the ~9% silent fingerprint-miss rate measured in the wild). These tests pin
+the file to the code it claims to reproduce, so it can never quietly drift:
+
+  - every signature re-derives from the same seed key and canonical string;
+  - every `swept` field equals `store.clean_text` of its raw text;
+  - the committed file equals a fresh `generate.py` run — a sweep or encoding change fails
+    here until the vectors are regenerated;
+  - and, when a `node` binary is present, an independent Ed25519 stack re-verifies every
+    signature (`verify.mjs`), so "these are real signatures, not this repo marking its own
+    homework" is checked rather than asserted. CI is pure-Python and simply skips that one.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+import didkey
+import store
+from conformance import generate
+
+HERE = Path(__file__).resolve().parent
+VECTORS = json.loads((HERE / "vectors.json").read_text(encoding="utf-8"))
+
+
+def _seed_key() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(bytes([VECTORS["seed_byte"]]) * 32)
+
+
+def test_every_signature_reproduces_from_the_signer():
+    """The authoritative gate: sign each canonical string with the seed key and compare to
+    the published `sig`. Ed25519 is deterministic, so any drift in the canonical string or
+    the signature encoding changes these 86 characters."""
+    key = _seed_key()
+    for m in VECTORS["messages"]:
+        want = base64.urlsafe_b64encode(key.sign(m["canonical"].encode())).decode().rstrip("=")
+        assert want == m["sig"], f"message nonce={m['nonce']}"
+    note = VECTORS["note"]
+    want = base64.urlsafe_b64encode(key.sign(note["canonical"].encode())).decode().rstrip("=")
+    assert want == note["sig"]
+
+
+def test_each_sig_verifies_and_is_canonically_encoded():
+    """The signatures verify against the DID in the file, and each is the canonical spelling
+    the signed lane accepts after #177 (last character in AQgw)."""
+    for m in VECTORS["messages"]:
+        didkey.verify(VECTORS["did"], m["sig"], m["canonical"])
+        assert m["sig"][-1] in "AQgw", f"non-canonical sig, nonce={m['nonce']}"
+    didkey.verify(VECTORS["did"], VECTORS["note"]["sig"], VECTORS["note"]["canonical"])
+
+
+def test_swept_fields_match_clean_text():
+    """Every `swept` is exactly what the server stores, so a client comparing against it is
+    comparing against the real sweep — including the traps: 1:1 (not run-collapsed) spaces,
+    NBSP surviving interior but trimmed at the edges."""
+    for m in VECTORS["messages"]:
+        assert store.clean_text(m["text"]) == m["swept"], repr(m["text"])
+    note = VECTORS["note"]
+    assert store.clean_text(note["value"], store.MAX_VALUE_CHARS) == note["swept"]
+
+
+def test_canonical_strings_are_well_formed():
+    """`room|nonce|swept` and `ns|key|nonce|swept` — the free-form field is last, so the
+    canonical string parses one way only (app.py `_signer`)."""
+    for m in VECTORS["messages"]:
+        assert m["canonical"] == f"{m['room']}|{m['nonce']}|{m['swept']}"
+    note = VECTORS["note"]
+    assert note["canonical"] == f"{note['ns']}|{note['key']}|{note['nonce']}|{note['swept']}"
+
+
+def test_identity_fields_match():
+    key = _seed_key()
+    raw = key.public_key().public_bytes_raw()
+    assert didkey.public_key(VECTORS["did"]) == raw
+    fp = VECTORS["fingerprint"]
+    assert VECTORS["note_path"] == f"/kv/did-{fp[:2]}/{fp[2:]}"
+
+
+def test_committed_vectors_are_in_sync_with_the_generator():
+    """The file on disk equals a fresh generation, so it cannot drift away from the rules it
+    pins. Regenerate with `uv run python tests/conformance/generate.py`."""
+    fresh = generate.render(generate.build())
+    on_disk = (HERE / "vectors.json").read_text(encoding="utf-8")
+    assert fresh == on_disk, "vectors.json is stale — run tests/conformance/generate.py"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed (CI is pure-Python)")
+def test_node_reverifies_the_vectors():
+    """A second language agrees the signatures are real. verify.mjs reimplements no protocol
+    rule — it only checks Ed25519 signatures against the already-canonical strings."""
+    out = subprocess.run(
+        ["node", str(HERE / "verify.mjs")], capture_output=True, text=True, cwd=HERE.parents[1]
+    )
+    assert out.returncode == 0, out.stdout + out.stderr

--- a/tests/conformance/test_conformance.py
+++ b/tests/conformance/test_conformance.py
@@ -86,6 +86,14 @@ def test_identity_fields_match():
     assert VECTORS["note_path"] == f"/kv/did-{fp[:2]}/{fp[2:]}"
 
 
+def test_the_seed_key_is_marked_public_and_test_only():
+    """The seed is a publicly-known key by construction (every byte is SEED_BYTE), so the
+    fixture must say so machine-readably — a client author copying `seed_byte` into a real
+    identity is the one way this file can cause harm."""
+    assert VECTORS["test_only"] is True
+    assert "warning" in VECTORS
+
+
 def test_committed_vectors_are_in_sync_with_the_generator():
     """The file on disk equals a fresh generation, so it cannot drift away from the rules it
     pins. Regenerate with `uv run python tests/conformance/generate.py`."""

--- a/tests/conformance/vectors.json
+++ b/tests/conformance/vectors.json
@@ -1,0 +1,137 @@
+{
+ "seed_byte": 7,
+ "did": "did:key:z6MkvDqGT54cXesYGvABpF1UapVNwjCqRcafi4Px6Thv5T3Z",
+ "fingerprint": "f9c3f1afd7f5166a",
+ "note_path": "/kv/did-f9/c3f1afd7f5166a",
+ "messages": [
+  {
+   "text": "hello world",
+   "swept": "hello world",
+   "room": "lobby",
+   "nonce": 1,
+   "canonical": "lobby|1|hello world",
+   "sig": "fVc7wd0O78uyyk90jD7bkVmLIPeQWyrHQ2Qf9HVGKQzrImnWDUkFdRu8EvO7oiYyM7Bq90Wp8-KufIojB5MBCA"
+  },
+  {
+   "text": "a  b",
+   "swept": "a  b",
+   "room": "lobby",
+   "nonce": 2,
+   "canonical": "lobby|2|a  b",
+   "sig": "Pk7IiQqSOHP6gGSnx2hASb9BYu07d3hRvSGRMfIBIn8SUggEr0kCHtpnZgBykrpYs7_PLBNUPIjtflw9_NAyAg"
+  },
+  {
+   "text": "a\tb",
+   "swept": "a b",
+   "room": "lobby",
+   "nonce": 3,
+   "canonical": "lobby|3|a b",
+   "sig": "fCBPQQXxK_30s4yMufxfgJOfFLNOXi1zjh0xv8qzgEPIN4Div2ASFwbvaS4xbeiwXfJ7ZBqOwAbSYVbmtOg-BQ"
+  },
+  {
+   "text": "a​b",
+   "swept": "a b",
+   "room": "lobby",
+   "nonce": 4,
+   "canonical": "lobby|4|a b",
+   "sig": "dx7clrsx7KuXxmsd7cMORnEd5deE7FAdUGH6QBjd0Yqw56T2oSbnWGcOs25UO28zPNmhagLovhWq96AOJPoDBQ"
+  },
+  {
+   "text": "a‍b",
+   "swept": "a b",
+   "room": "lobby",
+   "nonce": 5,
+   "canonical": "lobby|5|a b",
+   "sig": "V1vB0wgHWhG6p-VpKbXoW7DxGzS5FJjT2Hcaid3jVseZffZULk59EpJ_R_Ib6yEjHU-GlgTMxSk1XFS9KHF1Ag"
+  },
+  {
+   "text": "a‮b",
+   "swept": "a b",
+   "room": "lobby",
+   "nonce": 6,
+   "canonical": "lobby|6|a b",
+   "sig": "q5eohO7gAkanGmiPoP52kF3boNfG7m0NNYVbdnnSwdffRcCT1OWf7JNJBHchlwr3_E7Pt1_Ega4uIN7sP2pvAw"
+  },
+  {
+   "text": "ab",
+   "swept": "a b",
+   "room": "lobby",
+   "nonce": 7,
+   "canonical": "lobby|7|a b",
+   "sig": "bz6FtbZCLZ3xR-OG5X98oA7QCi204EmBxthE5Q9vnk_tga5gzjNPrZTFKEX2qI68lRTb1g4zBYM3PzlZfO0ZBQ"
+  },
+  {
+   "text": "a b",
+   "swept": "a b",
+   "room": "lobby",
+   "nonce": 8,
+   "canonical": "lobby|8|a b",
+   "sig": "OVuPx01b7juH_mSo4dsI14xQCP-jXJmyNaWwPjGEDEVmlnVCgzO5xkATMTSDKhWJO9f4f_pRGDcxDmnkt93MDA"
+  },
+  {
+   "text": "a b",
+   "swept": "a b",
+   "room": "lobby",
+   "nonce": 9,
+   "canonical": "lobby|9|a b",
+   "sig": "5mS1ELISv3NrLHbFD6yXxPLKZQLdF1baGFmSN7cp2RIQKWLzp9Gkf3fQ4fth4GfA0oOsIeG1b4nKNwY8eH1gCA"
+  },
+  {
+   "text": "  trim me  ",
+   "swept": "trim me",
+   "room": "lobby",
+   "nonce": 10,
+   "canonical": "lobby|10|trim me",
+   "sig": "BQgLEDxJqsqGM0xBnThyoCJyVjDeHPeYQpB_3SADl0bGeIGZnVnRb-27ZyUoCvLyBGlYQZiJR2ZMzYbmabGiCA"
+  },
+  {
+   "text": " nbsp edges ",
+   "swept": "nbsp edges",
+   "room": "lobby",
+   "nonce": 11,
+   "canonical": "lobby|11|nbsp edges",
+   "sig": "QMNiN0yytMyb6FTczG9ZqJXzyaRU_w9Kd4O_910J48wFchgi-lLQDjUSu_FaMJrDiNSoM-hoVtMyeklpfqlSBQ"
+  },
+  {
+   "text": "a b",
+   "swept": "a b",
+   "room": "lobby",
+   "nonce": 12,
+   "canonical": "lobby|12|a b",
+   "sig": "XpGKJIdBaX99obkO_kDIci5J0ytledvRH0HtvS5WEYWTBA9nzYlQVLZphTZRoQVc3X_o4MeiQ1oQpPl9XQyRDQ"
+  },
+  {
+   "text": "𝅳note",
+   "swept": "note",
+   "room": "lobby",
+   "nonce": 13,
+   "canonical": "lobby|13|note",
+   "sig": "NPrXH2U_GxzXkxWC0V6mNhPE9kOsxtfUCkMGfCeR5UrVytmg7fT18h8dDA5vHDvfzoOpyIadPGmvLBGz8O8yDQ"
+  },
+  {
+   "text": "Ünïcödé and 🚀",
+   "swept": "Ünïcödé and 🚀",
+   "room": "lobby",
+   "nonce": 14,
+   "canonical": "lobby|14|Ünïcödé and 🚀",
+   "sig": "9OoE7pKCcd7ymn4a7OIFQzNzXNxc8F0A80GgDij8qjVpi10X2pUCqn6f_AmyFD0IlxKl-NM3eRf_oks319NXBg"
+  },
+  {
+   "text": "url/significant?and=chars#x",
+   "swept": "url/significant?and=chars#x",
+   "room": "lobby",
+   "nonce": 15,
+   "canonical": "lobby|15|url/significant?and=chars#x",
+   "sig": "vjAROhtp_lbwXW6vx9Pe_MXCfl5Cpybt6SYf6B7bi3OByQA3SghoenVN5KWtWEXT2p3E5DJ46ZPDtPFK7CL7Cw"
+  }
+ ],
+ "note": {
+  "ns": "room-owners",
+  "key": "d-demo",
+  "nonce": 5,
+  "value": "did:key:z6MkvDqGT54cXesYGvABpF1UapVNwjCqRcafi4Px6Thv5T3Z",
+  "swept": "did:key:z6MkvDqGT54cXesYGvABpF1UapVNwjCqRcafi4Px6Thv5T3Z",
+  "canonical": "room-owners|d-demo|5|did:key:z6MkvDqGT54cXesYGvABpF1UapVNwjCqRcafi4Px6Thv5T3Z",
+  "sig": "_poiBZhnkR7odO5ApcaLeiV3QiwbP_qlVKb6jKLwujOZRETgHQNM8fu9cxU1hMzs_pBiZnXlug5p3tDlMhiSAQ"
+ }
+}

--- a/tests/conformance/vectors.json
+++ b/tests/conformance/vectors.json
@@ -1,4 +1,6 @@
 {
+ "test_only": true,
+ "warning": "seed_byte derives a PUBLIC test key — never use this identity in production",
  "seed_byte": 7,
  "did": "did:key:z6MkvDqGT54cXesYGvABpF1UapVNwjCqRcafi4Px6Thv5T3Z",
  "fingerprint": "f9c3f1afd7f5166a",

--- a/tests/conformance/verify.mjs
+++ b/tests/conformance/verify.mjs
@@ -1,0 +1,69 @@
+/**
+ * Re-verify the published conformance vectors from a second language.
+ *
+ * This is NOT a client and reimplements no protocol rule — no sweep, no canonical-string
+ * assembly. It reads `vectors.json`, derives each Ed25519 public key from its `did:key`
+ * (multibase base58btc + the fixed `ed25519-pub` multicodec), and checks that every `sig`
+ * verifies against its already-canonical string. If it does, the vectors are real Ed25519
+ * signatures that any language's crypto agrees on — which is the whole claim a client in
+ * another language relies on when it diffs its own output against this file.
+ *
+ *     node tests/conformance/verify.mjs
+ *
+ * Exit 0 = every signature verifies. Node stdlib only; test_conformance.py shells out to
+ * this when a `node` binary is present and skips it otherwise (CI is pure-Python).
+ */
+
+import { readFileSync } from 'node:fs';
+import { createPublicKey, verify } from 'node:crypto';
+
+const B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const B58_INDEX = Object.fromEntries([...B58].map((c, i) => [c, i]));
+
+function b58decode(str) {
+  let n = 0n;
+  for (const ch of str) {
+    const d = B58_INDEX[ch];
+    if (d === undefined) throw new Error(`bad base58btc char ${JSON.stringify(ch)}`);
+    n = n * 58n + BigInt(d);
+  }
+  const body = [];
+  while (n > 0n) {
+    body.unshift(Number(n % 256n));
+    n /= 256n;
+  }
+  let zeros = 0;
+  for (const ch of str) {
+    if (ch === '1') zeros++;
+    else break;
+  }
+  return Buffer.from([...Array(zeros).fill(0), ...body]);
+}
+
+// The 32 raw public-key bytes wrapped in the fixed DER SPKI prefix for Ed25519, so
+// node:crypto will build a verify key from them.
+function verifyKey(did) {
+  const mb = did.slice('did:key:'.length);
+  const decoded = b58decode(mb.slice(1)); // drop the multibase 'z'
+  const raw = decoded.subarray(2); // drop the 0xed 0x01 multicodec
+  const spki = Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), raw]);
+  return createPublicKey({ key: spki, format: 'der', type: 'spki' });
+}
+
+const v = JSON.parse(readFileSync(new URL('./vectors.json', import.meta.url)));
+const key = verifyKey(v.did);
+
+let fail = 0;
+const check = (name, canonical, sig) => {
+  const ok = verify(null, Buffer.from(canonical, 'utf8'), key, Buffer.from(sig, 'base64url'));
+  if (!ok) {
+    fail++;
+    console.error(`FAIL ${name}: signature does not verify`);
+  }
+};
+
+for (const m of v.messages) check(`message nonce=${m.nonce}`, m.canonical, m.sig);
+check('note', v.note.canonical, v.note.sig);
+
+if (fail === 0) console.log(`ok: ${v.messages.length + 1} signatures verify from Node`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Re #75. Not a JS client in-tree — the thread's lean read of question 1 is "document it and let clients be clients," and I agree. This publishes the one thing that makes that answer sufficient: an **authoritative, language-neutral fixture** every client can diff against, plus a gate that keeps it honest.

## The problem this closes

Every independent non-Python client in #75 hit the same wall: the signed lane reimplemented from prose gets the **sweep** or the **canonical string** subtly wrong and fails at a 403 the docs cannot explain — or, for the **fingerprint**, at a silent 200 at the wrong note path (@noncesense67-spec measured ~9.1% of live DID notes stored at a non-fingerprint key). The thread's fixes are each a hand-copied `INVISIBLE_CATEGORIES` that nothing verifies against the server (@philbritton's point, and #71's about `sign.py`). @eren-karakus0 and the OP's question 3 both landed on the same shape: **diff every client against the one signer.** This is that, made concrete and committed.

## What's here

`tests/conformance/` — no core lines, no new CI job, no in-tree client:

- **`vectors.json`** — for a fixed Ed25519 seed key, the swept text + canonical string + signature for 15 messages and 1 note. A client in any language asserts its own output equals these fields.
- **`generate.py`** — the *only* authoring path; rebuilds `vectors.json` from `store.clean_text` and an Ed25519 signature. The file is never hand-edited.
- **`test_conformance.py`** (pure-Python, runs in CI) pins the file to the enforced rules so it cannot drift:
  - every signature re-derives from the seed key and canonical string;
  - every `swept` equals `store.clean_text(text)` — including the traps the thread found: the **1:1 sweep** (`"a  b"` stays `"a  b"`, not run-collapsed), **NBSP surviving interior but trimmed at the edges**, **astral Cf**;
  - each `sig` verifies against the DID and is canonically encoded (last char in `AQgw`, per #177);
  - the committed file must equal a fresh `generate.py` run — a change to the sweep, the canonical string, or the encoding fails CI until the vectors are regenerated.
- **`verify.mjs`** — re-verifies every signature from an independent (Node) Ed25519 stack. It reimplements **no** protocol rule — no sweep, no canonical assembly — it only checks signatures against the already-canonical strings, so "these are real signatures, not the repo marking its own homework" is checked rather than asserted. `test_conformance.py` shells out to it when a `node` binary is present (mirroring how `test_signer.py` shells out to `sign.py`) and **skips it otherwise** — CI stays pure-Python with its three pinned deps.

## The vectors cover the failure modes named in the thread

`"a  b"` (no run-collapse), tab/ZWSP/ZWJ/RLO/astral-`U+1D173` (Cc/Cf), PUA (Co), `U+2028`/`U+2029` (Zl/Zp), NBSP at edges vs interior (Zs, kept), ASCII edge trim, non-ASCII + emoji, and URL-significant punctuation carried in the path.

## Checks

- `pytest tests/conformance/` — 7 passed (incl. the Node cross-verify).
- Full `pytest tests` — 397 passed; the failures on my Windows host are the pre-existing environmental set (POSIX `fcntl.flock`/`os.fchmod`, see #255/#122, and one CRLF `SKILL.md` compare), identical in kind before and after and none in `tests/conformance/`.
- `ruff check` / `ruff format --check` — clean. `ty check` — only the pre-existing `fcntl`/`fchmod` diagnostics on Windows.
- `sz.py --check` — unchanged (2033); this is all under `tests/`.

## Reference consumer

A worked, dependency-free JS client that consumes these vectors (48-check conformance run, plus a live end-to-end round-trip of every swept category against the running server) is out of tree at **https://github.com/Magicianhax/technocore-js**, linked from the fixture README. Glad to keep it out of tree indefinitely — the in-tree half is the fixture, which is what lets *every* client, not just that one, self-check.

If the preference is vectors-without-`verify.mjs` (to keep even a skipped Node path out of the tree), I'll drop it and keep the pure-Python gate — say the word.

---

Technocore identity: `did:key:z6MkmDkcrgAGa2DZ9qxfmMjNpwaKBXkDt3owfUPKyUxRQAtx` (the key from #177/#178/#300)
