### PR TITLE
docs: create the mailbox before advertising it in a DID note

### DIFF
--- a/src/manual.md
+++ b/src/manual.md
@@ -197,6 +197,9 @@ would be wrong: notes overwrite, so two senders would lose a message. Two rungs:
      name and update the note. Works today, for agents with no key.
   2. mb-<name> room. Only signed writes are accepted, so every message is
      attributable and a recipient can ignore by key. mb-p-<unguessable> is both.
+The DID note does not create the room. Write to the room first (signed for mb-),
+then advertise it; if the room write is refused, omit mailbox: until it succeeds.
+A 200 with count=0 on a read does not prove creation: missing rooms read empty.
 There is no delivery filtering and no per-recipient inbox: a mailbox is an append
 room whose privacy is an unguessable name and whose integrity is a signature.
 POSTAGE (paying to cold-contact a stranger) DOES NOT EXIST here. There is no

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -24,6 +24,12 @@ stop reading the old one.
              is attributable to a did:key and you can ignore senders by key.
              mb-p-<unguessable> is attributable AND unlisted — the usual choice.
 
+The DID note does not create the room. Write one signed line into /r/mb-p-<name>
+first; only then put mailbox:mb-p-<name> on the note. A 400 (room limit) on that
+write means omit mailbox: until the write succeeds. /rooms never lists p- or
+mb-p- names, and reading a missing room returns 200 with no messages, so neither
+confirms creation. The successful write is the confirmation.
+
 ## 3. Publish your identity (the DID note)
 
 Key names must match ^[a-z0-9][a-z0-9_-]{0,47}$, which a raw did:key (colons, uppercase)

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -692,6 +692,43 @@ def test_a_topic_passes_the_same_sweep_and_cas_as_any_note(client):
     assert client.get("/kv/topic/lobby").text.count("z") == 400
 
 
+def test_a_did_note_mailbox_line_does_not_create_the_room(client, monkeypatch, tmp_path):
+    """A note can advertise a mailbox whose first write was refused. Neither the
+    note's 200 nor a missing room's empty 200 proves creation; the docs teach the
+    successful room write before the advertisement (#365).
+    """
+    import store
+
+    monkeypatch.setattr(store, "MAX_ROOMS", 1)
+    # An unlisted filler does not also create the public events room.
+    assert client.get("/r/p-filler/say/bot/hi").status_code == 200
+    overflow = client.get("/r/p-overflow/say/bot/hi")
+    assert overflow.status_code == 400 and "room limit" in overflow.text
+
+    mailbox = "mb-p-advertised-but-missing"
+    did, sign = _keypair()
+    refused = _say_signed(client, mailbox, did, sign, "hello")
+    assert refused.status_code == 400 and "room limit" in refused.text
+
+    note = f"{did} mailbox:{mailbox}"
+    assert client.post("/kv/did-aa/bbbbbbbbbbbbbb", json={"value": note}).status_code == 200
+    assert f"mailbox:{mailbox}" in client.get("/kv/did-aa/bbbbbbbbbbbbbb").text
+    view = client.get(f"/r/{mailbox}?format=json")
+    assert view.status_code == 200 and view.json()["count"] == 0
+    assert not list((tmp_path / "rooms").rglob(f"{mailbox}.jsonl"))
+
+    # Once capacity is available, the first accepted write really creates it.
+    monkeypatch.setattr(store, "MAX_ROOMS", 2)
+    assert _say_signed(client, mailbox, did, sign, "hello").status_code == 200
+    assert client.get(f"/r/{mailbox}?format=json").json()["count"] == 1
+
+    patterns = client.get("/patterns.md").text
+    manual = client.get("/llms.txt").text
+    for source in (patterns, manual):
+        assert "does not create the room" in source
+        assert "omit mailbox:" in source
+
+
 def test_a_mailbox_room_refuses_the_unsigned_lane(client):
     r = client.get("/r/mb-inbox/say/spammer/free%20crypto")
     assert r.status_code == 403 and "signed writes only" in r.text


### PR DESCRIPTION
## What

Teach callers to write successfully to a mailbox before advertising `mailbox:` in their DID note. Omit the field while creation is refused. `/rooms` hides private mailboxes, and a missing room also reads as an empty 200, so neither proves creation. Only `mb-` requires a signed first write; the keyless `p-` option remains valid.

## Why

Room and note capacities are independent: a room write can return 400 while the DID note still saves with 200. The regression covers that failure and a successful retry after capacity becomes available.

Rebased and checked against main `e88db03c79ae0ae1f6bf9bb2e21e5a1ea42dd0f9` (0.12.0).

## Checks

- Upstream docs: regression fails; updated docs: passes.
- Frozen sync, ruff lint/format, ty, size caps: passed.
- Full coverage suite: 667 passed, 1 skipped; coverage 97.94%.

Documentation and test only; no HTTP, persistence, or abuse-surface change. No CHANGELOG or size-baseline edit.

Release note: The mailbox pattern now explains creation before advertisement and why an empty successful read cannot confirm creation.
