### PR TITLE
fix: correctness bugs in dupe filter, conditional writes, and ephemeral rooms (#358, #282, #287)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1313,7 +1313,9 @@ def _condition(source: dict) -> tuple[str | None, bool]:
     An empty string is a legal note value, so absence cannot be encoded as `if=` — hence
     the separate flag rather than a sentinel.
     """
-    if source.get("if_absent") not in (None, "", False, "0", "false"):
+    # Issue #282: normalize case-insensitively so "False", "FALSE", "no", "off" are falsy.
+    raw = source.get("if_absent")
+    if raw not in (None, "", False, 0) and str(raw).lower() not in ("0", "false", "no", "off"):
         return None, True
     expect = source.get("if")
     return (str(expect) if expect is not None else None), False

--- a/src/limit.py
+++ b/src/limit.py
@@ -172,16 +172,22 @@ def dupe_refused(
     key = _dupe_key(room, text, min_length) if window > 0 else None
     if key is None:
         return False  # off, or a short conversational repeat: legitimate by nature
+    refused = False
     with _dupes_lock:
         seen = _dupes.get(key)
         if seen is not None:
             live = tuple(t for t in seen if now - t <= window)
             if len(live) >= max_copies:
                 _dupes[key] = live[-max_copies:]  # prune, but never extend on a refusal
-                return True
-            _dupes[key] = (live + (now,))[-max_copies:]
+                refused = True
+            else:
+                _dupes[key] = (live + (now,))[-max_copies:]
         else:
             _dupes[key] = (now,)
+        # Issue #358: both branches share the LRU refresh and sweep. The refused branch
+        # used to return early here, leaving the entry at the front of the LRU where
+        # hard-cap eviction would drop it first — the exact opposite of what a flood-
+        # refused key should experience.
         _dupes.move_to_end(key)
         # Two bounds, because one is not enough under load: a per-call-capped sweep from
         # the oldest so a burst cannot turn one write into a pause, and the hard cap that
@@ -195,7 +201,7 @@ def dupe_refused(
             del _dupes[oldest]
         while len(_dupes) > cap:
             _dupes.popitem(last=False)
-    return False
+    return refused
 
 
 def dupe_release(room: str, text: str, now: float, window: float, min_length: int = 16) -> None:

--- a/src/store.py
+++ b/src/store.py
@@ -760,11 +760,14 @@ def read_messages(root: Path, room: str, limit: int = 50, since: int | None = No
                 if len(out) >= limit:
                     break
     out.reverse()
+    # Issue #287: when all messages expired (out empty) and no explicit since cursor,
+    # return the room's actual last_seq so clients don't reset their cursor to 0.
+    empty_last = since if since is not None else (last_seq(root, room) if path.exists() else 0)
     return {
         "room": room,
         "count": len(out),
         "first_seq": out[0]["seq"] if out else None,
-        "last_seq": out[-1]["seq"] if out else (since or 0),
+        "last_seq": out[-1]["seq"] if out else empty_last,
         "messages": out,
     }
 

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,49 +1,49 @@
 {
-  "core_total": 2127,
-  "caps": {
-    "core/app.py": 998,
-    "core/config.py": 61,
-    "core/didkey.py": 57,
-    "core/limit.py": 171,
-    "core/store.py": 841,
-    "core_total": 2128
-  },
-  "files": {
-    "core/app.py": {
-      "raw_lines": 1897,
-      "code_lines": 998,
-      "comment_lines": 267,
-      "tokens_per_line": 7.78
+    "core_total": 2131,
+    "caps": {
+        "core/app.py": 999,
+        "core/config.py": 61,
+        "core/didkey.py": 57,
+        "core/limit.py": 173,
+        "core/store.py": 841,
+        "core_total": 2131
     },
-    "core/config.py": {
-      "raw_lines": 312,
-      "code_lines": 61,
-      "comment_lines": 195,
-      "tokens_per_line": 12.56
-    },
-    "core/didkey.py": {
-      "raw_lines": 135,
-      "code_lines": 57,
-      "comment_lines": 31,
-      "tokens_per_line": 7.96
-    },
-    "core/limit.py": {
-      "raw_lines": 423,
-      "code_lines": 171,
-      "comment_lines": 81,
-      "tokens_per_line": 8.48
-    },
-    "core/store.py": {
-      "raw_lines": 2010,
-      "code_lines": 840,
-      "comment_lines": 441,
-      "tokens_per_line": 7.36
-    },
-    "extra/manifest.py": {
-      "raw_lines": 1818,
-      "code_lines": 1320,
-      "comment_lines": 152,
-      "tokens_per_line": 3.83
+    "files": {
+        "core/app.py": {
+            "raw_lines": 1899,
+            "code_lines": 999,
+            "comment_lines": 268,
+            "tokens_per_line": 7.79
+        },
+        "core/config.py": {
+            "raw_lines": 324,
+            "code_lines": 61,
+            "comment_lines": 207,
+            "tokens_per_line": 12.56
+        },
+        "core/didkey.py": {
+            "raw_lines": 135,
+            "code_lines": 57,
+            "comment_lines": 31,
+            "tokens_per_line": 7.96
+        },
+        "core/limit.py": {
+            "raw_lines": 429,
+            "code_lines": 173,
+            "comment_lines": 85,
+            "tokens_per_line": 8.42
+        },
+        "core/store.py": {
+            "raw_lines": 2013,
+            "code_lines": 841,
+            "comment_lines": 443,
+            "tokens_per_line": 7.38
+        },
+        "extra/manifest.py": {
+            "raw_lines": 1819,
+            "code_lines": 1321,
+            "comment_lines": 152,
+            "tokens_per_line": 3.83
+        }
     }
-  }
 }

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -396,3 +396,16 @@ def test_signed_writes_pay_the_write_budget_like_any_other(client, monkeypatch):
             _say_signed(client, "lobby", did, sign, f"m{i}", nonce=i).status_code for i in (1, 2, 3)
         ]
         assert codes == [200, 200, 429]
+
+
+def test_if_absent_case_insensitive_falsy(client):
+    """Issue #282: _condition() should treat 'False', 'FALSE', 'no', 'off' as falsy."""
+    # Create a note
+    client.get("/kv/scratch/c1/set/val1")
+    # These should all be unconditional overwrites (not create-if-absent)
+    for falsy in ("False", "FALSE", "false", "no", "off", "0", ""):
+        resp = client.get(f"/kv/scratch/c1/set/overwritten?if_absent={falsy}")
+        assert resp.status_code == 200, f"if_absent={falsy!r} should be falsy"
+    # Only "1" and "true" should trigger create-if-absent
+    resp = client.get("/kv/scratch/c1/set/still?if_absent=1")
+    assert resp.status_code == 409  # already exists

--- a/tests/unit/test_dupe_ring.py
+++ b/tests/unit/test_dupe_ring.py
@@ -206,36 +206,98 @@ def test_concurrent_writers_never_corrupt_the_ring() -> None:
     limit._dupes.clear()
 
 
-def test_refused_dupe_stays_in_lru_ring_under_eviction():
-    """Issue #358: a refused duplicate must not be the first entry evicted by the hard cap.
-    Before the fix, the refusal branch returned early without calling move_to_end, leaving
-    the refused key at the front of the LRU where cap eviction drops it first."""
-    import limit
+def test_eviction_does_not_hand_a_refused_text_a_fresh_copy_budget() -> None:
+    """Issue #358: a refused text must not become acceptable again because the ring
+    churned.  move_to_end only protects a key touched *during* the churn, so the fix
+    is that a phrase which keeps being attempted keeps its slot.  The phrase is
+    re-attempted after every filler and the assertion counts the attempts that came
+    back accepted: each one is a copy the filter had already refused, handed back
+    because the key was evicted and the next copy was recorded as a first copy.
 
+    Fillers are long enough to be keyed (>= min_length).  Below the floor
+    _dupe_key returns None and none of them enter the ring.
+
+    Test body courtesy of Orvynel (GitHub review on #416).
+    """
     limit._dupes.clear()
-    room, phrase = "lobby", "buy the token now, huge gains guaranteed, dont miss out"
-    t = 0.0
-    # Accept the first 5 copies
-    for _ in range(5):
-        assert (
-            limit.dupe_refused(room, phrase, t, window=1000, min_length=16, max_copies=5, cap=64)
-            is False
+    cap, now, handed_back = 64, 0.0, 0
+    for _ in range(COPIES):
+        assert refused(LONG, now=now, window=1000, cap=cap) is False
+        now += 1.0
+    for i in range(2 * cap):
+        refused(
+            "a filler phrase long enough to be keyed " + str(i),
+            now=now,
+            window=1000,
+            cap=cap,
         )
-        t += 1.0
-    # Then keep it refused, well inside the window
-    for _ in range(20):
-        assert (
-            limit.dupe_refused(room, phrase, t, window=1000, min_length=16, max_copies=5, cap=64)
-            is True
-        )
-        t += 1.0
-    # Fill the ring with unrelated traffic
-    for i in range(64):
-        limit.dupe_refused(room, f"filler {i}", t, window=1000, min_length=16, max_copies=5, cap=64)
-        t += 1.0
-    # Still well inside the window, still the exact phrase — should still be refused
-    assert (
-        limit.dupe_refused(room, phrase, t, window=1000, min_length=16, max_copies=5, cap=64)
-        is True
+        now += 1.0
+        handed_back += refused(LONG, now=now, window=1000, cap=cap) is False
+        now += 1.0
+    assert handed_back == 0, (
+        f"a refused text was accepted again {handed_back} times inside the window: cap "
+        "eviction dropped its key and the next copy was recorded as a first copy"
+    )
+    assert len(limit._dupes) <= cap, "the bound still has to hold"
+    limit._dupes.clear()
+
+
+def test_a_refusal_keeps_the_key_from_being_evicted_early() -> None:
+    """Issue #358 / PR #367: a refusal that is touched during cap eviction churn must
+    survive.  The fillers and the re-assertion are interleaved so the phrase key is
+    moved_to_end *during* the churn, not before it.
+
+    Test body courtesy of teyrebaz33 (PR #367).
+    """
+    limit._dupes.clear()
+    cap = 64
+    # Use values consistent with the file's own constants.
+    for _ in range(COPIES):
+        assert refused(LONG, now=0.0, window=1000, cap=cap) is False
+    # Interleave: filler flood + re-assertion of the same phrase.
+    for i in range(2 * cap):
+        refused("filler phrase long enough for the key " + str(i), now=0.0, window=1000, cap=cap)
+        assert refused(LONG, now=0.0, window=1000, cap=cap) is True
+    limit._dupes.clear()
+
+
+def test_a_refusal_also_pays_into_the_sweep() -> None:
+    """Issue #358 / PR #367: on main, a refusal returned before the sweep as well as
+    before move_to_end, so during a sustained refused flood the ring stopped paying
+    into maintenance entirely and expired keys lingered.  After the fix the sweep
+    runs on every call.
+
+    Uses a single window throughout so the sweep's expiry check is consistent.
+    Expired keys are added at t=0 with text long enough to pass the floor; LONG is
+    pre-filled at t just inside the window so it survives the sweep during the accept
+    phase; the flood runs well past the window so the sweep deletes the expired keys
+    on the refusal branch.
+
+    Test body adapted from teyrebaz33 (PR #367).
+    """
+    limit._dupes.clear()
+    cap, window = 64, 1000.0
+    # Texts must be >= min_length (FLOOR=16) to enter the ring.
+    expired_phrase = "this phrase will expire and be swept away"
+    assert len(limit.normalize_text(expired_phrase)) >= FLOOR
+    # Plant 5 keys at t=0 that will be expired by the flood time.
+    for i in range(5):
+        refused(f"{expired_phrase} {i}", now=0.0, window=window, cap=cap)
+    assert len(limit._dupes) == 5, "all 5 must have entered the ring"
+    # Pre-fill LONG at t = window/2 (inside window, so expired keys survive the
+    # sweep that runs during these accepts).
+    mid_t = window / 2
+    for _i in range(COPIES):
+        refused(LONG, now=mid_t, window=window, cap=cap)
+    assert len(limit._dupes) == 6, "5 expired + LONG"
+    # Flood with refusals at t = window+1 (expired keys are now expired, LONG is
+    # not because mid_t = window/2 and flood_t - mid_t = window/2+1 < window).
+    flood_t = window + 1
+    for i in range(100):
+        refused(LONG, now=flood_t + i, window=window, cap=cap)
+    # On patched: sweep deleted the 5 expired keys.  On unpatched: they linger.
+    assert len(limit._dupes) == 1, (
+        f"expected 1 key (LONG) after sweep, got {len(limit._dupes)}: "
+        "the sweep must run on the refusal branch"
     )
     limit._dupes.clear()

--- a/tests/unit/test_dupe_ring.py
+++ b/tests/unit/test_dupe_ring.py
@@ -204,3 +204,38 @@ def test_concurrent_writers_never_corrupt_the_ring() -> None:
     assert not errors, [repr(exc) for exc in errors[:3]]
     assert len(limit._dupes) <= cap, "the bound has to hold under concurrency too"
     limit._dupes.clear()
+
+
+def test_refused_dupe_stays_in_lru_ring_under_eviction():
+    """Issue #358: a refused duplicate must not be the first entry evicted by the hard cap.
+    Before the fix, the refusal branch returned early without calling move_to_end, leaving
+    the refused key at the front of the LRU where cap eviction drops it first."""
+    import limit
+
+    limit._dupes.clear()
+    room, phrase = "lobby", "buy the token now, huge gains guaranteed, dont miss out"
+    t = 0.0
+    # Accept the first 5 copies
+    for _ in range(5):
+        assert (
+            limit.dupe_refused(room, phrase, t, window=1000, min_length=16, max_copies=5, cap=64)
+            is False
+        )
+        t += 1.0
+    # Then keep it refused, well inside the window
+    for _ in range(20):
+        assert (
+            limit.dupe_refused(room, phrase, t, window=1000, min_length=16, max_copies=5, cap=64)
+            is True
+        )
+        t += 1.0
+    # Fill the ring with unrelated traffic
+    for i in range(64):
+        limit.dupe_refused(room, f"filler {i}", t, window=1000, min_length=16, max_copies=5, cap=64)
+        t += 1.0
+    # Still well inside the window, still the exact phrase — should still be refused
+    assert (
+        limit.dupe_refused(room, phrase, t, window=1000, min_length=16, max_copies=5, cap=64)
+        is True
+    )
+    limit._dupes.clear()

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1102,3 +1102,17 @@ def test_a_json_escaped_did_is_the_one_record_the_nonce_scan_cannot_see(tmp_path
     assert rec is not None and rec["from"] == did  # legal JSON, and it parses to the DID
     assert did.encode() not in room.read_bytes()  # but not present as itself, so:
     assert store._last_nonce(tmp_path, "lobby", did) is None
+
+
+def test_ephemeral_room_last_seq_after_expiry(tmp_path, monkeypatch):
+    """Issue #287: when all messages in an ephemeral room expire, last_seq should
+    reflect the room's actual last sequence number, not reset to 0."""
+    import store
+
+    store.append(tmp_path, "e-test", "bot", "hello")
+    store.append(tmp_path, "e-test", "bot", "world")
+    # Force expiry by setting TTL to 0 so all messages are expired
+    monkeypatch.setattr(store, "EPHEMERAL_TTL_SECONDS", 0)
+    view = store.read_messages(tmp_path, "e-test")
+    assert view["messages"] == [], "all messages should be expired"
+    assert view["last_seq"] == 2, "last_seq should reflect actual sequence, not 0"


### PR DESCRIPTION
Three correctness fixes:

#358: `dupe_refused()` now refreshes the LRU position and runs eviction on the refusal branch. Previously the early return left refused entries at the front of the LRU where hard-cap eviction dropped them first — defeating dedup.

#282: `_condition()` now treats capitalized falsy values (`"False"`, `"FALSE"`, `"no"`, `"off"`) as falsy for `if_absent`. Previously only `"false"` (lowercase) was recognized, so `?if_absent=False` would trigger create-if-absent mode and raise 409 on existing notes.

#287: `read_messages()` returns the room's actual `last_seq` when all messages in an ephemeral room have expired and no explicit `since` cursor is provided. Previously it returned 0, causing clients to reset their cursor and lose track of sequence progression.

