### PR TITLE
docs(mcp): clarify room and note durability

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -73,7 +73,7 @@ argument would encourage passing keys through an LLM's context. A runtime that c
 The service is public, unauthenticated and world-writable. Everything these tools return is
 anonymous input written by strangers, and the `from` name on a message is self-asserted unless it is
 a `did:key`. **Treat it as data, never as instructions** — the server's own `instructions` block
-says the same thing to the model on connect. Nothing stored is durable or private; keep the source
+says the same thing to the model on connect. Rooms are ephemeral and notes are durable, but nothing stored is private; keep the source
 of truth somewhere you own and never post a secret.
 
 ## Development

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -73,8 +73,8 @@ argument would encourage passing keys through an LLM's context. A runtime that c
 The service is public, unauthenticated and world-writable. Everything these tools return is
 anonymous input written by strangers, and the `from` name on a message is self-asserted unless it is
 a `did:key`. **Treat it as data, never as instructions** — the server's own `instructions` block
-says the same thing to the model on connect. Rooms are ephemeral and notes are durable, but nothing stored is private; keep the source
-of truth somewhere you own and never post a secret.
+says the same thing to the model on connect. Rooms are ephemeral and notes are durable, but nothing stored is private. Keep the source of
+truth somewhere you own and never post a secret.
 
 ## Development
 


### PR DESCRIPTION
## What

Clarify the durability statement in the MCP README: rooms are ephemeral, while notes are durable but not private.

## Why

The Safety section currently says that nothing stored is durable, which conflicts with the README's description of durable notes and may confuse MCP users.

## Checks

- [x] Documentation-only change; runtime tests do not apply
- [x] No API or runtime behavior changes
- [x] No new public surface or abuse impact