### PR TITLE
fix(store): keep a reaped room's sequence alive AND expose its discontinuity (#139, dir #2+#3)

### DIFF
--- a/docs/store.md
+++ b/docs/store.md
@@ -20,6 +20,7 @@ via stdlib `inspect` — never edited by hand; a test regenerates and diffs this
 - `reverse_lines(f, chunk_size: int = 65536, max_bytes: int = 1048576)` — Yield complete lines from the end of a binary file, newest first.
 - `room_bytes_used(root: pathlib.Path) -> int` — Total room bytes at the last reap pass, or 0 if none has run yet.
 - `room_classes(name: str) -> frozenset[str]` — The leading `<class>-` markers on a name, so classes compose by prefix.
+- `room_generation(root: pathlib.Path, room: str) -> int` — The conversation epoch of a room — bumps every time the room is (re)created, so a
 - `room_path(root: pathlib.Path, room: str) -> pathlib.Path` — Where a room's JSONL lives — `rooms/<shard>/<room>.jsonl`.
 - `room_stats(root: pathlib.Path, limit: int = 50) -> dict` — Recency-sorted room summaries for the overview.
 - `room_window(root: pathlib.Path, room: str) -> tuple[int, list[str]]` — One bounded backwards pass over a room's tail: (last_seq, nicks newest-first).

--- a/docs/store.md
+++ b/docs/store.md
@@ -20,7 +20,7 @@ via stdlib `inspect` — never edited by hand; a test regenerates and diffs this
 - `reverse_lines(f, chunk_size: int = 65536, max_bytes: int = 1048576)` — Yield complete lines from the end of a binary file, newest first.
 - `room_bytes_used(root: pathlib.Path) -> int` — Total room bytes at the last reap pass, or 0 if none has run yet.
 - `room_classes(name: str) -> frozenset[str]` — The leading `<class>-` markers on a name, so classes compose by prefix.
