### PR TITLE
fix(app): reject non-string POST room fields

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1240,13 +1240,13 @@ async def room_post(request: Request) -> Response:
     if isinstance(payload, Response):
         return payload
     room = request.path_params["room"]
-    credentials = _payload_credentials(payload)
+    if not isinstance(raw_text := payload.get("text", ""), str):
+        return text("400 bad text: field 'text' must be a JSON string.", 400)
     signer = None
-    if credentials:
+    if credentials := _payload_credentials(payload):
         did, sig, nonce = credentials
-        body = store.clean_text(str(payload.get("text", "")))
-        signer = _signer(did, sig, nonce, f"{room}|{nonce}|{body}")
-        if isinstance(signer, Response):
+        body = store.clean_text(raw_text)
+        if isinstance(signer := _signer(did, sig, nonce, f"{room}|{nonce}|{body}"), Response):
             return signer
 
     # Everything below is blocking disk work: the gate stats the room and walks the rooms
@@ -1257,15 +1257,15 @@ async def room_post(request: Request) -> Response:
     # never had this problem: they are `def`, and Starlette already runs a sync endpoint in
     # a threadpool. This puts the POST lanes where the GET lanes always were.
     def write() -> Response:
-        denied = _room_write_gate(request, room, signer)
-        if denied:
+        if denied := _room_write_gate(request, room, signer):
             return denied
         if signer is None:
-            nick, sent = str(payload.get("from", "")), str(payload.get("text", ""))
-            with _dupe_slot(room, sent) as refused:
+            if not isinstance(nick := payload.get("from", ""), str):
+                return text("400 bad name: field 'from' must be a JSON string.", 400)
+            with _dupe_slot(room, raw_text) as refused:
                 if refused:
                     return _dupe_refusal(request, room)
-                posted = store.append(config.ROOT, room, nick, sent)
+                posted = store.append(config.ROOT, room, nick, raw_text)
         else:
             with _dupe_slot(room, body) as refused:
                 if refused:

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -27,6 +27,39 @@ def test_post_lane(client):
     assert client.post("/r/lobby", content=b"x" * (app_module.MAX_BODY + 1)).status_code == 413
 
 
+def test_post_lane_rejects_non_string_room_fields(client):
+    """The OpenAPI schema says `from` and `text` are strings, so POST must not coerce.
+
+    Before #427, both requests below returned 200: `0` became the valid nick `"0"`, and
+    `12345` became the message text `"12345"`. The type mismatch itself is the refusal.
+    """
+    bad_from = client.post("/r/post-types-a", json={"from": 0, "text": "test"})
+    assert bad_from.status_code == 400
+    assert "bad name" in bad_from.text and "JSON string" in bad_from.text
+
+    bad_text = client.post("/r/post-types-b", json={"from": "bot", "text": 12345})
+    assert bad_text.status_code == 400
+    assert "bad text" in bad_text.text and "JSON string" in bad_text.text
+
+    assert client.get("/r/post-types-a?format=json").json()["count"] == 0
+    assert client.get("/r/post-types-b?format=json").json()["count"] == 0
+
+
+def test_signed_post_lane_rejects_non_string_text_before_verifying(client):
+    """A signature over `str(12345)` must not smuggle a schema-invalid JSON value in."""
+    did, sign = _keypair()
+    payload = {
+        "did": did,
+        "sig": sign("signed-type|1|12345"),
+        "nonce": "1",
+        "text": 12345,
+    }
+    r = client.post("/r/signed-type", json=payload)
+    assert r.status_code == 400
+    assert "bad text" in r.text and "JSON string" in r.text
+    assert client.get("/r/signed-type?format=json").json()["count"] == 0
+
+
 def test_post_lane_reports_write_budget_like_get_writes(client, monkeypatch):
     """POST pays the same write bucket as GET /say, so it must carry the same in-body
     budget hint for clients whose harness does not expose response headers.


### PR DESCRIPTION
## What

Closes #427. `POST /r/{room}` now rejects schema-invalid non-string `text` before signed canonicalisation, and rejects non-string unsigned `from` before nickname validation. This removes the accidental `str()` coercion path where JSON numbers could land as valid messages or nicknames.

## Checks

- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/ruff format --check .`
- [x] `.venv/bin/ty check`
- [x] `.venv/bin/python -m pytest tests -q` -> 461 passed
- [x] `.venv/bin/python -m coverage run -m pytest tests -q` -> 461 passed
- [x] `.venv/bin/python -m coverage report` -> 97.58%
- [x] `.venv/bin/python sz.py --check`

No new route, state, or world-writable surface. Abuse impact: closes one contract mismatch; no new abuse surface.