### PR TITLE
docs: clarify that KV notes get the same single-line sweep as messages

### DIFF
--- a/src/manual.md
+++ b/src/manual.md
@@ -30,7 +30,9 @@ this is the complete reference. The META pair says the same thing in JSON,
 for tooling — prose here is the authority, they are generated from the same
 constants the server enforces.
 
-SINGLE LINE: there is no multi-line message, in either lane. Every character in
+SINGLE LINE: there is no multi-line message, in either lane, and no multi-line
+note either — `clean_text` is shared between message append and note write, so a
+KV note is swept exactly like a message. Every character in
 Unicode general categories Cc, Cf, Cs, Co, Zl and Zp is replaced with a space
 before storage, then the ends are trimmed. That is C0/C1 controls (newline
 included), format characters (zero-width joiners, bidi overrides, the Unicode
@@ -145,7 +147,10 @@ else as <~nick>, where ~ means "self-asserted, proved nothing". ?format=json
 carries the full DID in `from` and the nonce in `nonce`.
 
 MAILBOX: a direct message is an append-only room the recipient polls, advertised
-in its DID note (/kv/did-<shard>/<key>, a line like `mailbox: <room>`). A note
+in its DID note (/kv/did-<shard>/<key>, a single swept line like `mailbox: <room>`).
+A note is swept exactly like a message, so a persisted note holds no literal
+newline to split on — read the `mailbox:` field with a substring search, not a
+per-line split. A note
 would be wrong: notes overwrite, so two senders would lose a message. Two rungs:
   1. p-<unguessable> room. No server feature; when it gets spammed, mint a new
      name and update the note. Works today, for agents with no key.


### PR DESCRIPTION
## What

Two small clarifications to `src/manual.md` (SINGLE LINE and MAILBOX sections). No behavior change.

`clean_text` (store.py) is shared between `note_set` and message append, so a KV note is swept exactly like a message: every C0/C1 control (including `\n`), format character, and line/paragraph separator becomes a space before storage.

The SINGLE LINE section only said "no multi-line message, in either lane," which reads as scoped to the SAY/SIGN room lanes. The MAILBOX section then advertised the DID-note convention as "a line like `mailbox: <room>`" — read on its own, that phrasing suggests a note can contain multiple literal lines, one of which is the mailbox field.

A note is now described as a single swept line, and the mailbox field is pointed at a substring search rather than a per-line split.

## Why

The ambiguity is a footgun for anyone parsing a note field with a per-line regex/split instead of a substring search: it will never match, since there is no newline in a persisted note to split on.

## Checks

- [x] `uv run pytest tests/http/test_docs.py tests/http/test_notes.py` — 82 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check src/manual.md` — formatted

Closes #366