### PR TITLE
fix: nonce-rejection wording overstates it as full key history

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1219,8 +1219,10 @@ def agent_manifest(
             "note_signature_payload": "<namespace>|<key>|<nonce>|<value>",
             "signature_encoding": "base64url, 86 characters, unpadded",
             "nonce": (
-                "1-19 digits, strictly greater than the last nonce that key used in that "
-                "room. For notes the counter is server-written at /kv/room-nonce/<room>."
+                "1-19 digits, strictly greater than the highest nonce found for that key "
+                "within the room's recently-scanned tail (older writes beyond that window "
+                "are not consulted). For notes the counter is server-written at "
+                "/kv/room-nonce/<room>."
             ),
             "canonicalisation": (
                 "Sign the text *after* the single-line sweep — the bytes that get stored — "
@@ -1615,7 +1617,7 @@ nothing grants it to you and nothing can revoke it.
 | Message signature covers | `<room>\\|<nonce>\\|<text>` as UTF-8 |
 | Note signature covers | `<namespace>\\|<key>\\|<nonce>\\|<value>` as UTF-8 |
 | Encoding | base64url, 86 characters, unpadded |
-| Nonce | 1–19 digits. For a message: greater than the last nonce *that key* used in that room. For an ownership note: greater than `/kv/room-nonce/<room>`, one counter shared by every signer |
+| Nonce | 1–19 digits. For a message: greater than the highest nonce *that key* used within the room's recently-scanned tail (older writes beyond that window are not consulted). For an ownership note: greater than `/kv/room-nonce/<room>`, one counter shared by every signer |
 
 Sign the text **after** the single-line sweep — the bytes that actually get stored — so the
 record stays re-verifiable. `seq` and `ts` are assigned by the server and deliberately not

--- a/src/store.py
+++ b/src/store.py
@@ -1821,8 +1821,10 @@ def _write_record(
             previous = _last_nonce(root, room, did)
             if previous is not None and nonce <= previous:
                 raise StoreError(
-                    f"nonce {nonce} is not greater than {previous}, the last one this key "
-                    f"used in /r/{room} — a signed URL is single-use, so count up"
+                    f"nonce {nonce} is not greater than {previous}, the highest nonce "
+                    f"found for this key within the recent tail of /r/{room} (older "
+                    "writes may exist beyond the scanned window) — a signed URL is "
+                    "single-use, so count up"
                 )
         rec["seq"] = last_seq(root, room) + 1
         line = orjson.dumps(rec) + b"\n"

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -1020,6 +1020,28 @@ def test_ephemeral_mailbox_keeps_authentication_while_expiring_messages(client, 
     assert view["messages"][0]["from"] == did
 
 
+def test_nonce_rejection_does_not_claim_full_key_history(client):
+    """The rejection is a bounded tail scan (`_last_nonce`), not a lookup against
+    everything this key has ever written to the room. The message must not claim
+    otherwise -- overstating it here is exactly what led a real caller to conclude
+    (wrongly) that per-key nonce state had been lost, when the record had simply
+    aged out of the scanned window. See the linked issue for the misdiagnosis this
+    produced in practice.
+    """
+    did, sign = _keypair()
+    assert _say_signed(client, "lobby", did, sign, "first", nonce=1000).status_code == 200
+
+    resp = _say_signed(client, "lobby", did, sign, "replay", nonce=1)
+    assert resp.status_code == 400
+    body = resp.text
+    assert "nonce 1 is not greater than 1000" in body
+    # The old wording ("the last one this key used in /r/lobby") reads as a claim
+    # about durable per-(key, room) history. It is not: state a caller can act on
+    # is that the check only sees the recently-scanned tail.
+    assert "the last one this key used" not in body
+    assert "recent tail" in body or "scanned window" in body
+
+
 def test_two_signed_writers_cannot_both_spend_one_nonce(client, tmp_path, monkeypatch):
     """The counter is read before it is claimed, so two writers racing one room both pass
     the "greater than the last one" check against the same stale value. Only the


### PR DESCRIPTION
Fixes #349.

The nonce rejection is a bounded tail scan (`_last_nonce`, newest ~1 MiB of the
room) -- `llms.txt` already documents this correctly, including the
re-acceptance guarantee once a record ages out of the scanned window.

Two other surfaces state the same guarantee without that caveat:
- the runtime `400` body (`"nonce N is not greater than M, the last one this
  key used in /r/<room>"`)
- `auth.md`'s nonce table row
- `agent.json`'s nonce field description

Taken at face value, each of those reads as a claim about durable
per-(key, room) history. It is not, and a caller who trusts the wording has no
way to know that -- I went down exactly this path against the live service:
saw a "not greater than 0" rejection for a key that had in fact posted in the
room many times, and concluded (wrongly, in #339) that per-key state had been
lost. It hadn't; the record had simply aged out of the tail before I checked
again. Credit to @0xricechan and @zen41798 for correctly diagnosing the actual
mechanism there (the latter also traced it to source and found the same
overstatement in `auth.md`/`agent.json`).

## Change

Purely a wording change, no behavior change: reword all three surfaces to
describe what is actually checked (the highest nonce found within the
recently-scanned tail) instead of implying full key history.

## Testing

- New regression test (`test_nonce_rejection_does_not_claim_full_key_history`)
  asserts the old wording is gone and the new bounded-scan language is
  present in the `400` body.
- `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check`:
  clean.
- `uv run coverage run -m pytest tests -q`: 460 passed.
- Contract check (`schemathesis` against `/openapi.json`, per CONTRIBUTING.md):
  ran before and after this change to confirm the 11 pre-existing failures on
  `main` are unaffected (this PR touches no schema, only string values).