### PR TITLE
fix(sz): stop storing derivable/unread fields in sz-baseline.json (#254)

### DIFF
--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,5 +1,4 @@
 {
-  "core_total": 2317,
   "caps": {
     "core/app.py": 1030,
     "core/config.py": 73,

--- a/sz.py
+++ b/sz.py
@@ -23,6 +23,14 @@ when the baseline was raised to match; --caps prints the table against the caps.
 core label and core_total must have a cap — a missing entry is an error in the enforcing
 modes, not an exemption, so a file added to CORE_FILES cannot slip past the policy.
 
+The baseline's core_total is never stored: it is always the sum of the "files" rows
+beside it, so a second copy on disk could only drift from what it is summing, never add
+information. --check derives it from baseline["files"] the same way it derives the fresh
+one from the tree. --update-baseline also leaves a file's row exactly as it was on disk
+when that file's code_lines did not move, rather than rewriting every row from a fresh
+measure_all() every time: two PRs touching different core files then collide only on the
+rows they actually changed, not on rows measure_all() happened to re-walk unchanged.
+
 Counting rules: a triple-quoted string literal is one token starting at one line, so an
 embedded prose document (app.py's MANUAL) counts as ~1 code line by design — embedded
 docs are effectively extra, and extracting one into a file will barely move code-lines.
@@ -135,9 +143,21 @@ def main():
     # untouched, or --update-baseline would silently delete the ceiling it ratchets under.
     caps = baseline.get("caps", {})
     if args.update_baseline:
-        caps = caps or json.loads(BASELINE.read_text(encoding="utf-8")).get("caps", {})
+        old = json.loads(BASELINE.read_text(encoding="utf-8")) if BASELINE.exists() else {}
+        caps = caps or old.get("caps", {})
+        old_files = old.get("files", {})
+        # Keep a file's previously-stored row byte-for-byte when its code_lines agrees
+        # with what is on disk, instead of the fresh measurement — see the docstring.
+        # The report printed below still walks the fresh `files`, only the write is
+        # stabilised, so this never hides what actually changed from the person running it.
+        stable_files = {
+            label: old_files[label]
+            if label in old_files and old_files[label]["code_lines"] == m["code_lines"]
+            else m
+            for label, m in files.items()
+        }
         BASELINE.write_text(
-            json.dumps({"core_total": core_total, "caps": caps, "files": files}, indent=2) + "\n",
+            json.dumps({"caps": caps, "files": stable_files}, indent=2) + "\n",
             encoding="utf-8",
         )
         print(f"baseline written: core code-lines = {core_total}")
@@ -209,9 +229,14 @@ def main():
             )
             print(f"core code-lines grew vs sz-baseline.json: {detail}", file=sys.stderr)
             return 1
-        if core_total > baseline["core_total"]:
+        # Derived, not read: see the docstring. Summed from the same baseline["files"]
+        # rows the per-file check above just walked, so this can never disagree with them.
+        baseline_total = sum(
+            v["code_lines"] for k, v in baseline["files"].items() if k.startswith("core/")
+        )
+        if core_total > baseline_total:
             print(
-                f"core total grew vs baseline: {baseline['core_total']} -> {core_total}"
+                f"core total grew vs baseline: {baseline_total} -> {core_total}"
                 f" (cap {caps['core_total']})",
                 file=sys.stderr,
             )
@@ -223,7 +248,7 @@ def main():
             )
             print(f"core code-lines past cap: {detail}", file=sys.stderr)
             return 1
-        print(f"check ok: core code-lines <= baseline ({baseline['core_total']})")
+        print(f"check ok: core code-lines <= baseline ({baseline_total})")
     return 0
 
 

--- a/tests/unit/test_sz_baseline.py
+++ b/tests/unit/test_sz_baseline.py
@@ -1,0 +1,90 @@
+"""Run: uv run --group dev python -m pytest tests
+
+sz-baseline.json used to store `core_total` as a top-level value even though it is always
+the sum of the per-file `code_lines` rows beside it, and `--update-baseline` rewrote every
+core file's row from a fresh measurement on every run regardless of whether that file
+changed. Two PRs growing different core files then collided on rows neither one touched,
+and a comment-only edit rewrote a row that no check ever reads past `code_lines` (see the
+flop-labs/technocore-chat issue #254 discussion this fixes).
+
+This runs the real sz.py against an isolated copy of the tree, not a reimplementation of
+its merge logic, so a regression here means the shipped tool actually collides again.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CORE_SRC_FILES = ("app.py", "config.py", "didkey.py", "limit.py", "store.py")
+
+
+def _sandbox(tmp_path):
+    root = tmp_path / "repo"
+    (root / "src").mkdir(parents=True)
+    shutil.copy(REPO_ROOT / "sz.py", root / "sz.py")
+    shutil.copy(REPO_ROOT / "sz-baseline.json", root / "sz-baseline.json")
+    for name in (*CORE_SRC_FILES, "manifest.py"):
+        shutil.copy(REPO_ROOT / "src" / name, root / "src" / name)
+    return root
+
+
+def _update_baseline(root):
+    subprocess.run(
+        [sys.executable, "sz.py", "--update-baseline"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads((root / "sz-baseline.json").read_text(encoding="utf-8"))
+
+
+def test_update_baseline_never_writes_a_top_level_core_total(tmp_path):
+    written = _update_baseline(_sandbox(tmp_path))
+    assert "core_total" not in written
+    # The cap is policy and stays; only the ratchet's cached copy of the sum is gone.
+    assert "core_total" in written["caps"]
+
+
+def test_update_baseline_preserves_a_row_whose_code_lines_did_not_move(tmp_path):
+    root = _sandbox(tmp_path)
+    before = _update_baseline(root)
+
+    didkey = root / "src" / "didkey.py"
+    edited = "# unrelated comment-only edit, adds a line without adding code\n" + didkey.read_text(
+        encoding="utf-8"
+    )
+    didkey.write_text(edited, encoding="utf-8")
+    edited_line_count = len(edited.splitlines())
+
+    after = _update_baseline(root)
+
+    stored = after["files"]["core/didkey.py"]
+    assert stored == before["files"]["core/didkey.py"]
+    # Proves the row was preserved rather than a fresh measurement that happens to match:
+    # the edit really did add a line, and the stored raw_lines does not reflect it.
+    assert stored["raw_lines"] != edited_line_count
+
+    # A file nobody touched keeps its row too, so this is a per-file comparison rather
+    # than an accidental skip of the whole rewrite.
+    assert after["files"]["core/app.py"] == before["files"]["core/app.py"]
+
+
+def test_update_baseline_writes_a_fresh_row_when_code_lines_actually_changed(tmp_path):
+    root = _sandbox(tmp_path)
+    before = _update_baseline(root)
+
+    didkey = root / "src" / "didkey.py"
+    didkey.write_text(
+        didkey.read_text(encoding="utf-8") + "\nSZ_TEST_MARKER = 1\n", encoding="utf-8"
+    )
+
+    after = _update_baseline(root)
+
+    before_row = before["files"]["core/didkey.py"]
+    after_row = after["files"]["core/didkey.py"]
+    assert after_row["code_lines"] == before_row["code_lines"] + 1
+    assert after_row != before_row


### PR DESCRIPTION
Follow-up to #254 (the "94% of the conflicting PR queue is two files everyone is told to edit" measurement), specifically djd39448's `sz-baseline.json` half of that thread: https://github.com/flop-labs/technocore-chat/issues/254#issuecomment-5426376229 (the comment identifying that `core_total` and three of four per-file fields are stored but either derivable or never read back).

## What changes

- `core_total` is no longer stored as a top-level value in `sz-baseline.json`. It was always `sum(files[*].code_lines)`, computed fresh at `sz.py:130` on every run and then also cached to disk and read back independently at `--check` time. Now it's derived from `baseline["files"]` wherever it's needed. `caps["core_total"]` (the policy ceiling, not a measurement) is untouched.
- `--update-baseline` now reads the existing baseline before writing, and keeps a file's row exactly as it was on disk when that file's `code_lines` didn't change, instead of always writing a fresh `measure_all()` result for every file on every run.

## Why

Both are the same failure shape: two branches touching different core files (or a comment-only edit next to a code change) end up colliding on `sz-baseline.json` lines that neither branch's actual diff has any reason to move. PR #68 hit this twice, two full rebase-and-regenerate cycles in ~30 hours, because the "correct" number in a checked-out PR is only ever correct against the exact commit it was computed against, and `main` doesn't sit still.

**Field evidence this isn't hypothetical:** djd39448's #236 has merged current main twice (0.9.5 → 0.9.7 → 0.10.0), and both times `sz-baseline.json` was the *only* conflict — every other file it touched, including one also edited by #244 in between, auto-merged cleanly. The file nobody meant to collide on is the one that always does.

## What this deliberately leaves alone

djd39448 also flagged that `raw_lines`, `comment_lines`, and `tokens_per_line` are stored per file but never read by `--check` (only `code_lines` is), with the caveat that they might be a deliberately-kept historical anti-golf record. That's a maintainer call, not something this PR assumes an answer to — those fields stay exactly as measured, and the row-preservation behavior above already limits their churn to files that actually changed anyway.

## One tradeoff worth naming

Preserving a file's row when `code_lines` didn't move means a comment-only edit to that file leaves its stored `raw_lines`/`comment_lines`/`tokens_per_line` disagreeing with the actual tree. `--check` never reads those three, so this enforces nothing and breaks nothing — but it does turn them from stale-by-accident into stale-by-design. That's an argument *for* eventually resolving the question in the section above, not an objection to this change; calling it out here rather than leaving it for a reviewer to find.

## Merge-order note

Dropping the stored top-level `core_total` means every other open PR carrying a baseline with that field will need a rebase after this one merges — #236 among them, whose author is already planning to rebase onto this rather than the other way round. Flagging it here so it doesn't surprise anyone.

## Testing

Added `tests/unit/test_sz_baseline.py`, three tests that run the real `sz.py` (not a reimplementation of its logic) against an isolated copy of the tree:
- `--update-baseline` never writes a top-level `core_total`, the cap stays.
- A comment-only edit to one core file leaves that file's stored row byte-for-byte unchanged (and proves it's not just a coincidence by checking the edit really did add a line the stored `raw_lines` doesn't reflect), and a file nobody touched is unaffected either way.
- A real code-line change to a file does produce a fresh row for that file.

Full gate run locally: `ruff check`, `ruff format --check`, `ty check`, `coverage run -m pytest tests` (462 passed), `sz.py --check`, all green against current `main`.

AI assistance (Claude Code) was used for the implementation and the verification above, consistent with the rest of this issue's discussion.
