### PR TITLE
docs(openapi): name the URL budget on the note value param, not just maxLength

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -199,6 +199,20 @@ _SIG_SCHEMA = {
 _TEXT_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_TEXT_CHARS}
 _VALUE_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_VALUE_CHARS}
 
+# The GET note lanes carry the value in the path, so the same URL ceiling that bounds a
+# message bounds a note — and it is the binding limit, not maxLength. Percent-encoding
+# costs 3 bytes per UTF-8 byte, so against the character cap and the ~16 KB a URL survives
+# at the edge the break-even is that ratio's inverse. `maxLength` was the only thing the
+# value param said about size, and a note reaching it in a URL is exactly the case that
+# needs POST; the say lanes' `text` param already carries this and the note lanes did not.
+_VALUE_URL_BUDGET = (
+    "URL-encoded note value. The URL length is the limit that bites first here, not "
+    f"maxLength: percent-encoding is 3 bytes per UTF-8 byte, so against the "
+    f"{store.MAX_VALUE_CHARS}-character cap and a ~16 KB URL the break-even is "
+    f"{(16 << 10) // store.MAX_VALUE_CHARS} bytes per character — a longer value must use "
+    "POST /kv/{ns}/{key} with a JSON body."
+)
+
 _NONCE_SCHEMA = {
     "type": "string",
     "pattern": f"^{didkey.NONCE_PATTERN}$",
@@ -1034,6 +1048,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "name": "value",
                             "required": True,
                             "schema": _VALUE_SCHEMA,
+                            "description": _VALUE_URL_BUDGET,
                         },
                         _IF_PARAM,
                         _IF_ABSENT_PARAM,
@@ -1080,6 +1095,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "name": "value",
                             "required": True,
                             "schema": _VALUE_SCHEMA,
+                            "description": _VALUE_URL_BUDGET,
                         },
                         # Both work here and neither was listed, leaving the unsigned lane
                         # as the only documented way to claim a room without racing.

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1182,6 +1182,46 @@ def test_a_free_form_field_publishes_that_it_cannot_be_empty(client):
     assert client.post("/kv/plans/k", json={"value": ""}).status_code == 400
 
 
+def test_the_note_value_param_names_the_url_budget_that_actually_bounds_it(client):
+    """The GET note lanes carry the value in the path, so a URL ceiling bounds them exactly
+    as it bounds a message — and it is the binding limit, not `maxLength`. The say lanes'
+    `text` param already says so ("use POST for long non-Latin text"); the note lanes'
+    `value` param published `maxLength` alone, so a value that fits the character cap but
+    not the URL met an opaque edge failure with no pointer at the POST lane that works.
+
+    Pinned on both note GET lanes because the signed one has even less URL budget — the
+    DID, signature and nonce sit in the path ahead of the value.
+    """
+    import store
+
+    doc = client.get("/openapi.json").json()
+
+    def value_param(path):
+        return next(p for p in doc["paths"][path]["get"]["parameters"] if p["name"] == "value")
+
+    break_even = (16 << 10) // store.MAX_VALUE_CHARS
+    for path in (
+        "/kv/{ns}/{key}/set/{value}",
+        "/kv/{ns}/{key}/set-signed/{did}/{sig}/{nonce}/{value}",
+    ):
+        description = value_param(path)["description"]
+        # It points at the escape hatch a conforming client needs when the URL runs out,
+        assert "POST" in description, path
+        # frames the limit as the URL rather than the character cap it publishes beside,
+        assert "URL" in description, path
+        # and states the arithmetic against this service's own cap, not a bare "16 KB".
+        assert f"{break_even} bytes per character" in description, path
+
+    # The say lanes carry the same kind of guidance on their `text` param, so the note
+    # lanes are no longer the only write path that leaves the URL budget unsaid.
+    say_text = next(
+        p
+        for p in doc["paths"]["/r/{room}/say/{nick}/{text}"]["get"]["parameters"]
+        if p["name"] == "text"
+    )
+    assert "POST" in say_text["description"]
+
+
 def test_openapi_limits_are_the_limits_the_server_enforces(client):
     """A published limit that disagrees with the enforced one is worse than none: a
     machine reader believes it. Generated from the constants, and this holds that line."""


### PR DESCRIPTION
## Summary

The GET note lanes carry the value in the URL path, so the same ~16 KB edge URL ceiling that bounds a message bounds a note — and it is the binding limit, not `maxLength`. Both note GET lanes published `maxLength: 8192` on their `value` param and nothing else about size:

| path | `value.description` |
|---|---|
| `/kv/{ns}/{key}/set/{value}` | *(absent)* |
| `/kv/{ns}/{key}/set-signed/{did}/{sig}/{nonce}/{value}` | *(absent)* |

Meanwhile the say lanes' `text` param already carries the URL-budget guidance (`use POST for long non-Latin text`, added for #76). A note value that fits the 8192-character cap but exceeds the URL budget met an opaque edge failure — a 4xx from the proxy, no body — with nothing in the machine-readable contract pointing at the POST lane that works.

This is the note-side twin of #76 (which covered the signed *say* lane). A generated client that trusts `maxLength` as the size contract builds a call that can silently fail at the edge for a value the schema says is valid.

## Changes

- Add a `description` to the `value` param on both note GET lanes (`writeNote` and `writeNoteSigned`), generated from `store.MAX_VALUE_CHARS` so it cannot drift from the enforced cap.
- The wording frames the limit as the URL (not the character count), states the break-even in bytes-per-character against this service's own cap, and names `POST /kv/{ns}/{key}` as the escape — the same axis PR #346 corrected the manual to.
- Add a regression test asserting the description is present on **both** note GET lanes (the signed one has even less budget, with did/sig/nonce ahead of the value) and that the say lane's guidance is still there.

## Scope

- OpenAPI document generation and a doc regression test only. No API or runtime behavior change, no new public surface.

## Validation

Run on WSL/Ubuntu (the suite needs POSIX `fcntl`):

```
uv run ruff check .
uv run ruff format --check .
uv run ty check
uv run python sz.py --check
uv run coverage run -m pytest tests -q   # 460 passed
```