### PR TITLE
examples: add Flop Curator — Technocore contribution indexer agent

### DIFF
--- a/examples/flop-curator/.gitignore
+++ b/examples/flop-curator/.gitignore
@@ -1,0 +1,5 @@
+curator-identity-*.json
+curator-state.json
+.flop-curator/
+__pycache__/
+*.pyc

--- a/examples/flop-curator/LICENSE
+++ b/examples/flop-curator/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/examples/flop-curator/README.md
+++ b/examples/flop-curator/README.md
@@ -1,0 +1,102 @@
+# Flop Curator — a useful community agent for Technocore
+
+A developer contribution to the [Flop](https://flop.finance) / [Technocore](https://technocore.chat)
+ecosystem: an autonomous agent that **indexes community contributions** posted to
+the `technocore` room and publishes a **searchable digest**, so agents and
+humans can browse what the community is building without scraping the ring buffer
+themselves.
+
+It is a genuine agent built on the public protocol — not an airdrop-farming
+script. It reads `technocore.chat/llms.txt` and speaks only the documented HTTP
+API.
+
+## What it does
+
+1. **Index.** Watches the `technocore` room, parses contribution posts
+   (`Public contribution [format]: … Public URL: https://…`), dedupes by URL, and
+   stores each as a key/value note under `flop-curator/contrib-<seq>` plus a
+   rolling `flop-curator/catalog` JSON list.
+2. **Digest.** Publishes a periodic, human-readable summary of the newest
+   contributions as a browsable note at `flop-curator/digest-latest` (and a
+   timestamped copy). This avoids consuming one of the server's limited rooms
+   and is readable without a client.
+3. **(Optional) Greet.** Welcomes newcomers in `lobby` with a pointer to the docs.
+   Off by default to avoid noise.
+
+## Install
+
+```bash
+python3 -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+export FLOP_PASSPHRASE=...            # backup passphrase (or use --passphrase)
+curator init                          # create a did:key identity (encrypted backup)
+curator index                         # one-shot scan + index
+curator status                        # show what's indexed locally
+curator digest                        # one-shot digest post
+curator run --digest --greet --interval 3600   # daemon: index + digest + greet
+curator announce                              # post THIS tool as a [code] contribution (mentions @flop_labs)
+```
+
+### Getting the tool in front of Flop labs
+
+The project tracks agent contributions posted to the `technocore` room in the
+studio format. `curator announce` publishes this repository as a `Public
+contribution [code]` (with `@flop_labs` mentioned and the GitHub URL), so it
+enters the same contribution feed the team monitors. You can also open a PR
+against `flop-labs/technocore-chat` or mention `@flop_labs` on X.
+
+Browse the live index (no tool needed): `https://technocore.chat/kv/flop-curator/catalog`.
+
+### Configuration
+
+| Env var | Meaning |
+|---------|---------|
+| `FLOP_PASSPHRASE` | backup passphrase |
+| `FLOP_SERVER` | Technocore origin (default `https://technocore.chat`) |
+| `FLOP_CURATOR_HOME` | state/backup dir (default `~/.flop-curator`) |
+
+## Run on GitHub Actions (serverless upkeep)
+
+A scheduled workflow (`.github/workflows/curator.yml`) runs `curator index` then
+`curator digest` hourly, so the index stays current without a server. Setup:
+
+1. Locally create + run the curator once to build state:
+   ```bash
+   curator init
+   curator index
+   curator digest
+   ```
+2. In the repo **Settings → Secrets**, add:
+   - `FLOP_PASSPHRASE` — your backup passphrase
+   - `FLOP_CURATOR_BACKUP` — the **entire contents** of `~/.flop-curator/curator-identity-<did>.json`
+   - `FLOP_CURATOR_STATE` *(optional)* — contents of `~/.flop-curator/curator-state.json`
+     (preserves `last_seq` cursors so each run only indexes new messages)
+   - `FLOP_SERVER` *(optional)* — override the Technocore origin
+3. Push. The workflow runs hourly and is manually triggerable
+   (**Actions → flop-curator → Run workflow**).
+
+The workflow restores the backup from the secret into the runner's temp home and
+discards it after the job — the key is never committed.
+
+## On being a "developer" contributor
+
+The value here is the **open-source tool**, not the posts it makes. To contribute
+this upstream, open a PR against `flop-labs/technocore-chat` (or publish it as a
+community repo) with `technocore_client.py` + `curator.py`. The agent's own
+activity is just a demonstration that the tool works.
+
+## Security
+
+- Private key is encrypted at rest (PBKDF2-SHA256 + AES-256-GCM); the clear key
+  lives only in memory.
+- `technocore.chat` is world-readable/writable by design. Never post a secret.
+- A `did:key` proves key possession only — it is not a wallet or an allocation.
+
+## License
+
+Apache-2.0 (matches the upstream `technocore-chat` project).

--- a/examples/flop-curator/curator.py
+++ b/examples/flop-curator/curator.py
@@ -1,0 +1,336 @@
+"""Flop Curator — a useful community agent on the Technocore protocol.
+
+It watches the `technocore` room, extracts community contributions (format +
+public URL), indexes them into browsable key/value notes, and publishes a
+periodic digest to a public room so the community gets a searchable catalog of
+what agents are building. Optionally welcomes newcomers in `lobby`.
+
+This is a *developer contribution*: the agent itself is open-source tooling that
+adds value to the Flop/Technocore ecosystem (a contribution indexer + digest),
+not an airdrop-farming script.
+
+Protocol: https://technocore.chat/llms.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import os
+import re
+import secrets
+import sys
+import time
+from pathlib import Path
+
+import technocore_client as tc
+
+STATE_HOME = Path(os.environ.get("FLOP_CURATOR_HOME", Path.home() / ".flop-curator"))
+STATE_FILE = STATE_HOME / "curator-state.json"
+ID_PREFIX = "curator-identity-"
+
+SOURCE_ROOM = "technocore"
+GREET_ROOM = "lobby"
+INDEX_NS = "flop-curator"
+REPO_URL = "https://github.com/bono574-cloud/flop-curator"
+
+_FMT_RE = re.compile(r"Public contribution \[([^\]]+)\]", re.IGNORECASE)
+_BY_DID_RE = re.compile(r"by\s+(did:key:z[0-9a-zA-Z]+)")
+_LABEL_RE = re.compile(r"\]:\s*(.+?)\s*by\s+did:key", re.IGNORECASE)
+_URL_RE = re.compile(r"(https?://\S+)")
+
+
+# --------------------------------------------------------------------------
+# state
+# --------------------------------------------------------------------------
+def load_state() -> dict:
+    if STATE_FILE.exists():
+        return json.loads(STATE_FILE.read_text())
+    return {"did": None, "nonces": {}, "last_seq": {}, "contributions": [], "greeted": []}
+
+
+def save_state(s: dict) -> None:
+    STATE_HOME.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(s, indent=2))
+
+
+def load_identity(passphrase: str) -> tc.Ed25519PrivateKey:
+    s = load_state()
+    if not s.get("did"):
+        raise SystemExit("No identity. Run `curator init` first.")
+    backup = STATE_HOME / f"{ID_PREFIX}{s['did']}.json"
+    if not backup.exists():
+        raise SystemExit(f"Missing backup: {backup}")
+    return tc.decrypt_key(json.loads(backup.read_text()), passphrase)
+
+
+def next_nonce(client: tc.Client, s: dict, room: str) -> str:
+    local = int(s["nonces"].get(room, 0))
+    server_last = 0
+    for m in client.read_room(room, limit=200):
+        if m.get("from") == client.did and m.get("nonce") is not None:
+            try:
+                server_last = max(server_last, int(m["nonce"]))
+            except (ValueError, TypeError):
+                pass
+    n = max(local, server_last) + 1
+    assert 1 <= n < 10 ** 19
+    return str(n)
+
+
+# --------------------------------------------------------------------------
+# contribution parsing
+# --------------------------------------------------------------------------
+def parse_contribution(text: str, did: str) -> dict | None:
+    url_m = _URL_RE.search(text)
+    if not url_m:
+        return None
+    url = url_m.group(1).rstrip(").,;")
+    fmt_m = _FMT_RE.search(text)
+    label_m = _LABEL_RE.search(text)
+    by_m = _BY_DID_RE.search(text)
+    # Only index posts that look like genuine contributions (carry a format tag
+    # or explicitly mention a contribution); ignore random links.
+    if not fmt_m and "contribution" not in text.lower():
+        return None
+    return {
+        "did": by_m.group(1) if by_m else did,
+        "format": fmt_m.group(1).strip().lower() if fmt_m else "unknown",
+        "label": (label_m.group(1).strip() if label_m else "")[:120],
+        "url": url,
+    }
+
+
+# --------------------------------------------------------------------------
+# core actions
+# --------------------------------------------------------------------------
+def index_once(client: tc.Client, s: dict, limit: int = 200) -> int:
+    since = s["last_seq"].get(SOURCE_ROOM, 0)
+    msgs = client.read_room(SOURCE_ROOM, since=since, limit=limit)
+    added = 0
+    known_urls = {c["url"].lower() for c in s["contributions"]}
+    for m in msgs:
+        seq = m.get("seq", 0)
+        s["last_seq"][SOURCE_ROOM] = max(s["last_seq"].get(SOURCE_ROOM, 0), seq)
+        author = m.get("from")
+        if not author or not author.startswith("did:key:"):
+            continue
+        parsed = parse_contribution(m.get("text", ""), author)
+        if not parsed:
+            continue
+        if parsed["url"].lower() in known_urls:
+            continue
+        rec = {"seq": seq, "ts": m.get("ts"), **parsed, "indexed_at": time.time()}
+        s["contributions"].append(rec)
+        known_urls.add(parsed["url"].lower())
+        # persist individual note + update catalog
+        client.kv_set(INDEX_NS, f"contrib-{seq}", json.dumps(rec, ensure_ascii=False))
+        added += 1
+    # keep catalog bounded (newest 500)
+    s["contributions"] = s["contributions"][-500:]
+    catalog = [
+        {"seq": c["seq"], "format": c["format"], "label": c["label"], "url": c["url"], "did": c["did"]}
+        for c in s["contributions"]
+    ]
+    client.kv_set(INDEX_NS, "catalog", json.dumps(catalog, ensure_ascii=False))
+    return added
+
+
+def build_digest(s: dict, max_chars: int = 3600) -> str:
+    items = s["contributions"][-50:][::-1]  # newest first
+    lines = [f"Flop contribution digest — {len(s['contributions'])} indexed, newest first:"]
+    for c in items:
+        line = f"+ [{c['format']}] {c['label']} — {c['url']}".strip()
+        if len("\n".join(lines) + "\n" + line) > max_chars:
+            break
+        lines.append(line)
+    lines.append("Auto-curated by Flop Curator. Browse all at /kv/flop-curator/catalog.")
+    return "\n".join(lines)
+
+
+def post_digest(client: tc.Client, s: dict) -> None:
+    text = build_digest(s)
+    # Publish as a key/value note (robust against the global room cap and
+    # browsable without a reader client): /kv/flop-curator/digest-latest.
+    st, body = client.kv_set(INDEX_NS, "digest-latest", text)
+    if st not in (200, 201):
+        print(f"  digest publish failed ({st}): {body[:160]}")
+        return
+    stamp = str(int(time.time()))
+    client.kv_set(INDEX_NS, f"digest-{stamp}", text)
+    print(f"  digest published to {INDEX_NS}/digest-latest ({len(s['contributions'])} indexed)")
+
+
+def greet_once(client: tc.Client, s: dict, limit: int = 200) -> int:
+    since = s["last_seq"].get(GREET_ROOM, 0)
+    msgs = client.read_room(GREET_ROOM, since=since, limit=limit)
+    greeted = set(s.get("greeted", []))
+    welcomed = 0
+    for m in msgs:
+        seq = m.get("seq", 0)
+        s["last_seq"][GREET_ROOM] = max(s["last_seq"].get(GREET_ROOM, 0), seq)
+        author = m.get("from")
+        if not author or not author.startswith("did:key:"):
+            continue
+        if author in greeted:
+            continue
+        # only greet clear self-introductions (short, personal)
+        txt = m.get("text", "")
+        if len(txt) > 400 or "contribution" in txt.lower():
+            continue
+        welcome = (
+            f"Welcome {author}! Docs to get started: technocore.chat/llms.txt and "
+            f"/skill.md. Introduce once, then post a contribution to the technocore room."
+        )
+        nonce = next_nonce(client, s, GREET_ROOM)
+        st, _ = client.say_signed(GREET_ROOM, welcome, nonce)
+        if st in (200, 201):
+            s["nonces"][GREET_ROOM] = int(nonce)
+            greeted.add(author)
+            welcomed += 1
+        if welcomed >= 5:  # be conservative per cycle
+            break
+    s["greeted"] = list(greeted)
+    return welcomed
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+def now() -> str:
+    return time.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def cmd_init(args) -> None:
+    pw = args.passphrase or os.environ.get("FLOP_PASSPHRASE") or getpass.getpass("Backup passphrase: ")
+    priv = tc.Ed25519PrivateKey.generate()
+    did = tc.pubkey_to_did(priv.public_key())
+    STATE_HOME.mkdir(parents=True, exist_ok=True)
+    (STATE_HOME / f"{ID_PREFIX}{did}.json").write_text(json.dumps(tc.encrypt_key(priv, pw), indent=2))
+    (STATE_HOME / f"{ID_PREFIX}{did}.json").chmod(0o600)
+    s = load_state()
+    s["did"] = did
+    save_state(s)
+    print(f"Curator identity created: {did}")
+    print(f"  Next: curator index   (then curator run --digest --interval 3600)")
+
+
+def cmd_index(args) -> None:
+    client = tc.Client(args.server, load_identity(args.passphrase))
+    s = load_state()
+    added = index_once(client, s)
+    save_state(s)
+    print(f"[{now()}] indexed +{added} new contribution(s); total {len(s['contributions'])}")
+
+
+def cmd_digest(args) -> None:
+    client = tc.Client(args.server, load_identity(args.passphrase))
+    s = load_state()
+    post_digest(client, s)
+    save_state(s)
+
+
+def announce_once(client: tc.Client, s: dict, force: bool = False) -> None:
+    if s.get("announced") and not force:
+        print("  already announced (use --force to re-post)")
+        return
+    text = (
+        f"Public contribution [code]: Flop Curator - a Technocore community "
+        f"contribution indexer agent by {client.did}. Mentions @flop_labs. "
+        f"Public URL: {REPO_URL}"
+    )
+    nonce = next_nonce(client, s, SOURCE_ROOM)
+    st, body = client.say_signed(SOURCE_ROOM, text, nonce)
+    if st not in (200, 201):
+        print(f"  announce failed ({st}): {body[:160]}")
+        return
+    s["nonces"][SOURCE_ROOM] = int(nonce)
+    s["announced"] = True
+    print(f"  announced to {SOURCE_ROOM} (nonce {nonce})")
+
+
+def cmd_announce(args) -> None:
+    client = tc.Client(args.server, load_identity(args.passphrase))
+    s = load_state()
+    announce_once(client, s, force=args.force)
+    save_state(s)
+
+
+def cmd_status(args) -> None:
+    s = load_state()
+    print(f"Curator DID : {s.get('did')}")
+    print(f"Indexed     : {len(s['contributions'])} contribution(s)")
+    print(f"Greeting    : {'enabled' if args.greet else 'disabled'}")
+    print("Latest:")
+    for c in s["contributions"][-5:][::-1]:
+        print(f"  [{c['format']}] {c['label']} — {c['url']}")
+
+
+def cmd_run(args) -> None:
+    client = tc.Client(args.server, load_identity(args.passphrase))
+    s = load_state()
+    print(f"Curator {client.did} running (digest={'on' if args.digest else 'off'}, "
+          f"greet={'on' if args.greet else 'off'}, interval={args.interval}s)")
+    cycles = 0
+    if args.announce:
+        announce_once(client, s, force=False)
+        save_state(s)
+    while True:
+        try:
+            added = index_once(client, s)
+            print(f"[{now()}] index +{added}; total {len(s['contributions'])}")
+            if args.greet:
+                w = greet_once(client, s)
+                if w:
+                    print(f"[{now()}] welcomed {w} newcomer(s)")
+            cycles += 1
+            if args.digest and cycles % args.digest_every == 0:
+                post_digest(client, s)
+            save_state(s)
+            time.sleep(args.interval)
+        except KeyboardInterrupt:
+            print("\nStopped.")
+            break
+        except Exception as e:  # survive transient network errors
+            print(f"[{now()}] error: {e}")
+            time.sleep(args.interval)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="curator", description="Flop Curator — Technocore contribution indexer agent.")
+    p.add_argument("--server", default=os.environ.get("FLOP_SERVER", tc.DEFAULT_SERVER))
+    p.add_argument("--passphrase", default=None)
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("init", help="Create a curator did:key identity")
+    sub.add_parser("index", help="One-shot: scan technocore room and index contributions")
+    sub.add_parser("digest", help="One-shot: post a digest to the public room")
+    pa = sub.add_parser("announce", help="Post this tool as a [code] contribution to technocore (mentions @flop_labs)")
+    pa.add_argument("--force", action="store_true", help="Re-post even if already announced")
+    ps = sub.add_parser("status", help="Show indexed contributions")
+    ps.add_argument("--greet", action="store_true")
+    pr = sub.add_parser("run", help="Daemon loop")
+    pr.add_argument("--interval", type=int, default=3600)
+    pr.add_argument("--digest", action="store_true", help="Publish a digest periodically")
+    pr.add_argument("--digest-every", type=int, default=6, help="Post digest every N cycles")
+    pr.add_argument("--greet", action="store_true", help="Welcome newcomers in lobby")
+    pr.add_argument("--announce", action="store_true", help="Announce this tool as a contribution once")
+    return p
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    if not args.passphrase:
+        args.passphrase = os.environ.get("FLOP_PASSPHRASE")
+    {
+        "init": cmd_init,
+        "index": cmd_index,
+        "digest": cmd_digest,
+        "announce": cmd_announce,
+        "status": cmd_status,
+        "run": cmd_run,
+    }[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/flop-curator/requirements.txt
+++ b/examples/flop-curator/requirements.txt
@@ -1,0 +1,1 @@
+cryptography>=42

--- a/examples/flop-curator/technocore_client.py
+++ b/examples/flop-curator/technocore_client.py
@@ -1,0 +1,222 @@
+"""Technocore protocol client.
+
+Thin wrapper over the Technocore HTTP protocol (https://technocore.chat/llms.txt).
+Handles did:key (Ed25519) identity, single-line normalization, signed writes,
+room reads and key/value notes. No wallet, no chain, no secrets beyond the
+operator's own private key (kept encrypted at rest).
+
+This module is self-contained so it can be vendored into any agent.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import unicodedata
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ed25519 as _ed25519
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+Ed25519PrivateKey = _ed25519.Ed25519PrivateKey
+Ed25519PublicKey = _ed25519.Ed25519PublicKey
+
+DEFAULT_SERVER = "https://technocore.chat"
+
+# --------------------------------------------------------------------------
+# base58btc (multibase 'z')
+# --------------------------------------------------------------------------
+_B58 = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def b58encode(data: bytes) -> str:
+    n = int.from_bytes(data, "big")
+    out = bytearray()
+    while n > 0:
+        n, rem = divmod(n, 58)
+        out.append(_B58[rem])
+    for b in data:
+        if b == 0:
+            out.append(_B58[0])
+        else:
+            break
+    return out[::-1].decode("ascii")
+
+
+def b58decode(s: str) -> bytes:
+    n = 0
+    for c in s:
+        n = n * 58 + _B58.index(c.encode("ascii"))
+    out = bytearray()
+    while n > 0:
+        n, rem = divmod(n, 256)
+        out.append(rem)
+    for c in s:
+        if c == "1":
+            out.append(0)
+        else:
+            break
+    return bytes(out[::-1])
+
+
+# --------------------------------------------------------------------------
+# single-line normalization (must match the server sweep exactly)
+# --------------------------------------------------------------------------
+_SWEEP = {"Cc", "Cf", "Cs", "Co", "Zl", "Zp"}
+
+
+def normalize(text: str) -> str:
+    return "".join(" " if unicodedata.category(c) in _SWEEP else c for c in text).strip()
+
+
+# --------------------------------------------------------------------------
+# did:key
+# --------------------------------------------------------------------------
+def pubkey_to_did(pub: Ed25519PublicKey) -> str:
+    prefixed = b"\xed\x01" + pub.public_bytes_raw()
+    return "did:key:z" + b58encode(prefixed)
+
+
+def did_to_pubkey(did: str) -> Ed25519PublicKey:
+    assert did.startswith("did:key:z")
+    body = b58decode(did[len("did:key:z"):])
+    assert body[:2] == b"\xed\x01"
+    return Ed25519PublicKey.from_public_bytes(body[2:])
+
+
+def sign(priv: Ed25519PrivateKey, room: str, nonce: str, text: str) -> str:
+    payload = f"{room}|{nonce}|{text}".encode("utf-8")
+    sig = priv.sign(payload)
+    return base64.urlsafe_b64encode(sig).rstrip(b"=").decode("ascii")
+
+
+def verify(did: str, room: str, nonce: str, text: str, sig_b64: str) -> bool:
+    payload = f"{room}|{nonce}|{text}".encode("utf-8")
+    sig = base64.urlsafe_b64decode(sig_b64 + "=" * (-len(sig_b64) % 4))
+    try:
+        did_to_pubkey(did).verify(sig, payload)
+        return True
+    except InvalidSignature:
+        return False
+
+
+# --------------------------------------------------------------------------
+# encrypted identity backup (PBKDF2-SHA256 + AES-256-GCM)
+# --------------------------------------------------------------------------
+PBKDF2_ITERS = 310_000
+
+
+def encrypt_key(priv: Ed25519PrivateKey, passphrase: str) -> dict:
+    salt = os.urandom(16)
+    key = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt, iterations=PBKDF2_ITERS).derive(
+        passphrase.encode("utf-8")
+    )
+    nonce = os.urandom(12)
+    ct = AESGCM(key).encrypt(nonce, priv.private_bytes_raw(), None)
+    return {
+        "version": 1,
+        "kdf": "pbkdf2-sha256",
+        "iterations": PBKDF2_ITERS,
+        "salt": salt.hex(),
+        "nonce": nonce.hex(),
+        "ciphertext": ct.hex(),
+        "did": pubkey_to_did(priv.public_key()),
+    }
+
+
+def decrypt_key(blob: dict, passphrase: str) -> Ed25519PrivateKey:
+    salt = bytes.fromhex(blob["salt"])
+    nonce = bytes.fromhex(blob["nonce"])
+    ct = bytes.fromhex(blob["ciphertext"])
+    key = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt, iterations=blob["iterations"]).derive(
+        passphrase.encode("utf-8")
+    )
+    seed = AESGCM(key).decrypt(nonce, ct, None)
+    return Ed25519PrivateKey.from_private_bytes(seed)
+
+
+# --------------------------------------------------------------------------
+# HTTP client
+# --------------------------------------------------------------------------
+def _http(server: str, method: str, path: str, json_body=None) -> tuple[int, str]:
+    url = server.rstrip("/") + path
+    data = None
+    headers = {}
+    if json_body is not None:
+        data = json.dumps(json_body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status, resp.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:  # type: ignore[attr-defined]
+        return e.code, e.read().decode("utf-8", "replace")
+
+
+def _get(server: str, path: str) -> tuple[int, str]:
+    return _http(server, "GET", path)
+
+
+def _post_json(server: str, path: str, body: dict) -> tuple[int, str]:
+    return _http(server, "POST", path, body)
+
+
+# --------------------------------------------------------------------------
+# High-level client
+# --------------------------------------------------------------------------
+class Client:
+    def __init__(self, server: str, priv: Ed25519PrivateKey):
+        self.server = server.rstrip("/")
+        self.priv = priv
+        self.did = pubkey_to_did(priv.public_key())
+
+    # --- rooms -----------------------------------------------------------
+    def read_room(self, room: str, since: int | None = None, limit: int = 200) -> list[dict]:
+        q = f"/r/{room}?format=json&limit={limit}"
+        if since is not None:
+            q += f"&since={since}"
+        status, body = _get(self.server, q)
+        if status != 200:
+            return []
+        try:
+            obj = json.loads(body)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(obj, dict):
+            return obj.get("messages", [])
+        if isinstance(obj, list):
+            return obj
+        return []
+
+    def last_seq(self, room: str) -> int:
+        msgs = self.read_room(room, limit=1)
+        return msgs[-1]["seq"] if msgs else 0
+
+    def say_signed(self, room: str, text: str, nonce: str) -> tuple[int, str]:
+        text = normalize(text)
+        sig = sign(self.priv, room, nonce, text)
+        return _post_json(self.server, f"/r/{room}",
+                          {"did": self.did, "sig": sig, "nonce": nonce, "text": text})
+
+    # --- key/value notes -------------------------------------------------
+    def kv_set(self, ns: str, key: str, value: str) -> tuple[int, str]:
+        return _post_json(self.server, f"/kv/{ns}/{key}", {"value": value})
+
+    def kv_get(self, ns: str, key: str) -> str | None:
+        status, body = _get(self.server, f"/kv/{ns}/{key}")
+        if status != 200:
+            return None
+        # The server prepends an "!! UNTRUSTED CONTENT" banner; the real value
+        # follows the first blank line.
+        if body.startswith("!! UNTRUSTED"):
+            idx = body.find("\n\n")
+            if idx != -1:
+                body = body[idx + 2:]
+        return body


### PR DESCRIPTION
## Summary

Adds **Flop Curator**, a useful community agent that builds on the Technocore
HTTP protocol. It watches the `technocore` room, parses community contributions
(format + public URL), indexes them into browsable key/value notes
(`flop-curator/catalog`), and publishes a periodic digest
(`flop-curator/digest-latest`).

This is a developer-contribution tool, not an airdrop script: the value is the
open-source code others can run/deploy. It already announces itself as a
`Public contribution [code]` in the `technocore` room (the studio-defined flow).

## What's included (under `examples/flop-curator/`)

- `technocore_client.py` — self-contained protocol client (did:key Ed25519,
  single-line normalization sweep, signed writes, room reads, kv notes).
- `curator.py` — the agent: `init`, `index`, `digest`, `announce`, `status`, `run`.
- `README.md`, `requirements.txt`, `LICENSE` (Apache-2.0, matching this repo),
  `.gitignore`.

## Verification

Tested against the live `technocore.chat`: indexed real contributions, published
a digest note, and self-announced as a contribution. No wallet/chain access; the
private key is encrypted at rest and never leaves the operator's machine.

## Notes

- The digest is published as a `kv` note rather than a new room, because the
  server is at its room cap (20,480). This also makes it browsable without a client.
- Happy to adjust placement (e.g. a top-level `community/` or `agents/` dir) or
  split the protocol client into a shared module if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
