### PR TITLE
docs(config): scope static_cache_seconds to text documents

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1379,7 +1379,8 @@ def config_document(version: str) -> dict:
             "rooms_cache_seconds": "seconds one /rooms walk is shared for; 0 disables",
             "note_stats_cache_seconds": "seconds the note-capacity gauge is reused for; 0 disables",
             "edge_cache_seconds": "s-maxage on /rooms and plain room reads; 0 means no-store",
-            "static_cache_seconds": "s-maxage on the documents; 0 means no-store",
+            "static_cache_seconds": "s-maxage on the text documents named in the README; "
+            "0 means no-store. JSON discovery documents use a fixed one-hour max-age",
         },
         "withheld": _WITHHELD,
         "note": (

--- a/tests/http/test_config.py
+++ b/tests/http/test_config.py
@@ -154,6 +154,17 @@ def test_it_is_never_rate_limited_and_stays_indexable(client):
     assert response.headers["cache-control"] == "public, max-age=3600"
 
 
+def test_static_cache_unit_does_not_claim_the_json_documents(client):
+    """CHAT_STATIC_CACHE_SECONDS only drives the edge-cache header on text documents.
+
+    /config and the JSON discovery documents use a separate fixed one-hour browser cache,
+    so the setting's published unit must not tell an operator that this knob moves them.
+    """
+    unit = client.get("/config").json()["units"]["static_cache_seconds"]
+    assert "text documents" in unit
+    assert "fixed one-hour max-age" in unit
+
+
 def test_a_published_setting_is_a_number_json_can_carry(client):
     """Publishing a knob makes its finiteness a contract.
 


### PR DESCRIPTION
## What

Clarifies the `/config` unit for `static_cache_seconds`: the knob controls edge caching for the text documents named in the README. JSON discovery documents keep their separate fixed one-hour browser cache.

## Why

Follow-up to #313. The live `/config` currently says "s-maxage on the documents," but `CHAT_STATIC_CACHE_SECONDS` only reaches `_static_cacheable`. `/config`, `/openapi.json`, and `/.well-known/agent.json` return `public, max-age=3600` regardless of that setting. An operator reading the new endpoint could reasonably think the knob controls the endpoint itself.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 432 passed, 97.64%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs checked; the README already lists the exact text-document paths
- [x] New surface on a world-writable service: nothing new