### PR TITLE
fix(config): the duplicate-filter length floor is exclusive, as everywhere else says

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1423,7 +1423,7 @@ def config_document(version: str) -> dict:
             "dupe_filter_seconds": "seconds a room remembers the normalised texts it "
             "accepted, refusing further copies of them inside the window whoever sends "
             "them; 0 is off",
-            "dupe_min_length": "normalised characters; a text at or under this length is "
+            "dupe_min_length": "normalised characters; a text shorter than this length is "
             "never refused as a duplicate",
             "dupe_max_copies": "copies of one text a room accepts inside the window "
             "before further copies are refused",

--- a/tests/http/test_dupe_filter.py
+++ b/tests/http/test_dupe_filter.py
@@ -169,8 +169,8 @@ def test_the_floor_is_a_knob_and_16_decides_which_class_is_protected(client) -> 
     lowers it must know exactly which messages just became refuseable. The longest
     conversational repeat measured on production was 6 characters; 16 clears all of
     them, and this pins the boundary itself rather than trusting the default."""
-    # +1 because the exemption is strict: at or UNDER the floor is refused-able, below
-    # it is not, so exempting a 72-char phrase takes a 73-char floor.
+    # +1 because the exemption is strict: at the floor is refuse-able, below it is not,
+    # so exempting a 72-char phrase takes a 73-char floor.
     with _filter_on(DUPE_MIN_LENGTH=len(PHRASE) + 1):
         for i in range(COPIES + 3):
             assert _say(client, "lobby", "n" + str(i), PHRASE).status_code == 200
@@ -180,6 +180,23 @@ def test_the_floor_is_a_knob_and_16_decides_which_class_is_protected(client) -> 
         assert (
             _say(client, "meta", "x", "thanks for the summary, this helps a lot").status_code == 422
         )
+
+
+def test_the_floor_is_strict_a_text_at_the_floor_length_is_refuseable(client) -> None:
+    """The boundary itself, because the published wording is one word from getting it
+    wrong. The exemption is `len(normalised) < floor`, so a text of EXACTLY the floor
+    length is a duplicate like any longer one, and only a strictly shorter text is exempt.
+    The 422 body ("under N characters"), the manual ("shorter than the length floor") and
+    /config's own units line all have to describe this one fact the same way."""
+    at_floor = "a" * FLOOR  # no whitespace or case to fold, so normalises to FLOOR chars
+    below = "b" * (FLOOR - 1)  # one shorter: exempt however many copies arrive
+    with _filter_on():
+        for i in range(COPIES):
+            assert _say(client, "lobby", "n" + str(i), at_floor).status_code == 200
+        at_the_floor = _say(client, "lobby", "x", at_floor)
+        assert at_the_floor.status_code == 422, "the floor length is not exempt"
+        for i in range(COPIES + 3):
+            assert _say(client, "meta", "m" + str(i), below).status_code == 200
 
 
 def test_the_window_expires_and_a_refusal_does_not_extend_it(client, monkeypatch) -> None:


### PR DESCRIPTION
## What

`GET /config` described the duplicate-filter length floor one character off from what the
service enforces. Its `units.dupe_min_length` said a text **"at or under this length is
never refused"** — but the enforced rule is `len(normalised) < min_length`, so a text of
*exactly* the floor length is filtered like any longer one. Corrected to "shorter than
this length". No behaviour changes; the published description now matches enforcement.

## Why

`/config` exists to publish what the instance actually enforces, and every other
description of this boundary is already exclusive: the 422 body ("under N characters"),
the manual ("shorter than the length floor"), the OpenAPI ("the length under which a
message is never filtered"), the `config.py` comment ("a text SHORTER than this ...
`len(normalised) < min_length`"), and the code itself. `/config`'s own units line was the
lone outlier claiming the floor length is exempt — the kind of published-vs-enforced
disagreement this repo treats as worse than saying nothing.

Verified against the running service at the shipped floor of 16: a 15-character text is
exempt, a 16-character text is refused after the copy threshold. The new test pins that
boundary so the wording and the code cannot drift apart again; a stale comment in the
neighbouring floor test carried the same "at or under" slip and is corrected with it.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report`
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] `uv run sz.py --check` (manifest.py is extra, not core; no cap moves)
- [x] Docs: this *is* the doc fix — `/config` is generated in `src/manifest.py`; no other
      document described the boundary this way. `CHANGELOG.md` left to the maintainer per
      CONTRIBUTING.
- [x] New surface on a world-writable service: none — a string correction in an existing
      response, no route, state or status code.

---
AI assistance (Claude, Anthropic) was used in preparing this change; every check above was
run and verified before sending.
