### PR TITLE
fix(mcp): advertise additionalProperties:false so tools/list matches tools/call (#105)

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -206,7 +206,16 @@ def schema_of(handler: Callable[..., str]) -> dict[str, Any]:
         properties[name] = fragment(hints[name])
         if parameter.default is inspect.Parameter.empty:
             required.append(name)
-    schema: dict[str, Any] = {"type": "object", "properties": properties}
+    # `additionalProperties: False` so the advertised contract matches what `_validate`
+    # enforces: a client that validates a call locally against this schema reaches *valid*
+    # only when every argument the tool declares. Without it, JSON Schema admits any
+    # un-named property, so an `unknown_argument` call validates locally, is sent, and is
+    # then refused with `-32602` — the exact round-trip the generated schema exists to end.
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
     if required:
         schema["required"] = required
     return schema

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -259,6 +259,24 @@ def test_generated_schemas_still_say_what_clients_already_integrated_against(mcp
     assert pages["enum"] == ["manual", "patterns", "skill"]
 
 
+def test_generated_schemas_reject_unknown_arguments_like_the_call_path(mcp):
+    """`tools/list` must advertise the same rejection the `tools/call` path enforces.
+
+    The call path (_validate) refuses any argument the handler does not declare; the
+    advertised schema must too, via `additionalProperties: False`, or a client that
+    validates locally against our own document reaches *valid* on a call that is then
+    refused with -32602. This is the contract #105 reports as broken.
+    """
+    server, _ = mcp
+    tools = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})["result"]["tools"]
+    for tool in tools:
+        schema = tool["inputSchema"]
+        assert schema.get("additionalProperties") is False
+    # Mirror the call path: an undeclared argument is refused.
+    bad = call(server, "read_room", {"room": "lobby", "colour": "blue"})
+    assert "unexpected arguments: colour" in bad["error"]["message"]
+
+
 def test_the_descriptions_the_model_reads_survive_the_generation(mcp):
     """The point of `Annotated` here: the sentence lives next to the parameter, and one
     room description is shared by the four tools that take a room."""


### PR DESCRIPTION
Fixes #105 — `tools/list` advertises a schema that contradicts what `tools/call` enforces.

## Root cause
`schema_of()` in `mcp/src/technocore_mcp/protocol.py` built the JSON Schema for every tool's `inputSchema` without `additionalProperties: false`. JSON Schema admits any property a schema does not name, so a client that validates a call locally against the document `tools/list` hands out reaches *valid* on an argument the handler never declares — then `tools/call` → `_validate` refuses it with `-32602 unexpected arguments`.

The advertised contract and the enforced one disagreed, which is exactly the round-trip the generated schema exists to prevent (per the module docstring: "the function *is* the schema, so what `tools/list` advertises and what `tools/call` enforces cannot disagree").

## Change
Add `"additionalProperties": False` to the generated `inputSchema`. Now a locally-validated call and a server-accepted call are the same set.

## Test
Added `test_generated_schemas_reject_unknown_arguments_like_the_call_path` (tests/test_mcp.py): every advertised schema carries `additionalProperties: False`, and an undeclared argument (`colour`) on `read_room` is refused with the same message `_validate` produces.

## CI
- `uv run ruff check .` — pass
- `uv run ruff format --check .` — pass
- `uv run ty check` — pass
- `uv run coverage run -m pytest tests -q` — 382 passed
- core size caps (`sz.py`) unaffected: change is in `mcp/` (extra, not core)

Branch is rebased onto current `main`.