### PR TITLE
docs(contributing): agent-facing documents stay English-only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,10 +119,10 @@ version changes to a dedicated release change unless a maintainer asks otherwise
 
 ### Translations of agent-facing documents
 
-The documents an agent reads — `/llms.txt`, `SKILL.md`, `src/patterns.md`, `interop.md`, the
-refusal bodies — are English-only, and a pull request that adds a translated copy of one is
-declined. This is about instructions written *for agents*, not about people: open issues, review,
-and discuss in whatever language you think in.
+The documents an agent reads — `/llms.txt`, `/skill.md`, `/patterns.md`, `/interop.md`,
+`/auth.md`, the refusal bodies — are English-only, and a pull request that adds a translated copy
+of one is declined. This is about instructions written *for agents*, not about people: open issues,
+review, and discuss in whatever language you think in.
 
 The reason is drift. These documents carry the sentences an agent's safety rests on — `TRUST`, the
 `!! UNTRUSTED CONTENT` banner, the swept character set a signature has to match — and a second copy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,32 @@ unless a maintainer asks.
 The service, MCP wrapper, and published skill share the version in `pyproject.toml`. Leave release
 version changes to a dedicated release change unless a maintainer asks otherwise.
 
+### Translations of agent-facing documents
+
+The documents an agent reads — `/llms.txt`, `SKILL.md`, `src/patterns.md`, `interop.md`, the
+refusal bodies — are English-only, and a pull request that adds a translated copy of one is
+declined. This is about instructions written *for agents*, not about people: open issues, review,
+and discuss in whatever language you think in.
+
+The measurement has been taken once. #116 was closed asking for an eval; #168 ran it and found a
+capable agent onboarded from a translated guide no better than from the English manual alone —
+every arm delivered, every pass/fail number unmoved, and the one figure that did move came from a
+number missing from the *English* manual. The cost is less speculative. These documents carry the
+sentences an agent's safety rests on — `TRUST`, the `!! UNTRUSTED CONTENT` banner, the swept
+character set a signature has to match — a second copy can lag the first by one commit, and a
+stale translation of a warning is worse than none because it is still believed. Keeping copies
+current is machinery, not goodwill: MDN archived nearly every locale in 2020 after unmaintained
+ones drifted, and Kubernetes takes a localization only from a team that commits to staying current.
+
+To change this, measure rather than argue — an eval in the shape of #168 where the translated arm
+wins something the English arm does not, plus a harness that holds the copy in sync and fails CI
+when it drifts, generated from the same constants the server enforces. Until then, publish the
+translation in your own repository: name the upstream commit it was built from, say plainly that
+the English document is authoritative, and list it from a community index such as an
+`awesome-technocore` repository. And if translating showed you something the English document gets
+wrong or leaves unsaid, that is a bug in the English document — send it as its own small pull
+request. Those land.
+
 ## Pull requests
 
 In the pull request description:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,24 +124,24 @@ refusal bodies — are English-only, and a pull request that adds a translated c
 declined. This is about instructions written *for agents*, not about people: open issues, review,
 and discuss in whatever language you think in.
 
-The measurement has been taken once. #116 was closed asking for an eval; #168 ran it and found a
-capable agent onboarded from a translated guide no better than from the English manual alone —
-every arm delivered, every pass/fail number unmoved, and the one figure that did move came from a
-number missing from the *English* manual. The cost is less speculative. These documents carry the
-sentences an agent's safety rests on — `TRUST`, the `!! UNTRUSTED CONTENT` banner, the swept
-character set a signature has to match — a second copy can lag the first by one commit, and a
-stale translation of a warning is worse than none because it is still believed. Keeping copies
-current is machinery, not goodwill: MDN archived nearly every locale in 2020 after unmaintained
-ones drifted, and Kubernetes takes a localization only from a team that commits to staying current.
+The reason is drift. These documents carry the sentences an agent's safety rests on — `TRUST`, the
+`!! UNTRUSTED CONTENT` banner, the swept character set a signature has to match — and a second copy
+of them can lag the first by a commit. A stale translation of a warning is worse than none, because
+it is still believed. Keeping copies current is machinery, not goodwill: a maintainer per language,
+tooling that shows what the English source changed under them, and a check that fails while they
+disagree. Nothing here is set up to carry that, and the reader of these files is a model, so the
+gain that would pay for building it is not the obvious one.
 
-To change this, measure rather than argue — an eval in the shape of #168 where the translated arm
-wins something the English arm does not, plus a harness that holds the copy in sync and fails CI
-when it drifts, generated from the same constants the server enforces. Until then, publish the
-translation in your own repository: name the upstream commit it was built from, say plainly that
-the English document is authoritative, and list it from a community index such as an
-`awesome-technocore` repository. And if translating showed you something the English document gets
-wrong or leaves unsaid, that is a bug in the English document — send it as its own small pull
-request. Those land.
+The bar for changing this is therefore a measurement rather than an argument: an eval that runs the
+same tasks against a real instance, one arm given the English document and one given your
+translation, scored on the server's answer and on what landed; a result where the translated arm
+does something the English arm does not; and a harness that holds the copy in sync and fails CI
+when it drifts, generated from the same constants the server enforces rather than restated by hand
+in prose. Until then, publish the translation in your own repository — name the upstream commit it
+was built from, say plainly that the English document is authoritative, and list it from a
+community index such as an `awesome-technocore` repository. And if translating showed you something
+the English document gets wrong or leaves unsaid, that is a bug in the English document: send it as
+its own small pull request. Those land.
 
 ## Pull requests
 


### PR DESCRIPTION
## What

A `Translations of agent-facing documents` section in `CONTRIBUTING.md`. Translated copies of the documents an agent reads — `/llms.txt`, `/skill.md`, `/patterns.md`, `/interop.md`, `/auth.md`, the refusal bodies — are declined; issues, review and discussion in any language are explicitly unaffected. Nothing a caller of the service or the MCP wrapper sees changes.

## Why

The question keeps arriving one pull request at a time and deserves one answer in the open. #116 was closed asking for an eval, #168 ran it and honestly reported a null result, and #171 then demonstrated the maintenance cost live — 21 files regenerated per constant change, translated copies describing the sweep more accurately than the manual an agent reads first, and a request for language 21 arriving mid-review. Those three are now closed pointing here.

The section itself carries none of that history: it reads as guidance — the rule, why drift makes it the rule, what measurement would change it, and where the work goes instead. It keeps the door open for what translating genuinely surfaced: gaps in the English documents, sent as their own small pull requests. Two are still unclaimed — `/llms.txt` omits `Cs`/`Co`/`Zl`/`Zp` from the swept set it names, and its URL budget is framed as "ASCII vs non-Latin" rather than bytes (#180 is the neighbouring point).

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — not exercised: no code changed
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — not exercised: no code changed
- [x] Docs that would now be wrong are updated: none — this adds contributor guidance, and no served document or manifest constant is touched
- [x] New surface on a world-writable service: nothing new