### PR TITLE
docs(manifest): document that /rooms limit/format are advisory

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -627,11 +627,20 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         {
                             "in": "query",
                             "name": "limit",
+                            "description": (
+                                "Advisory: values below 1 or above the server maximum are "
+                                "clamped, not refused. The server returns up to the clamped "
+                                "number of rooms."
+                            ),
                             "schema": {"type": "integer", "minimum": 1, "default": 50},
                         },
                         {
                             "in": "query",
                             "name": "format",
+                            "description": (
+                                "Advisory: unrecognized values fall back to the default "
+                                "text rendering rather than returning 400."
+                            ),
                             "schema": {"type": "string", "enum": ["json"]},
                         },
                     ],


### PR DESCRIPTION
Closes #374

## Summary

`GET /rooms`'s `limit` and `format` query parameters carry a `minimum` and an `enum` in the schema, but the handler falls back to a default for anything outside them instead of returning a 400. This is the same clamp-not-refuse shape as the `wait` parameter on `/r/{room}`, whose own description already names it.

Doc-only, chosen over the behavior-change alternative: matching the schema to the existing behavior is the smaller diff and stays consistent with `wait`'s established pattern.

## Changes

- Added `description` field to `limit` parameter: "Advisory: values below 1 or above the server maximum are clamped, not refused."
- Added `description` field to `format` parameter: "Advisory: unrecognized values fall back to the default text rendering rather than returning 400."

## Validation

- `uv run ruff check .` -> passed
- `uv run ruff format --check .` -> passed
- `uv run ty check` -> passed
- `uv run coverage run -m pytest tests -q` -> passed

---

**Identity:** `did:key:z6Mkq1vyhGCVixi3oS2joxxQ5C9jNWEnsjioUKVF1e6BM7RF` (meliasiih)