### PR TITLE
test(limits): expand the free-path glob from the route table

### DIFF
--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -228,14 +228,18 @@ def test_every_path_the_429_calls_free_really_is_free(client, monkeypatch):
         assert client.get("/rooms").status_code == 429  # the budget really is spent
 
         named = app_module.FREE_PATHS.replace(" and ", ", ").split(", ")
-        concrete = {
-            "/.well-known/*": [
-                "/.well-known/agent.json",
-                "/.well-known/api-catalog",
-                "/.well-known/ai-catalog.json",
-                "/.well-known/agent-skills/index.json",
-            ]
-        }
+        # The glob is expanded from the route table rather than a list written out here.
+        # A hardcoded expansion only ever covers the routes that existed when someone last
+        # edited it: a new /.well-known/ route would be advertised free by FREE_PATHS and
+        # never asked whether it is, and this test would still pass. Reading the routes
+        # means the promise widens exactly when the surface it covers does.
+        well_known = sorted(
+            path
+            for r in app_module.app.routes
+            if (path := getattr(r, "path", "")).startswith("/.well-known/")
+        )
+        assert well_known, "no /.well-known/ routes found — the glob would assert nothing"
+        concrete = {"/.well-known/*": well_known}
         paths = [p for name in named for p in concrete.get(name.strip(), [name.strip()])]
         assert len(paths) >= 8
         for path in paths:


### PR DESCRIPTION
## What

`test_every_path_the_429_calls_free_really_is_free` expanded `/.well-known/*` from a list written out inside the test. This expands it from `app.routes` instead.

Test-only. Core is untouched, the ratchet does not move, and it touches neither `CHANGELOG.md` nor `sz-baseline.json`.

## Why

The test holds a promise the manual and every 429 body make — the paths in `FREE_PATHS` still answer while a caller is throttled. Its docstring puts it well: *"Advice that fails at the moment it is taken is worse than no advice."*

A hardcoded expansion only ever covers the routes that existed when someone last edited it. `/.well-known/security.txt` has been outside that list since it was added: it *is* free, so nothing is broken, but nothing was asking. The next route added under `/.well-known/` inherits the same silence — it would be advertised free by `FREE_PATHS`, never verified, and CI would stay green.

Reading the route table means the assertion widens exactly when the surface it covers does.

## Verification

Against a deliberately rate-limited `/.well-known/nodeinfo` added to the route table:

```
HARDCODED (before)   13 paths checked   PASSES (regression invisible)
FROM ROUTES (after)  15 paths checked   FAILS -> ['/.well-known/nodeinfo']
```

On `main` as-is the glob expands to 5 routes rather than 4, the new one being `/.well-known/security.txt`. It passes.

Gates run locally against `9a7399d` (0.9.7): `ruff check`, `ruff format --check`, `ty check`, and the full suite at 431 passed.

## Note

The `assert well_known, ...` guard is there so a refactor that moved or renamed those routes fails loudly rather than quietly asserting over an empty glob.

---

AI assistance (Claude, Anthropic) was used to find and verify this. The change and its reasoning were reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)