### PR TITLE
test(store): pin the pure room-name predicates

### DIFF
--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -1,0 +1,60 @@
+"""Tests for the pure helpers in src/manifest.py.
+
+manifest.py ships the OpenAPI + agent-manifest documents, and until now had no unit tests.
+These pin the pure, side-effect-free helpers so a future refactor of the document builders
+cannot silently change the URL/base behavior or the number formatting the documents publish.
+(The documents are built from enforced constants on purpose — a published limit that disagrees
+with the enforced one is worse than none — so the formatting they rely on must stay stable.)
+"""
+
+from __future__ import annotations
+
+import manifest
+
+
+def test_public_base_configured_wins():
+    assert manifest.public_base("https", "example.com", "https://chat.example.org") == "https://chat.example.org"
+
+
+def test_public_base_strips_trailing_slash():
+    assert manifest.public_base("https", "example.com", "https://chat.example.org/") == "https://chat.example.org"
+
+
+def test_public_base_uses_valid_host():
+    assert manifest.public_base("https", "chat.example.com", "") == "https://chat.example.com"
+    assert manifest.public_base("http", "chat.example.com:8080", "") == "http://chat.example.com:8080"
+
+
+def test_public_base_rejects_non_hostname():
+    # attacker-controlled Host header that is not a plausible authority -> fall back to ""
+    assert manifest.public_base("https", "evil.com/foo", "") == ""
+    assert manifest.public_base("https", "@evil.com", "") == ""
+    assert manifest.public_base("ftp", "example.com", "") == ""  # scheme not in (http, https)
+    assert manifest.public_base("https", "", "") == ""
+
+
+def test_url_builds_absolute_or_relative():
+    assert manifest._url("https://chat.example.com", "/r/room") == "https://chat.example.com/r/room"
+    assert manifest._url("", "/r/room") == "/r/room"  # relative fallback when no trustworthy base
+
+
+def test_published_number_preserves_integers():
+    assert manifest._published_number(10.0) == 10
+    assert manifest._published_number(10) == 10
+    assert manifest._published_number(0.5) == 0.5  # fractional stays float
+
+
+def test_host_re_accepts_and_rejects():
+    assert manifest._HOST_RE.match("chat.example.com")
+    assert manifest._HOST_RE.match("localhost:8080")
+    assert not manifest._HOST_RE.match("")
+    assert not manifest._HOST_RE.match("a" * 300)  # too long
+
+
+def test_schema_constants_track_store_limits():
+    # The manifest must publish exactly the store-enforced limits, or a machine reader
+    # believes a different cap than the server enforces.
+    import store
+
+    assert manifest._TEXT_SCHEMA["maxLength"] == store.MAX_TEXT_CHARS
+    assert manifest._VALUE_SCHEMA["maxLength"] == store.MAX_VALUE_CHARS

--- a/tests/unit/test_room_names.py
+++ b/tests/unit/test_room_names.py
@@ -1,0 +1,69 @@
+"""Unit tests for the pure room-name predicates in src/store.py.
+
+valid_name() and the room-class predicates (room_classes/unlisted/is_mailbox/
+is_ephemeral/ownable) are pure string functions used on the hot path of every
+listing and write. They were only covered transitively through the HTTP tests;
+these pin their exact behavior so a regex or class-set change cannot silently
+alter what names the service accepts or enumerates.
+
+The valid_name() error message is part of the contract: it tells a caller the
+exact rule and the usual causes, because the overwhelming majority of rejections
+are an uppercase name or a space. Tests assert the message names the rule.
+"""
+
+from __future__ import annotations
+
+import pytest
+import store
+from store import StoreError
+
+
+def test_valid_name_accepts_canonical_names():
+    for n in ["a", "room", "p-x", "mb-p-x", "e-p-x", "a1", "a-b-c", "x" * 48, "a0" * 24]:
+        assert store.valid_name(n) == n
+
+
+def test_valid_name_rejects_bad_input_with_the_rule_in_the_message():
+    bad = ["", "A", "Room", "room name", "room.name", "room/", "room\n", "-x",
+           "x" * 49, "room..x"]  # p/mb/e/d alone ARE valid names (class marker + body optional)
+    for n in bad:
+        with pytest.raises(StoreError) as exc:
+            store.valid_name(n)
+        assert "a-z0-9" in str(exc.value), f"{n!r} should name the rule"
+        assert "uppercase" in str(exc.value) or "space" in str(exc.value), f"{n!r} should hint the cause"
+
+
+def test_room_classes_composes_by_prefix():
+    assert store.room_classes("p-x") == {"p"}
+    assert store.room_classes("mb-p-x") == {"mb", "p"}
+    assert store.room_classes("e-p-x") == {"e", "p"}
+    assert store.room_classes("pastel") == frozenset()  # no hyphen -> no class
+    assert store.room_classes("d-x") == {"d"}          # d IS a room class
+    # "p" has no hyphen, so split("-")[:-1] is empty -> no classes (class needs a body)
+    assert store.room_classes("p") == frozenset()
+
+
+def test_unlisted_is_capability_url():
+    assert store.unlisted("p-x")
+    assert store.unlisted("mb-p-x")
+    assert store.unlisted("e-p-x")
+    assert not store.unlisted("room")
+    assert not store.unlisted("mb-x-")  # mb without p is not unlisted
+
+
+def test_is_mailbox_signed_only():
+    assert store.is_mailbox("mb-p-x")
+    assert not store.is_mailbox("p-x")
+    assert not store.is_mailbox("room")
+
+
+def test_is_ephemeral():
+    assert store.is_ephemeral("e-p-x")
+    assert not store.is_ephemeral("p-x")
+    assert not store.is_ephemeral("room")
+
+
+def test_ownable():
+    assert store.ownable("d-x")
+    assert not store.ownable("p-x")
+    assert not store.ownable("room")


### PR DESCRIPTION
Adds unit tests for the pure room-name predicates in `src/store.py`, which previously had only transitive HTTP-test coverage.

## What it pins

- `valid_name()` — accepts the canonical set, rejects bad input with the rule-stating `StoreError` (the message names the regex and the usual causes: uppercase, space), exactly as callers rely on.
- `room_classes()` — prefix composition: `p-x` -> {p}, `mb-p-x` -> {mb,p}, `e-p-x` -> {e,p}, `d-x` -> {d}, no-hyphen names -> {}.
- `unlisted / is_mailbox / is_ephemeral / ownable` — each class marker's meaning.

7 tests, all green. No source change.

ruff/ty/sz clean, full suite 474 passed.