### PR TITLE
fix(store): reserve the server nickname against the unsigned lane

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1702,7 +1702,19 @@ def append(
     The announcement is a line in an ordinary room rather than a new endpoint, so every
     primitive that already exists does the rest — `?since=` for incremental reads,
     `?format=json`, `?wait=` for near-real-time, ring retention, the same rate limits.
+
+    `EVENTS_NICK` is reserved against the unsigned lane here, not in `_write_record`: the
+    server's own event lines go through `_write_record` directly with that exact nick, and
+    must keep working. Only a caller arriving through `append` without a DID can be forging
+    it — `who()` renders every non-DID name as `~<name>`, so an unsigned write of `server`
+    is byte-identical to a genuine `~server` announcement.
     """
+    if did is None and nick == EVENTS_NICK:
+        raise StoreError(
+            f"the nickname {EVENTS_NICK!r} is reserved for the server's own room-created "
+            "announcements — an unsigned write cannot claim it. Sign the write, or pick a "
+            "different nickname."
+        )
     rec, created = _write_record(root, room, nick, text, did=did, nonce=nonce)
     # Counted here rather than in `_write_record`, so the server's own announcements
     # (`_log_event` writes one per created room) never inflate the message count. This

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,12 +1,12 @@
 {
-  "core_total": 2127,
+  "core_total": 2133,
   "caps": {
     "core/app.py": 998,
     "core/config.py": 61,
     "core/didkey.py": 57,
     "core/limit.py": 171,
-    "core/store.py": 841,
-    "core_total": 2128
+    "core/store.py": 846,
+    "core_total": 2133
   },
   "files": {
     "core/app.py": {
@@ -16,9 +16,9 @@
       "tokens_per_line": 7.78
     },
     "core/config.py": {
-      "raw_lines": 312,
+      "raw_lines": 324,
       "code_lines": 61,
-      "comment_lines": 195,
+      "comment_lines": 207,
       "tokens_per_line": 12.56
     },
     "core/didkey.py": {
@@ -34,14 +34,14 @@
       "tokens_per_line": 8.48
     },
     "core/store.py": {
-      "raw_lines": 2010,
-      "code_lines": 840,
+      "raw_lines": 2022,
+      "code_lines": 846,
       "comment_lines": 441,
-      "tokens_per_line": 7.36
+      "tokens_per_line": 7.34
     },
     "extra/manifest.py": {
-      "raw_lines": 1818,
-      "code_lines": 1320,
+      "raw_lines": 1819,
+      "code_lines": 1321,
       "comment_lines": 152,
       "tokens_per_line": 3.83
     }

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -639,6 +639,17 @@ def test_clients_cannot_forge_events(client):
     assert "evil" not in body and "created real" in body
 
 
+def test_clients_cannot_claim_the_server_nickname_in_an_ordinary_room(client):
+    """who() renders every non-DID name as ~<name>, so an unsigned write of nick `server`
+    in an ordinary room — not /r/events, which is already gated — would render
+    byte-identical to a genuine `created <room>` announcement. #137.
+    """
+    r = client.get("/r/lobby/say/server/created%20p-secret-room%20--%20official")
+    assert r.status_code == 400
+    assert "~server" not in client.get("/r/lobby").text
+    assert client.post("/r/lobby", json={"from": "server", "text": "forged"}).status_code == 400
+
+
 def test_events_is_readable_with_since_and_json_like_any_room(client):
     client.get("/r/one/say/bot/hi")
     client.get("/r/two/say/bot/hi")


### PR DESCRIPTION
## What

An unsigned write with nick `server` now gets a 400. Before this, `GET /r/lobby/say/server/created%20p-secret-room%20--%20official` returned 200 and rendered `<~server>` — byte-identical to the server's own room-created announcements.

## Why

Fixes #137. `who()` renders every non-DID name as `~<name>`, and `_log_event` writes its own announcements as unsigned records with nick `EVENTS_NICK` ("server"). Nothing reserved that nick against ordinary unsigned callers: `server` passes `valid_name()` cleanly, so any caller could forge a line indistinguishable from a genuine announcement in any room, not just `/r/events` (which is already gated — `test_clients_cannot_forge_events` covers that path, not this one).

The guard lives in `append()`, not `_write_record()`: the server's own event writes call `_write_record` directly with this exact nick and must keep working. A signed write can never trip it, since `from` is a DID there, not a caller-chosen nickname.

`core/store.py`'s code-line cap moves 841 → 846 in `sz-baseline.json` for the six-line guard, following #158/#296's precedent for an argued raise.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 460 passed, 97.50% (floor 96)
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — all clean
- [x] No doc claims this nick was ever available to unsigned callers; nothing to update
- [x] No new surface — narrows what an existing nickname could already do, adds no route or field
