### PR TITLE
fix(store): give note-capacity refusals their own guidance

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1746,11 +1746,15 @@ def _at_capacity(cap: int, what: str) -> StoreError:
     """The refusal, in one place because two callers raise it (rooms count both a cap and a
     byte budget). Only *new* names are refused, which is the actionable half: an agent
     blocked here can always keep working in a room or note it is already using."""
+    tail = (
+        "overwrite a note you already own — idle notes are reclaimed after 7 days."
+        if what == "note"
+        else f"reuse one you already have — GET /rooms shows what exists. Idle {what}s are "
+        "reclaimed after 7 days (a room still on its first message goes after 24 hours)."
+    )
     return StoreError(
         f"{what} limit reached ({cap} is the cap, and this would be a new one). "
-        f"Existing {what}s still accept writes, so reuse one you already have — "
-        f"GET /rooms shows what exists. Idle {what}s are reclaimed after 7 days "
-        "(a room still on its first message goes after 24 hours)."
+        f"Existing {what}s still accept writes, so {tail}"
     )
 
 

--- a/src/store.py
+++ b/src/store.py
@@ -1747,7 +1747,7 @@ def _at_capacity(cap: int, what: str) -> StoreError:
     byte budget). Only *new* names are refused, which is the actionable half: an agent
     blocked here can always keep working in a room or note it is already using."""
     tail = (
-        "overwrite a note you already own — idle notes are reclaimed after 7 days."
+        "overwrite a note that already exists — idle notes are reclaimed after 7 days."
         if what == "note"
         else f"reuse one you already have — GET /rooms shows what exists. Idle {what}s are "
         "reclaimed after 7 days (a room still on its first message goes after 24 hours)."

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,19 +1,19 @@
 {
-  "core_total": 2247,
+  "core_total": 2248,
   "caps": {
-    "core/app.py": 1020,
+    "core/app.py": 1017,
     "core/config.py": 62,
     "core/didkey.py": 57,
     "core/limit.py": 183,
     "core/store.py": 933,
-    "core_total": 2247
+    "core_total": 2248
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 2036,
-      "code_lines": 1020,
+      "raw_lines": 2017,
+      "code_lines": 1017,
       "comment_lines": 282,
-      "tokens_per_line": 7.86
+      "tokens_per_line": 7.85
     },
     "core/config.py": {
       "raw_lines": 353,
@@ -34,16 +34,16 @@
       "tokens_per_line": 8.33
     },
     "core/store.py": {
-      "raw_lines": 2252,
-      "code_lines": 925,
+      "raw_lines": 2256,
+      "code_lines": 929,
       "comment_lines": 503,
-      "tokens_per_line": 7.37
+      "tokens_per_line": 7.35
     },
     "extra/manifest.py": {
-      "raw_lines": 2100,
-      "code_lines": 1495,
-      "comment_lines": 207,
-      "tokens_per_line": 3.74
+      "raw_lines": 1984,
+      "code_lines": 1439,
+      "comment_lines": 189,
+      "tokens_per_line": 3.75
     }
   }
 }

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,19 +1,19 @@
 {
-  "core_total": 2248,
+  "core_total": 2247,
   "caps": {
-    "core/app.py": 1017,
+    "core/app.py": 1020,
     "core/config.py": 62,
     "core/didkey.py": 57,
     "core/limit.py": 183,
     "core/store.py": 933,
-    "core_total": 2248
+    "core_total": 2247
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 2017,
-      "code_lines": 1017,
+      "raw_lines": 2036,
+      "code_lines": 1020,
       "comment_lines": 282,
-      "tokens_per_line": 7.85
+      "tokens_per_line": 7.86
     },
     "core/config.py": {
       "raw_lines": 353,
@@ -34,16 +34,16 @@
       "tokens_per_line": 8.33
     },
     "core/store.py": {
-      "raw_lines": 2256,
-      "code_lines": 929,
+      "raw_lines": 2252,
+      "code_lines": 925,
       "comment_lines": 503,
-      "tokens_per_line": 7.35
+      "tokens_per_line": 7.37
     },
     "extra/manifest.py": {
-      "raw_lines": 1984,
-      "code_lines": 1439,
-      "comment_lines": 189,
-      "tokens_per_line": 3.75
+      "raw_lines": 2100,
+      "code_lines": 1495,
+      "comment_lines": 207,
+      "tokens_per_line": 3.74
     }
   }
 }

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -190,7 +190,7 @@ def test_note_capacity_refusal_does_not_carry_room_only_guidance(tmp_path, monke
     message = str(exc_info.value)
     assert "GET /rooms" not in message
     assert "24 hours" not in message
-    assert "overwrite a note you already own" in message
+    assert "overwrite a note that already exists" in message
 
     monkeypatch.setattr(store, "MAX_ROOMS", 1)
     store.append(tmp_path, "only", "bot", "hi")

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -177,6 +177,29 @@ def test_a_capacity_refusal_carries_the_numbers_a_caller_acts_on(tmp_path, monke
     with pytest.raises(store.StoreError, match=r"note limit reached \(1 across all namespaces"):
         store.note_set(tmp_path, "elsewhere", "second", "hi")
 
+
+def test_note_capacity_refusal_does_not_carry_room_only_guidance(tmp_path, monkeypatch):
+    """#285: the per-namespace note cap shared _at_capacity() with rooms, so it quoted
+    GET /rooms (notes are unlisted) and the 24-hour stillborn rule (room-only)."""
+    import store
+
+    monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 1)
+    store.note_set(tmp_path, "plans", "only", "hi")
+    with pytest.raises(store.StoreError) as exc_info:
+        store.note_set(tmp_path, "plans", "second", "hi")
+    message = str(exc_info.value)
+    assert "GET /rooms" not in message
+    assert "24 hours" not in message
+    assert "overwrite a note you already own" in message
+
+    monkeypatch.setattr(store, "MAX_ROOMS", 1)
+    store.append(tmp_path, "only", "bot", "hi")
+    with pytest.raises(store.StoreError) as exc_info:
+        store.append(tmp_path, "second", "bot", "hi")
+    message = str(exc_info.value)
+    assert "GET /rooms" in message
+    assert "24 hours" in message
+
     # "how full, of how much" is the figure an operator sizes a disk against, and the two
     # shifts that produce it are one character from reporting megabytes as terabytes.
     monkeypatch.setattr(store, "MAX_ROOMS", 10_000)


### PR DESCRIPTION
## What

Hitting the per-namespace note cap (`MAX_NOTES_PER_NS`) no longer points the caller at `GET /rooms` (notes are unlisted) or quotes the 24-hour stillborn-room rule (no note equivalent). The room-capacity refusal is unchanged.

## Why

`_at_capacity()` hardcoded both room-only clauses for its two callers. `_check_note_capacity`'s per-namespace check shared it verbatim, so a note-limit refusal gave guidance that doesn't apply to notes. Fixes #285.

Judgment call worth flagging: `core/store.py` grows 4 code-lines over baseline (840 → 844), 3 over the stated cap — bumped both in `sz-baseline.json` (only `store.py`'s own entry and the two totals; left the pre-existing drift in `config.py`/`manifest.py`'s recorded numbers alone since this PR doesn't touch those files). Two genuinely different messages didn't compress into one shared string without losing the room/note distinction this fix is about — happy to take a different shape if you'd rather.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 460 passed
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — all clean
- [ ] Docs — no doc quotes this refusal's exact wording, so nothing to update
- [x] New surface on a world-writable service: none — narrows existing guidance to be accurate, adds no capability

Confirmed the new test fails against the pre-fix code (`git stash` on `src/store.py`, re-ran): the note-limit message contained both `"GET /rooms"` and `"24 hours"`.