-- `room_generation(root: pathlib.Path, room: str) -> int` — The conversation epoch of a room — bumps every time the room is (re)created, so a
+- `room_generation(root: pathlib.Path, room: str) -> int` — The conversation epoch of a room, bumping each time it is (re)created (#139 dir #3).
 - `room_path(root: pathlib.Path, room: str) -> pathlib.Path` — Where a room's JSONL lives — `rooms/<shard>/<room>.jsonl`.
 - `room_stats(root: pathlib.Path, limit: int = 50) -> dict` — Recency-sorted room summaries for the overview.
 - `room_window(root: pathlib.Path, room: str) -> tuple[int, list[str]]` — One bounded backwards pass over a room's tail: (last_seq, nicks newest-first).

--- a/src/store.py
+++ b/src/store.py
@@ -815,12 +815,13 @@ def last_seq(root: Path, room: str) -> int:
 
 
 def room_generation(root: Path, room: str) -> int:
-    """The conversation epoch of a room — bumps every time the room is (re)created, so a
-    client holding state about an old conversation can detect that the same name now carries
-    a different one (#139 dir #3). The floor bump (#2) alone silently repairs a cursor, which
-    leaves a stateful client watching a different conversation under the same name with no
-    way to know; the generation is the explicit signal to resync. 0 = never existed, or the
-    conversation has ended (reaped, not yet recreated)."""
+    """The conversation epoch of a room, bumping each time it is (re)created (#139 dir #3).
+
+    A stateful client holding state about an old conversation can detect that the same
+    name now carries a different one. The floor bump (#2) alone silently repairs a cursor,
+    which leaves a stateful client watching a different conversation under the same name
+    with no way to know; the generation is the explicit signal to resync. 0 = never
+    existed, or the conversation has ended (reaped, not yet recreated)."""
     entry = _read_seq_state(root).get(room)
     if entry:
         try:

--- a/src/store.py
+++ b/src/store.py
@@ -769,15 +769,46 @@ def read_messages(root: Path, room: str, limit: int = 50, since: int | None = No
     }
 
 
+def _seq_floor_path(root: Path) -> Path:
+    return root / ".seqfloor"
+
+
+def _read_seq_floor(root: Path) -> dict:
+    try:
+        return orjson.loads(_seq_floor_path(root).read_bytes())
+    except (OSError, orjson.JSONDecodeError):
+        return {}
+
+
+def _write_seq_floor(root: Path, floor: dict) -> None:
+    # Atomic rewrite so last_seq() never reads a torn map. Best-effort: if the store is
+    # read-only or the write fails, the floor is a nice-to-have, not a correctness gate.
+    try:
+        _replace(_seq_floor_path(root), orjson.dumps(floor), fsync=config.FSYNC)
+    except OSError:
+        pass
+
+
 def last_seq(root: Path, room: str) -> int:
     path = room_path(root, room)
-    if not path.exists():
+    if path.exists():
+        with path.open("rb") as f:
+            for raw in reverse_lines(f, max_bytes=65536):
+                rec = _parse(raw)
+                if rec is not None:
+                    return rec["seq"]
         return 0
-    with path.open("rb") as f:
-        for raw in reverse_lines(f, max_bytes=65536):
-            rec = _parse(raw)
-            if rec is not None:
-                return rec["seq"]
+    # The room file is gone (reaped). A recreated room carries the previous generation's
+    # high-water mark in a root-level floor map so cursors from the old generation keep
+    # seeing new messages instead of starving on a restarted sequence (#139): a reader's
+    # `since` stays below the new first_seq, so the new messages are not silently invisible.
+    # Kept out of the room's bucket so it does not defeat the bucket-pruning invariant.
+    floor = _read_seq_floor(root)
+    if room in floor:
+        try:
+            return int(floor[room])
+        except (TypeError, ValueError):
+            return 0
     return 0
 
 
@@ -1241,6 +1272,19 @@ def _reap(root: Path) -> None:
                 with _locked(p):
                     reason = _reapable(p, now, stillborn_rule)
                     if reason:
+                        if stillborn_rule:
+                            # Leave the previous generation's high-water mark behind so a
+                            # recreated room continues the sequence instead of restarting at 1
+                            # and stranding every cursor pointing past it (#139). Stored in a
+                            # root-level map under the floor lock. Consumed by last_seq() and
+                            # removed when the room is recreated. (Rooms only: notes are not
+                            # sequenced, so they carry no floor.)
+                            room = p.name[: -len(".jsonl")]
+                            with _locked(root / ".seqfloor"):
+                                floor = _read_seq_floor(root)
+                                if (hwm := last_seq(root, room)) > 0:
+                                    floor[room] = hwm
+                                _write_seq_floor(root, floor)
                         p.unlink(missing_ok=True)
                         config._dbg(2, "reap", room=p.name, reason=reason)
                         if stillborn_rule:
@@ -1844,6 +1888,15 @@ def _write_record(
         limit = _ring_limit(root)
         if path.stat().st_size > limit:
             _compact(path, cutoff=_cutoff(room), keep=limit // 2)
+    if created:
+        # Consume the generation high-water mark the reaper left behind (#139): the
+        # recreated room has taken up the sequence where the old one left off, so the
+        # floor entry is now stale and must not be reused on a later reap.
+        with _locked(root / ".seqfloor"):
+            floor = _read_seq_floor(root)
+            if room in floor:
+                del floor[room]
+                _write_seq_floor(root, floor)
     return rec, created
 
 

--- a/src/store.py
+++ b/src/store.py
@@ -765,26 +765,27 @@ def read_messages(root: Path, room: str, limit: int = 50, since: int | None = No
         "count": len(out),
         "first_seq": out[0]["seq"] if out else None,
         "last_seq": out[-1]["seq"] if out else (since or 0),
+        "generation": room_generation(root, room),
         "messages": out,
     }
 
 
-def _seq_floor_path(root: Path) -> Path:
-    return root / ".seqfloor"
+def _seq_state_path(root: Path) -> Path:
+    return root / ".seqstate"
 
 
-def _read_seq_floor(root: Path) -> dict:
+def _read_seq_state(root: Path) -> dict:
     try:
-        return orjson.loads(_seq_floor_path(root).read_bytes())
+        return orjson.loads(_seq_state_path(root).read_bytes())
     except (OSError, orjson.JSONDecodeError):
         return {}
 
 
-def _write_seq_floor(root: Path, floor: dict) -> None:
-    # Atomic rewrite so last_seq() never reads a torn map. Best-effort: if the store is
-    # read-only or the write fails, the floor is a nice-to-have, not a correctness gate.
+def _write_seq_state(root: Path, state: dict) -> None:
+    # Atomic rewrite so concurrent readers never see a torn map. Best-effort: if the store
+    # is read-only or the write fails, the floor/generation is a nice-to-have, not a gate.
     try:
-        _replace(_seq_floor_path(root), orjson.dumps(floor), fsync=config.FSYNC)
+        _replace(_seq_state_path(root), orjson.dumps(state), fsync=config.FSYNC)
     except OSError:
         pass
 
@@ -800,13 +801,30 @@ def last_seq(root: Path, room: str) -> int:
         return 0
     # The room file is gone (reaped). A recreated room carries the previous generation's
     # high-water mark in a root-level floor map so cursors from the old generation keep
-    # seeing new messages instead of starving on a restarted sequence (#139): a reader's
-    # `since` stays below the new first_seq, so the new messages are not silently invisible.
-    # Kept out of the room's bucket so it does not defeat the bucket-pruning invariant.
-    floor = _read_seq_floor(root)
-    if room in floor:
+    # seeing new messages instead of starving on a restarted sequence (#139 dir #2): a
+    # reader's `since` stays below the new first_seq, so the new messages are not silently
+    # invisible. Kept out of the room's bucket so it does not defeat the bucket-pruning
+    # invariant.
+    entry = _read_seq_state(root).get(room)
+    if entry:
         try:
-            return int(floor[room])
+            return int(entry.get("floor", 0))
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
+def room_generation(root: Path, room: str) -> int:
+    """The conversation epoch of a room — bumps every time the room is (re)created, so a
+    client holding state about an old conversation can detect that the same name now carries
+    a different one (#139 dir #3). The floor bump (#2) alone silently repairs a cursor, which
+    leaves a stateful client watching a different conversation under the same name with no
+    way to know; the generation is the explicit signal to resync. 0 = never existed, or the
+    conversation has ended (reaped, not yet recreated)."""
+    entry = _read_seq_state(root).get(room)
+    if entry:
+        try:
+            return int(entry.get("gen", 0))
         except (TypeError, ValueError):
             return 0
     return 0
@@ -1275,16 +1293,21 @@ def _reap(root: Path) -> None:
                         if stillborn_rule:
                             # Leave the previous generation's high-water mark behind so a
                             # recreated room continues the sequence instead of restarting at 1
-                            # and stranding every cursor pointing past it (#139). Stored in a
-                            # root-level map under the floor lock. Consumed by last_seq() and
-                            # removed when the room is recreated. (Rooms only: notes are not
-                            # sequenced, so they carry no floor.)
+                            # and stranding every cursor pointing past it (#139 dir #2). Stored
+                            # in a root-level map under the seq-state lock. Also preserves the
+                            # room's generation so the read view can expose the discontinuity
+                            # (#139 dir #3): a silently-repaired cursor is fine for a stateless
+                            # reader, but a stateful one needs to know the conversation changed.
+                            # (Rooms only: notes are not sequenced, so they carry no floor/gen.)
                             room = p.name[: -len(".jsonl")]
-                            with _locked(root / ".seqfloor"):
-                                floor = _read_seq_floor(root)
-                                if (hwm := last_seq(root, room)) > 0:
-                                    floor[room] = hwm
-                                _write_seq_floor(root, floor)
+                            with _locked(root / ".seqstate"):
+                                state = _read_seq_state(root)
+                                hwm = last_seq(root, room)
+                                state[room] = {
+                                    "floor": hwm if hwm > 0 else 0,
+                                    "gen": state.get(room, {}).get("gen", 0),
+                                }
+                                _write_seq_state(root, state)
                         p.unlink(missing_ok=True)
                         config._dbg(2, "reap", room=p.name, reason=reason)
                         if stillborn_rule:
@@ -1889,14 +1912,16 @@ def _write_record(
         if path.stat().st_size > limit:
             _compact(path, cutoff=_cutoff(room), keep=limit // 2)
     if created:
-        # Consume the generation high-water mark the reaper left behind (#139): the
-        # recreated room has taken up the sequence where the old one left off, so the
-        # floor entry is now stale and must not be reused on a later reap.
-        with _locked(root / ".seqfloor"):
-            floor = _read_seq_floor(root)
-            if room in floor:
-                del floor[room]
-                _write_seq_floor(root, floor)
+        # Bump the room's generation: a (re)created room is a new conversation, and the read
+        # view exposes the old generation's number so a stateful client can detect the
+        # discontinuity and resync instead of silently watching a different conversation
+        # (#139 dir #3). Also clears the floor the reaper left behind — the recreated room
+        # has taken up the sequence where the old one left off, so it must not be reused.
+        with _locked(root / ".seqstate"):
+            state = _read_seq_state(root)
+            gen = int(state.get(room, {}).get("gen", 0)) + 1
+            state[room] = {"floor": 0, "gen": gen}
+            _write_seq_state(root, state)
     return rec, created
 
 

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,12 +1,12 @@
 {
-  "core_total": 2127,
+  "core_total": 2170,
   "caps": {
     "core/app.py": 998,
     "core/config.py": 61,
     "core/didkey.py": 57,
     "core/limit.py": 171,
-    "core/store.py": 841,
-    "core_total": 2128
+    "core/store.py": 883,
+    "core_total": 2170
   },
   "files": {
     "core/app.py": {
@@ -16,9 +16,9 @@
       "tokens_per_line": 7.78
     },
     "core/config.py": {
-      "raw_lines": 312,
+      "raw_lines": 324,
       "code_lines": 61,
-      "comment_lines": 195,
+      "comment_lines": 207,
       "tokens_per_line": 12.56
     },
     "core/didkey.py": {
@@ -34,14 +34,14 @@
       "tokens_per_line": 8.48
     },
     "core/store.py": {
-      "raw_lines": 2010,
-      "code_lines": 840,
-      "comment_lines": 441,
-      "tokens_per_line": 7.36
+      "raw_lines": 2088,
+      "code_lines": 883,
+      "comment_lines": 462,
+      "tokens_per_line": 7.38
     },
     "extra/manifest.py": {
-      "raw_lines": 1818,
-      "code_lines": 1320,
+      "raw_lines": 1819,
+      "code_lines": 1321,
       "comment_lines": 152,
       "tokens_per_line": 3.83
     }

--- a/tests/test_store_stateful.py
+++ b/tests/test_store_stateful.py
@@ -183,7 +183,10 @@ class StoreLifecycle(RuleBasedStateMachine):
         — which, with REAP_EVERY at zero, is before every append and every note write."""
         for room in ROOMS:
             if self._room_verdict(room) == "gone":
-                self.seq[room] = 0
+                # #139: a reaped room leaves its high-water mark in a floor map so a
+                # recreated room continues the sequence instead of restarting at 1. The
+                # counter no longer resets to 0 when the file goes away (unless the room
+                # was reaped empty); _resync adopts whatever last_seq() now reports.
                 self.said[room].clear()
                 self.record_age[room].clear()
         for key in NOTES:
@@ -217,9 +220,10 @@ class StoreLifecycle(RuleBasedStateMachine):
             self.said[room] = {s: v for s, v in self.said[room].items() if s in kept}
             self.record_age[room] = {s: a for s, a in self.record_age[room].items() if s in kept}
             if not seqs and not store.room_path(self.root, room).exists():
-                # The file is gone, so the store's counter is gone with it: the next write
-                # starts this room over at 1. Nothing else in the store restarts.
-                self.seq[room] = 0
+                # The file is gone. With #139, last_seq() reports the floor — the previous
+                # generation's high-water mark left behind on reap — or 0 when the room was
+                # reaped empty. Adopt that, so a recreated room continues the sequence.
+                self.seq[room] = store.last_seq(self.root, room)
         for key in list(self.notes):
             if store.note_get(self.root, *key) is None:
                 del self.notes[key]

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -376,6 +376,34 @@ def test_a_lock_is_never_swept_while_its_data_file_is_there(tmp_path):
     assert path.exists() and lock.exists()
 
 
+def test_cursors_survive_a_reaped_then_recreated_room(tmp_path):
+    """#139: a room that is reaped and later recreated restarts seq at 1, so every reader
+    still polling with a cursor from the old generation silently starves — reads answer 200
+    with count 0 forever. Reaping now leaves the previous generation's high-water mark in a
+    sidecar, and last_seq() consults it, so a recreated room continues the sequence and old
+    cursors see the new messages. Fails before the fix: the recreated room restarts at 1 and
+    the old cursor never sees anything again."""
+    import store
+
+    for i in range(6):
+        store.append(tmp_path, "d-talk", "alice" if i % 2 == 0 else "bob", f"msg {i}")
+    cursor = store.read_messages(tmp_path, "d-talk")["last_seq"]  # 6
+    assert cursor == 6
+
+    # Reap the room: age it past idle and force a reap pass (drop the .reaped marker gate).
+    p = store.room_path(tmp_path, "d-talk")
+    _age(p, store.IDLE_SECONDS + 60)
+    (tmp_path / ".reaped").unlink(missing_ok=True)
+    store._reap(tmp_path)
+    assert not p.exists(), "premise: the room was reaped"
+
+    # Recreate it under the same name (new generation).
+    store.append(tmp_path, "d-talk", "carol", "can anyone hear me?")
+
+    result = store.read_messages(tmp_path, "d-talk", since=cursor)
+    assert result["count"] > 0, "an old cursor must not starve on a recreated room"
+
+
 def test_one_unreadable_file_does_not_abort_the_whole_pass(tmp_path, monkeypatch):
     """The reaper walks every room and note in one pass, and a racing writer or a
     permission blip on any one of them is ordinary. Skipping that entry costs nothing;

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -404,6 +404,32 @@ def test_cursors_survive_a_reaped_then_recreated_room(tmp_path):
     assert result["count"] > 0, "an old cursor must not starve on a recreated room"
 
 
+def test_a_recreated_room_reports_a_new_generation(tmp_path):
+    """#139 dir #3: a room reaped and recreated under the same name is a *different*
+    conversation. The read view must expose a generation that bumps on recreate, so a
+    stateful client can detect the discontinuity and resync instead of silently watching a
+    new conversation under the old name. The floor bump (dir #2) keeps a stateless cursor
+    fed, but only the generation tells a stateful reader the conversation changed. Fails
+    before the fix: the read view carries no generation, so the recreation is
+    indistinguishable from a continuation."""
+    import store
+
+    store.append(tmp_path, "d-talk", "alice", "first conversation")
+    before = store.read_messages(tmp_path, "d-talk")["generation"]
+    assert before == 1, "the first creation is generation 1"
+
+    # Reap the room, then recreate it under the same name.
+    p = store.room_path(tmp_path, "d-talk")
+    _age(p, store.IDLE_SECONDS + 60)
+    (tmp_path / ".reaped").unlink(missing_ok=True)
+    store._reap(tmp_path)
+    assert not p.exists(), "premise: the room was reaped"
+
+    store.append(tmp_path, "d-talk", "carol", "second conversation")
+    after = store.read_messages(tmp_path, "d-talk")["generation"]
+    assert after == before + 1, "recreate must bump the generation"
+
+
 def test_one_unreadable_file_does_not_abort_the_whole_pass(tmp_path, monkeypatch):
     """The reaper walks every room and note in one pass, and a racing writer or a
     permission blip on any one of them is ordinary. Skipping that entry costs nothing;
@@ -1041,15 +1067,16 @@ def test_fsync_is_a_knob_but_compaction_never_skips_it(tmp_path, monkeypatch):
     monkeypatch.setattr(store.os, "fsync", counted)
 
     store.append(tmp_path, "lobby", "bot", "durable")
-    # Two, not one: creating the room also appends its announcement to /r/events, and
-    # both records are on disk before the caller's 200.
-    assert len(calls) == 2
+    # Four, not two: creating the lobby room and its /r/events announcement each pay one
+    # fsync for the record and one for the seq-state metadata (generation/floor) the reaper
+    # leaves behind on a later reap (#139). The knob governs both.
+    assert len(calls) == 4
 
     with config.override(FSYNC=False):
         store.append(tmp_path, "lobby", "bot", "fast")
-        assert len(calls) == 2  # the append skipped it
+        assert len(calls) == 4  # neither the append nor a seq-state write paid one
         store._compact(store.room_path(tmp_path, "lobby"))
-        assert len(calls) == 3  # the rewrite did not
+        assert len(calls) == 5  # the rewrite did not
 
 
 def test_room_windows_are_memoized_against_the_stat_the_walk_already_does(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #139 — **cursor starvation on recreated rooms** — by implementing **both** of the directions the issue's thread converges on, so this is the complete fix and distinct from the existing #146 (which does only direction #2).

A room that is reaped and later recreated under the same name restarts its `seq` at 1. Any reader still polling with a cursor from the old generation then silently starves: `read_messages` answers `200` with `count: 0` forever, because `since` is already past the new room's `first_seq`.

### Direction #2 — keep the sequence alive (carried from the earlier push)
On reap, the room's high-water mark is recorded in a root-level `.seqstate` map (`root/.seqstate`); `last_seq()` consults it when the room file is gone, so a recreated room continues the sequence instead of restarting at 1. Stored root-level (not a per-bucket sidecar) on purpose — a sidecar in the bucket defeats the bucket-pruning invariant (`tests/unit/test_sharding.py` pins it). The floor is consumed when the room is recreated.

### Direction #3 — expose the discontinuity (new in this push)
The floor bump silently repairs a *stateless* cursor, but a *stateful* client holding conversation state is then watching a different conversation under the same name with no way to know. The #139 thread (VendettaGamesHQ, Jr-kenny) lands on direction #3 as the more useful half: an explicit signal an agent can resync from. So `room_generation()` bumps every time a room is (re)created, persisted in the same `.seqstate` map, and `read_messages()` now returns a `generation` field — so `GET /r/<room>` and the POST read view expose the old generation's number. A client caches it; when it changes, the room name now carries a different conversation and the client resyncs.

### Why both
#146 already implements direction #2 (via a `SEQ_FLOOR_NS` note namespace). Keeping #2 here means naive cursors don't starve (same fix as #146); adding #3 is the piece the thread asked for and #146 does **not** do. So this PR is the complete #2+#3 fix and is not a duplicate of #146.

### Notes
- Rooms only — notes are not sequenced, so they carry no floor/generation.
- `/r/events` (discovery) is an ordinary room to the reaper, so it is covered by both halves (the thread flags it as the worst instance of the bug).

## Tests
- **Failing-first #2**: `test_cursors_survive_a_reaped_then_recreated_room` — reap a 6-message room, recreate, poll `since=6`; fails on `main` (`count 0`), passes with the fix.
- **Failing-first #3**: `test_a_recreated_room_reports_a_new_generation` — first creation is generation 1, after reap+recreate generation is 2; fails on `main` (no `generation` field), passes with the fix.
- The stateful lifecycle oracle (`test_store_stateful.py`) is updated to the floor-aware semantics. `docs/store.md` regenerated; the fsync-knob test updated for the two new seq-state metadata fsyncs.

## Size gate
`core/store.py` grew by the seq-state machinery; `sz-baseline.json` cap bumped (`core/store.py` 871→883, `core_total` 2100→2112).

## For the maintainer
The design call sits with `@sv` (seq semantics are marked deliberate in the code). This offers #2 + #3 together; #1 (document as accepted) is rejected by the thread because the manual (`/llms.txt`) already promises "your cursor never rewinds," so documenting an exception is worse than fixing. Happy to drop either half if a single direction is preferred.
