### PR TITLE
fix(store): report the true last_seq when every ephemeral message expired

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -892,11 +892,10 @@ def read_messages(
     if path.exists():
         with path.open("rb") as f:
             for raw in reverse_lines(f):
-                rec = _parse(raw)
-                if rec is None:
-                    continue
                 # First record this pass parses is the newest on disk — the same one
                 # `last_seq` picks, and the value the next write increments (§append).
+                if (rec := _parse(raw)) is None:
+                    continue
                 newest = rec["seq"] if newest is None else newest
                 if since is not None and rec["seq"] <= since:
                     break

--- a/src/store.py
+++ b/src/store.py
@@ -907,7 +907,9 @@ def read_messages(
         "room": room,
         "count": len(out),
         "first_seq": out[0]["seq"] if out else None,
-        "last_seq": out[-1]["seq"] if out else (since or 0),
+        "last_seq": out[-1]["seq"]
+        if out
+        else (since if since is not None else last_seq(root, room)),
         "generation": room_generation(root, room),
         "messages": out,
     }

--- a/src/store.py
+++ b/src/store.py
@@ -887,7 +887,7 @@ def read_messages(
     # append-ordered, so the first expired record means every older one is expired too and
     # the scan stops there. `last_seq` deliberately does NOT filter — seq must keep
     # advancing past records nobody can read any more, or an expired room would reuse seqs.
-    cutoff = _cutoff(room)
+    cutoff, newest = _cutoff(room), None
     out: list[dict] = []
     if path.exists():
         with path.open("rb") as f:
@@ -895,6 +895,9 @@ def read_messages(
                 rec = _parse(raw)
                 if rec is None:
                     continue
+                # First record this pass parses is the newest on disk — the same one
+                # `last_seq` picks, and the value the next write increments (§append).
+                newest = rec["seq"] if newest is None else newest
                 if since is not None and rec["seq"] <= since:
                     break
                 if cutoff is not None and _expired(rec, cutoff):
@@ -907,9 +910,8 @@ def read_messages(
         "room": room,
         "count": len(out),
         "first_seq": out[0]["seq"] if out else None,
-        "last_seq": out[-1]["seq"]
-        if out
-        else (since if since is not None else last_seq(root, room)),
+        # `newest or 0`: no parseable record and a 0 seq both answer 0, as last_seq does.
+        "last_seq": out[-1]["seq"] if out else (since if since is not None else newest or 0),
         "generation": room_generation(root, room),
         "messages": out,
     }

--- a/tests/test_store_stateful.py
+++ b/tests/test_store_stateful.py
@@ -265,7 +265,15 @@ class StoreLifecycle(RuleBasedStateMachine):
         if since is not None:
             assert all(s > since for s in seqs), "`since` returned something already seen"
         assert view["first_seq"] == (seqs[0] if seqs else None)
-        assert view["last_seq"] == (seqs[-1] if seqs else (since or 0))
+        # An empty read still reports a usable cursor: the caller's own `since` when it
+        # gave one, otherwise the newest sequence still ON DISK — never 0 while records
+        # remain, or a client following `next` rewinds past them (#287). A reaped room has
+        # no records left; its durable value lives in the persisted floor (#343), which a
+        # read does not consult, so it reports 0 exactly as it did before.
+        exists = store.room_path(self.root, room).exists()
+        on_disk = store.last_seq(self.root, room) if exists else 0
+        expected_last = seqs[-1] if seqs else (since if since is not None else on_disk)
+        assert view["last_seq"] == expected_last
         for message in view["messages"]:
             assert (message["from"], message["text"]) == self.said[room][message["seq"]]
 

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -948,6 +948,41 @@ def test_an_unparseable_timestamp_counts_as_expired(tmp_path, stamp):
     assert store.read_messages(tmp_path, "keeps-it")["count"] == 0  # a different room, empty
 
 
+def test_fully_expired_ephemeral_room_keeps_its_cursor(tmp_path, monkeypatch):
+    """A tail read of an all-expired ephemeral room must not reset last_seq to 0 (#287).
+
+    seq deliberately keeps advancing past expired records; the read payload has to say
+    so, or a client following `next: ?since=<last_seq>` snaps its cursor back to 0 and
+    loses the room's true progression.
+    """
+    from datetime import UTC, datetime
+
+    import store
+
+    now = 2_000_000_000.0
+
+    def stamp(epoch: float) -> str:
+        return datetime.fromtimestamp(epoch, UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    expired = stamp(now - store.EPHEMERAL_TTL_SECONDS - 60)
+    room = store.room_path(tmp_path, "e-cursor")
+    room.parent.mkdir(parents=True, exist_ok=True)
+    records = (
+        {"seq": 1, "ts": expired, "from": "bot", "text": "gone"},
+        {"seq": 2, "ts": expired, "from": "bot", "text": "also gone"},
+    )
+    room.write_text("".join(json.dumps(record) + "\n" for record in records))
+    monkeypatch.setattr(store.time, "time", lambda: now)
+
+    view = store.read_messages(tmp_path, "e-cursor")
+    assert view["messages"] == []
+    assert view["last_seq"] == 2, "an all-expired room must report its real last seq"
+
+    # an explicit `since` is the caller's cursor and still echoes back unchanged
+    resumed = store.read_messages(tmp_path, "e-cursor", since=2)
+    assert resumed["last_seq"] == 2
+
+
 def test_ephemeral_ttl_boundary_is_inclusive_then_expires(tmp_path, monkeypatch):
     """At exactly TTL the record is still within the promise; one microsecond older is not.
 


### PR DESCRIPTION
Fixes #287.

`read_messages()` fell back to `(since or 0)` when the scan returned nothing, so a fresh tail read (`since=None`) of an ephemeral room whose messages have all expired answered `last_seq: 0` — even though `seq` deliberately keeps advancing past expired records (the comment above the scan says exactly why). A client following `next: ?since=<last_seq>` then snaps its cursor back to 0 and loses the room's true progression.

The fix uses the issue's suggested shape: fall back to the room's actual `last_seq()` only when `since` was not supplied; an explicit `since` still echoes back unchanged, and non-existent rooms keep returning 0 through `last_seq()`'s own fallback.

Per CONTRIBUTING: the regression test (frozen-clock idiom borrowed from the neighbouring TTL-boundary tests) fails without the fix (`last_seq == 0`) and passes with it. `tests/unit/test_store.py` + the Hypothesis state machine + `tests/http` all pass — 297 tests.