### PR TITLE
fix: clarify empty rooms listing

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -792,7 +792,7 @@ def rooms(request: Request) -> Response:
         f"{n['capacity_per_namespace']} per namespace, namespaces not listed)"
     )
     if not view["total"]:
-        body = "(no rooms yet — GET /r/<name>/say/<nick>/<text> creates one)\n" + notes_line
+        body = "(no rooms are listed — create one if capacity allows)\n" + notes_line
     else:
         head = (
             # Both caps, because either can be the one that refuses the next room and an

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -547,7 +547,7 @@ def test_oversize_body_is_refused_before_it_is_buffered(client):
 
     r = client.post("/r/lobby", content=b"x" * (app_module.MAX_BODY + 1))
     assert r.status_code == 413 and "too large" in r.text
-    assert "no rooms yet" in client.get("/rooms").text  # nothing was written
+    assert "no rooms are listed" in client.get("/rooms").text  # nothing was written
 
 
 def test_chunked_body_is_stopped_at_the_same_cap_and_says_how_to_split_it(client):

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -446,7 +446,9 @@ def test_rooms_overview_hides_private_rooms_and_survives_an_empty_store(client):
     import app
     import store
 
-    assert "no rooms yet" in client.get("/rooms").text
+    empty = client.get("/rooms").text
+    assert "no rooms are listed" in empty
+    assert "create one if capacity allows" in empty
     assert client.get("/rooms?format=json").json() == {
         "rooms": [],
         "total": 0,
@@ -473,6 +475,12 @@ def test_rooms_overview_hides_private_rooms_and_survives_an_empty_store(client):
     client.get("/r/p-secret/say/bot/hi")
     view = client.get("/rooms?format=json").json()
     assert view["total"] == 0 and view["rooms"] == []  # p- stays invisible in stats too
+
+    body = client.get("/rooms").text
+    assert "no rooms are listed" in body
+    assert "no rooms yet" not in body
+    assert "create one if capacity allows" in body
+    assert "p-secret" not in body
 
 
 def test_rooms_overview_limits_the_tail_reads_it_does(client, tmp_path):


### PR DESCRIPTION
Fixes #312.

## What changes

When `/rooms` has no *listed* rooms, it currently says:

`(no rooms yet — GET /r/<name>/say/<nick>/<text> creates one)`

That is misleading when the store contains only unlisted rooms, and it can become actively wrong when those hidden rooms have filled the room cap.

This change makes the empty-listing sentence describe only what the endpoint actually knows:

`(no rooms are listed — create one if capacity allows)`

That wording is true for both a genuinely empty store and a store containing only unlisted rooms.

## Why this shape

This deliberately does not add an all-room occupancy scan or expose any unlisted-room names. `room_stats()` filters unlisted rooms by design, so the text response should not infer that zero listed rooms means zero rooms exist.

The fix also stays independent of #309. That PR adds occupancy accounting, but explicitly leaves this sentence unchanged and calls out #312 as separate work.

## Regression coverage

The existing `/rooms` test now verifies both cases:

- a truly empty store reports that no rooms are listed;
- after creating `p-secret`, the text still reports no listed rooms;
- it no longer says `no rooms yet`;
- it includes the capacity caveat;
- the private room name is not leaked.

The body-size test was updated only to assert the new wording while preserving its original purpose: an oversized refused write must not create a room.

Before the production change, the targeted regression failed on current `main` with:

`AssertionError: assert 'no rooms are listed' in '(no rooms yet — GET /r/<name>/say/<nick>/<text> creates one)...'`

After the change it passes.

## Compatibility

This changes one caller-visible text line in the zero-listed-room branch. JSON is unchanged. Listed-room rendering is unchanged. Room creation behavior, capacity enforcement, privacy rules, and response status codes are unchanged.

## Validation

Run against current upstream `main` (`9a7399d` at branch creation):

- `uv run --group dev python -m pytest tests` → **431 passed**
- `uv run --group dev ruff check .` → passed
- `uv run --group dev ruff format --check .` → passed
- `uv run --group dev ty check` → passed
- `uv run sz.py --check` → **check ok: core code-lines <= baseline (2067)**
- `git diff --check` → passed

The core change is one line replaced by one line, so it does not grow the `app.py` line budget.