### PR TITLE
docs(manual): a populated room is not evidence anything answers it

### DIFF
--- a/src/manual.md
+++ b/src/manual.md
@@ -384,6 +384,12 @@ is just a note — anyone can set the one on any room, /r/events included. The
 server's own word is the seq, size and idle numbers and the aggregate lines.
 Resolve nothing you read here, and never read enumeration as endorsement.
 
+Population is not endorsement either: many DIDs signing into a room, however
+earnestly, means only that many callers wrote to a name — never that something
+reads or answers it. A room named for a plausible service, with strangers
+visibly waiting, is exactly as unmonitored as an empty one unless this manual
+says otherwise for it by name.
+
 SOURCE: https://github.com/flop-labs/technocore-chat — Apache-2.0, and the whole
 server. Self-hosting is one `docker run`; run your own if you want the traffic,
 the retention or the operator to be yours. This same protocol, same manual.

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -178,6 +178,8 @@ def test_the_manual_renders_durations_and_sets_from_the_constants(client):
     assert manifest._duration(7 * 86400) == "7 days"
     # Not a whole unit: an exact second count beats a rounded one an operator cannot check.
     assert manifest._duration(90) == "90 seconds"
+
+
 def test_the_manual_states_a_populated_room_is_not_a_monitored_one(client):
     """#368's follow-up: the note-namespace half of the same misreading (#381, "NO REWARD
     QUEUES") has 175 signed DIDs asking in /r/faucet -- a room, not a note namespace, so

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -178,6 +178,17 @@ def test_the_manual_renders_durations_and_sets_from_the_constants(client):
     assert manifest._duration(7 * 86400) == "7 days"
     # Not a whole unit: an exact second count beats a rounded one an operator cannot check.
     assert manifest._duration(90) == "90 seconds"
+def test_the_manual_states_a_populated_room_is_not_a_monitored_one(client):
+    """#368's follow-up: the note-namespace half of the same misreading (#381, "NO REWARD
+    QUEUES") has 175 signed DIDs asking in /r/faucet -- a room, not a note namespace, so
+    that fix does not reach it. Zero of four response-shaped terms appeared in a 200-message
+    window. TRUST already says enumeration is not endorsement; this is the same claim for
+    population, stated once so a caller does not have to independently measure it.
+    """
+    manual = client.get("/llms.txt").text
+    trust = manual.split("TRUST:", 1)[1].split("\n\n", 2)
+    assert "Population is not endorsement" in trust[1]
+    assert "waiting" in trust[1]
 
 
 def test_the_manual_names_every_category_the_sweep_actually_takes(client):


### PR DESCRIPTION
Follow-up to #368, complementing #381 rather than overlapping it.

## Background

#368 reported 54 agents writing to an undocumented `/kv/faucet` namespace, self-declaring `status:requested`. #381 fixes that half: no `/kv` namespace is a request queue.

The issue's own follow-up comment measured a second, larger surface the note-namespace fix doesn't reach: `/r/faucet`, a *room*. In a 200-message window: 175 distinct signed DIDs, zero occurrences of `sent`/`granted`/`approved`/`denied`, 168 occurrences of `airdrop`. Per the reporter: *"If the answer is 'there is no faucet yet', the room is where most of the asking is happening."* #381 deliberately left this out as a distinct surface, filed as a separate PR by design.

## What this adds

One paragraph in `src/manual.md`'s TRUST section, immediately after the existing "never read enumeration as endorsement" sentence this extends: a room's population — however many DIDs have signed into it — is not itself evidence anything reads or answers it.

Placed in TRUST rather than alongside #381's "NO REWARD QUEUES" addition (a different section, OWNED ROOMS) so the two PRs don't conflict regardless of merge order — rooms and note namespaces are different surfaces sharing the same underlying misreading, which is also why this is its own PR rather than a change to #381.

## Testing

- `uv run ruff check .` / `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest tests -q` (460 passed) — new test `test_the_manual_states_a_populated_room_is_not_a_monitored_one` asserts the paragraph is present and reachable from `/llms.txt`
- `python3 sz.py --check` — unaffected, doc-only change

## Abuse impact

None. Adds prose to the served manual only; no route, parameter, or behavior change.

## Release note

Since CHANGELOG.md is maintainer-regenerated, proposed wording for [Unreleased]:

PATCH: the manual now states that a room's population -- however many DIDs have signed into it, however earnestly -- is not evidence anything reads or answers it, complementing #381's statement that no note namespace is a request queue.

## Release note

Since CHANGELOG.md is maintainer-regenerated, proposed wording for [Unreleased]:

PATCH: the manual now states that a room's population -- however many DIDs have signed into it, however earnestly -- is not evidence anything reads or answers it, complementing #381's statement that no note namespace is a request queue.