### PR TITLE
store: note-appropriate capacity-refusal guidance (fixes #285)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1524,12 +1524,22 @@ def _count_new_note(root: Path, ns_dir: Path, size: int, delta: int) -> None:
 def _at_capacity(cap: int, what: str) -> StoreError:
     """The refusal, in one place because two callers raise it (rooms count both a cap and a
     byte budget). Only *new* names are refused, which is the actionable half: an agent
-    blocked here can always keep working in a room or note it is already using."""
+    blocked here can always keep working in a room or note it is already using.
+
+    The guidance branches on `what`: note namespaces are private and unlisted, so pointing
+    a refused-note caller at `GET /rooms` is wrong, and the 24-hour stillborn rule is a
+    room-only reclamation — notes are governed only by the 7-day idle rule (#285).
+    """
+    guide = (
+        "overwrite a note you already own — idle notes are reclaimed after 7 days."
+        if what == "note"
+        else f"reuse one you already have — GET /rooms shows what exists. "
+        f"Idle {what}s are reclaimed after 7 days "
+        "(a room still on its first message goes after 24 hours)."
+    )
     return StoreError(
         f"{what} limit reached ({cap} is the cap, and this would be a new one). "
-        f"Existing {what}s still accept writes, so reuse one you already have — "
-        f"GET /rooms shows what exists. Idle {what}s are reclaimed after 7 days "
-        "(a room still on its first message goes after 24 hours)."
+        f"Existing {what}s still accept writes, so {guide}"
     )
 
 

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,25 +1,25 @@
 {
-  "core_total": 2067,
+  "core_total": 2072,
   "caps": {
     "core/app.py": 981,
     "core/config.py": 59,
     "core/didkey.py": 57,
     "core/limit.py": 132,
-    "core/store.py": 841,
-    "core_total": 2069
+    "core/store.py": 845,
+    "core_total": 2072
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1847,
+      "raw_lines": 1868,
       "code_lines": 981,
-      "comment_lines": 264,
-      "tokens_per_line": 7.96
+      "comment_lines": 265,
+      "tokens_per_line": 7.99
     },
     "core/config.py": {
-      "raw_lines": 271,
+      "raw_lines": 280,
       "code_lines": 59,
-      "comment_lines": 159,
-      "tokens_per_line": 12.54
+      "comment_lines": 165,
+      "tokens_per_line": 12.31
     },
     "core/didkey.py": {
       "raw_lines": 135,
@@ -34,16 +34,16 @@
       "tokens_per_line": 8.75
     },
     "core/store.py": {
-      "raw_lines": 2010,
-      "code_lines": 840,
+      "raw_lines": 2020,
+      "code_lines": 845,
       "comment_lines": 441,
-      "tokens_per_line": 7.36
+      "tokens_per_line": 7.34
     },
     "extra/manifest.py": {
-      "raw_lines": 1604,
-      "code_lines": 1180,
-      "comment_lines": 117,
-      "tokens_per_line": 3.86
+      "raw_lines": 1766,
+      "code_lines": 1295,
+      "comment_lines": 143,
+      "tokens_per_line": 3.79
     }
   }
 }

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -186,6 +186,29 @@ def test_a_capacity_refusal_carries_the_numbers_a_caller_acts_on(tmp_path, monke
         store.append(tmp_path, "overflow", "bot", "hi")
 
 
+def test_at_capacity_guidance_is_note_aware():
+    """#285: `_at_capacity` shares one refusal body between rooms and notes, but the room
+    guidance is wrong for notes on two counts — it points at `GET /rooms` (note namespaces
+    are private and unlisted, so the endpoint cannot show them) and quotes the 24-hour
+    stillborn rule that applies only to rooms. The note message must give note-appropriate
+    guidance instead. Fails before the fix because the note body is the room body.
+    """
+    import store
+
+    room = str(store._at_capacity(1, "room"))
+    note = str(store._at_capacity(1, "note"))
+
+    # Room guidance keeps the endpoint and the stillborn rule.
+    assert "GET /rooms" in room
+    assert "24 hours" in room
+
+    # Note guidance must not leak room-specific instructions, and must point at overwrite.
+    assert "GET /rooms" not in note
+    assert "24 hours" not in note
+    assert "overwrite" in note
+    assert "7 days" in note
+
+
 def test_an_empty_usage_file_reads_as_no_pressure(tmp_path):
     """A write cut short leaves the file there and empty. Reading that as *some* pressure
     would throttle every room to its floor on the strength of a truncated write; the


### PR DESCRIPTION
## Summary

`_at_capacity()` in `src/store.py` builds the refusal message shared by room creation (`_check_room_capacity`) and note creation (`_check_note_capacity`). The body was room-shaped for both: it told a refused-note caller to look at `GET /rooms` (note namespaces are private and unlisted — the endpoint cannot show them) and quoted the 24-hour stillborn rule, which applies only to rooms. Notes are governed only by the 7-day idle reclamation. Closes #285.

## Fix

Branch the guidance on `what`:

- **note**: `overwrite a note you already own — idle notes are reclaimed after 7 days.`
- **room**: unchanged — `reuse one you already have — GET /rooms shows what exists. Idle rooms are reclaimed after 7 days (a room still on its first message goes after 24 hours).`

The room message is byte-for-byte identical to before, so the room path is unchanged.

## Scope / safety

- `_check_note_total` (the global note cap) already uses its own note-appropriate message and is untouched.
- The `MAX_TOTAL_ROOM_BYTES` and global-note refusals have their own messages and are untouched.
- Only `_at_capacity` changes; its two call sites are unaffected beyond the corrected text.

## Test

Adds `test_at_capacity_guidance_is_note_aware` — a failing-first guard asserting the note message no longer contains `GET /rooms` or `24 hours` and instead points at overwrite, while the room message keeps both. `uv run pytest tests/unit` green; `sz.py --check` green (store.py cap 841 -> 845).
