### PR TITLE
fix(mcp): pin stdio to UTF-8 so a legacy code page cannot kill the server

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -21,6 +21,7 @@ advertises and what `tools/call` enforces cannot disagree with what the handler 
 from __future__ import annotations
 
 import inspect
+import io
 import json
 import sys
 import types
@@ -368,8 +369,8 @@ class Server:
         stdout carries protocol and nothing else — anything this process wants to say to a
         human goes to stderr, because one stray print corrupts the stream.
         """
-        stdin = stdin or sys.stdin
-        stdout = stdout or sys.stdout
+        stdin = stdin or _utf8(sys.stdin)
+        stdout = stdout or _utf8(sys.stdout, newline="\n")
         for line in stdin:
             line = line.strip()
             if not line:
@@ -418,6 +419,30 @@ def _ok(ident: RequestId | None, result: dict[str, Any]) -> Success:
 
 def _error(ident: RequestId | None, code: int, message: str) -> Failure:
     return {"jsonrpc": "2.0", "id": ident, "error": {"code": code, "message": message}}
+
+
+def _utf8(stream: TextIO, newline: str | None = None) -> TextIO:
+    """The process's own stdio, in the encoding this transport is defined in.
+
+    MCP stdio is UTF-8. Python gives a pipe the *locale* encoding instead, which on
+    Windows is the ANSI code page, and `_write` sends the reply through with
+    `ensure_ascii=False`. Both arms fail, and neither needs exotic input: the em dash
+    in this server's own instructions is enough. On cp932 the first reply raises
+    UnicodeEncodeError and the process dies before `initialize` is answered; on cp1252
+    it encodes to a lone 0x97 the client cannot decode as UTF-8.
+
+    Newline translation goes with it: `\\r\\n` is not the framing this transport
+    describes, and only Windows was inserting the `\\r`.
+
+    Only the fallback streams are touched. A caller that passes its own stream owns its
+    encoding, and the StringIO the tests inject is not a TextIOWrapper to begin with.
+    """
+    if isinstance(stream, io.TextIOWrapper):
+        try:
+            stream.reconfigure(encoding="utf-8", newline=newline)
+        except (ValueError, OSError):
+            pass  # detached, or already read from: keep whatever it had
+    return stream
 
 
 def _write(stdout: TextIO, message: Reply | list[Reply]) -> None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import email.message
 import io
 import json
+import os
+import subprocess
 import sys
 import urllib.error
 import urllib.request
@@ -639,3 +641,59 @@ def test_the_registry_ownership_marker_is_present_and_matches():
     readme = (ROOT / "mcp" / "README.md").read_text()
     assert f"mcp-name: {manifest['name']}" in readme
     assert manifest["name"].startswith("io.github.")  # the namespace OIDC can actually prove
+
+
+# ------------------------------------------------------------------ stdio encoding
+
+# The transport tests above inject StringIO, which has no encoding at all, so nothing
+# there can see what the process's own stdio does. These run the console entry point the
+# way `uvx technocore-mcp` does, over a real pipe, with the encoding pinned to a legacy
+# code page the way Windows pins it by default. `initialize` and `tools/list` reach no
+# network.
+
+HANDSHAKE = b"".join(
+    json.dumps(message).encode("utf-8") + b"\n"
+    for message in (
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+    )
+)
+
+
+def _spawn(code_page: str) -> subprocess.CompletedProcess[bytes]:
+    env = dict(os.environ, PYTHONIOENCODING=code_page)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(ROOT / "mcp" / "src"), env.get("PYTHONPATH", "")) if part
+    )
+    env.pop("PYTHONUTF8", None)  # would mask exactly what this test is for
+    return subprocess.run(
+        [sys.executable, "-c", "from technocore_mcp.server import main; main()"],
+        input=HANDSHAKE,
+        capture_output=True,
+        env=env,
+        timeout=60,
+    )
+
+
+@pytest.mark.parametrize("code_page", ["cp932", "cp1252"])
+def test_stdio_is_utf8_whatever_the_locale_says(code_page):
+    """MCP stdio is UTF-8, and the locale does not get a vote.
+
+    Python hands a pipe the locale encoding, which on Windows is the ANSI code page, and
+    the reply goes out with `ensure_ascii=False`. The em dash in this server's own
+    instructions is enough to break both arms: cp932 cannot encode it, so the process
+    dies before `initialize` is answered, and cp1252 encodes it to a lone 0x97 that a
+    client reading UTF-8 cannot decode. Neither arm needs a message from a room.
+    """
+    done = _spawn(code_page)
+    assert done.returncode == 0, done.stderr.decode("utf-8", "replace")
+    replies = [json.loads(line) for line in done.stdout.decode("utf-8").splitlines() if line]
+    assert [reply["id"] for reply in replies] == [1, 2]
+    assert "—" in replies[0]["result"]["instructions"]  # the character that used to kill it
+
+
+def test_stdio_framing_carries_no_carriage_return():
+    """One JSON object per `\\n`. Windows text mode was inserting a `\\r` that the framing
+    this transport describes does not have."""
+    assert b"\r" not in _spawn("utf-8").stdout


### PR DESCRIPTION
## The problem

MCP stdio is UTF-8. Python gives a pipe the *locale* encoding instead, and on Windows that is the ANSI code page. `Server.serve()` uses `sys.stdin` / `sys.stdout` as they come, and `_write` sends the reply through with `ensure_ascii=False`, so the encoding of the wire is whatever the client machine's code page happens to be.

Neither failure needs a message from a room. The em dash in this server's own `instructions` is enough, so `initialize` is already past the point of no return:

| code page | what happens |
|---|---|
| `cp932` (Japanese / Chinese / Korean Windows) | `UnicodeEncodeError: 'cp932' codec can't encode character '—'`. The process exits 1 having written **zero** replies — the client watches the server die during the handshake. |
| `cp1252` (Western Windows) | No crash. The em dash goes out as a lone `0x97`, and a client reading UTF-8 gets `'utf-8' codec can't decode byte 0x97 in position 496: invalid start byte`. |

Reproduced against the console entry point over a real pipe, `initialize` + `tools/list` only, no network:

```
PYTHONIOENCODING=cp932    exit=1 replies=0/2  UnicodeEncodeError: 'cp932' codec can't encode character '—'
PYTHONIOENCODING=cp1252   exit=0 replies=2/2  client-side UnicodeDecodeError at byte 0x97
PYTHONIOENCODING=utf-8    exit=0 replies=2/2  OK
```

The first `tools/call` a Windows user makes is worse only in how ordinary it is: `list_rooms` returns the service's own listing, and every line of `/rooms` carries ` — ` between the room and its topic.

Windows text mode was also translating the framing newline, so replies went out `}\r\n` rather than the one-object-per-`\n` this transport describes.

## The fix

`serve()` reconfigures the two fallback streams to UTF-8 and stops newline translation on stdout: one helper, two changed lines in `serve()`, and a stdlib import.

A caller-supplied stream is deliberately left alone — it owns its own encoding, and the `StringIO` the existing transport tests inject is not a `TextIOWrapper`. That `isinstance` check is also what keeps `ty` happy: `reconfigure` lives on `TextIOWrapper`, not on the `TextIO` protocol.

`errors` stays strict. UTF-8 encodes everything on the way out, and a client sending bytes that are not UTF-8 on the way in is out of spec; making the read lane lenient is a separate decision and not bundled here.

## Why nothing caught it

`test_stdio_framing_is_one_json_object_per_line` and its neighbours inject `io.StringIO`, which has no encoding at all. Nothing in the suite ever observed the process's own stdio, so the one thing that varies per client machine was the one thing untested.

## The tests

Three, in `tests/test_mcp.py`, next to the transport tests. They spawn the console entry point the way `uvx technocore-mcp` does, pin `PYTHONIOENCODING`, and assert on what comes back over the pipe. They are platform-independent — pinning the code page reproduces on Linux too — and reach no network.

Before the fix (Linux, `uv run python -m pytest tests/test_mcp.py -k 'stdio_is_utf8 or carriage'`):

```
FAILED tests/test_mcp.py::test_stdio_is_utf8_whatever_the_locale_says[cp932]
FAILED tests/test_mcp.py::test_stdio_is_utf8_whatever_the_locale_says[cp1252]
2 failed, 1 passed
```

(the CRLF assertion passes on Linux, which does not translate newlines; on Windows all three fail.)

After the fix: `3 passed`.

## Checks

Run on Linux (Ubuntu 22.04 / WSL2, Python 3.12.3, uv 0.12.6):

```
uv run ruff check .          All checks passed!
uv run ruff format --check . 59 files already formatted
uv run ty check              All checks passed!
uv run python -m pytest tests -q   436 passed in 36.47s
```

Also exercised on Windows 11 (Python 3.13, ANSI code page 932), where the suite cannot run in full because `src/store.py` imports `fcntl`; `tests/test_mcp.py -k stdio` passes there.

No new dependency — `io` is stdlib, which keeps the empty dependency set this package exists to demonstrate.
