### PR TITLE
fix(mcp): validate JSON-RPC request version

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -64,7 +64,7 @@ RequestId = str | int
 class Notification(TypedDict):
     """A message with no `id` key. It gets no reply — not even for an unknown method."""
 
-    jsonrpc: NotRequired[str]
+    jsonrpc: Literal["2.0"]
     method: str
     params: NotRequired[dict[str, Any]]
 
@@ -307,6 +307,8 @@ class Server:
         ident = message["id"]
         if not _is_request_id(ident):
             return _error(None, INVALID_REQUEST, "request id must be a string or integer")
+        if message.get("jsonrpc") != "2.0":
+            return _error(ident, INVALID_REQUEST, 'jsonrpc must be "2.0"')
         if not _is_request(message):
             return _error(ident, INVALID_REQUEST, "missing method")
         params = message.get("params", {})

--- a/tests/test_mcp_jsonrpc_version.py
+++ b/tests/test_mcp_jsonrpc_version.py
@@ -1,0 +1,46 @@
+"""JSON-RPC envelope validation for the stdio MCP server."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "mcp" / "src"))
+
+from technocore_mcp import protocol  # noqa: E402
+
+
+@pytest.mark.parametrize("version", [None, "1.0", 2, True])
+def test_mcp_requests_require_jsonrpc_2(version):
+    server = protocol.Server("test", "0")
+    message = {"id": 7, "method": "ping"}
+    if version is not None:
+        message["jsonrpc"] = version
+
+    reply = server.handle(message)
+
+    assert reply == {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "error": {
+            "code": protocol.INVALID_REQUEST,
+            "message": 'jsonrpc must be "2.0"',
+        },
+    }
+
+
+def test_mcp_jsonrpc_2_request_still_succeeds():
+    server = protocol.Server("test", "0")
+    assert server.handle({"jsonrpc": "2.0", "id": 7, "method": "ping"}) == {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "result": {},
+    }
+
+
+def test_valid_notification_remains_silent():
+    server = protocol.Server("test", "0")
+    assert server.handle({"jsonrpc": "2.0", "method": "ping"}) is None


### PR DESCRIPTION
Fixes #436.

## What changes for a caller

The stdio MCP server now requires requests with an `id` to carry the JSON-RPC 2.0 envelope exactly: `"jsonrpc": "2.0"`.

Previously these malformed requests reached the handler and returned success:

```json
{"id":1,"method":"ping"}
{"jsonrpc":"1.0","id":1,"method":"ping"}
```

They now return `-32600 Invalid Request` and preserve a valid request id. Valid JSON-RPC 2.0 requests are unchanged, and valid notifications remain silent.

## Why

MCP uses JSON-RPC 2.0 framing. `Server.handle()` already validates the request id, method and params, but did not validate the required version member. The `Notification` TypedDict also described `jsonrpc` as an optional arbitrary string, so the typed shape and runtime shared the same gap.

This change makes the typed request shape `Literal["2.0"]` and enforces that same requirement at dispatch.

## Tests

Added `tests/test_mcp_jsonrpc_version.py` covering:

- missing `jsonrpc`
- `jsonrpc: "1.0"`
- non-string version values
- a valid `"2.0"` request
- valid notification silence

The regression cases fail on `main` because malformed pings currently return success.

## Compatibility and abuse impact

No HTTP route, parameter, storage, or other public Technocore surface changes. This only tightens malformed MCP/JSON-RPC input; conforming clients already send `"jsonrpc": "2.0"`.

No new abuse surface.