### PR TITLE
fix: clarify nonce replay error message

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1821,8 +1821,9 @@ def _write_record(
             previous = _last_nonce(root, room, did)
             if previous is not None and nonce <= previous:
                 raise StoreError(
-                    f"nonce {nonce} is not greater than {previous}, the last one this key "
-                    f"used in /r/{room} — a signed URL is single-use, so count up"
+                    f"nonce {nonce} is not greater than {previous}, the highest nonce found "
+                    f"for this key in the newest 1 MiB of /r/{room} — older writes may exist "
+                    f"beyond that window, so count up"
                 )
         rec["seq"] = last_seq(root, room) + 1
         line = orjson.dumps(rec) + b"\n"

--- a/src/store.py
+++ b/src/store.py
@@ -1821,8 +1821,8 @@ def _write_record(
             previous = _last_nonce(root, room, did)
             if previous is not None and nonce <= previous:
                 raise StoreError(
-                    f"nonce {nonce} is not greater than {previous}, the highest nonce found "
-                    f"for this key in the newest 1 MiB of /r/{room} — older writes may exist "
+                    f"nonce {nonce} is not greater than {previous}, the newest nonce encountered "
+                    f"for this key within the newest 1 MiB of /r/{room} — older writes may exist "
                     f"beyond that window, so count up"
                 )
         rec["seq"] = last_seq(root, room) + 1

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -218,6 +218,7 @@ def test_a_replayed_signed_url_is_refused_while_the_message_is_still_there(clien
     assert client.get(url).status_code == 200
     r = client.get(url)  # the identical captured URL, again
     assert r.status_code == 400 and "not greater than 7" in r.text
+    assert "newest 1 MiB" in r.text and "older writes may exist" in r.text
     assert (
         client.get(f"/r/lobby/say-signed/{did}/{sign('lobby|6|older')}/6/older").status_code == 400
     )

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -218,7 +218,7 @@ def test_a_replayed_signed_url_is_refused_while_the_message_is_still_there(clien
     assert client.get(url).status_code == 200
     r = client.get(url)  # the identical captured URL, again
     assert r.status_code == 400 and "not greater than 7" in r.text
-    assert "newest 1 MiB" in r.text and "older writes may exist" in r.text
+    assert "newest nonce encountered" in r.text and "older writes may exist" in r.text
     assert (
         client.get(f"/r/lobby/say-signed/{did}/{sign('lobby|6|older')}/6/older").status_code == 400
     )


### PR DESCRIPTION
## Summary

Clarify the signed-message nonce replay error so it accurately describes the scope of the replay-protection scan.

The previous message described the detected nonce as "the last one this key used in this room", but `_last_nonce` only searches the newest 1 MiB of the room log.

The new message makes that limitation explicit and notes that older writes may exist outside the scanned window.

## Tests

- Added a regression assertion for the updated error message.
- `459 passed`
- `ruff check` passed
- `ruff format --check` passed
- `ty check` passed

Closes #349