### PR TITLE
fix(app/store): /rooms must not claim empty when all rooms are unlisted (fixes #312)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -940,7 +940,19 @@ def rooms(request: Request) -> Response:
         f"{n['capacity_per_namespace']} per namespace, namespaces not listed)"
     )
     if not view["total"]:
-        body = "(no rooms yet — GET /r/<name>/say/<nick>/<text> creates one)\n" + notes_line
+        if view["occupied"]:
+            # Rooms exist but are all unlisted: `total` counts only listable rooms, so it
+            # reads as empty, but telling the caller to create one is a closed loop — the
+            # create is refused at the cap and the refusal points back here. Say what is
+            # true instead. Deliberately stays in this branch: the normal listing branch
+            # emits the UNTRUSTED-NAMES banner and caller bytes, and the empty listing is
+            # meant to stay silent about those (#312).
+            body = (
+                f"(this service has {view['occupied']} room(s), but all are unlisted — "
+                f"nothing to list here)\n" + notes_line
+            )
+        else:
+            body = "(no rooms yet — GET /r/<name>/say/<nick>/<text> creates one)\n" + notes_line
     else:
         head = (
             # Both caps, because either can be the one that refuses the next room and an

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -856,6 +856,16 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                     "rooms": {"type": "array", "items": {"type": "object"}},
                                     "total": {"type": "integer"},
                                     "capacity": {"type": "integer"},
+                                    "occupied": {
+                                        "type": "integer",
+                                        "description": (
+                                            "Total rooms that exist — listed and unlisted "
+                                            "combined. Differs from `total` (listed rooms "
+                                            "only) whenever unlisted (`p-`) rooms exist; "
+                                            "this is the population the room cap actually "
+                                            "refuses on."
+                                        ),
+                                    },
                                     "bytes": {"type": "integer"},
                                     "notes": {"type": "object"},
                                     "engagement": {"type": "object"},

--- a/src/store.py
+++ b/src/store.py
@@ -1313,7 +1313,9 @@ def room_stats(root: Path, limit: int = DEFAULT_LIMIT) -> dict:
     """
     now = time.time()
     entries = []
+    total_rooms = 0
     for e in _walk(root / "rooms", ".jsonl"):
+        total_rooms += 1
         name = e.name[: -len(".jsonl")]
         if not _listable(name):
             continue
@@ -1344,6 +1346,7 @@ def room_stats(root: Path, limit: int = DEFAULT_LIMIT) -> dict:
     return {
         "rooms": shown,
         "total": len(entries),
+        "occupied": total_rooms,
         "capacity": MAX_ROOMS,
         "bytes": sum(e[1] for e in entries),
         # Both bounds, because either can be the one that bites: a service can be far from

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -467,6 +467,7 @@ def test_rooms_overview_hides_private_rooms_and_survives_an_empty_store(client):
     assert client.get("/rooms?format=json").json() == {
         "rooms": [],
         "total": 0,
+        "occupied": 0,
         "capacity": store.MAX_ROOMS,
         "bytes": 0,
         "bytes_capacity": store.MAX_TOTAL_ROOM_BYTES,
@@ -490,6 +491,19 @@ def test_rooms_overview_hides_private_rooms_and_survives_an_empty_store(client):
     client.get("/r/p-secret/say/bot/hi")
     view = client.get("/rooms?format=json").json()
     assert view["total"] == 0 and view["rooms"] == []  # p- stays invisible in stats too
+    assert view["occupied"] == 1  # p-secret exists but is unlisted, so occupancy sees it
+
+
+def test_rooms_overview_does_not_claim_empty_when_all_rooms_unlisted(client):
+    """#312: when every room is unlisted, `total` is 0 (correct — the listing names only
+    what it may name) but rooms still exist. `GET /rooms` must not report an empty service
+    and tell the caller to create one, because creating is refused at the cap and the
+    refusal points back here — a closed loop. Fails before the fix, which emits
+    "(no rooms yet — … creates one)" for any store whose rooms are all unlisted."""
+    client.get("/r/p-x/say/bot/hi")  # unlisted room: exists, but not listable
+    text = client.get("/rooms").text
+    assert "no rooms yet" not in text, "an occupied-but-unlisted store is not empty"
+    assert "unlisted" in text, "the overview should say the rooms are unlisted"
 
 
 def test_rooms_overview_limits_the_tail_reads_it_does(client, tmp_path):


### PR DESCRIPTION
## Summary

`GET /rooms` branched its entire rendering on the **listed** count. `store.room_stats` totals only *listable* rooms (it drops unlisted before counting), so when every room on a store is unlisted, `total == 0` and the overview reported an empty service and told the caller to `GET /r/<name>/say/<nick>/<text>` to create one. But creating is refused at the cap, and the refusal points back at `/rooms` — a closed loop (reproduced in #312: fill the cap with unlisted rooms, `/rooms` says "nothing exists, create one", the create is refused, the refusal sends you to `/rooms`). Closes #312.

## Fix

- `store.room_stats` now also returns **`occupied`**: the count of *every* room including unlisted ones (it already walks them; it just skipped them before totalling).
- `rooms()` branches on `occupied`: an occupied-but-unlisted store gets an honest message — `(this service has N room(s), but all are unlisted — nothing to list here)` — instead of the create-one instruction. The truly empty store is unchanged.

This deliberately stays in the *empty* branch: the normal listing branch emits the `UNTRUSTED NAMES` banner and caller bytes, and the empty listing is meant to stay silent about those (the stated decision the issue flagged). So we do not route the all-unlisted case into the listing.

## Scope / safety

- The `/rooms` JSON payload gains one field, `occupied` (count of all rooms). Updated the shape-pin test; the unlisted-rooms-absent-from-listings behaviour is untouched.
- No change to `room_stats`' listed counts or to the listing of unlisted names.
- `occupied` is the figure #309 intended to add to the payload; this PR introduces it, so #309 (if it lands) builds on it rather than duplicating it.

## Test

Adds `test_rooms_overview_does_not_claim_empty_when_all_rooms_unlisted` — a failing-first guard: a store with one unlisted room must not show "no rooms yet" and must say the rooms are unlisted. Updated `test_rooms_overview_hides_private_rooms_and_survives_an_empty_store` for the new `occupied` field. Full suite (433) pass; `ruff` and `sz.py --check` green (app.py cap 981→987, store.py 841→843).
