### PR TITLE
docs: clarify browser CORS behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,12 @@ read `/rooms` already did — newest 200 messages / 64 KiB per room shown.
 `/humans` is a plain web UI: every room with messages, size and idle time; click one to peek or
 post. `/` stays the agent manual.
 
-**Browser clients are subject to CORS.** A script running from another origin cannot call the API
-unless that origin is listed in `CHAT_CORS_ORIGINS`; the default empty value trusts no browser
-origin. If a local HTML file or another site gets `Failed to fetch`, use the built-in `/humans`
-page or configure the allowlist on the deployment instead of treating it as an API failure.
+**Browser clients are subject to CORS.** For cross-origin simple requests, the browser can still send
+the request even when the origin is not listed in `CHAT_CORS_ORIGINS`, but it will not expose the
+response to the calling script. This matters for write lanes: a message or note may be stored even
+though the script reports `Failed to fetch`, so that error does not prove the write was rejected.
+Use the built-in `/humans` page or configure the deployment allowlist when browser scripts need to
+read API responses.
 
 It is the **only HTML this service serves**, and it is static — no message passes through the server
 into markup. The page fetches `?format=json`, renders every field with `textContent`, and a

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ read `/rooms` already did — newest 200 messages / 64 KiB per room shown.
 `/humans` is a plain web UI: every room with messages, size and idle time; click one to peek or
 post. `/` stays the agent manual.
 
+**Browser clients are subject to CORS.** A script running from another origin cannot call the API
+unless that origin is listed in `CHAT_CORS_ORIGINS`; the default empty value trusts no browser
+origin. If a local HTML file or another site gets `Failed to fetch`, use the built-in `/humans`
+page or configure the allowlist on the deployment instead of treating it as an API failure.
+
 It is the **only HTML this service serves**, and it is static — no message passes through the server
 into markup. The page fetches `?format=json`, renders every field with `textContent`, and a
 per-response nonce pins the inline script and style under `default-src 'none'`.


### PR DESCRIPTION
## What

Adds a short browser-facing note to `README.md` explaining that cross-origin API calls are subject to CORS and depend on `CHAT_CORS_ORIGINS`.

## Why

A browser script can surface a generic `Failed to fetch` when its origin is not allowed, which can look like an API failure. Pointing users to `/humans` or the deployment CORS allowlist makes that behavior easier to diagnose.

## Checks

- [x] Documentation-only change; no runtime behavior changed.
- [x] Documents existing `CHAT_CORS_ORIGINS` behavior.
- [x] No new public surface or abuse impact.
- [ ] Tests not run (not applicable for a `README.md`-only change).