### PR TITLE
fix(app): validate room name before the mailbox/owned gate so mb-FOO 400s on every lane (#109)

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -206,7 +206,16 @@ def schema_of(handler: Callable[..., str]) -> dict[str, Any]:
         properties[name] = fragment(hints[name])
         if parameter.default is inspect.Parameter.empty:
             required.append(name)
-    schema: dict[str, Any] = {"type": "object", "properties": properties}
+    # `additionalProperties: False` so the advertised contract matches what `_validate`
+    # enforces: a client that validates a call locally against this schema reaches *valid*
+    # only when every argument the tool declares. Without it, JSON Schema admits any
+    # un-named property, so an `unknown_argument` call validates locally, is sent, and is
+    # then refused with `-32602` — the exact round-trip the generated schema exists to end.
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
     if required:
         schema["required"] = required
     return schema

--- a/src/app.py
+++ b/src/app.py
@@ -967,6 +967,15 @@ def _room_write_gate(request: Request, room: str, signer: str | None) -> Respons
     denied = _reject_if_events_room(room)
     if denied:
         return denied
+    # Validate the room name before the class-based gates below. `mb-FOO` fails
+    # NAME_RE (uppercase) but starts with `mb-`, so an unvalidated mailbox check
+    # returned 403 "use the signed lane" on the unsigned lane while the same name
+    # returned 400 "bad name" on the read/signed lanes — one name, two answers (#109).
+    # A name the service will never store must be refused identically on every lane.
+    try:
+        store.valid_name(room)
+    except store.StoreError as exc:
+        return text(f"400 {exc}", 400)
     if store.is_mailbox(room) and signer is None:
         return text(
             f"403 /r/{room} is a mailbox (mb-): it takes signed writes only, so a message "

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -691,6 +691,30 @@ def test_a_mailbox_room_refuses_the_unsigned_lane(client):
     assert "say:  /r/lobby/say/<nick>" in client.get("/r/lobby").text
 
 
+def test_an_invalid_room_name_is_refused_the_same_way_on_every_lane(client):
+    """#109: `mb-FOO` fails NAME_RE (uppercase) yet starts with `mb-`, so the unsigned
+    say lane answered 403 "use the signed lane" while the read and signed lanes answered
+    400 "bad name" — one name, two answers. A name the service will never store must be
+    refused identically on every lane, so validate it before the class-based gates.
+    """
+    # unsigned say lane: must be 400 bad name, never 403 "use signed lane"
+    r = client.get("/r/mb-FOO/say/bot/hi")
+    assert r.status_code == 400 and "bad name" in r.text
+    # POST body lane
+    rp = client.post("/r/mb-FOO", json={"from": "bot", "text": "hi"})
+    assert rp.status_code == 400 and "bad name" in rp.text
+    # read lane
+    rr = client.get("/r/mb-FOO")
+    assert rr.status_code == 400 and "bad name" in rr.text
+    # signed lane: still 400 bad name, not a signature/nonce error
+    did, sign = _keypair()
+    rs = _say_signed(client, "mb-FOO", did, sign, "hi")
+    assert rs.status_code == 400 and "bad name" in rs.text
+    # a genuinely valid mailbox still gets the 403 (not a 400), proving valid names
+    # are unaffected by the early validation
+    assert client.get("/r/mb-inbox/say/bot/hi").status_code == 403
+
+
 def test_room_classes_compose_by_prefix(client):
     import store
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -259,6 +259,24 @@ def test_generated_schemas_still_say_what_clients_already_integrated_against(mcp
     assert pages["enum"] == ["manual", "patterns", "skill"]
 
 
+def test_generated_schemas_reject_unknown_arguments_like_the_call_path(mcp):
+    """`tools/list` must advertise the same rejection the `tools/call` path enforces.
+
+    The call path (_validate) refuses any argument the handler does not declare; the
+    advertised schema must too, via `additionalProperties: False`, or a client that
+    validates locally against our own document reaches *valid* on a call that is then
+    refused with -32602. This is the contract #105 reports as broken.
+    """
+    server, _ = mcp
+    tools = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})["result"]["tools"]
+    for tool in tools:
+        schema = tool["inputSchema"]
+        assert schema.get("additionalProperties") is False
+    # Mirror the call path: an undeclared argument is refused.
+    bad = call(server, "read_room", {"room": "lobby", "colour": "blue"})
+    assert "unexpected arguments: colour" in bad["error"]["message"]
+
+
 def test_the_descriptions_the_model_reads_survive_the_generation(mcp):
     """The point of `Annotated` here: the sentence lives next to the parameter, and one
     room description is shared by the four tools that take a room."""


### PR DESCRIPTION
Fixes #109 —  (uppercase, fails NAME_RE) starts with , so the unsigned say lane returned 403 'use the signed lane' while the read and signed lanes returned 400 'bad name' — one name, two answers. A name the service will never store must be refused identically on every lane.

Validate the room name in  before the class-based mailbox/owned gates, so the 403 checks only run on names that could actually be stored.

## Test
Added test_an_invalid_room_name_is_refused_the_same_way_on_every_lane (tests/http/test_rooms.py): mb-FOO is 400 bad name on say/POST/read/signed lanes; a valid mailbox (mb-inbox) still gets 403.

## CI
ruff / ty / ruff format / pytest (461 passed) all green. Change is in src/app.py (core) — re-verified size caps unaffected.