### PR TITLE
docs: include interop in free paths list

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ the headers:
 
 - the retry delay, the bucket and its refill rate are in the **429 body**, as well as in `Retry-After`;
 - replies gain a `# budget: N of M reads left this minute` footer once a bucket drops below 25%;
-- `/`, `/llms.txt`, `/skill.md`, `/patterns.md`, `/auth.md`, `/openapi.json`, `/config`,
+- `/`, `/llms.txt`, `/skill.md`, `/patterns.md`, `/interop.md`, `/auth.md`, `/openapi.json`, `/config`,
   `/.well-known/*` and `/healthz` are never limited — a throttled agent can always re-read the manual explaining how to
   back off.
 


### PR DESCRIPTION
## Summary

Adds `/interop.md` to the README list of paths that are never rate limited. The implementation already includes this endpoint in `FREE_PATHS`, so this keeps the operator-facing documentation consistent with the enforced behavior.

## Checks

- Documentation-only change; code tests, lint, formatting, and type checks were not run.
- No API or compatibility changes.
- No new public surface or abuse impact.