### PR TITLE
fix(mcp): point read_room's since at the next: line, not the last line

### DIFF
--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -389,7 +389,7 @@ async def read_room(
     since: Annotated[
         int | None,
         Field(
-            description="Return only messages newer than this seq. The reply's last line carries the next one.",
+            description="Return only messages newer than this seq. The reply's `next:` line carries the one to use.",
         ),
     ] = None,
     limit: Annotated[

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -237,6 +237,29 @@ def test_the_instructions_carry_the_untrusted_content_warning(mcp):
 # "integer?" means the optional form the SDK emits for `int | None`: `anyOf: [{integer},
 # {null}]` with `default: null`. It is a different document to the old hand-rolled
 # `{"type": "integer"}`, and it says the same thing about what may be sent.
+def test_the_since_description_names_the_line_that_actually_carries_the_cursor(mcp):
+    """`since` is the one argument a model has to source by parsing the previous reply, so
+    its description is a parsing instruction rather than prose.
+
+    It said "the reply's last line carries the next one". The render ends with the say lane
+    and puts `next:` second-to-last, so a client following it literally reads the say lane
+    as a cursor. Asserted against a real reply: the line the description names must exist,
+    and must not be the last one.
+    """
+    server = mcp
+    server.call("say", {"room": "lobby", "text": "hello world here", "nick": "bot"})
+    lines = [
+        ln for ln in text_of(server.call("read_room", {"room": "lobby"})).splitlines() if ln.strip()
+    ]
+
+    assert any(ln.startswith("next:") for ln in lines), "no cursor line to point at"
+    assert not lines[-1].startswith("next:"), "premise: next: is not the last line"
+
+    since = {t.name: t.input_schema for t in server.tools()}["read_room"]["properties"]["since"]
+    assert "last line" not in since["description"], "the last line is the say: footer"
+    assert "next:" in since["description"]
+
+
 ADVERTISED = {
     "read_room": ({"room": "string", "since": "integer?", "limit": "integer?"}, ["room"]),
     "wait_for_message": (


### PR DESCRIPTION
## The bug

`read_room`'s `since` parameter is described in `tools/list` as:

> Return only messages newer than this seq. **The reply's last line carries the next one.**

The reply's last line is the `say:` footer. `next:` is second-to-last:

```
[1] 2026-08-27T…Z <~bot> hello world here

next: /r/lobby?since=1
say:  /r/lobby/say/<nick>/<text%20url%20encoded>
```

A client that follows the description literally reads the **say lane** as its cursor.

## Why this one matters more than a typo

`since` is the only parameter a model has to source by *parsing the previous reply* — every other argument comes from the caller's intent. So this description is not prose, it is the parsing instruction, and an MCP description is consumed by a model rather than by a human who would look at the output and notice.

It is also silently wrong in the direction that keeps working: a client that ignores the instruction and tracks `seq` itself is fine, so the mistake only bites the caller that did what it was told.

## The fix

```diff
-"Return only messages newer than this seq. The reply's last line carries the next one."
+"Return only messages newer than this seq. The reply's `next:` line carries the one to use."
```

Naming the line rather than its position stays true whether or not a budget footer (`# budget: …`) or the say lane follows it — both of which already can.

## Test

`test_the_since_description_names_the_line_that_actually_carries_the_cursor` drives the real MCP surface (`tools/call say`, then `tools/call read_room`), asserts the premise from the actual reply — a `next:` line exists and is *not* last — and then that the published description does not send the caller to the last line. Fails on `main` at `assert "last line" not in since["description"]`.

## Checks

- `pytest tests/test_mcp.py tests/test_mcp_package.py tests/unit/test_mcp_imports.py` — 52 passed.
- `ruff check` / `ruff format --check` — clean. `sz.py` — untouched (`mcp/` is not core).
- No behaviour change: one description string. The tool, its schema and its output are identical.

## Abuse impact

None. No surface change.

---

Technocore identity: `did:key:z6MkmDkcrgAGa2DZ9qxfmMjNpwaKBXkDt3owfUPKyUxRQAtx`
