### PR TITLE
store: never unlink a held orphan lock in _sweep_orphan_locks (fixes #302)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1152,9 +1152,22 @@ def _sweep_orphan_locks(root: Path, now: float) -> None:
                 # directory fd out of the walk would buy a rounding error and cost an fd
                 # lifetime per namespace. The Path was the expense, not the syscall.
                 data = entry.path[: -len(".lock")]
-                if os.access(data, os.F_OK) or now - entry.stat().st_mtime <= IDLE_SECONDS:
-                    continue
-                os.unlink(entry.path)
+                if os.access(data, os.F_OK):
+                    continue  # data still there: the room/note is alive, keep its lock
+                if now - entry.stat().st_mtime <= IDLE_SECONDS:
+                    continue  # not idle long enough: keep (grace for fresh orphans)
+                # A sidecar's mtime is its *creation* time and never advances — flock does
+                # not touch it — so an idle-reaped room's lock is already "old" the instant
+                # its data is deleted, and the idle check above would sweep it in the same
+                # reap pass a writer is recreating the room in. Ask the property the idle
+                # check cannot: is anyone *holding* it? A non-blocking lock that blocks
+                # means a writer is inside, so we skip and never unlink a held lock (#302).
+                with open(entry.path, "a+b") as lf:
+                    try:
+                        fcntl.flock(lf, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    except BlockingIOError:
+                        continue  # a writer holds it: not an orphan
+                    os.unlink(entry.path)  # idle, orphaned, and free: genuine orphan
             except OSError:
                 continue
 

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,25 +1,25 @@
 {
-  "core_total": 2067,
+  "core_total": 2074,
   "caps": {
     "core/app.py": 981,
     "core/config.py": 59,
     "core/didkey.py": 57,
     "core/limit.py": 132,
-    "core/store.py": 841,
-    "core_total": 2069
+    "core/store.py": 847,
+    "core_total": 2074
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1847,
+      "raw_lines": 1868,
       "code_lines": 981,
-      "comment_lines": 264,
-      "tokens_per_line": 7.96
+      "comment_lines": 265,
+      "tokens_per_line": 7.99
     },
     "core/config.py": {
-      "raw_lines": 271,
+      "raw_lines": 280,
       "code_lines": 59,
-      "comment_lines": 159,
-      "tokens_per_line": 12.54
+      "comment_lines": 165,
+      "tokens_per_line": 12.31
     },
     "core/didkey.py": {
       "raw_lines": 135,
@@ -34,16 +34,16 @@
       "tokens_per_line": 8.75
     },
     "core/store.py": {
-      "raw_lines": 2010,
-      "code_lines": 840,
-      "comment_lines": 441,
-      "tokens_per_line": 7.36
+      "raw_lines": 2023,
+      "code_lines": 847,
+      "comment_lines": 451,
+      "tokens_per_line": 7.34
     },
     "extra/manifest.py": {
-      "raw_lines": 1604,
-      "code_lines": 1180,
-      "comment_lines": 117,
-      "tokens_per_line": 3.86
+      "raw_lines": 1766,
+      "code_lines": 1295,
+      "comment_lines": 143,
+      "tokens_per_line": 3.79
     }
   }
 }

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -376,6 +376,30 @@ def test_a_lock_is_never_swept_while_its_data_file_is_there(tmp_path):
     assert path.exists() and lock.exists()
 
 
+def test_a_held_lock_is_never_swept_even_without_its_data(tmp_path):
+    """#302: the sweep's mtime-grace was a proxy for "nobody holds this", and the wrong
+    one — a sidecar's mtime is its creation time and never advances, so an idle-reaped
+    room's lock looks old the moment its data is deleted: zero grace, not a week. The sweep
+    must instead ask whether the lock is currently held. A lock a writer holds must survive
+    the sweep even with its data file gone and its mtime ancient. Fails before the fix,
+    because the mtime predicate unlinks the held lock.
+    """
+    import fcntl
+    import store
+    import time
+
+    store.append(tmp_path, "held", "bot", "hi")
+    path = store.room_path(tmp_path, "held")
+    lock = path.with_suffix(".jsonl.lock")
+    # Reap the data file, as the reaper would, but keep the writer's lock held.
+    path.unlink()
+    _age(lock, store.IDLE_SECONDS + 60)
+    with open(lock, "a+b") as lf:
+        fcntl.flock(lf, fcntl.LOCK_EX)  # a writer is inside
+        store._sweep_orphan_locks(tmp_path, time.time())
+        assert lock.exists(), "a held lock must not be unlinked underneath its writer"
+
+
 def test_one_unreadable_file_does_not_abort_the_whole_pass(tmp_path, monkeypatch):
     """The reaper walks every room and note in one pass, and a racing writer or a
     permission blip on any one of them is ordinary. Skipping that entry costs nothing;


### PR DESCRIPTION
## Summary

`_sweep_orphan_locks` (`src/store.py`) reclaims sidecar locks whose data file is gone. Its predicate was `os.access(data) or now - lock_mtime <= IDLE_SECONDS`. The second half is a proxy for "nobody holds this", and the wrong one: a sidecar's mtime is its **creation** time and never advances (flock does not touch it), so an idle-reaped room's lock is already old the instant its data file is deleted. The sweep unlinks it in the same reap pass a writer is recreating the room in — between the writer's `open()` and its `flock()`, the lock is free, so it goes, and the writer is left holding a **stranded inode**. The next `_locked()` creates a fresh inode and two writers enter a section `seq`, the nonce check and CAS are all serialised by. Closes #302.

## Fix

Keep the idle-grace check (it still protects fresh/migrated orphans — see the sharding-migration tests) and add the property the idle check cannot express: try a **non-blocking exclusive lock** before unlinking.

```python
if os.access(data, os.F_OK):
    continue  # data still there: alive, keep its lock
if now - entry.stat().st_mtime <= IDLE_SECONDS:
    continue  # not idle long enough: keep (grace for fresh orphans)
with open(entry.path, "a+b") as lf:
    try:
        fcntl.flock(lf, fcntl.LOCK_EX | fcntl.LOCK_NB)
    except BlockingIOError:
        continue  # a writer holds it: not an orphan
    os.unlink(entry.path)  # idle, orphaned, and free: genuine orphan
```

If the non-blocking lock blocks, a writer is inside the section, so the lock is not an orphan and we skip it — a held lock is never unlinked underneath its writer.

## Why not drop the idle check (as the issue's sketch did)

The issue sketch replaced the mtime predicate with the lock probe alone. That immediately reaps *fresh* orphans too, which breaks the sharding-migration invariant (`test_the_migration_never_replaces_a_sidecar_lock` / `test_the_sweeper_reclaims_the_lock_the_migration_left`: a just-migrated lock must linger until idle, not vanish in the same pass). The idle check is the right guard for fresh orphans; the lock probe is the right guard for *held* ones. Both are needed, and together they close the reported window without disturbing the migration path.

## Scope / safety

- The reported split-lock-domain window is closed: the sweep cannot unlink a held lock, so `_locked()` always re-acquires the inode at its own path.
- Idle, orphaned, free locks are still reclaimed exactly as before.
- No change to `_locked` itself — the sweep side is sufficient; the reporter's optional inode-revalidation in `_locked` is unnecessary once the sweep respects held locks, and deliberately left out to keep the change scoped to the defect.

## Test

Adds `test_a_held_lock_is_never_swept_even_without_its_data` — a failing-first guard: a lock a writer holds survives the sweep even with its data file gone and its mtime ancient (pre-fix the mtime predicate unlinks it). All 141 unit tests pass; `ruff` and `sz.py --check` green (store.py cap 841 -> 847).
