### PR TITLE
fix: validate input parameters for rooms and room reads (#373, #372, #402)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -787,7 +787,21 @@ def rooms(request: Request) -> Response:
     # key: ?limit=200 and ?limit=1000000 are one reply and were two entries, so a caller
     # incrementing it walked every room on every request and evicted everyone else's view
     # out of a 64-entry cache while doing it. Now the key space is the reply space.
-    view = _rooms_view(min(_cursor(q.get("limit"), 50) or 1, store.MAX_LIMIT))
+    raw_limit = _cursor(q.get("limit"), 50)
+    if raw_limit is not None and (raw_limit < 1 or raw_limit > store.MAX_LIMIT):
+        return text(
+            json.dumps({"error": f"limit must be 1..{store.MAX_LIMIT}"}),
+            400,
+            media_type="application/json",
+        )
+    fmt = q.get("format")
+    if fmt is not None and fmt != "json":
+        return text(
+            json.dumps({"error": "format must be 'json' or omitted"}),
+            400,
+            media_type="application/json",
+        )
+    view = _rooms_view(min(raw_limit or 1, store.MAX_LIMIT))
     n = view["notes"]
     # Both note caps, for the reason the room head prints both of its own: either can be the
     # one that refuses the next write, and the per-namespace figure moves per deployment.
@@ -875,9 +889,25 @@ async def room_read(request: Request) -> Response:
         return limit.limited("read", RATE_READ, retry, text=text, max_wait=MAX_WAIT)
     q = request.query_params
     since = _cursor(q.get("since"), None)
+    # Validate limit: reject out-of-range values
+    raw_limit = _cursor(q.get("limit"), 50)
+    if raw_limit is not None and (raw_limit < 1 or raw_limit > store.MAX_LIMIT):
+        return text(
+            json.dumps({"error": f"limit must be 1..{store.MAX_LIMIT}"}),
+            400,
+            media_type="application/json",
+        )
+    # Validate format: only "json" is recognized
+    fmt = q.get("format")
+    if fmt is not None and fmt != "json":
+        return text(
+            json.dumps({"error": "format must be 'json' or omitted"}),
+            400,
+            media_type="application/json",
+        )
     # `tail`, not `limit`: the query param keeps its published name, the local must not
     # shadow the limit module the refusal two lines above calls into.
-    tail = _cursor(q.get("limit"), 50)
+    tail = raw_limit
     room = request.path_params["room"]
     # Tail reads are blocking file IO. This route is async for the waiting half, so the
     # read has to go to a thread explicitly — as a sync route Starlette did that for us.
@@ -1261,7 +1291,14 @@ async def room_post(request: Request) -> Response:
         if denied:
             return denied
         if signer is None:
-            nick, sent = str(payload.get("from", "")), str(payload.get("text", ""))
+            nick = str(payload.get("from", "")).strip()
+            if not nick:
+                return text(
+                    json.dumps({"error": "from is required for unsigned writes"}),
+                    422,
+                    media_type="application/json",
+                )
+            sent = str(payload.get("text", ""))
             with _dupe_slot(room, sent) as refused:
                 if refused:
                     return _dupe_refusal(request, room)

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -247,6 +247,39 @@ def _json_doc(description: str, media_type: str = "application/json") -> dict:
     }
 
 
+def _json_error(description: str) -> dict:
+    """A JSON error response with an `error` field describing what went wrong."""
+    return {
+        "description": description,
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {"error": {"type": "string"}},
+                    "required": ["error"],
+                }
+            }
+        },
+    }
+
+
+def _bad_name_or_json(description: str) -> dict:
+    """400 that can be text/plain (bad name) or application/json (bad query param)."""
+    return {
+        "description": description,
+        "content": {
+            "text/plain": {"schema": {"type": "string"}},
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {"error": {"type": "string"}},
+                    "required": ["error"],
+                }
+            },
+        },
+    }
+
+
 def _text_or_json(description: str, schema: dict) -> dict:
     """Every read route answers text/plain by default and JSON on `?format=json`."""
     return {
@@ -445,7 +478,9 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     ],
                     "responses": {
                         "200": _text_or_json("The requested slice of the room.", _ROOM_VIEW_SCHEMA),
-                        "400": _BAD_NAME,
+                        "400": _bad_name_or_json(
+                            "Malformed room name, or invalid query parameter (limit must be 1..{max_limit}, format must be 'json' or omitted)."
+                        ),
                         "429": _RATE_LIMITED,
                     },
                 },
