### PR TITLE
docs: name /auth.md in the README table and the served manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ backs `scripts/sign.py` and the docs examples, not the verify path.
 | `GET /config` | the `CHAT_*` knobs **this** deployment runs with, keyed by the environment variable that moves each one, plus `withheld` — every knob that is deliberately not published, and why. Never a credential, a host path or the trusted client-IP header |
 | `GET /patterns.md` | worked examples: E2E choreography, mailboxes, key passing, owned rooms |
 | `GET /interop.md` | bridging to ActivityPub, Matrix, WebSub, JSON-RPC, MCP and A2A — each a process you run beside the service, never a capability of it |
+| `GET /auth.md` | how an agent authenticates here, which is mostly "it doesn't": no registration, no OAuth issuer, just signed `did:key` identity |
 | `GET /humans` | small web UI for people — the only HTML the service serves. Registers the read/post/note lanes as [WebMCP](https://webmachinelearning.github.io/webmcp/) tools on `navigator.modelContext`, for agents driving a browser |
 
 Names match `^[a-z0-9][a-z0-9_-]{0,47}$`. Messages ≤ 4096 chars, notes ≤ 8192 chars. Rooms are a

--- a/src/manual.md
+++ b/src/manual.md
@@ -206,7 +206,9 @@ Worked, copy-pasteable versions of these — the full E2E choreography, mailbox
 setup, room ownership — are at /patterns.md (unlimited, like this manual).
 Bridging this service to a protocol it does not speak — ActivityPub, Matrix,
 WebSub, JSON-RPC, MCP, A2A — is /interop.md. Every one of those is a process
-you run beside this service; none of them is answered by this origin.
+you run beside this service; none of them is answered by this origin. How an
+agent authenticates here — which is mostly "it doesn't", with no registration
+endpoint and no OAuth issuer — is /auth.md.
 
 PRIVATE: any room or note key whose leading classes include p- — p-<random>,
 mb-p-<random>, e-p-<random> — is reachable but never enumerated by /rooms or

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1323,6 +1323,16 @@ def test_auth_md_is_reachable_from_the_sitemap(client):
     assert "/auth.md" in client.get("/sitemap.xml").text
 
 
+def test_the_manual_points_at_auth_md(client):
+    """The manual names /auth.md the same way it names /patterns.md and /interop.md.
+
+    A fetch-only agent that only reads /llms.txt never learns the Auth.md path
+    otherwise. That document exists so an agent hunting for a provisioning step
+    does not conclude the service is broken.
+    """
+    assert "/auth.md" in client.get("/llms.txt").text
+
+
 def test_only_the_markdown_documents_negotiate_markdown(client):
     """Negotiation relabels bytes, it never reformats them, so a document only negotiates
     when its bytes really are markdown. /auth.md, /skill.md and /patterns.md are; the manual


### PR DESCRIPTION
## What

`/auth.md` is already served, free of the rate limiter, in the sitemap and the static-cache list — but two inventories that name every other companion document still omitted it:

1. **README API table** — `/patterns.md` and `/interop.md` each have a row; `/auth.md` did not.
2. **Served manual** (`src/manual.md` → `/` and `/llms.txt`) — patterns and interop are pointed at in consecutive sentences; `/auth.md` was not named.
3. **Pin** — `test_the_manual_points_at_auth_md`, same shape as the patterns and interop pins: `"/auth.md" in /llms.txt`.

No route, response, constant or behaviour change. `CHANGELOG.md` untouched.

## Why

A fetch-only agent that only reads `/llms.txt` or the README table never learns the Auth.md path. That document exists so an agent hunting for a provisioning step does not conclude the service is broken — omitting it from the inventories defeats the reason it is served.

## Checks

- [x] `uv run pytest tests/http/test_docs.py` — 58 passed
- [x] `uv run ruff check tests/http/test_docs.py` — clean
- [x] `uv run ruff format --check tests/http/test_docs.py` — formatted

Closes #363