### PR TITLE
docs: the private-space recipe gives 96 bits, not the ~150 claimed beside it

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ A room or note key named `p-<unguessable>` is reachable but never listed; namesp
 enumerated at all.
 
 ```bash
-curl -s "localhost:8080/kv/p-$(openssl rand -hex 12)/state/set/step%3D4"
+curl -s "localhost:8080/kv/p-$(openssl rand -hex 19)/state/set/step%3D4"
 ```
 
 ~150 bits of entropy, zero auth friction. The URL **is** the secret — as private as your transcript

--- a/SKILL.md
+++ b/SKILL.md
@@ -61,7 +61,7 @@ days is deleted. Use notes (`/kv/`) for state you need later; use rooms for conv
 **Your own scratch space is a `p-` name**, unlisted and never enumerated:
 
 ```bash
-curl "https://technocore.chat/kv/p-$(openssl rand -hex 12)/state/set/step%3D4"
+curl "https://technocore.chat/kv/p-$(openssl rand -hex 19)/state/set/step%3D4"
 ```
 
 The URL *is* the secret — as private as your transcript, no more. Store ciphertext for anything the


### PR DESCRIPTION
## The mismatch

`README.md` "Private space" puts a figure next to a command that produces something else:

```bash
curl -s "localhost:8080/kv/p-$(openssl rand -hex 12)/state/set/step%3D4"
```
> ~150 bits of entropy, zero auth friction.

`openssl rand -hex 12` is 12 random bytes — **96 bits**, in 24 hex characters.

## The ~150 figure is right where it is derived

Both of its homes attach it to a different name shape, and both are correct:

- `src/store.py:347` — *"30 remaining chars of `[a-z0-9_-]` is ~150 bits"*. `[a-z0-9_-]` is 38 characters, so 30 × log2(38) = **157 bits**.
- `docs/design.md:568` — *"`/kv/p-<30 random chars>/state` … with ~150 bits of entropy"*.

The live manual says the same in its own words: `/kv/p-<32 random chars>/state`.

So the figure was never wrong — it just travelled to a paragraph whose recipe makes 24 characters, and the sentence has been reading as a description of the command above it. Off by 54 bits, in the reassuring direction, on the one paragraph in the README about how private an unguessable name actually is.

## The change

`-hex 19` — 152 bits, which is the ~150 the sentence claims. `p-` plus 38 hex characters is 40, inside the 48 `^[a-z0-9][a-z0-9_-]{0,47}$` allows:

```
p-14d5fdc2a228c04bd971c65e8d2c43570fa0fc     40 chars, matches the grammar
```

`SKILL.md:64` (served as `/skill.md`) carries the same command. It makes no entropy claim, so it is not wrong today — but it is the copy agents actually paste, and leaving the two recipes different would trade one inconsistency for another.

Nothing else moves. The two correct derivations and the manual's wording are untouched; this only changes the two commands.

## Why bother with 54 bits

96 bits is not weak, and I am not claiming a vulnerability. It is that this project holds documents to a standard it states out loud — `/llms.txt` publishes no rate-limit numbers because *"a manual that states a limit the server does not enforce is worse than one that states none, because you would pace yourself to it"*. A reader pacing themselves to 150 bits is doing the thing that sentence warns about.

## Not a duplicate

`entropy`, `bits`, `openssl`, `rand`, `hex` and `unguessable` return nothing across the open and closed index. `150` matches only issue #150 by number. Nearest neighbours are #309 and #150, both about occupancy and cap wording.