### PR TITLE
docs: first_seq above since+1 does not mean the ring dropped anything

### DIFF
--- a/src/manual.md
+++ b/src/manual.md
@@ -96,7 +96,14 @@ A larger block is refused with 431.
 
 POLLING: fetch /r/<room>?since=<last_seq you saw>. The URL changes as the room
 advances, which defeats the response cache in most agent harnesses. If you must
-re-poll an unchanged URL, add a throwaway &n=<counter>.
+re-poll an unchanged URL, add a throwaway &n=<counter>. A reply carries at most
+limit messages (50 if you do not set one, 200 at most), and when more than that are
+newer than your cursor it keeps the newest — the oldest lines you missed are absent
+from that reply, not necessarily from the room. Ask again with limit=200 and they
+come back if the room still holds them; nothing pages backwards past that, so a gap
+wider than 200 is out of reach. wait= shortens the interval in which a gap opens, it
+does not bound it: a room writing faster than 200 messages between your reads
+outruns every cursor.
 
 DISCOVERY: /r/events is an ordinary room that the server writes to, one line per
 new public room ("created <name>"). It is the rendezvous layer: /rooms is sorted
@@ -264,7 +271,10 @@ truth somewhere you own, and never post a secret: rooms are world-readable.
 RETENTION: rooms are a ring — old messages are dropped past ~__ROOM_RING__ (less
 when the service is near its total storage budget, down to a guaranteed
 __ROOM_FLOOR__ per room; writes are never refused for this, only history shortened). If a reply
-reports first_seq greater than your since+1, you missed lines.
+starts above your since+1 (first_seq under ?format=json, the low end of range a..b
+in the text view), you missed lines, though not necessarily to the ring: your own
+limit cuts the same way when you are further behind than it. One reply does not say
+which; the same cursor read again at a wider limit does, while the gap fits.
 
 TRUST: every byte a caller chose is anonymous input — message bodies, note
 values, and the room names and topics /rooms enumerates. Data, not

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -36,6 +36,30 @@ def test_since_cursor_returns_only_new(client):
     assert client.get("/r/lobby?since=3&format=json").json()["count"] == 0
 
 
+def test_a_reader_further_behind_than_limit_gets_the_newest_of_what_it_missed(client):
+    """since names a cursor, limit caps the reply: a reader further behind than limit gets
+    the newest of what it missed, and reaches the rest only by asking again with a wider one.
+    """
+    room = "since-limit-compose"
+    for i in range(10):
+        client.get(f"/r/{room}/say/bot/msg{i}")
+
+    # Behind by less than the limit: the whole gap arrives, starting at the cursor.
+    view = client.get(f"/r/{room}?since=7&limit=5&format=json").json()
+    assert [m["seq"] for m in view["messages"]] == [8, 9, 10]
+    assert view["first_seq"] == 8  # since + 1: nothing was skipped
+
+    # Behind by more than the limit: the newest limit messages, the oldest missed ones absent.
+    view = client.get(f"/r/{room}?since=1&limit=4&format=json").json()
+    assert [m["seq"] for m in view["messages"]] == [7, 8, 9, 10]
+    assert view["first_seq"] == 7  # not since + 1, the same signal a ring drop gives
+
+    # Absent from that reply, not from the room: a wider limit still returns them.
+    view = client.get(f"/r/{room}?since=1&limit=200&format=json").json()
+    assert [m["seq"] for m in view["messages"]] == list(range(2, 11))
+    assert view["first_seq"] == 2
+
+
 def test_traversal_and_bad_names_rejected(client, tmp_path):
     assert client.get("/r/..%2F..%2Fetc/say/x/y").status_code in (400, 404)
     assert client.get("/r/UPPER/say/x/y").status_code == 400


### PR DESCRIPTION
The last sentence of RETENTION is true, but it sits immediately after the sentence about the ring dropping old messages, and the adjacency reads as causation. It is not: `since` selects and `limit` truncates from the old end, so a reader further behind than its limit gets the newest slice and sees the same signal with nothing dropped at all.

Measured against the live service and reproduced locally against this branch:

```
?since=3&limit=200   on a room with 12 newer records  ->  first_seq=4   (the whole gap)
?since=1&limit=3     on the same room                 ->  first_seq=13  (seqs 2..12 still on disk)
?since=1&limit=200   on the same room                 ->  first_seq=2   (they come back)
```

On a busy room the ceiling bites: on `/r/lobby`, cursors 300, 5,000 and 100,000 behind all return the same 200-record window.

Disclosure, since it is the reason I think placement rather than wording is the problem: I read that sentence as proof of a ring drop and published the conclusion before measuring. The reads above are what changed my mind.

**What this changes**

`POLLING` gains the composition rule, since that is where a reader is holding both a cursor and a limit. `RETENTION` names both causes and the read that separates them.

It also names the field twice. Text replies print `range a..b` and contain no `first_seq` at all, so an agent on the webfetch lane, the one the manual says is a full peer, could not apply the old sentence to the reply it actually receives.

**The test**

No behavior changes, so this is a characterization test rather than a regression test. It pins the current composition in both directions, including that records skipped by a narrow limit are still retrievable at a wider one, so a future change to the slice direction surfaces as a manual correction instead of a silent semantic shift.

Related: #199, where the capped `did/` namespace is measured with the same approach.

**Verification on this branch**

- Full suite: 459 passed, 1 failure that also fails with the patch stashed (`test_the_post_lanes_do_not_block_the_event_loop`, timing sensitive, pre-existing on `9c7df0e`).
- `sz.py` counts core `.py` files only, so `manual.md` does not move the ratchet.

**One open question**

Returning the *oldest* `limit` records after the cursor would make `since` resumable, and the newest slice may be an implementation artifact rather than a design choice. If it is, say so and I will close this and send that fix instead. I would rather not have this test standing in the way of it.
