### PR TITLE
fix(mcp): bound inbound JSON integers

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -51,6 +51,17 @@ METHOD_NOT_FOUND = -32601
 INVALID_PARAMS = -32602
 INTERNAL_ERROR = -32603
 
+# Keep every accepted integer serializable under Python's lowest permitted nonzero
+# int-string conversion limit. This is transport policy, not mutable interpreter policy.
+MAX_JSON_INTEGER_DIGITS = 640
+
+
+def _parse_int(token: str) -> int:
+    digits = token.removeprefix("-")
+    if len(digits) > MAX_JSON_INTEGER_DIGITS:
+        raise ValueError(f"JSON integer exceeds {MAX_JSON_INTEGER_DIGITS} digits")
+    return int(token)
+
 
 # ------------------------------------------------------------------ the message on the wire
 
@@ -375,8 +386,8 @@ class Server:
             if not line:
                 continue
             try:
-                message = json.loads(line)
-            except json.JSONDecodeError as exc:
+                message = json.loads(line, parse_int=_parse_int)
+            except (json.JSONDecodeError, ValueError) as exc:
                 _write(stdout, _error(None, PARSE_ERROR, f"invalid JSON: {exc}"))
                 continue
             # Batches were removed in 2025-06-18 but older clients may still send one.

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -600,6 +600,78 @@ def test_malformed_json_does_not_kill_the_session(mcp):
     assert replies[1] == {"jsonrpc": "2.0", "id": 9, "result": {}}
 
 
+def test_json_integer_limit_is_transport_owned_and_serializable(mcp):
+    """Accepted integer IDs round-trip under Python's lowest legal global limit."""
+    server, protocol = mcp
+    assert protocol.MAX_JSON_INTEGER_DIGITS <= sys.int_info.str_digits_check_threshold
+    boundary = "9" * protocol.MAX_JSON_INTEGER_DIGITS
+    too_large = boundary + "9"
+    old_limit = sys.get_int_max_str_digits()
+    try:
+        for process_limit in (0, 640, 5000):
+            sys.set_int_max_str_digits(process_limit)
+            stdout = io.StringIO()
+            server.serve(
+                io.StringIO(
+                    f'{{"jsonrpc":"2.0","id":{boundary},"method":"ping"}}\n'
+                    f'{{"jsonrpc":"2.0","id":-{boundary},"method":"ping"}}\n'
+                    f'{{"jsonrpc":"2.0","id":{too_large},"method":"ping"}}\n'
+                    f'{{"jsonrpc":"2.0","id":-{too_large},"method":"ping"}}\n'
+                    '{"jsonrpc":"2.0","id":7,"method":"ping"}\n'
+                ),
+                stdout,
+            )
+            replies = [json.loads(line) for line in stdout.getvalue().splitlines()]
+            assert len(str(replies[0]["id"])) == protocol.MAX_JSON_INTEGER_DIGITS
+            assert len(str(replies[1]["id"]).removeprefix("-")) == protocol.MAX_JSON_INTEGER_DIGITS
+            assert [reply["error"]["code"] for reply in replies[2:4]] == [protocol.PARSE_ERROR] * 2
+            assert replies[4] == {"jsonrpc": "2.0", "id": 7, "result": {}}
+    finally:
+        sys.set_int_max_str_digits(old_limit)
+
+
+def test_accepted_integer_serializes_after_process_limit_is_lowered(mcp):
+    """Changing interpreter policy after parsing cannot strand an accepted response."""
+    server, protocol = mcp
+    boundary = "9" * protocol.MAX_JSON_INTEGER_DIGITS
+    old_limit = sys.get_int_max_str_digits()
+    try:
+        sys.set_int_max_str_digits(0)
+        messages = [
+            json.loads(
+                f'{{"jsonrpc":"2.0","id":{sign}{boundary},"method":"ping"}}',
+                parse_int=protocol._parse_int,
+            )
+            for sign in ("", "-")
+        ]
+        sys.set_int_max_str_digits(sys.int_info.str_digits_check_threshold)
+        stdout = io.StringIO()
+        for message in messages:
+            protocol._write(stdout, protocol._response(server, message))
+        replies = [json.loads(line) for line in stdout.getvalue().splitlines()]
+        assert [reply["id"] for reply in replies] == [message["id"] for message in messages]
+    finally:
+        sys.set_int_max_str_digits(old_limit)
+
+
+def test_oversized_json_integer_positions_do_not_kill_the_session(mcp):
+    """One oversized token invalidates its whole frame without affecting later frames."""
+    server, protocol = mcp
+    oversized = "9" * (protocol.MAX_JSON_INTEGER_DIGITS + 1)
+    frames = [
+        f'{{"jsonrpc":"2.0","id":1,"method":"ping","params":{{"n":{oversized}}}}}',
+        f'[{{"jsonrpc":"2.0","id":2,"method":"ping"}},{{"n":{oversized}}}]',
+        f'{{"jsonrpc":"2.0","method":"notifications/initialized","n":{oversized}}}',
+        '{"jsonrpc":"2.0","id":8,"method":"ping"}',
+    ]
+    stdout = io.StringIO()
+    server.serve(io.StringIO("\n".join(frames) + "\n"), stdout)
+    replies = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert [reply["error"]["code"] for reply in replies[:3]] == [protocol.PARSE_ERROR] * 3
+    assert all(len(json.dumps(reply)) < 300 for reply in replies[:3])
+    assert replies[3] == {"jsonrpc": "2.0", "id": 8, "result": {}}
+
+
 # ------------------------------------------------------------------ packaging
 
 


### PR DESCRIPTION
## Summary

- give MCP stdio a transport-owned 640-decimal-digit limit for inbound JSON integers
- return a bounded JSON-RPC parse error for larger tokens and continue processing later frames
- keep accepted integer IDs serializable even if Python's process-wide conversion limit changes

## Why

PR #228 catches the `ValueError` raised by CPython's default integer-conversion limit. That fixes the default 5,000-digit crash, but behavior still depends on mutable `sys.set_int_max_str_digits()` state: raising or disabling the limit accepts and reflects huge IDs, and lowering it before response serialization can terminate the session.

This branch instead supplies `json.loads()` with a bounded `parse_int` callback. The 640-digit bound matches CPython's minimum legal nonzero conversion threshold, so every integer accepted by the transport can still be serialized under any legal process setting.

This is a current-main alternative to #228 rather than a modification of that contributor's branch.

## Coverage

Tests cover:

- positive and negative values at the exact 640-digit boundary
- positive and negative 641-digit rejection
- process limits of 0, 640, and 5,000
- parsing while unlimited, then serializing after lowering the limit to 640
- oversized tokens in IDs, nested params, batches, and notification-shaped frames
- bounded errors and continued processing of the next valid frame

## Validation

- `uv run pytest -q tests/test_mcp.py -k 'malformed_json_does_not_kill_the_session or json_integer_limit_is_transport_owned_and_serializable or accepted_integer_serializes_after_process_limit_is_lowered or oversized_json_integer_positions_do_not_kill_the_session'` — 4 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run sz.py --caps` — core 2127/2128
- `uv run coverage run -m pytest tests -q` — 462 passed
- `uv run coverage report` — 97.50%

The commit tree is `1f5d38ea2b682fb6b32574d3a6fbf468dd919bd8` on base `9c7df0e3616cf28d17e7c8ebeb0c05de6adf117c`.