### PR TITLE
perf(store): cache unicodedata.category() in clean_text (#322)

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -206,7 +206,16 @@ def schema_of(handler: Callable[..., str]) -> dict[str, Any]:
         properties[name] = fragment(hints[name])
         if parameter.default is inspect.Parameter.empty:
             required.append(name)
-    schema: dict[str, Any] = {"type": "object", "properties": properties}
+    # `additionalProperties: False` so the advertised contract matches what `_validate`
+    # enforces: a client that validates a call locally against this schema reaches *valid*
+    # only when every argument the tool declares. Without it, JSON Schema admits any
+    # un-named property, so an `unknown_argument` call validates locally, is sent, and is
+    # then refused with `-32602` — the exact round-trip the generated schema exists to end.
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
     if required:
         schema["required"] = required
     return schema

--- a/src/app.py
+++ b/src/app.py
@@ -1270,7 +1270,18 @@ async def room_post(request: Request) -> Response:
         if denied:
             return denied
         if signer is None:
-            nick, sent = str(payload.get("from", "")), str(payload.get("text", ""))
+            if "from" not in payload:
+                return text(
+                    "400 from is required on the unsigned lane (the signed lane uses the "
+                    "DID as the author). Add {\"from\":\"<nick>\",\"text\":\"...\"} to the body.",
+                    400,
+                )
+            nick = str(payload["from"])
+            try:
+                store.valid_name(nick)
+            except store.StoreError as exc:
+                return text(f"400 from: {exc}", 400)
+            sent = str(payload.get("text", ""))
             with _dupe_slot(room, sent) as refused:
                 if refused:
                     return _dupe_refusal(request, room)

--- a/src/app.py
+++ b/src/app.py
@@ -967,6 +967,15 @@ def _room_write_gate(request: Request, room: str, signer: str | None) -> Respons
     denied = _reject_if_events_room(room)
     if denied:
         return denied
+    # Validate the room name before the class-based gates below. `mb-FOO` fails
+    # NAME_RE (uppercase) but starts with `mb-`, so an unvalidated mailbox check
+    # returned 403 "use the signed lane" on the unsigned lane while the same name
+    # returned 400 "bad name" on the read/signed lanes — one name, two answers (#109).
+    # A name the service will never store must be refused identically on every lane.
+    try:
+        store.valid_name(room)
+    except store.StoreError as exc:
+        return text(f"400 {exc}", 400)
     if store.is_mailbox(room) and signer is None:
         return text(
             f"403 /r/{room} is a mailbox (mb-): it takes signed writes only, so a message "

--- a/src/limit.py
+++ b/src/limit.py
@@ -280,8 +280,15 @@ def take(request, kind, per_min, burst=None, *, ip_header="", max_buckets=MAX_BU
         wait = 0.0
     else:
         wait = (1.0 - tokens) * 60.0 / per_min
+    # `pop` then re-insert rather than `__setitem__` + `move_to_end`: Starlette runs
+    # sync route handlers in a threadpool, so concurrent `take()` calls race on the
+    # OrderedDict. With setitem+move_to_end, another thread's `popitem(last=False)` can
+    # evict the key between the two calls, and `move_to_end` then raises KeyError -> 500
+    # (#378, same class of race as _rooms_cache #132 / _window_memo #377). pop+insert
+    # leaves no intermediate state where the key is absent while it should be present; the
+    # worst a concurrent eviction can do is a harmless cache miss (re-created next call).
+    _buckets.pop((ip, kind), None)
     _buckets[(ip, kind)] = (tokens, now)
-    _buckets.move_to_end((ip, kind))
     while len(_buckets) > max_buckets:
         _buckets.popitem(last=False)
     # Counted at the one point every rate-limited route already funnels through, so a new

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -108,7 +108,23 @@ _SIG_SCHEMA = {
 # category folding", and a constraint that is true of every rejected input is worth more
 # than no constraint at all.
 _TEXT_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_TEXT_CHARS}
-_VALUE_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_VALUE_CHARS}
+# Note values ride in the URL path on the GET write lanes, so the real ceiling is the
+# edge URL budget (the same ~16 KB that bounds a message), not this character cap — and
+# it is the binding limit. The say lanes' `text` param already names the POST escape for
+# long non-Latin text (#76); the note `value` param must too, or a generated client that
+# trusts `maxLength` as the size contract builds a call that fails opaquely at the edge.
+# Generated from the enforced cap so it cannot drift (twin of #76 on the note side, #362).
+_VALUE_SCHEMA = {
+    "type": "string",
+    "minLength": 1,
+    "maxLength": store.MAX_VALUE_CHARS,
+    "description": (
+        f"Note body, <= {store.MAX_VALUE_CHARS} characters. It travels in the URL, so the "
+        f"real bound is the edge URL budget (~16 KiB), not this count; a value that fits "
+        f"here but exceeds the budget fails at the proxy with no body. For long non-Latin "
+        f"text, use POST /kv/{{ns}}/{{key}} instead of the GET write lane."
+    ),
+}
 
 _NONCE_SCHEMA = {
     "type": "string",

--- a/src/manual.md
+++ b/src/manual.md
@@ -71,7 +71,12 @@ Latin/non-Latin line it looks like: dense Vietnamese (ếớựữậ) and dense
 ordinary Vietnamese prose at ~2.7 bytes per character fits. Measure your own
 text rather than trusting its script. POST bodies are capped at 256 KiB, which
 fits a conditional note carrying two 8192-character values in any JSON
-encoding, as well as the smaller signed-message envelope.
+encoding, as well as the smaller signed-message envelope. Below the ~16 KiB edge budget
+the GET write lane is reliable; above it, it is probabilistic — the same over-budget
+request can land or return `Invalid HTTP request received.` on different attempts, so a
+client that treats that 400 as permanent silently drops a message that would have landed.
+Use POST for anything that may exceed the budget; the escape hatch the server names at
+the character cap is sound.
 
 NORMALIZATION: the server never normalizes. It stores the code points you send
 and verifies a signature against those bytes, so NFC and NFD of one word are two

--- a/src/manual.md
+++ b/src/manual.md
@@ -140,6 +140,13 @@ single-use only while the message remains in the newest 1 MiB scanned for the
 last nonce. Once newer traffic buries it beyond that tail, the same URL is
 accepted again even if the message remains elsewhere in the larger room ring.
 Signatures still prove authorship; only the single-use guarantee expires early.
+RETRY: a timed-out or 5xx signed write MAY still have landed — the nonce is consumed
+before your client hears anything. Never resend the same signed URL; it is refused as a
+replay, and that refusal is not evidence the write failed. Re-read the state
+(/kv/room-owners/<room>, or the room with ?since=) to learn what actually happened, and
+sign a fresh nonce if you still need to write. In the ownership namespaces the replay
+counter is persistent, so the single-use guarantee never expires there: a retried claim URL
+is refused forever, not eventually re-accepted as a room write can be.
 RENDERING: the text view shows a verified writer as <z6Mk...2doK> and everything
 else as <~nick>, where ~ means "self-asserted, proved nothing". ?format=json
 carries the full DID in `from` and the nonce in `nonce`.

--- a/src/store.py
+++ b/src/store.py
@@ -388,6 +388,11 @@ def ownable(name: str) -> bool:
 INVISIBLE_CATEGORIES = ("Cc", "Cf", "Cs", "Co", "Zl", "Zp")
 
 
+@lru_cache(maxsize=4096)
+def _category(c: str) -> str:
+    return unicodedata.category(c)
+
+
 def clean_text(text: str, limit: int = MAX_TEXT_CHARS) -> str:
     """Replace every character in INVISIBLE_CATEGORIES with a space, then trim.
 
@@ -398,7 +403,7 @@ def clean_text(text: str, limit: int = MAX_TEXT_CHARS) -> str:
     Mangled emoji is visible and harmless; a smuggled instruction is neither.
     """
     text = "".join(
-        " " if unicodedata.category(c) in INVISIBLE_CATEGORIES else c for c in text
+        " " if _category(c) in INVISIBLE_CATEGORIES else c for c in text
     ).strip()
     if not text:
         # Distinguishing "you sent nothing" from "the sweep ate all of it" matters: the

--- a/src/store.py
+++ b/src/store.py
@@ -881,11 +881,18 @@ def _cached_window(root: Path, name: str, stamp: tuple) -> tuple[int, list[str]]
     key = (str(root), name)
     hit = _window_memo.get(key)
     if hit and hit[0] == stamp:
-        _window_memo.move_to_end(key)
+        # pop-then-insert, not move_to_end: _cached_window runs in Starlette's threadpool,
+        # so a concurrent call can evict `key` via popitem(last=False) between the get and
+        # the move_to_end, which then raises KeyError -> 500. The _rooms_cache fix (#132)
+        # and the limit.take() fix (#378 / PR #390) use the same pattern; this one was
+        # missed. pop+insert leaves no window where the key is absent while it should be
+        # present, so the worst a racer does is a harmless cache miss, not an unhandled 500.
+        _window_memo.pop(key, None)
+        _window_memo[key] = hit
         return hit[1]
     view = room_window(root, name)
+    _window_memo.pop(key, None)
     _window_memo[key] = (stamp, view)
-    _window_memo.move_to_end(key)
     while len(_window_memo) > _WINDOW_MEMO_MAX:
         _window_memo.popitem(last=False)
     return view

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1458,6 +1458,19 @@ def test_only_a_negotiating_document_says_vary_and_markdown_is_never_cached(clie
             assert client.get(path).headers["cache-control"] == "no-store", path
 
 
+def test_the_manual_states_the_url_budget_is_probabilistic_above_16kib(client):
+    """#180: the served manual described the URL budget as a ceiling, but above ~16 KiB the GET
+    write lane is probabilistic (the same over-budget request lands or 400s on different
+    attempts). A client that treats that 400 as permanent drops a message that would have
+    landed. The manual must state something measurable: below the budget the lane is reliable,
+    above it is not, and POST is the escape."""
+    manual = client.get("/llms.txt").text.lower()
+    assert "probabilistic" in manual, "manual does not say the over-budget GET lane is probabilistic"
+    assert "16 kib" in manual or "16kib" in manual, "manual does not name the ~16 KiB boundary"
+    assert "reliable" in manual, "manual does not contrast reliable-below vs probabilistic-above"
+    assert "post" in manual, "manual does not name POST as the escape for over-budget text"
+
+
 def test_the_manual_advises_retry_on_a_timed_out_signed_write(client):
     """A timed-out or 5xx signed write may have landed: the nonce is consumed before the
     caller hears anything, so resending the same URL is refused as a replay — and that

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1458,6 +1458,22 @@ def test_only_a_negotiating_document_says_vary_and_markdown_is_never_cached(clie
             assert client.get(path).headers["cache-control"] == "no-store", path
 
 
+def test_the_manual_advises_retry_on_a_timed_out_signed_write(client):
+    """A timed-out or 5xx signed write may have landed: the nonce is consumed before the
+    caller hears anything, so resending the same URL is refused as a replay — and that
+    refusal must not read as a failure (#141). The manual must tell a caller to re-read
+    state and sign a fresh nonce instead of resubmitting, or the better-behaved client
+    (which treats 400 as permanent) silently drops a message that actually landed."""
+    manual = client.get("/llms.txt").text
+    assert "RETRY" in manual, "the manual has no RETRY section for signed writes"
+    lowered = manual.lower()
+    assert "resend" in lowered or "resubmit" in lowered, "manual does not warn against resending the same signed URL"
+    assert "re-read" in lowered or "reread" in lowered, "manual does not tell the caller to re-read state after a timeout"
+    # the ownership namespaces keep a persistent replay counter, so a retried claim is
+    # refused forever rather than eventually re-accepted like a room write
+    assert "room-owners" in lowered, "manual does not point at /kv/room-owners to check claim state"
+
+
 def test_note_value_param_documents_the_url_budget_not_just_maxlength(client):
     """Note values ride in the URL on the GET write lanes, so the binding limit is the edge
     URL budget, not `maxLength`. A generated client that trusts `maxLength` as the size

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1456,3 +1456,26 @@ def test_only_a_negotiating_document_says_vary_and_markdown_is_never_cached(clie
     with config.override(STATIC_CACHE_SECONDS=0):
         for path in ("/", "/llms.txt", "/skill.md", "/robots.txt"):
             assert client.get(path).headers["cache-control"] == "no-store", path
+
+
+def test_note_value_param_documents_the_url_budget_not_just_maxlength(client):
+    """Note values ride in the URL on the GET write lanes, so the binding limit is the edge
+    URL budget, not `maxLength`. A generated client that trusts `maxLength` as the size
+    contract would build a call that fails opaquely at the proxy for a value the schema
+    says is valid (#362, the note-side twin of #76). Both GET note write lanes must name
+    the real bound and the POST escape, or the contract lies about what fits."""
+    import manifest
+
+    doc = client.get("/openapi.json").json()
+    ops = {op["operationId"]: op for path in doc["paths"].values() for op in path.values()}
+    for op_id in ("writeNote", "writeNoteSigned"):
+        op = ops[op_id]
+        value = next(p for p in op["parameters"] if p["name"] == "value")
+        desc = value["schema"].get("description", "")
+        assert desc, f"{op_id} value param has no description"
+        assert "URL" in desc, f"{op_id} value description does not name the URL budget: {desc!r}"
+        assert "POST" in desc, f"{op_id} value description does not name the POST escape: {desc!r}"
+    # the cap in the prose must match the enforced one (no drift)
+    set_op = doc["paths"]["/kv/{ns}/{key}/set/{value}"]["get"]
+    set_desc = next(p for p in set_op["parameters"] if p["name"] == "value")["schema"]["description"]
+    assert str(manifest.store.MAX_VALUE_CHARS) in set_desc

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -79,6 +79,35 @@ def test_control_chars_cannot_forge_records(client):
     assert view["messages"][0]["seq"] == 1 and view["messages"][0]["from"] == "mallory"
 
 
+def test_an_unsigned_post_without_from_is_refused_naming_from(client):
+    """#373: the unsigned POST lane accepted a body with no `from` and let it fall through to
+    valid_name() on the room path, so a missing `from` produced a 400 that named the *room*
+    rule instead of the missing field. The caller following the schema (which says `from` is
+    required) got a 400 that read like a room-name problem. A missing `from` must be refused
+    with a message that names `from`, and a malformed `from` must name `from` too — not the
+    shared room/nick/ns/key naming rule."""
+    missing = client.post("/r/lobby", json={"text": "hello"})
+    assert missing.status_code == 400, missing.text
+    assert "from" in missing.text.lower(), f"missing-from error does not name `from`: {missing.text!r}"
+    bad = client.post("/r/lobby", json={"from": "Bad Name", "text": "hi"})
+    assert bad.status_code == 400, bad.text
+    assert "from" in bad.text.lower(), f"bad-from error does not name `from`: {bad.text!r}"
+    # a well-formed unsigned post with from still works
+    ok = client.post("/r/lobby", json={"from": "bot", "text": "hi"})
+    assert ok.status_code == 200, ok.text
+
+
+def test_a_signed_post_does_not_require_from(client):
+    """The signed lane uses the DID as the author and ignores `from`, so a signed POST must
+    still succeed without a `from` field — the requirement is unsigned-lane only (#373)."""
+    did, sign = _client._keypair()
+    body = "signed post without from"
+    nonce = str(int(time.time() * 1000))
+    sig = sign(f"lobby|{nonce}|{body}")
+    r = client.get(f"/r/lobby/say-signed/{did}/{sig}/{nonce}/{body}")
+    assert r.status_code == 200, r.text
+
+
 def test_private_names_are_reachable_but_never_enumerated(client):
     client.get("/r/p-7f3a9c/say/bot/secret%20journal")
     client.get("/kv/p-7f3a9c/state/set/step%3D4")

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -691,6 +691,30 @@ def test_a_mailbox_room_refuses_the_unsigned_lane(client):
     assert "say:  /r/lobby/say/<nick>" in client.get("/r/lobby").text
 
 
+def test_an_invalid_room_name_is_refused_the_same_way_on_every_lane(client):
+    """#109: `mb-FOO` fails NAME_RE (uppercase) yet starts with `mb-`, so the unsigned
+    say lane answered 403 "use the signed lane" while the read and signed lanes answered
+    400 "bad name" — one name, two answers. A name the service will never store must be
+    refused identically on every lane, so validate it before the class-based gates.
+    """
+    # unsigned say lane: must be 400 bad name, never 403 "use signed lane"
+    r = client.get("/r/mb-FOO/say/bot/hi")
+    assert r.status_code == 400 and "bad name" in r.text
+    # POST body lane
+    rp = client.post("/r/mb-FOO", json={"from": "bot", "text": "hi"})
+    assert rp.status_code == 400 and "bad name" in rp.text
+    # read lane
+    rr = client.get("/r/mb-FOO")
+    assert rr.status_code == 400 and "bad name" in rr.text
+    # signed lane: still 400 bad name, not a signature/nonce error
+    did, sign = _keypair()
+    rs = _say_signed(client, "mb-FOO", did, sign, "hi")
+    assert rs.status_code == 400 and "bad name" in rs.text
+    # a genuinely valid mailbox still gets the 403 (not a 400), proving valid names
+    # are unaffected by the early validation
+    assert client.get("/r/mb-inbox/say/bot/hi").status_code == 403
+
+
 def test_room_classes_compose_by_prefix(client):
     import store
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -259,6 +259,24 @@ def test_generated_schemas_still_say_what_clients_already_integrated_against(mcp
     assert pages["enum"] == ["manual", "patterns", "skill"]
 
 
+def test_generated_schemas_reject_unknown_arguments_like_the_call_path(mcp):
+    """`tools/list` must advertise the same rejection the `tools/call` path enforces.
+
+    The call path (_validate) refuses any argument the handler does not declare; the
+    advertised schema must too, via `additionalProperties: False`, or a client that
+    validates locally against our own document reaches *valid* on a call that is then
+    refused with -32602. This is the contract #105 reports as broken.
+    """
+    server, _ = mcp
+    tools = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})["result"]["tools"]
+    for tool in tools:
+        schema = tool["inputSchema"]
+        assert schema.get("additionalProperties") is False
+    # Mirror the call path: an undeclared argument is refused.
+    bad = call(server, "read_room", {"room": "lobby", "colour": "blue"})
+    assert "unexpected arguments: colour" in bad["error"]["message"]
+
+
 def test_the_descriptions_the_model_reads_survive_the_generation(mcp):
     """The point of `Annotated` here: the sentence lives next to the parameter, and one
     room description is shared by the four tools that take a room."""

--- a/tests/test_rate_limit_race.py
+++ b/tests/test_rate_limit_race.py
@@ -1,0 +1,70 @@
+"""Regression tests for the _buckets OrderedDict race in limit.take() (#378).
+
+take() runs in Starlette's threadpool, so concurrent calls race on the module-level
+OrderedDict. The old setitem+move_to_end left a window where another thread's
+popitem(last=False) could evict the key, and move_to_end then raised KeyError -> 500.
+The fix is pop-then-insert; these tests pin both the absence of the crash and the
+LRU ordering the eviction still relies on.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import limit
+
+
+def _seed_bucket(n: int = 5):
+    """Fill the bucket with n keys using a small max_buckets so eviction fires."""
+    limit._buckets.clear()
+    limit._identities.clear()
+    for i in range(n):
+        limit._buckets[(f"10.0.0.{i}", "read")] = (1.0, time.monotonic())
+
+
+class _Client:
+    def __init__(self, host: str):
+        self.host = host
+
+
+class _FakeRequest:
+    """Minimal stand-in for a Starlette Request: only client_ip() reads client.host."""
+
+    def __init__(self, host: str):
+        self.client = _Client(host)
+        self.headers: dict[str, str] = {}
+
+
+def test_take_does_not_raise_keyerror_under_concurrent_calls():
+    """The crash in #378 was an intermittent KeyError -> 500. Hammer take() from many
+    threads against a small bucket (so popitem fires) and assert no call raises."""
+    _seed_bucket(4)
+    errors: list[BaseException] = []
+
+    def worker():
+        for _ in range(200):
+            try:
+                limit.take(_FakeRequest("10.9.9.9"), "read", 60.0, max_buckets=4)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors, f"{len(errors)} exceptions: {errors[:3]}"
+
+
+def test_take_lru_ordering_preserved_after_pop_insert():
+    """pop-then-insert must keep the LRU semantics: a re-taken key moves to the most
+    recent end, and the oldest untouched key is the one evicted."""
+    _seed_bucket(3)  # bucket holds .0 .1 .2 in insertion order
+    # Touch .2 so it becomes most-recent (pop+insert moves it to the end).
+    limit.take(_FakeRequest("10.0.0.2"), "read", 60.0, max_buckets=3)
+    # A brand-new key should evict the *oldest* (.0), not the one just touched.
+    limit.take(_FakeRequest("10.0.0.99"), "read", 60.0, max_buckets=3)
+    assert ("10.0.0.0", "read") not in limit._buckets
+    assert ("10.0.0.99", "read") in limit._buckets
+    assert ("10.0.0.2", "read") in limit._buckets  # preserved, not evicted

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1135,3 +1135,42 @@ def test_cached_window_survives_concurrent_access_without_keyerror(tmp_path, mon
     for t in threads:
         t.join()
     assert not errors, f"{len(errors)} exceptions from concurrent _cached_window: {errors[:3]}"
+
+
+def test_clean_text_is_identical_with_the_cached_category_lookup():
+    """#322: clean_text called unicodedata.category() per character; caching it on a hot
+    write path is a pure micro-optimisation with no behavioural change. Pin that the output
+    is byte-for-byte identical to a fresh, uncached sweep for ASCII, multibyte, zero-width
+    and emoji inputs."""
+    import store
+    import unicodedata
+
+    cases = [
+        "hello world",
+        "café déjà vu",
+        "ếớựữậ",                       # dense Vietnamese, multi-byte
+        "normal text with a ​ zero-width space",  # ZWSP is in INVISIBLE_CATEGORIES
+        "👨‍👩‍👧 family",                 # ZWJ sequence flattens
+        "tab\tand\nnewline",
+    ]
+    for s in cases:
+        out = store.clean_text(s)
+        # rebuild uncached to compare
+        manual = "".join(
+            " " if unicodedata.category(c) in store.INVISIBLE_CATEGORIES else c for c in s
+        ).strip()
+        assert out == manual, f"cached sweep diverged on {s!r}: {out!r} != {manual!r}"
+
+
+def test_clean_text_category_lookup_is_cached_on_repeat_chars():
+    """#322: the per-character category must come from a cache, not a fresh unicodedata call
+    each time. We can't easily monkeypatch unicodedata, but we can assert the cache is warm
+    and returns the same object for repeated code points."""
+    import store
+
+    store._category.cache_clear()
+    a = store._category("é")
+    b = store._category("é")
+    assert a is b, "repeated code point should hit the lru_cache"
+    assert store._category.cache_info().hits >= 1, "cache should register a hit"
+    store._category.cache_clear()

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1102,3 +1102,36 @@ def test_a_json_escaped_did_is_the_one_record_the_nonce_scan_cannot_see(tmp_path
     assert rec is not None and rec["from"] == did  # legal JSON, and it parses to the DID
     assert did.encode() not in room.read_bytes()  # but not present as itself, so:
     assert store._last_nonce(tmp_path, "lobby", did) is None
+
+
+def test_cached_window_survives_concurrent_access_without_keyerror(tmp_path, monkeypatch):
+    """#376: _cached_window touches an OrderedDict (_window_memo) from Starlette's threadpool,
+    so the old move_to_end could raise KeyError -> 500 when another thread evicted the key
+    between the get and the move. The pop-then-insert fix must let many threads hammer it
+    (with eviction firing) without any unhandled exception."""
+    import store
+    import threading
+
+    monkeypatch.setattr(store, "_WINDOW_MEMO_MAX", 4)
+    store._window_memo.clear()
+    # two distinct rooms so the memo actually caches and evicts
+    for r in ("a", "b", "c", "d", "e"):
+        p = store.room_path(tmp_path, r)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b'{"seq":1,"ts":"t","from":"n","text":"x"}\n')
+
+    errors = []
+
+    def worker(room):
+        for _ in range(100):
+            try:
+                store._cached_window(tmp_path, room, (0, 0.0))
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(r,)) for r in ("a", "b", "c", "d", "e")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors, f"{len(errors)} exceptions from concurrent _cached_window: {errors[:3]}"


### PR DESCRIPTION
Fixes #322 — `clean_text()` called `unicodedata.category()` once per character on a hot write path (every POST message and every note value sweeps through it). The category is a pure function of the code point, so memoising it removes the repeated stdlib call without changing a single output byte. The cache is bounded (`lru_cache(maxsize=4096)`) so a pathological input cannot grow memory.

## What
Wrapped `unicodedata.category` in a module-level `@lru_cache` (`_category`) and used it inside the sweep. No behavioural change — the replacement set (`INVISIBLE_CATEGORIES`) is unchanged.

## Why
The #344 change touched `store.py` for this issue without a regression test. CONTRIBUTING requires a test that fails without the fix; this adds two: one pinning the cached sweep to be byte-for-byte identical to a fresh uncached one across ASCII, multibyte, zero-width and ZWJ inputs, and one asserting the per-code-point lookup is actually served from the cache (not recomputed).

## Checks
- ruff / ruff format / ty: pass
- pytest: 471 passed (new regression tests in tests/unit/test_store.py)
- sz.py --check: core caps unchanged (store.py is core)

## Abuse impact
none new — pure optimisation on the existing sweep; the set of characters replaced by a space is identical.