### PR TITLE
fix(store): pop-then-insert with a shared bound tail in _cached_window (#376)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -879,16 +879,18 @@ _window_memo: OrderedDict[tuple, tuple] = OrderedDict()
 
 def _cached_window(root: Path, name: str, stamp: tuple) -> tuple[int, list[str]]:
     key = (str(root), name)
-    hit = _window_memo.get(key)
-    if hit and hit[0] == stamp:
-        _window_memo.move_to_end(key)
-        return hit[1]
-    view = room_window(root, name)
-    _window_memo[key] = (stamp, view)
-    _window_memo.move_to_end(key)
+    # pop-then-insert, as _rooms_cache (app.py): a keyed touch after the entry is in
+    # the dict races another worker's popitem, and the move_to_end that refreshed the
+    # LRU here was the KeyError (#376). pop is one atomic step, and reinserting puts
+    # the entry at the back on its own. Both paths then share one bound-enforcing
+    # tail: a hit that skipped it could land its reinsert on top of a concurrent
+    # insert and leave the memo one past _WINDOW_MEMO_MAX for good.
+    hit = _window_memo.pop(key, None)
+    entry = hit if hit and hit[0] == stamp else (stamp, room_window(root, name))
+    _window_memo[key] = entry
     while len(_window_memo) > _WINDOW_MEMO_MAX:
         _window_memo.popitem(last=False)
-    return view
+    return entry[1]
 
 
 # Topic previews, valid while topics_written holds (bumped only by a `topic` note); reaper

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1102,3 +1102,76 @@ def test_a_json_escaped_did_is_the_one_record_the_nonce_scan_cannot_see(tmp_path
     assert rec is not None and rec["from"] == did  # legal JSON, and it parses to the DID
     assert did.encode() not in room.read_bytes()  # but not present as itself, so:
     assert store._last_nonce(tmp_path, "lobby", did) is None
+
+
+def test_cached_window_survives_eviction_landing_inside_the_touch(tmp_path, monkeypatch):
+    """A concurrent worker's popitem can land inside _cached_window's compound dict
+    ops; the get/set-then-move_to_end shape turned that into a KeyError (#376). The
+    dict below deletes the key from inside each touch — the same interleave, without
+    threads (cf. _race_before_lock) — and the sentinel proves the race actually ran.
+    pop-then-insert leaves no second keyed touch to lose."""
+    from collections import OrderedDict
+
+    import store
+
+    class EvictorWins(OrderedDict):
+        fired: list = []
+
+        def pop(self, key, default=None):
+            value = super().pop(key, default)
+            if value is not None:
+                self.fired.append("pop")
+            return value
+
+        def __setitem__(self, key, value):
+            super().__setitem__(key, value)
+            super().__delitem__(key)
+            self.fired.append("set")
+
+    hostile = EvictorWins()
+    monkeypatch.setattr(store, "_window_memo", hostile)
+
+    store.append(tmp_path, "aaa", "bot", "hello")
+    first = store.room_stats(tmp_path)
+    second = store.room_stats(tmp_path)  # entry was evicted each time: recompute, again
+
+    assert hostile.fired, "the race never fired — the test proved nothing"
+    assert "aaa" in {r["room"] for r in first["rooms"]}
+    assert "aaa" in {r["room"] for r in second["rooms"]}
+
+
+def test_cached_window_bound_holds_when_an_insert_lands_inside_a_hit(tmp_path, monkeypatch):
+    """The hit path must run the same bound-enforcing tail as the miss path (#376
+    review). Calls _cached_window directly, not room_stats, so a later room's miss
+    path cannot clean up after the hit and hide the leak. With the memo at its cap,
+    a concurrent insert landing inside a cache hit — armed from inside pop(),
+    threadless — leaves the memo at MAX+1 unless the reinsert is also followed by the
+    eviction sweep. Fails against a hit path that returns early (verified red against
+    the reviewed shape)."""
+    from collections import OrderedDict
+
+    import store
+
+    monkeypatch.setattr(store, "_WINDOW_MEMO_MAX", 1)
+
+    class InsertInsideHit(OrderedDict):
+        armed = False
+
+        def pop(self, key, default=None):
+            value = super().pop(key, default)
+            if self.armed and value is not None:  # inside the hit's pop -> a rival insert
+                super().__setitem__(("intruder", "x"), (("s",), (0, [])))
+            return value
+
+    hostile = InsertInsideHit()
+    monkeypatch.setattr(store, "_window_memo", hostile)
+
+    store.append(tmp_path, "aaa", "bot", "hello")  # room_window has something to read
+    stamp = ("v1",)
+    store._cached_window(tmp_path, "aaa", stamp)  # miss: fills "aaa", evicts to the bound
+    hostile.armed = True
+    store._cached_window(tmp_path, "aaa", stamp)  # hit on the same stamp: pop fires the insert
+
+    assert len(hostile) <= store._WINDOW_MEMO_MAX, (
+        f"hit path skipped the bound: {len(hostile)} > {store._WINDOW_MEMO_MAX}"
+    )


### PR DESCRIPTION
## What

`_cached_window` refreshes its LRU entry with pop-then-insert instead of a second keyed touch, and the hit path now falls through the same eviction sweep as the miss path.

## Why

#376 — the get/set-then-`move_to_end` pair races a concurrent worker's `popitem` into a `KeyError`, the interleave `_rooms_cache` (app.py) already fixed. Review of a first cut added the shared tail: a hit that returned early could reinsert on top of a concurrent insert and leave the memo one past `_WINDOW_MEMO_MAX` for good.

Both regression tests are threadless (a hostile OrderedDict drives the interleave, in the spirit of `_race_before_lock`) and were verified red against the shapes they target: the crash test fails on current `main` at `src/store.py:888`; the bound test fails against an early-returning hit path. It calls `_cached_window` directly so a later room's miss sweep cannot hide the leak.

## Checks

- [x] `coverage run -m pytest tests` — 461 passed, 97.57% (local uv is <0.9, so the same commands ran via a pinned 3.12 venv with the locked dev deps)
- [x] `ruff check .` / `ruff format --check .` / `ty check` — clean
- [x] Docs that would now be wrong: none — no caller-visible behavior changed
- [x] New surface on a world-writable service: nothing new