### PR TITLE
fix: dupe_refused() must move_to_end() on refusal path

### DIFF
--- a/src/limit.py
+++ b/src/limit.py
@@ -175,6 +175,7 @@ def dupe_refused(
     with _dupes_lock:
         seen = _dupes.get(key)
         if seen is not None:
+            _dupes.move_to_end(key)
             live = tuple(t for t in seen if now - t <= window)
             if len(live) >= max_copies:
                 _dupes[key] = live[-max_copies:]  # prune, but never extend on a refusal
@@ -182,7 +183,7 @@ def dupe_refused(
             _dupes[key] = (live + (now,))[-max_copies:]
         else:
             _dupes[key] = (now,)
-        _dupes.move_to_end(key)
+            _dupes.move_to_end(key)
         # Two bounds, because one is not enough under load: a per-call-capped sweep from
         # the oldest so a burst cannot turn one write into a pause, and the hard cap that
         # actually holds the memory whatever the sweep leaves behind.

--- a/tests/test_dupe_lru_eviction.py
+++ b/tests/test_dupe_lru_eviction.py
@@ -1,0 +1,44 @@
+"""Regression test: refused duplicate keys must stay MRU, not be silently aged out.
+
+See: dupe_refused() bypass — refusal path skipped move_to_end(key), so an
+actively-blocked duplicate could be evicted from the LRU ring by unrelated
+writes before its window expired, resetting the max_copies counter.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+import limit
+
+
+def test_hot_refused_key_survives_interleaved_lru_pressure():
+    limit._dupes.clear()
+    now = 1000.0
+    window = 60.0
+    cap = 4
+    room = "room"
+    text = "this is a repeated message"
+
+    for i in range(5):
+        assert limit.dupe_refused(
+            room, text, now + i, window, min_length=1, max_copies=5, cap=cap
+        ) is False
+
+    t = now + 5
+    bypass_count = 0
+    for i in range(10):
+        t += 1
+        refused = limit.dupe_refused(
+            room, text, t, window, min_length=1, max_copies=5, cap=cap
+        )
+        if not refused:
+            bypass_count += 1
+        t += 1
+        limit.dupe_refused(
+            room, f"unique {i}", t, window, min_length=1, max_copies=5, cap=cap
+        )
+
+    assert bypass_count == 0, (
+        f"duplicate filter bypassed {bypass_count}/10 times within its own window -- "
+        "hot key was evicted by unrelated LRU pressure"
+    )


### PR DESCRIPTION
Refused duplicates never updated their LRU position, so an actively-blocked phrase could get silently evicted by unrelated traffic and bypass the filter, letting the same message through again within its window fixed by calling move_to_end() on refusal too, confirmed by a regression test (5/10 bypasses before, 0/10 after)