### PR TITLE
Add pure-Python Ed25519 fallback for scripts/sign.py (fixes #417)

### DIFF
--- a/scripts/_ed25519_fallback.py
+++ b/scripts/_ed25519_fallback.py
@@ -1,0 +1,145 @@
+"""Pure stdlib Ed25519 (RFC 8032), used only when `cryptography` cannot be
+imported — e.g. environments with no working C-extension build (PEP 723's
+`uv run` requires a package manager and a working wheel; some sandboxes,
+like a-Shell on iOS, have neither).
+
+This implements exactly the reference algorithm specified in RFC 8032 §5.1
+(key generation and signing over edwards25519), using only `hashlib` from
+the standard library. Ed25519 is deterministic, so for a given seed and
+message this produces byte-identical output to any other correct
+implementation — verified in tests/test_ed25519_fallback.py against:
+  - RFC 8032 §7.1 test vectors 1 and 2
+  - direct comparison against `cryptography`'s output for random seeds
+  - round-trip verification through this repo's own src/didkey.py (nacl)
+
+Intentionally minimal: this exists to keep the signed lane reachable when
+`cryptography` is not installable, not to replace it as the default path.
+"""
+from __future__ import annotations
+
+import hashlib
+
+_B = 256
+_Q = 2**255 - 19
+_L = 2**252 + 27742317777372353535851937790883648493
+
+
+def _H(m: bytes) -> bytes:
+    return hashlib.sha512(m).digest()
+
+
+def _expmod(base: int, e: int, m: int) -> int:
+    if e == 0:
+        return 1
+    t = _expmod(base, e // 2, m) ** 2 % m
+    if e & 1:
+        t = (t * base) % m
+    return t
+
+
+def _inv(x: int) -> int:
+    return _expmod(x, _Q - 2, _Q)
+
+
+_D = -121665 * _inv(121666) % _Q
+_I = _expmod(2, (_Q - 1) // 4, _Q)
+
+
+def _xrecover(y: int) -> int:
+    xx = (y * y - 1) * _inv(_D * y * y + 1)
+    x = _expmod(xx, (_Q + 3) // 8, _Q)
+    if (x * x - xx) % _Q != 0:
+        x = (x * _I) % _Q
+    if x % 2 != 0:
+        x = _Q - x
+    return x
+
+
+_BY = 4 * _inv(5)
+_BX = _xrecover(_BY)
+_BASE = (_BX % _Q, _BY % _Q)
+
+
+def _edwards(P: tuple[int, int], Q: tuple[int, int]) -> tuple[int, int]:
+    x1, y1 = P
+    x2, y2 = Q
+    x3 = (x1 * y2 + x2 * y1) * _inv(1 + _D * x1 * x2 * y1 * y2)
+    y3 = (y1 * y2 + x1 * x2) * _inv(1 - _D * x1 * x2 * y1 * y2)
+    return (x3 % _Q, y3 % _Q)
+
+
+def _scalarmult(P: tuple[int, int], e: int) -> tuple[int, int]:
+    if e == 0:
+        return (0, 1)
+    Qp = _scalarmult(P, e // 2)
+    Qp = _edwards(Qp, Qp)
+    if e & 1:
+        Qp = _edwards(Qp, P)
+    return Qp
+
+
+def _encodeint(y: int) -> bytes:
+    bits = [(y >> i) & 1 for i in range(_B)]
+    return bytes(
+        sum(bits[i * 8 + j] << j for j in range(8)) for i in range(_B // 8)
+    )
+
+
+def _encodepoint(P: tuple[int, int]) -> bytes:
+    x, y = P
+    bits = [(y >> i) & 1 for i in range(_B - 1)] + [x & 1]
+    return bytes(
+        sum(bits[i * 8 + j] << j for j in range(8)) for i in range(_B // 8)
+    )
+
+
+def _bit(h: bytes, i: int) -> int:
+    return (h[i // 8] >> (i % 8)) & 1
+
+
+def _clamped_scalar(seed_hash: bytes) -> int:
+    return 2 ** (_B - 2) + sum(2**i * _bit(seed_hash, i) for i in range(3, _B - 2))
+
+
+def _hint(m: bytes) -> int:
+    h = _H(m)
+    return sum(2**i * _bit(h, i) for i in range(2 * _B))
+
+
+class Ed25519PublicKey:
+    def __init__(self, raw: bytes):
+        self._raw = raw
+
+    def public_bytes_raw(self) -> bytes:
+        return self._raw
+
+
+class Ed25519PrivateKey:
+    """Drop-in replacement for the two
+    `cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PrivateKey`
+    methods sign.py actually uses: `from_private_bytes`, `.sign`, and
+    `.public_key().public_bytes_raw()`.
+    """
+
+    def __init__(self, seed: bytes):
+        if len(seed) != 32:
+            raise ValueError("Ed25519 seed must be exactly 32 bytes")
+        self._seed = seed
+        h = _H(seed)
+        a = _clamped_scalar(h)
+        self._a = a
+        self._prefix = h[_B // 8 : _B // 4]
+        self._public_raw = _encodepoint(_scalarmult(_BASE, a))
+
+    @classmethod
+    def from_private_bytes(cls, data: bytes) -> "Ed25519PrivateKey":
+        return cls(data)
+
+    def public_key(self) -> Ed25519PublicKey:
+        return Ed25519PublicKey(self._public_raw)
+
+    def sign(self, message: bytes) -> bytes:
+        r = _hint(self._prefix + message)
+        R = _scalarmult(_BASE, r)
+        S = (r + _hint(_encodepoint(R) + self._public_raw + message) * self._a) % _L
+        return _encodepoint(R) + _encodeint(S)

--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -54,7 +54,15 @@ import re
 import secrets
 import unicodedata
 
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+try:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+except BaseException:
+    # BaseException, not Exception: cryptography's C extension can fail in ways
+    # that don't subclass Exception (e.g. a pyo3 PanicException on some builds),
+    # and environments with no working package manager for it at all (no pip, no
+    # uv — e.g. a-Shell on iOS) also need to land here. cryptography stays the
+    # default, fast path; this is only reached when it's genuinely unusable.
+    from _ed25519_fallback import Ed25519PrivateKey
 
 PREFIX = "did:key:z6Mk"  # multibase 'z' + the fixed ed25519-pub prefix base58-encodes to z6Mk
 MULTICODEC_ED25519 = b"\xed\x01"  # varint ed25519-pub, the two bytes every z6Mk key decodes from

--- a/tests/test_ed25519_fallback.py
+++ b/tests/test_ed25519_fallback.py
@@ -1,0 +1,104 @@
+"""Verify scripts/_ed25519_fallback.py against RFC 8032 test vectors,
+against `cryptography` (byte-for-byte), and against this repo's own
+server-side verifier (src/didkey.py)."""
+import base64
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from _ed25519_fallback import Ed25519PrivateKey as FallbackKey  # noqa: E402
+
+# RFC 8032 §7.1 — Test Vectors, entries 1 and 2 (secret key, public key, message, signature)
+# Straight from RFC 8032 https://www.rfc-editor.org/rfc/rfc8032.txt Section 7.1,
+# Test 1 and Test 2, with the RFC's line-wrapped hex concatenated back together.
+RFC8032_VECTORS = [
+    (
+        "9d61b19deffd5a60ba844af492ec2cc4" "4449c5697b326919703bac031cae7f60",
+        "d75a980182b10ab7d54bfed3c964073a" "0ee172f3daa62325af021a68f707511a",
+        "",
+        "e5564300c360ac729086e2cc806e828a" "84877f1eb8e5d974d873e06522490155"
+        "5fb8821590a33bacc61e39701cf9b46b" "d25bf5f0595bbe24655141438e7a100b",
+    ),
+    (
+        "4ccd089b28ff96da9db6c346ec114e0f" "5b8a319f35aba624da8cf6ed4fb8a6fb",
+        "3d4017c3e843895a92b70aa74d1b7ebc" "9c982ccf2ec4968cc0cd55f12af4660c",
+        "72",
+        "92a009a9f0d4cab8720e820b5f642540" "a2b27b5416503f8fb3762223ebdb69da"
+        "085ac1e43e15996e458f3613d0f11d8c" "387b2eaeb4302aeeb00d291612bb0c00",
+    ),
+]
+
+
+def test_rfc8032_vectors():
+    for seed_hex, pub_hex, msg_hex, sig_hex in RFC8032_VECTORS:
+        seed = bytes.fromhex(seed_hex)
+        message = bytes.fromhex(msg_hex)
+        key = FallbackKey.from_private_bytes(seed)
+        assert key.public_key().public_bytes_raw().hex() == pub_hex, "public key mismatch"
+        assert key.sign(message).hex() == sig_hex, "signature mismatch"
+    print("PASS: RFC 8032 test vectors 1-2")
+
+
+def test_matches_cryptography_library():
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PrivateKey as RealKey,
+        )
+    except BaseException:
+        print("SKIP: cryptography not importable in this environment")
+        return
+
+    import secrets
+
+    for _ in range(20):
+        seed = secrets.token_bytes(32)
+        message = secrets.token_bytes(secrets.randbelow(200))
+        real = RealKey.from_private_bytes(seed)
+        fake = FallbackKey.from_private_bytes(seed)
+        assert (
+            real.public_key().public_bytes_raw() == fake.public_key().public_bytes_raw()
+        ), "public key differs from cryptography"
+        assert real.sign(message) == fake.sign(message), "signature differs from cryptography"
+    print("PASS: 20 random cases match `cryptography` byte-for-byte")
+
+
+def test_verifies_against_server_didkey():
+    import didkey  # noqa: E402
+
+    def multibase_encode(raw: bytes) -> str:
+        b58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+        n = int.from_bytes(raw, "big")
+        out = ""
+        while n:
+            n, rem = divmod(n, 58)
+            out = b58[rem] + out
+        return out
+
+    import secrets
+
+    seed = secrets.token_bytes(32)
+    key = FallbackKey.from_private_bytes(seed)
+    pub_raw = key.public_key().public_bytes_raw()
+    did = "did:key:z" + multibase_encode(b"\xed\x01" + pub_raw)
+
+    message = "lobby|1|hello from the fallback signer"
+    sig_raw = key.sign(message.encode("utf-8"))
+    sig_b64url = base64.urlsafe_b64encode(sig_raw).decode().rstrip("=")
+
+    didkey.verify(did, sig_b64url, message)  # raises on failure
+    print("PASS: server's own didkey.verify() accepts a fallback-signed message")
+
+    try:
+        didkey.verify(did, sig_b64url, message + " tampered")
+        raise AssertionError("tampered message should have been rejected")
+    except didkey.SignatureError:
+        print("PASS: server's own didkey.verify() rejects a tampered message")
+
+
+if __name__ == "__main__":
+    test_rfc8032_vectors()
+    test_matches_cryptography_library()
+    test_verifies_against_server_didkey()
+    print("\nAll tests passed.")


### PR DESCRIPTION
Fixes #417.

## What
Adds `scripts/_ed25519_fallback.py`, a pure-stdlib Ed25519 implementation (RFC 8032 §5.1), used only when `cryptography` cannot be imported. `sign.py`'s existing CLI, canonicalization, and output format are completely unchanged — this only swaps the signing backend when necessary.

## Why
`sign.py` currently hard-depends on `cryptography` via its PEP 723 header. In environments with no working package manager or C-extension build (a-Shell on iOS, some hardened/read-only containers), the signed lane is entirely unreachable — even though Ed25519 itself needs only `hashlib` and integer arithmetic.

The import guard catches `BaseException`, not `Exception`, since `cryptography`'s C extension can fail in ways that don't subclass `Exception` (the `pyo3 PanicException` case reported in #417) — a narrower catch would miss the exact failure this fixes.

## Testing
`tests/test_ed25519_fallback.py` covers, per the maintainer's guidance in #417:
- RFC 8032 §7.1 Test Vectors 1 and 2, taken directly from the RFC text
- 20 random seed/message pairs, byte-for-byte identical to `cryptography`'s `Ed25519PrivateKey`
- Round-trip through this repo's own `src/didkey.py`: a fallback-signed message verifies successfully; a tampered message is correctly rejected

Also manually verified end-to-end: `scripts/sign.py did` and `scripts/sign.py say` produce byte-for-byte identical output for the same seed, whether `cryptography` is installed or not (confirmed by temporarily uninstalling it and comparing output directly).

## Scope
Per the maintainer's note in #417, this is submitted standalone rather than bundled with unrelated work, given it's cryptographic code.