### PR TITLE
build(uv): sync root package version in lockfile

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.9.7"
+version = "0.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

Sync the root `technocore-chat` entry in `uv.lock` from 0.9.7 to 0.10.0, matching `pyproject.toml` and the released service version. No dependency, hash, or runtime code changes.

## Why

The v0.10.0 release updated the package and service version declarations, but the lockfile kept 0.9.7. `uv sync --frozen` accepts that checkout; the first normal project-aware `uv run` then silently rewrites `uv.lock`. Following the documented CI commands therefore dirties a clean tree.

This keeps the checked-in lock metadata stable. Caller behaviour and the public API are unchanged.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 459 passed, 97.58%
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run ty check`
- [x] `uv run sz.py --caps` — core remains within caps
- [x] Docs: no behaviour or documented contract changed
- [x] New world-writable surface: nothing new

AI assistance (OpenAI Codex) found the mismatch during a clean v0.10.0 audit; I reproduced and verified it against a pristine upstream worktree.