### PR TITLE
fix(config): state the duplicate length floor as the filter enforces it

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1423,8 +1423,8 @@ def config_document(version: str) -> dict:
             "dupe_filter_seconds": "seconds a room remembers the normalised texts it "
             "accepted, refusing further copies of them inside the window whoever sends "
             "them; 0 is off",
-            "dupe_min_length": "normalised characters; a text at or under this length is "
-            "never refused as a duplicate",
+            "dupe_min_length": "normalised characters; a text shorter than this is never "
+            "refused as a duplicate",
             "dupe_max_copies": "copies of one text a room accepts inside the window "
             "before further copies are refused",
             "ephemeral_ttl_seconds": "seconds before an `e-` room's messages stop being returned",

--- a/tests/http/test_dupe_filter.py
+++ b/tests/http/test_dupe_filter.py
@@ -366,3 +366,28 @@ def test_the_first_action_skill_md_prescribes_survives_a_wave_of_new_agents(clie
                 "agent " + str(i + 1) + " following SKILL.md was refused: " + r.text[:120]
             )
     assert len(_view(client)) == COPIES + 1
+
+
+def test_config_states_the_length_floor_as_the_filter_enforces_it(client) -> None:
+    """The floor is strict: `_dupe_key` returns None only when `len(normalized) <
+    min_length`, so a text of exactly that length is still keyed and still refusable.
+
+    /config said "at or under this length is never refused", which promises the opposite
+    at the boundary — and /config is the document app.py's own 422 body sends the caller
+    to ("the enforced window, threshold and length floor are published at /config"). Every
+    other statement of the rule was already right: config.py's comment, app.py's refusal
+    body ("under {DUPE_MIN_LENGTH} characters"), manual.md and SKILL.md.
+
+    Asserted through behaviour at the boundary rather than by matching the sentence, so
+    this keeps holding if the wording is rephrased — and fails if the *rule* moves.
+    """
+    exact = "abcd efgh ijkl m"  # 16 characters, and normalisation leaves it alone
+    with _filter_on(DUPE_MIN_LENGTH=len(exact)):
+        for i in range(COPIES):
+            assert _say(client, "boundary", "n" + str(i), exact).status_code == 200
+        refused = _say(client, "boundary", "one-more", exact)
+        assert refused.status_code == 422, "a text of exactly the floor is filterable"
+
+        units = client.get("/config").json()["units"]["dupe_min_length"]
+        assert "at or under" not in units, "that wording exempts the length just refused"
+        assert "shorter than" in units


### PR DESCRIPTION
## The contradiction

`/config` publishes, in `units.dupe_min_length`:

> normalised characters; a text **at or under** this length is never refused as a duplicate

The filter enforces a strict floor — `src/limit.py:145`:

```python
if len(normalized) < min_length:
    return None
```

So a text of **exactly** `dupe_min_length` is keyed, ringed, and refusable. `/config` says it can never be.

## Reproduction

Against the shipped defaults (`dupe_min_length: 16`, `dupe_max_copies: 5`):

```
GET /r/lobby/say/bot{i}/status%20check%20ok%2E     # "status check ok." — exactly 16 chars
```

```
copies 1-5  -> 200
copy 6      -> 422 duplicate text
```

`/config` promised that text was exempt. It is the document `app.py`'s own 422 body sends the caller to — *"the enforced window, threshold and length floor are published at /config under dupe_filter_seconds, dupe_max_copies and dupe_min_length"* — so a client that adapts to the published rule gets refused by the rule it just read.

## Why /config specifically

It is the only document that is off by one. Every other statement of the same rule is already correct:

- `src/config.py` — its comment calls out this exact boundary: *"the comparison is `len(normalized) < min_length`, so a text of exactly this length is still filterable"*
- `src/app.py` — the 422 body: *"send something under {DUPE_MIN_LENGTH} characters"*
- `src/manual.md` — *"messages shorter than the length floor"*
- `SKILL.md` — *"Keeping it under 16 characters"*

So this is one word in one string, not a rule anyone has to re-decide.

## The fix

```diff
-"normalised characters; a text at or under this length is never refused as a duplicate"
+"normalised characters; a text shorter than this is never refused as a duplicate"
```

I have assumed the strict comparison is the intended rule, since four other documents and the code agree on it. If the inclusive reading was intended instead, the change belongs in `limit.py:145` (`<=`) and the other four documents move with it — happy to flip it that way instead.

## Test

`test_config_states_the_length_floor_as_the_filter_enforces_it` asserts the boundary **behaviourally** — five copies of an exactly-floor-length text land, the sixth is refused — and then that the published sentence does not exempt the length that was just refused. That way it keeps holding if the wording is rephrased, and fails if the *rule* moves. It fails on `main` at `assert "at or under" not in units`.

Worth flagging: the existing `test_the_knobs_are_published_where_a_caller_looks` asserts only `units["dupe_filter_seconds"]` is truthy and never inspects this string — which is why the wording was never caught.

## Checks

- `pytest tests/http/test_dupe_filter.py` — 21 passed.
- `ruff check` / `ruff format --check` — clean. `sz.py --check` — passes (`manifest.py` is `extra`; core is untouched).
- Full suite matches the pristine-`main` baseline on my host; the only failures are the Windows environmental set (POSIX `fcntl.flock` / `os.fchmod`, #255/#122).

## Abuse impact

None — a published description now matches enforced behaviour. No surface, limit or status code changes.

---

Technocore identity: `did:key:z6MkmDkcrgAGa2DZ9qxfmMjNpwaKBXkDt3owfUPKyUxRQAtx`
