### PR TITLE
perf(store): skip the sweep entirely when there is nothing to sweep

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -432,10 +432,17 @@ def clean_text(text: str, limit: int = MAX_TEXT_CHARS) -> str:
 
     Trade-off, accepted deliberately: ZWJ emoji sequences flatten (👨‍👩‍👧 → 👨👩👧).
     Mangled emoji is visible and harmless; a smuggled instruction is neither.
+
+    The str.isprintable() gate skips the per-character walk for text that has nothing to
+    sweep, which is the overwhelming majority of stored records. It is safe because every
+    category in INVISIBLE_CATEGORIES is non-printable by definition, so an isprintable()
+    string cannot contain one (verified across all 1,114,112 codepoints). The converse does
+    not hold — Zs and Cn are non-printable but not swept — so a false gate only costs the
+    walk it would have done anyway.
     """
-    text = "".join(
-        " " if unicodedata.category(c) in INVISIBLE_CATEGORIES else c for c in text
-    ).strip()
+    if not text.isprintable():
+        text = "".join(" " if unicodedata.category(c) in INVISIBLE_CATEGORIES else c for c in text)
+    text = text.strip()
     if not text:
         # Distinguishing "you sent nothing" from "the sweep ate all of it" matters: the
         # second is surprising, and a caller whose message was pure zero-width or bidi

--- a/tests/unit/test_parse_properties.py
+++ b/tests/unit/test_parse_properties.py
@@ -17,6 +17,7 @@ Run: uv run --group dev python -m pytest tests/unit/test_parse_properties.py
 from __future__ import annotations
 
 import json
+import sys
 import unicodedata
 from datetime import UTC, datetime
 from pathlib import Path
@@ -69,6 +70,22 @@ def _json_line(rec: dict) -> bytes:
 
 
 # --------------------------------------------------------------------------- sweep
+
+
+def test_nothing_the_sweep_takes_can_pass_for_printable() -> None:
+    """clean_text's fast path trusts str.isprintable() to mean "nothing to sweep".
+
+    That shortcut is only sound while every swept category is non-printable, which is a
+    property of the Unicode database, not of store.py — a category added to
+    INVISIBLE_CATEGORIES (Zs, say) would break the gate and let real invisibles through
+    silently. So assert it over the whole codepoint space, not a sample.
+    """
+    leaks = [
+        cp
+        for cp in range(sys.maxunicode + 1)
+        if unicodedata.category(chr(cp)) in store.INVISIBLE_CATEGORIES and chr(cp).isprintable()
+    ]
+    assert leaks == [], f"printable but swept: {[hex(cp) for cp in leaks[:8]]}"
 
 
 @given(ANY_TEXT)


### PR DESCRIPTION
## What

Gate `clean_text`'s per-character sweep behind `str.isprintable()`.

```python
if not text.isprintable():
    text = "".join(" " if unicodedata.category(c) in INVISIBLE_CATEGORIES else c for c in text)
text = text.strip()
```

The walk itself is untouched. What changes is that it no longer runs for records
that have nothing to sweep, which is the overwhelming majority of them.

## Why the gate is sound

Every category in `INVISIBLE_CATEGORIES` (`Cc Cf Cs Co Zl Zp`) is non-printable
*by definition*, so an `isprintable()` string cannot contain a character the
sweep would take. The converse does not hold — `Zs` and `Cn` are non-printable
but not swept — so a string that fails the gate merely pays for the walk it
would have done anyway. There is no input for which output changes.

That soundness is a property of the Unicode database, not of `store.py`, so it
is pinned by a test rather than a comment: `INVISIBLE_CATEGORIES` growing to
include a printable category (`Zs`, say) fails the whole codepoint space at
once instead of silently letting invisibles through.

## Verification

- **All 1,114,112 codepoints**: zero characters are both swept and printable.
- **Byte-equivalence vs the old implementation**: 0 mismatches over every
  codepoint individually, plus 40,000 random strings drawn from ASCII, C0
  controls, `Cf`, the `U+E0000` tag block, surrogates and mixed pools —
  identical output and identical `StoreError` raises.
- **Full suite**: `636 passed` (the +1 is the codepoint test below).
- `sz.py --check`, `ruff check`, `ruff format --check` clean.

## Numbers

| input | before | after | |
|---|---|---|---|
| ASCII 4050 B | 2.1111 ms | 0.0260 ms | 81x |
| ASCII 180 B | 0.1088 ms | 0.0017 ms | 66x |
| clean unicode 300 ch | 0.1571 ms | 0.0025 ms | 64x |
| ZWSP every 20 ch | 0.4598 ms | 0.4439 ms | unchanged |
| all-C0 4050 B | 1.4919 ms | 1.4891 ms | unchanged |

Dirty input still walks, as it must. The win is that clean input stops paying
for the hazard it does not carry.

## Size

`core/store.py` stays at **935** code lines — same as baseline. `sz.py --check`
passes without touching `sz-baseline.json`:

```
core/store.py              2544    935       583      7.74
core total (code)                 2256
check ok: core code-lines <= baseline (2256)
```

## Test

`tests/unit/test_parse_properties.py::test_nothing_the_sweep_takes_can_pass_for_printable`
— asserts no codepoint is simultaneously in `INVISIBLE_CATEGORIES` and
printable. RED confirmed by adding `"Zs"` to the tuple:

```
AssertionError: printable but swept: ['0x20']
```

GREEN on the real tuple, and the existing sweep properties
(`test_clean_text_sweeps_trims_and_is_idempotent`, the hostile-input HTTP test,
the stateful model) pass unchanged.

Refs #322