### PR TITLE
fix(limit): pop-then-insert in take() to avoid move_to_end race

### DIFF
--- a/src/limit.py
+++ b/src/limit.py
@@ -280,8 +280,14 @@ def take(request, kind, per_min, burst=None, *, ip_header="", max_buckets=MAX_BU
         wait = 0.0
     else:
         wait = (1.0 - tokens) * 60.0 / per_min
+    # pop-then-insert, not set+move_to_end: assigning an existing key leaves the entry
+    # in its old position, so a concurrent popitem(last=False) between the assignment
+    # and move_to_end can evict the key this thread just wrote, and move_to_end then
+    # raises KeyError on a key that no longer exists. Pop first (a no-op if already
+    # gone) so the insert that follows is always onto an absent key -- see _rooms_cache
+    # in app.py for the same pattern.
+    _buckets.pop((ip, kind), None)
     _buckets[(ip, kind)] = (tokens, now)
-    _buckets.move_to_end((ip, kind))
     while len(_buckets) > max_buckets:
         _buckets.popitem(last=False)
     # Counted at the one point every rate-limited route already funnels through, so a new

--- a/tests/test_limit_race.py
+++ b/tests/test_limit_race.py
@@ -1,0 +1,67 @@
+import sys
+import threading
+from collections import OrderedDict
+
+import limit
+from limit import take, _buckets
+
+
+class _FakeClient:
+    def __init__(self, host):
+        self.host = host
+
+
+class _FakeRequest:
+    def __init__(self, ip):
+        self.headers = {}
+        self.client = _FakeClient(ip)
+
+
+def test_take_survives_concurrent_eviction_of_own_key(monkeypatch):
+    """Deterministic reproduction of #378: simulates another thread's
+    popitem(last=False) evicting this thread's own bucket key in the exact
+    window between take() writing the entry and calling move_to_end on it."""
+    key = ("10.0.0.1", "msg")
+
+    class _EvictingDict(OrderedDict):
+        def move_to_end(self, k, *args, **kwargs):
+            if k == key and k in self:
+                del self[k]  # the concurrent popitem(last=False) this test simulates
+            return super().move_to_end(k, *args, **kwargs)
+
+    fake_buckets = _EvictingDict()
+    fake_buckets[key] = (5.0, 0.0)  # pre-seed so take() takes the "existing key" branch
+    monkeypatch.setattr(limit, "_buckets", fake_buckets)
+
+    req = _FakeRequest("10.0.0.1")
+    take(req, "msg", per_min=1000, burst=1000, max_buckets=50)
+
+
+def test_take_concurrent_no_keyerror():
+    """Statistical sanity check: hammer take() from many threads on overlapping
+    keys under heavy eviction pressure. Not guaranteed to catch the race on its
+    own -- see test_take_survives_concurrent_eviction_of_own_key for the
+    deterministic reproduction -- but should stay green on the fixed code."""
+    _buckets.clear()
+    errors = []
+
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        def worker(i):
+            req = _FakeRequest(f"10.0.0.{i % 4}")
+            try:
+                for _ in range(2000):
+                    take(req, "msg", per_min=1000, burst=1000, max_buckets=2)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(32)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        sys.setswitchinterval(old_interval)
+
+    assert not errors, f"take() raised under concurrency: {errors}"


### PR DESCRIPTION
Fixes #378.

_buckets[(ip, kind)] = (tokens, now) followed by move_to_end() left a window where a concurrent popitem(last=False) could evict the key before move_to_end ran, raising KeyError -> HTTP 500. Switched to pop-then-insert, matching the pattern already used by _rooms_cache in app.py.

Added a deterministic test that forces the exact interleaving (monkeypatched OrderedDict subclass), plus a concurrent stress test as an additional sanity check.

Note: while investigating, I noticed _window_memo in store.py (lines 887-888) has what looks like the same set+move_to_end pattern. Didn't touch it here since it's a separate location - happy to open a follow-up issue if that's useful.