### PR TITLE
fix(app): reject non-string from/text instead of silently str()-coercing them

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1239,6 +1239,18 @@ async def room_post(request: Request) -> Response:
     payload = await read_json(request)
     if isinstance(payload, Response):
         return payload
+    # The schema promises "from"/"text" are strings; str()-coercing whatever JSON type
+    # arrived (below) let a bare number through as a name/text by accident, whenever its
+    # string form happened to also pass NAME_RE/length. Reject the type mismatch here,
+    # before either lane touches the value, rather than coercing it away silently.
+    for field in ("from", "text"):
+        value = payload.get(field)
+        if value is not None and not isinstance(value, str):
+            return text(
+                f"400 {field!r} must be a string, not a {type(value).__name__} — "
+                'e.g. {"from":"bot","text":"hi"}.',
+                400,
+            )
     room = request.path_params["room"]
     credentials = _payload_credentials(payload)
     signer = None


### PR DESCRIPTION
## Summary

Closes #427. `room_post()` called `str()` unconditionally on whatever JSON type arrived for `from` and `text`, before any type check — both fields are declared `"type": "string"` in the schema (`_NAME_SCHEMA`/`_TEXT_SCHEMA` in `manifest.py`), but a JSON number slipped straight through whenever its `str()` form happened to also pass `NAME_RE`/length by luck (`str(0) == "0"`, which matches the name regex; `str(12345)` is a valid 5-char text body).

## Fix

Adds an explicit `isinstance(value, str)` check for both fields right after the payload is parsed, before either the signed or unsigned lane touches them. A non-string value gets the same `400` shape other validation failures on this route already use, naming the offending Python type.

## Caller-visible impact

A `from`/`text` value that is present but not a JSON string now gets `400` instead of `200` with a silently-coerced value. No change for any request where both fields are already strings (the overwhelming majority — this only affects adversarial or buggy clients sending the wrong JSON type).

## Validation

- `uv run ruff check .` -> passed
- `uv run ruff format --check .` -> passed
- `uv run ty check` -> passed
- `uv run coverage run -m pytest tests -q` -> 459 passed
- Reproduced locally before/after: `{"from": 0, "text": "test", ...}` and `{"from": "validnick", "text": 12345}` both landed as `200` pre-fix, both `400` (naming the type) post-fix; a normal all-strings request still `200`s
- Contract check (CI's exact schemathesis invocation from `.github/workflows/ci.yml`) run against this branch: 885 generated, 885 passed, 0 failures

---

AI assistance (Claude Code, Anthropic) was used to investigate and draft this fix (a schemathesis fuzzing pass surfaced the discrepancy). The analysis and verification were reviewed by the author before submitting.
