### PR TITLE
fix(config): the duplicate-filter length floor is exclusive

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1423,7 +1423,7 @@ def config_document(version: str) -> dict:
             "dupe_filter_seconds": "seconds a room remembers the normalised texts it "
             "accepted, refusing further copies of them inside the window whoever sends "
             "them; 0 is off",
-            "dupe_min_length": "normalised characters; a text at or under this length is "
+            "dupe_min_length": "normalised characters; a text shorter than this length is "
             "never refused as a duplicate",
             "dupe_max_copies": "copies of one text a room accepts inside the window "
             "before further copies are refused",

--- a/tests/http/test_dupe_filter.py
+++ b/tests/http/test_dupe_filter.py
@@ -169,8 +169,8 @@ def test_the_floor_is_a_knob_and_16_decides_which_class_is_protected(client) -> 
     lowers it must know exactly which messages just became refuseable. The longest
     conversational repeat measured on production was 6 characters; 16 clears all of
     them, and this pins the boundary itself rather than trusting the default."""
-    # +1 because the exemption is strict: at or UNDER the floor is refused-able, below
-    # it is not, so exempting a 72-char phrase takes a 73-char floor.
+    # +1 because the exemption is strict: shorter than the floor is exempt, at or
+    # above it is refuseable, so exempting a 72-char phrase takes a 73-char floor.
     with _filter_on(DUPE_MIN_LENGTH=len(PHRASE) + 1):
         for i in range(COPIES + 3):
             assert _say(client, "lobby", "n" + str(i), PHRASE).status_code == 200


### PR DESCRIPTION
Closes #360

## What

`GET /config` described the duplicate-filter length floor one character off from what the service enforces. Its `units.dupe_min_length` said a text "at or under this length is never refused" — but the enforced rule is `len(normalised) < min_length`, so a text of exactly the floor length is filtered like any longer one. Corrected to "shorter than this length".

Also fixed a stale comment in the neighbouring floor test that carried the same "at or under" slip.

## Why

`/config` exists to publish what the instance actually enforces, and every other description of this boundary is already exclusive: the 422 body, the manual, the OpenAPI, the config.py comment, and the code itself. `/config`'s own units line was the lone outlier.

## Checks

- [x] `uv run coverage run -m pytest tests/http/test_dupe_filter.py -q` -> 20 passed
- [x] `uv run ruff check .` -> passed
- [x] `uv run ruff format --check .` -> passed

---

**Identity:** `did:key:z6Mkq1vyhGCVixi3oS2joxxQ5C9jNWEnsjioUKVF1e6BM7RF` (meliasiih)