### PR TITLE
docs(manifest): require did or from in the room-post body schema

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -192,6 +192,11 @@ _ROOM_POST_BODY = {
                 # lane. Not stated the other way round: a stray `sig` with no `did` is an
                 # ordinary unsigned post and is accepted.
                 "dependentRequired": {"did": ["sig", "nonce"]},
+                # `from`'s own description already says it is required on the unsigned
+                # lane; this is what makes that true in the schema `required` alone
+                # cannot express, since `from` is meaningless (and ignored) on the signed
+                # one. At least one lane's author field must be present.
+                "anyOf": [{"required": ["did"]}, {"required": ["from"]}],
             }
         }
     },


### PR DESCRIPTION
## Summary

Closes #373. The `POST /r/{room}` body schema declared only `text` as required, while `from`'s own `description` already said it is required on the unsigned lane and ignored on the signed one -- the schema's `required` array and its own field description disagreed about whether `from` is required.

## Fix

Adds `"anyOf": [{"required": ["did"]}, {"required": ["from"]}]`, mirroring the existing `dependentRequired` sibling a few lines up (`did` -> `sig`, `nonce`): at least one lane's author field must be present, so the schema now says what the field's own description always claimed.

Chosen over the room_post()/error-message alternative the issue also raised (distinguishing a missing `from` from a malformed `room` in the refusal text) to keep this PR to the schema-correctness fix alone; happy to follow up separately if that's also wanted.

## Caller-visible impact

Documentation/contract-correctness only. `room_post()` already treats a missing `from` as an empty nick and refuses it via `valid_name()` -- this change only makes the schema stop claiming that input was ever valid, it does not change what the server accepts or how it responds.

## Validation

- `uv run ruff check .` -> passed
- `uv run ruff format --check .` -> passed
- `uv run ty check` -> passed
- `uv run coverage run -m pytest tests -q` -> 459 passed
- Contract check (`.github/workflows/ci.yml`'s exact schemathesis invocation, run locally against both this branch and a clean `main` checkout for comparison): both pass with 0 failures on the CI-gated check set. The `anyOf` addition reduces schemathesis's own "operation mostly rejected generated data" warning count for this path (1 fewer, from 4 to 3 operations) since the generator can now produce valid examples that satisfy the corrected schema

---

AI assistance (Claude Code, Anthropic) was used to investigate and draft this fix. The analysis and verification were reviewed by the author before submitting.
