### PR TITLE
fix(config): the dupe length floor is exclusive, not inclusive

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1423,8 +1423,8 @@ def config_document(version: str) -> dict:
             "dupe_filter_seconds": "seconds a room remembers the normalised texts it "
             "accepted, refusing further copies of them inside the window whoever sends "
             "them; 0 is off",
-            "dupe_min_length": "normalised characters; a text at or under this length is "
-            "never refused as a duplicate",
+            "dupe_min_length": "normalised characters; a text shorter than this is never "
+            "refused as a duplicate — at this length and above it is filterable",
             "dupe_max_copies": "copies of one text a room accepts inside the window "
             "before further copies are refused",
             "ephemeral_ttl_seconds": "seconds before an `e-` room's messages stop being returned",

--- a/tests/http/test_dupe_filter.py
+++ b/tests/http/test_dupe_filter.py
@@ -169,7 +169,7 @@ def test_the_floor_is_a_knob_and_16_decides_which_class_is_protected(client) -> 
     lowers it must know exactly which messages just became refuseable. The longest
     conversational repeat measured on production was 6 characters; 16 clears all of
     them, and this pins the boundary itself rather than trusting the default."""
-    # +1 because the exemption is strict: at or UNDER the floor is refused-able, below
+    # +1 because the exemption is strict: AT the floor and above is refuse-able, below
     # it is not, so exempting a 72-char phrase takes a 73-char floor.
     with _filter_on(DUPE_MIN_LENGTH=len(PHRASE) + 1):
         for i in range(COPIES + 3):
@@ -180,6 +180,22 @@ def test_the_floor_is_a_knob_and_16_decides_which_class_is_protected(client) -> 
         assert (
             _say(client, "meta", "x", "thanks for the summary, this helps a lot").status_code == 422
         )
+
+
+def test_the_floor_itself_is_filterable_and_one_below_it_is_not(client) -> None:
+    """The comparison is `len(normalized) < min_length`, so the floor is the first
+    refusable length, not the last exempt one. /config publishes this boundary for
+    clients tuning themselves off it, so pin the off-by-one rather than the wording."""
+    at_floor = "sixteen chars ok"
+    below_floor = "fifteen chars!!"
+    assert len(limit.normalize_text(at_floor)) == FLOOR
+    assert len(limit.normalize_text(below_floor)) == FLOOR - 1
+    with _filter_on():
+        for i in range(COPIES):
+            assert _say(client, "lobby", "n" + str(i), at_floor).status_code == 200
+        assert _say(client, "lobby", "x", at_floor).status_code == 422
+        for i in range(COPIES + 3):
+            assert _say(client, "meta", "m" + str(i), below_floor).status_code == 200
 
 
 def test_the_window_expires_and_a_refusal_does_not_extend_it(client, monkeypatch) -> None:


### PR DESCRIPTION
## What

`/config` describes `dupe_min_length` as exempting a text *at or under* that length. The comparison in `limit._dupe_key` is `len(normalized) < min_length`, so a text of exactly `dupe_min_length` characters is refusable. A client tuning itself off `/config` — which is what that document is for — sends a 16-character text believing it is exempt and takes a 422.

## Why

The 422 body already gets it right ("send something under 16 characters") and points the caller at `/config` for the length floor, so the error routes people to the one document that contradicts it. `/config`'s own note says its values cannot disagree with the service's behaviour; the prose describing the semantics did. The same wording had also reached a comment in `test_dupe_filter.py`, corrected here.

No behaviour change. The added test is the boundary case the wording had nothing to fail against: the existing floor test works from `len(PHRASE) + 1` and a lowered floor, so it never exercises `len == min_length`. Follows #313, which published the document.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 460 passed, 97.58%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: `/config` is built in `src/manifest.py`; the manual, `/skill.md`, `README.md` and `src/patterns.md` do not restate this floor
- [x] New surface on a world-writable service: nothing new