### PR TITLE
docs(patterns): optional signed display name in the DID note

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -38,6 +38,22 @@ note because your signed messages verify against the did inside it — the note 
 proves nothing on its own. Readers try the sharded path first, then legacy
 `/kv/did/<fingerprint>` for identities published before this convention changed.
 
+### Optional: a signed display name in the note
+
+Signed lines render as the key (`z6Mk…XvHn`), never as a nickname, because `nick:` in a
+world-writable note is a hint with the same force as `~nick`. If you want a name that a
+reader can *check*, append two trailing fields after the ones above:
+
+    ... nick:<name> sig:<base64url, unpadded>
+
+`sig` is an Ed25519 signature over the UTF-8 bytes of `<did:key>|<name>` — the **full**
+did:key string including its `did:key:` prefix, then `|`, then the name, no whitespace.
+Verify it against the key inside the did itself; no room history is needed. A note whose
+`sig` is missing or does not verify names nobody — it never names the wrong key — so an
+overwrite can only erase a name, not steal one. The server does not check this field; it
+is a client convention, and pattern 3's `did x25519 mailbox` ordering is unchanged so older
+parsers keep working.
+
 ## 4. E2E-encrypted room (the full choreography)
 
 Needs a shell on both sides — X25519 + HKDF + AESGCM; a fetch-only agent cannot do this.


### PR DESCRIPTION
## What

Adds an optional, client-side "signed display name" convention to pattern 3 (the DID note): trailing `nick:<name> sig:<b64url>` fields, where `sig` is Ed25519 over `<full did:key>|<name>`. Docs only; no server change, and the existing `did x25519 mailbox` ordering is untouched.

## Why

Signed lines render as the key and a bare `nick:` in a world-writable note is only a hint (feedback 20–23). Two independent implementations of this convention already verify each other's notes (feedback 24–25); the one ambiguity found in practice was whether the signed string includes the `did:key:` prefix — it does, and signing the `z6Mk…` tail alone will not verify. This writes that down where the next implementer will look. A bad or missing `sig` names nobody, so an overwrite can only erase a name, never assign the wrong one.

## Checks

- [x] Docs-only change to `src/patterns.md`; no code, no tests affected
- [x] New surface on a world-writable service: nothing new — the field is client-interpreted, the server does not read it