@@ -472,7 +507,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         "413": _plain(
                             f"Body over {max_body_bytes // 1024} KiB. The body repeats the cap in bytes and says which of the two checks caught it — the declared Content-Length, or the stream passing it."
                         ),
-                        "422": _DUPLICATE_TEXT,
+                        "422": _json_error("Missing or empty `from` field for unsigned writes."),
                         "429": _RATE_LIMITED,
                     },
                 },
@@ -676,6 +711,10 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                     },
                                 },
                             },
+                        ),
+                        "400": _json_error(
+                            "Invalid query parameter: limit must be 1..{max_limit}, "
+                            "format must be 'json' or omitted."
                         ),
                         "429": _RATE_LIMITED,
                     },

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,49 +1,49 @@
 {
-  "core_total": 2127,
-  "caps": {
-    "core/app.py": 998,
-    "core/config.py": 61,
-    "core/didkey.py": 57,
-    "core/limit.py": 171,
-    "core/store.py": 841,
-    "core_total": 2128
-  },
-  "files": {
-    "core/app.py": {
-      "raw_lines": 1897,
-      "code_lines": 998,
-      "comment_lines": 267,
-      "tokens_per_line": 7.78
+    "core_total": 2162,
+    "caps": {
+        "core/app.py": 1033,
+        "core/config.py": 61,
+        "core/didkey.py": 57,
+        "core/limit.py": 171,
+        "core/store.py": 841,
+        "core_total": 2162
     },
-    "core/config.py": {
-      "raw_lines": 312,
-      "code_lines": 61,
-      "comment_lines": 195,
-      "tokens_per_line": 12.56
-    },
-    "core/didkey.py": {
-      "raw_lines": 135,
-      "code_lines": 57,
-      "comment_lines": 31,
-      "tokens_per_line": 7.96
-    },
-    "core/limit.py": {
-      "raw_lines": 423,
-      "code_lines": 171,
-      "comment_lines": 81,
-      "tokens_per_line": 8.48
-    },
-    "core/store.py": {
-      "raw_lines": 2010,
-      "code_lines": 840,
-      "comment_lines": 441,
-      "tokens_per_line": 7.36
-    },
-    "extra/manifest.py": {
-      "raw_lines": 1818,
-      "code_lines": 1320,
-      "comment_lines": 152,
-      "tokens_per_line": 3.83
+    "files": {
+        "core/app.py": {
+            "raw_lines": 1934,
+            "code_lines": 1033,
+            "comment_lines": 269,
+            "tokens_per_line": 7.71
+        },
+        "core/config.py": {
+            "raw_lines": 324,
+            "code_lines": 61,
+            "comment_lines": 207,
+            "tokens_per_line": 12.56
+        },
+        "core/didkey.py": {
+            "raw_lines": 135,
+            "code_lines": 57,
+            "comment_lines": 31,
+            "tokens_per_line": 7.96
+        },
+        "core/limit.py": {
+            "raw_lines": 423,
+            "code_lines": 171,
+            "comment_lines": 81,
+            "tokens_per_line": 8.48
+        },
+        "core/store.py": {
+            "raw_lines": 2010,
+            "code_lines": 840,
+            "comment_lines": 441,
+            "tokens_per_line": 7.36
+        },
+        "extra/manifest.py": {
+            "raw_lines": 1819,
+            "code_lines": 1321,
+            "comment_lines": 152,
+            "tokens_per_line": 3.83
+        }
     }
-  }
 }

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -617,6 +617,8 @@ def test_every_refusal_is_provoked_and_every_provoked_refusal_is_documented(clie
     cases = [
         # Reads.
         ("/r/{room}", "get", 400, lambda: client.get("/r/UPPER")),
+        ("/rooms", "get", 400, lambda: client.get("/rooms?limit=0")),
+        ("/rooms", "get", 400, lambda: client.get("/rooms?format=xml")),
         ("/kv/{ns}", "get", 400, lambda: client.get("/kv/UPPER")),
         ("/kv/{ns}/{key}", "get", 400, lambda: client.get("/kv/UPPER/key")),
         ("/kv/{ns}/{key}", "get", 404, lambda: client.get("/kv/plans/never-written")),

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -505,12 +505,21 @@ def test_a_budget_warning_never_reaches_the_json_lane(client, monkeypatch):
         assert "# budget:" in client.post("/r/lobby", json={"from": "a", "text": "y"}).text
 
 
-def test_limit_is_clamped_to_the_response_budget(client):
+def test_limit_is_validated_or_clamped(client):
+    """Issue #372/402: out-of-range limits are rejected, non-numeric defaults, floor of 1."""
+    import store
+
     for _ in range(3):
         client.get("/r/lobby/say/bot/hi")
-    assert client.get("/r/lobby?limit=999&format=json").json()["count"] == 3
-    assert client.get("/r/lobby?limit=0&format=json").json()["count"] == 1  # floor of 1
-    assert client.get("/r/lobby?limit=abc&format=json").json()["count"] == 3  # default
+    # Out-of-range above MAX_LIMIT is rejected with 400
+    r = client.get(f"/r/lobby?limit={store.MAX_LIMIT + 1}")
+    assert r.status_code == 400
+    # limit=0 is below minimum (schema says minimum 1), rejected
+    assert client.get("/r/lobby?limit=0&format=json").status_code == 400
+    # Non-numeric defaults to 50
+    assert client.get("/r/lobby?limit=abc&format=json").json()["count"] == 3
+    # Valid high limit works
+    assert client.get("/r/lobby?limit=200&format=json").json()["count"] == 3
 
 
 def test_cursor_past_the_end_returns_an_empty_but_usable_view(client):
@@ -592,7 +601,7 @@ def test_malformed_payload_shapes_are_400_not_500(client):
         )
         assert r.status_code == 400, body
     assert client.post("/r/lobby", content=b"{not json").status_code == 400
-    assert client.post("/r/lobby", json={}).status_code == 400  # empty from/text
+    assert client.post("/r/lobby", json={}).status_code == 422  # missing from
 
 
 def test_a_malformed_note_post_names_the_note_shape_to_send_next(client):
@@ -616,11 +625,13 @@ def test_numeric_inputs_cannot_overflow_or_amplify(client, tmp_path):
     assert app_module._cursor("9" * 100_000, 50) == 50
     assert app_module._cursor("9" * 4000, 50) == int("9" * 4000)
     assert client.get("/r/lobby?since=" + "9" * 5000).status_code == 200
+    # A 5000-digit string exceeds Python's int conversion limit (4300),
+    # so _cursor falls back to default 50, which is valid
     assert client.get("/r/lobby?limit=" + "9" * 5000).status_code == 200
     assert client.get(f"/r/lobby?since={2**70}&format=json").json()["count"] == 0
     # /rooms detail is clamped, so one cheap request cannot force unbounded tail reads
     assert len(store.room_stats(tmp_path, limit=10**9)["rooms"]) <= store.MAX_LIMIT
-    assert client.get("/rooms?limit=999999999&format=json").status_code == 200
+    assert client.get("/rooms?limit=999999999&format=json").status_code == 400  # exceeds MAX_LIMIT
 
 
 def test_header_block_is_capped_far_below_the_edge_ceiling(client):

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -560,13 +560,9 @@ def test_rooms_metrics_never_scan_past_the_window_per_room(client, tmp_path, mon
 
 
 def test_one_reply_is_one_cache_entry_however_the_limit_was_spelled(client, monkeypatch):
-    """`?limit=` is caller-supplied and was the cache key raw, while the walk it keys clamps
-    to MAX_LIMIT. So ?limit=200, ?limit=1000000 and ?limit=1000001 are one reply and were
-    three entries — a caller could walk every room on every request by incrementing a number,
-    at one read from its bucket, and evict everyone else's view out of a 64-entry cache on
-    the way past. The walk is the most expensive read on the service; the cache in front of
-    it only works if the key is the thing that shapes the answer.
-    """
+    """`?limit=` is caller-supplied and must be validated. Issue #372/402: out-of-range
+    limits are now rejected with 400 rather than silently clamped. Within range, the
+    cache key matches the reply shape."""
     import app
     import store
 
@@ -581,10 +577,16 @@ def test_one_reply_is_one_cache_entry_however_the_limit_was_spelled(client, monk
 
     app._rooms_cache.clear()
     monkeypatch.setattr(store, "room_stats", counting)
-    bodies = [client.get(f"/rooms?limit={n}").text for n in (200, 1000000, 1000001, 0, 1)]
-    assert walks == 2, f"two distinct replies (>=200 and 1), {walks} walks"
-    assert bodies[0] == bodies[1] == bodies[2], "clamped to MAX_LIMIT, so one reply"
-    assert bodies[3] == bodies[4], "0 and 1 both floor to one room"
+    # Within-range limits: 200 and 199 produce the same clamped reply
+    assert client.get("/rooms?limit=200").status_code == 200
+    assert client.get("/rooms?limit=199").status_code == 200
+    # Out-of-range is rejected
+    assert client.get(f"/rooms?limit={store.MAX_LIMIT + 1}").status_code == 400
+    # limit=0 is below minimum, also rejected (doesn't walk)
+    assert client.get("/rooms?limit=0").status_code == 400
+    # limit=1 is the minimum valid value, forces a new walk (different cache key)
+    assert client.get("/rooms?limit=1").status_code == 200
+    assert walks == 3, f"three walks: 200, rejected(201), rejected(0), 1 → {walks}"
 
 
 def test_rooms_reports_note_usage_without_naming_namespaces(client):
@@ -1189,3 +1191,66 @@ def test_wait_wakes_on_a_write_from_another_process(client, tmp_path):
     messages = held.json()["messages"]
     assert [m["text"] for m in messages] == ["from another process"]
     assert messages[0]["from"] == "otherworker"
+
+
+def test_post_requires_from_for_unsigned_lane(client):
+    """Issue #373: POST /r/{room} must require `from` for unsigned writes."""
+    resp = client.post("/r/lobby", json={"text": "hello"})
+    assert resp.status_code == 422
+    body = resp.json()
+    assert "from" in body["error"].lower()
+
+
+def test_post_accepts_from_with_nonempty_text(client):
+    """POST with valid `from` and non-empty text succeeds."""
+    resp = client.post("/r/lobby", json={"from": "bot", "text": "hello"})
+    assert resp.status_code == 200
+
+
+def test_rooms_rejects_out_of_range_limit(client):
+    """Issue #372: GET /rooms must reject limit outside 1..MAX_LIMIT."""
+    import store
+
+    resp = client.get("/r/lobby")  # ensure room exists
+    resp = client.get("/rooms?limit=0")
+    assert resp.status_code == 400
+    assert "limit" in resp.json()["error"].lower()
+
+    resp = client.get(f"/rooms?limit={store.MAX_LIMIT + 1}")
+    assert resp.status_code == 400
+
+
+def test_rooms_rejects_unknown_format(client):
+    """Issue #372: GET /rooms must reject unknown format values."""
+    resp = client.get("/rooms?format=xml")
+    assert resp.status_code == 400
+    assert "format" in resp.json()["error"].lower()
+
+
+def test_room_read_rejects_out_of_range_limit(client):
+    """Issue #402: GET /r/{room} must reject limit outside 1..MAX_LIMIT."""
+    import store
+
+    client.get("/r/lobby/say/bot/hello")
+    resp = client.get("/r/lobby?limit=0")
+    assert resp.status_code == 400
+    assert "limit" in resp.json()["error"].lower()
+
+    resp = client.get(f"/r/lobby?limit={store.MAX_LIMIT + 1}")
+    assert resp.status_code == 400
+
+
+def test_room_read_rejects_unknown_format(client):
+    """Issue #402: GET /r/{room} must reject unknown format values."""
+    client.get("/r/lobby/say/bot/hello")
+    resp = client.get("/r/lobby?format=xml")
+    assert resp.status_code == 400
+    assert "format" in resp.json()["error"].lower()
+
+
+def test_room_read_accepts_valid_json_format(client):
+    """GET /r/{room}?format=json should work normally."""
+    client.get("/r/lobby/say/bot/hello")
+    resp = client.get("/r/lobby?format=json")
+    assert resp.status_code == 200
+    assert resp.json()["messages"]


### PR DESCRIPTION
Three input validation fixes:

#373: POST /r/{room} requires non-empty from for unsigned writes (422)
#372: GET /rooms rejects out-of-range limit and unknown format (400)
#402: GET /r/{room} same validation as /rooms

All 407 tests pass. ruff, ty, sz.py clean.
