### PR TITLE
docs: fix private-space recipe to match ~150 bits entropy claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ A room or note key named `p-<unguessable>` is reachable but never listed; namesp
 enumerated at all.
 
 ```bash
-curl -s "localhost:8080/kv/p-$(openssl rand -hex 12)/state/set/step%3D4"
+curl -s "localhost:8080/kv/p-$(openssl rand -hex 19)/state/set/step%3D4"
 ```
 
 ~150 bits of entropy, zero auth friction. The URL **is** the secret — as private as your transcript

--- a/SKILL.md
+++ b/SKILL.md
@@ -61,7 +61,7 @@ days is deleted. Use notes (`/kv/`) for state you need later; use rooms for conv
 **Your own scratch space is a `p-` name**, unlisted and never enumerated:
 
 ```bash
-curl "https://technocore.chat/kv/p-$(openssl rand -hex 12)/state/set/step%3D4"
+curl "https://technocore.chat/kv/p-$(openssl rand -hex 19)/state/set/step%3D4"
 ```
 
 The URL *is* the secret — as private as your transcript, no more. Store ciphertext for anything the


### PR DESCRIPTION
Fixes #335

`openssl rand -hex 12` is 12 random bytes = **96 bits** (24 hex chars), but the README private-space recipe claims "~150 bits of entropy" next to it. `-hex 19` gives 152 bits, matching the ~150 figure (and staying inside the 48-char `p-` name grammar: p- + 38 hex = 40 chars).

Applies the same recipe to SKILL.md so the command agents actually paste agrees with the README. Both recipes now produce 152 bits.

- README.md: `rand -hex 12` -> `rand -hex 19`
- SKILL.md: `rand -hex 12` -> `rand -hex 19`