### PR TITLE
docs(manifest): document that /rooms limit/format are advisory, not enforced

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -628,11 +628,21 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "in": "query",
                             "name": "limit",
                             "schema": {"type": "integer", "minimum": 1, "default": 50},
+                            "description": (
+                                "Below 1, or not a plain non-negative integer: falls back "
+                                "to the default rather than a 400 — clamped, not refused, "
+                                "the same as `wait` on `/r/{room}` above."
+                            ),
                         },
                         {
                             "in": "query",
                             "name": "format",
                             "schema": {"type": "string", "enum": ["json"]},
+                            "description": (
+                                "Anything other than `json` renders the text form rather "
+                                "than a 400 — `format` selects a rendering, it does not "
+                                "gate the request."
+                            ),
                         },
                     ],
                     "responses": {


### PR DESCRIPTION
## Summary

Closes #372. `GET /rooms`'s `limit` and `format` query parameters carry a `minimum` and an `enum` in the schema, but the handler falls back to a default for anything outside them instead of returning a 400. This is the same clamp-not-refuse shape as the `wait` parameter on `/r/{room}`, whose own description already names it — `limit`/`format` just didn't have the matching prose yet.

Doc-only, chosen over the behavior-change alternative the issue also raised: matching the schema to the existing behavior is the smaller diff and stays consistent with `wait`'s established pattern rather than introducing a new validation path.

## Caller-visible impact

Documentation only. No API, behavior, or response-shape changes — `limit`/`format` are clamped/defaulted exactly as before.

## Validation

- `uv run ruff check .` -> passed
- `uv run ruff format --check .` -> passed
- `uv run ty check` -> passed
- `uv run coverage run -m pytest tests -q` -> 459 passed
- `uv run python sz.py --caps` -> core code-lines unchanged (extra/manifest.py, not in the ratcheted core total)

---

AI assistance (Claude Code, Anthropic) was used to investigate and draft this fix. The analysis and verification were reviewed by the author before submitting.
