### PR TITLE
docs(manifest): document that GET /r/{room}'s limit/format are advisory, not enforced

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -419,6 +419,11 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                 "maximum": store.MAX_LIMIT,
                                 "default": 50,
                             },
+                            "description": (
+                                "Below 1, above the maximum, or not a plain non-negative "
+                                "integer: falls back to the default rather than a 400 — "
+                                "clamped, not refused, the same as `wait` below."
+                            ),
                         },
                         {
                             "in": "query",
@@ -444,6 +449,11 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "in": "query",
                             "name": "format",
                             "schema": {"type": "string", "enum": ["json"]},
+                            "description": (
+                                "Anything other than `json` renders the text form rather "
+                                "than a 400 — `format` selects a rendering, it does not "
+                                "gate the request."
+                            ),
                         },
                         {
                             "in": "query",

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -420,9 +420,10 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                 "default": 50,
                             },
                             "description": (
-                                "Below 1, above the maximum, or not a plain non-negative "
-                                "integer: falls back to the default rather than a 400 — "
-                                "clamped, not refused, the same as `wait` below."
+                                f"Below 1, above the maximum ({store.MAX_LIMIT}), or not a "
+                                "plain non-negative integer: falls back to the default "
+                                "rather than a 400 — clamped, not refused, the same as "
+                                "`wait` below."
                             ),
                         },
                         {

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -555,6 +555,22 @@ def test_an_integral_ceiling_publishes_as_an_integer(client):
     assert manifest.agent_manifest("", "0.7.0", 1, 1, 1, 10.0)["limits"]["long_poll_seconds"] == 10
 
 
+def test_the_room_limit_advisory_names_the_actual_bound(client):
+    """The doc claims 'clamped, not refused' — that sentence is only a real contract if it
+    also states the number a caller is clamped to. A stray unrendered placeholder would
+    read as prose to a human and lie to a validator that never sees the real bound."""
+    import store
+
+    limit_param = next(
+        p
+        for p in client.get("/openapi.json").json()["paths"]["/r/{room}"]["get"]["parameters"]
+        if p["name"] == "limit"
+    )
+    assert limit_param["schema"]["maximum"] == store.MAX_LIMIT
+    assert str(store.MAX_LIMIT) in limit_param["description"]
+    assert "{" not in limit_param["description"] and "}" not in limit_param["description"]
+
+
 _REFUSALS = frozenset({"400", "403", "404", "409", "422"})
 
 


### PR DESCRIPTION
## Summary

Closes #402. `GET /r/{room}`'s `limit` and `format` query parameters carry a `minimum`/`maximum` and an `enum` in the schema, but the handler falls back to a default for anything outside them instead of returning a 400 — the same clamp-not-refuse shape `wait` on this same endpoint already names, and that #374 is documenting for `/rooms`.

Doc-only, matching #374's direction: naming the existing behavior in the schema is the smaller diff and stays consistent with `wait`'s established pattern here, rather than introducing a new validation path.

## Caller-visible impact

Documentation only. No API, behavior, or response-shape changes — `limit`/`format` are clamped/defaulted exactly as before.

## Validation

- `uv run ruff check .` -> passed
- `uv run ruff format --check .` -> passed
- `uv run ty check` -> passed
- `uv run coverage run -m pytest tests -q` -> 459 passed
- `uv run python sz.py --caps` -> `manifest.py` is `extra/`, not in the ratcheted core total; unaffected
