### PR TITLE
fix(http): a POST body field typed as a string is a string, or refused

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1130,6 +1130,23 @@ def room_say_signed(request: Request) -> Response:
     return respond(request, {**view, "posted": rec}, note=budget_note("write", left, RATE_WRITE))
 
 
+def _body_string(payload: dict, field: str) -> str | Response:
+    """A body field the schema types as a string: the string, "" when absent or JSON null,
+    a 400 for anything else. `str()` here stored a null `text` as the literal message
+    `None` and an object as its Python repr — a record nobody sent, indistinguishable to
+    every reader from one somebody did."""
+    value = payload.get(field)
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return text(
+        f"400 {field} must be a JSON string, not a {type(value).__name__} — "
+        f'e.g. {{"{field}":"..."}}.',
+        400,
+    )
+
+
 def _payload_credentials(payload: dict) -> tuple[str, str, str] | None:
     """did/sig/nonce out of a POST body, or None for an unsigned post."""
     did = str(payload.get("did", "")).strip()
@@ -1197,11 +1214,17 @@ async def room_post(request: Request) -> Response:
     if isinstance(payload, Response):
         return payload
     room = request.path_params["room"]
+    sent = _body_string(payload, "text")
+    if isinstance(sent, Response):
+        return sent
+    nick = _body_string(payload, "from")
+    if isinstance(nick, Response):
+        return nick
     credentials = _payload_credentials(payload)
     signer = None
     if credentials:
         did, sig, nonce = credentials
-        body = store.clean_text(str(payload.get("text", "")))
+        body = store.clean_text(sent)  # sweep first: the signature covers what is stored
         signer = _signer(did, sig, nonce, f"{room}|{nonce}|{body}")
         if isinstance(signer, Response):
             return signer
@@ -1218,7 +1241,6 @@ async def room_post(request: Request) -> Response:
         if denied:
             return denied
         if signer is None:
-            nick, sent = str(payload.get("from", "")), str(payload.get("text", ""))
             key = _retry_key(request, room, nick, sent)
             replay = _already_written(request, key, room, left)
             if replay is not None:
@@ -1461,7 +1483,10 @@ async def note_post(request: Request) -> Response:
         return payload
     p = request.path_params
     ns, key = p["ns"], p["key"]
-    value = store.clean_text(str(payload.get("value", "")), store.MAX_VALUE_CHARS)
+    sent = _body_string(payload, "value")
+    if isinstance(sent, Response):
+        return sent
+    value = store.clean_text(sent, store.MAX_VALUE_CHARS)
     credentials = _payload_credentials(payload)
     signer = None
     if credentials:

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -396,3 +396,12 @@ def test_signed_writes_pay_the_write_budget_like_any_other(client, monkeypatch):
             _say_signed(client, "lobby", did, sign, f"m{i}", nonce=i).status_code for i in (1, 2, 3)
         ]
         assert codes == [200, 200, 429]
+
+
+def test_post_refuses_a_value_that_is_not_a_string(client):
+    """A null value used to be stored as the note `None`, an object as its Python repr."""
+    assert client.post("/kv/plans/n", json={"value": None}).status_code == 400
+    for sent in ({"a": 1}, [1], False, 0):
+        r = client.post("/kv/plans/n", json={"value": sent})
+        assert r.status_code == 400 and "value must be a JSON string" in r.text, sent
+    assert client.get("/kv/plans/n").status_code == 404

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -1189,3 +1189,14 @@ def test_wait_wakes_on_a_write_from_another_process(client, tmp_path):
     messages = held.json()["messages"]
     assert [m["text"] for m in messages] == ["from another process"]
     assert messages[0]["from"] == "otherworker"
+
+
+def test_post_refuses_a_text_that_is_not_a_string(client):
+    """`str()` on the body used to store a JSON null as the message `None` and an object as
+    its Python repr — a line nobody wrote, that every reader would parse as text."""
+    assert client.post("/r/lobby", json={"from": "bot", "text": None}).status_code == 400
+    for sent in ({"a": 1}, [1, 2], True, 5):
+        r = client.post("/r/lobby", json={"from": "bot", "text": sent})
+        assert r.status_code == 400 and "text must be a JSON string" in r.text, sent
+    assert client.post("/r/lobby", json={"from": 123, "text": "hi"}).status_code == 400
+    assert client.get("/r/lobby?format=json").json()["count"] == 0


### PR DESCRIPTION
## What

`POST /r/<room>` and `POST /kv/<ns>/<key>` refuse a `text`, `from` or `value` that is not a JSON string with a 400 naming the field and the type it got. A JSON `null` (or a missing field) reads as empty and lands on the existing empty-text refusal, as before.

## Why

Both lanes pulled the field through `str()`, so `{"from":"bot","text":null}` stored the message `None`, `{"text":{"a":1}}` stored `{'a': 1}`, and `{"value":null}` stored a note reading `None` — records nobody sent, that every reader parses as ordinary text. Reproduced against the live instance before this change. The schema already types all three as `string`; the guard makes the server agree with its own manifest. `if` is left alone: it is compared as text and `str()` of a scalar is what a caller would mean by it.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` (424 passed)
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: none — the manual and OpenAPI already say `string`
- [x] New surface on a world-writable service: nothing new; one more input is refused