### PR TITLE
didkey: reject non-canonical signature encodings (fixes #177)

### DIFF
--- a/src/didkey.py
+++ b/src/didkey.py
@@ -125,6 +125,15 @@ def verify(did: str, signature: str, message: str) -> None:
     if not SIG_RE.fullmatch(signature or ""):
         raise DidError(f"bad signature encoding: expected {SIG_CHARS} base64url characters")
     raw = base64.urlsafe_b64decode(signature[:SIG_CHARS] + "==")
+    # An 86-char base64url signature carries four slack bits in its final character, so
+    # sixteen spellings decode to the same 64-byte signature and all of them verify. A
+    # signature is an integrity token, so accept exactly one spelling: the canonical
+    # re-encode. Without this (#177) a captured signed URL admits sixteen equivalent
+    # signatures, which defeats any replay/signature-uniqueness tracking keyed on the
+    # string. servers never store the signature (§5.4) and the only signer emits the
+    # canonical form, so this only refuses the slack variants.
+    if base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii") != signature:
+        raise DidError("non-canonical signature encoding")
     try:
         # Note the argument order: libsodium takes (message, signature), the reverse
         # of the OpenSSL binding this replaced. Backwards does not fail *open* -- a

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,31 +1,31 @@
 {
-  "core_total": 2067,
+  "core_total": 2069,
   "caps": {
     "core/app.py": 981,
     "core/config.py": 59,
-    "core/didkey.py": 57,
+    "core/didkey.py": 59,
     "core/limit.py": 132,
     "core/store.py": 841,
     "core_total": 2069
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1847,
+      "raw_lines": 1868,
       "code_lines": 981,
-      "comment_lines": 264,
-      "tokens_per_line": 7.96
+      "comment_lines": 265,
+      "tokens_per_line": 7.99
     },
     "core/config.py": {
-      "raw_lines": 271,
+      "raw_lines": 280,
       "code_lines": 59,
-      "comment_lines": 159,
-      "tokens_per_line": 12.54
+      "comment_lines": 165,
+      "tokens_per_line": 12.31
     },
     "core/didkey.py": {
-      "raw_lines": 135,
-      "code_lines": 57,
-      "comment_lines": 31,
-      "tokens_per_line": 7.96
+      "raw_lines": 144,
+      "code_lines": 59,
+      "comment_lines": 38,
+      "tokens_per_line": 8.12
     },
     "core/limit.py": {
       "raw_lines": 316,
@@ -40,10 +40,10 @@
       "tokens_per_line": 7.36
     },
     "extra/manifest.py": {
-      "raw_lines": 1604,
-      "code_lines": 1180,
-      "comment_lines": 117,
-      "tokens_per_line": 3.86
+      "raw_lines": 1766,
+      "code_lines": 1295,
+      "comment_lines": 143,
+      "tokens_per_line": 3.79
     }
   }
 }

--- a/tests/unit/test_didkey.py
+++ b/tests/unit/test_didkey.py
@@ -40,3 +40,50 @@ def test_a_did_key_has_exactly_one_spelling(client):
         assert not didkey.is_did(spelling)
 
     assert didkey.public_key(did) == real  # …and the canonical one still works
+
+
+def test_a_signature_has_exactly_one_spelling():
+    """A signature is an integrity token, so it must have exactly one accepted spelling.
+
+    An 86-char base64url signature carries four slack bits in its final character, so
+    sixteen strings decode to the same 64-byte Ed25519 signature and all of them verify.
+    #177: accept only the canonical re-encode, so a captured signed URL cannot be replayed
+    under any of its fifteen aliases. servers never store the signature (§5.4) and the
+    only signer emits the canonical form, so this refuses only the slack variants.
+    """
+    import base64
+    import didkey
+
+    # The exact urlsafe alphabet order base64.urlsafe_b64{en,de}code uses.
+    B64URL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    index = {c: i for i, c in enumerate(B64URL)}
+
+    did, sign = _keypair()
+    message = "lobby|1|hello"
+    sig = sign(message)  # canonical 86-char base64url
+    assert len(sig) == didkey.SIG_CHARS
+
+    # The canonical signature verifies.
+    didkey.verify(did, sig, message)
+
+    # Build a slack spelling: keep the top two bits of the final base64url character, vary
+    # its four slack bits to a value that differs. Sixteen spellings share the same bytes;
+    # pick any one that is not the canonical character.
+    last = sig[-1]
+    v = index[last]
+    top2 = (v >> 4) & 0x3
+    slack_bits = (v & 0xF) ^ 0x1  # guaranteed to differ from the canonical low four bits
+    slack = sig[:-1] + B64URL[(top2 << 4) | slack_bits]
+    assert slack != sig
+    # Sanity: the slack spelling decodes to the same 64 bytes the canonical one does.
+    dec = base64.urlsafe_b64decode(slack + "==")[:64]
+    assert dec == base64.urlsafe_b64decode(sig + "==")[:64]
+
+    # Before the fix this raised nothing; after it must be refused as non-canonical.
+    with pytest.raises(didkey.DidError):
+        didkey.verify(did, slack, message)
+
+    # Mirror: the signer (scripts/sign.py) emits the canonical form, so a freshly signed
+    # string re-encodes to itself — the verifier and the signer cannot drift here.
+    raw = base64.urlsafe_b64decode(sig + "==")[:64]
+    assert base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii") == sig


### PR DESCRIPTION
## Summary

`SIG_PATTERN` is `[A-Za-z0-9_-]{86}`, so any 86-character base64url string is accepted before decode. An 86-char base64url *signature* carries four slack bits in its final character, which means **sixteen** distinct strings decode to the exact same 64-byte Ed25519 signature — and all sixteen verify. A signature is an integrity token, so this defeats any signature-uniqueness / replay tracking keyed on the string (one captured signed URL admits sixteen aliases). Closes #177.

## Fix

`didkey.verify()` now re-encodes the decoded bytes and accepts only the canonical spelling:

```python
raw = base64.urlsafe_b64decode(signature[:SIG_CHARS] + "==")
if base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii") != signature:
    raise DidError("non-canonical signature encoding")
```

`SIG_PATTERN` stays as the syntactic pre-filter (a static regex can't express canonicalness for a fixed 64-byte payload); the canonicality is enforced at verify time, where it belongs.

## Scope / safety

- The service never stores the signature (§5.4), so nothing is keyed on the old loose form.
- The only signer (`scripts/sign.py`) emits the canonical form (`urlsafe_b64encode(...).rstrip("=")`), so legitimate writes are unaffected — this only refuses the slack variants.
- `manifest.py`'s published `^<SIG_PATTERN>$` constraint remains a length/alphabet description; the enforced canonical rule is documented in `didkey.verify`.

## Test

Adds `test_a_signature_has_exactly_one_spelling` — a failing-first guard that builds a slack spelling of a valid signature (same decoded bytes, different final character) and asserts `verify` now refuses it. Mirrors the existing `test_a_did_key_has_exactly_one_spelling`.

`uv run pytest tests/unit` green; `sz.py --check` green (didkey cap 57 -> 59).
