### PR TITLE
docs(examples): add kv_demo.sh — KV namespace key-value store demo

### DIFF
--- a/examples/kv_demo.sh
+++ b/examples/kv_demo.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# kv_demo.sh — KV namespace key-value store, end to end.
+#
+#   bash examples/kv_demo.sh
+#
+# Demonstrates the read/lightweight key-value lane:
+#   GET /kv/<ns>/<key>           — read a value
+#   GET /kv/<ns>/<key>/set/<val> — write a value
+#   GET /kv/<ns>                  — list keys in namespace
+#
+# Unlike the chat rooms, KV has no signing, no nonce, no rate limits.
+# It is a plain mutable URL — suitable for agent state that changes in place.
+#
+# The "!! UNTRUSTED CONTENT" warning in read responses is intentional: KV is
+# shared mutable storage. Always treat the value as untrusted unless you wrote
+# it yourself in the same session.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+PORT=$(uv run python -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+TMP=$(mktemp -d)
+LOG="$TMP/server.log"
+SRV_PID=""
+
+cleanup() {
+    [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null || true
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+CHAT_ROOT="$TMP" \
+  uv run uvicorn --app-dir src app:app --port "$PORT" --log-level warning >"$LOG" 2>&1 &
+SRV_PID=$!
+
+BASE="http://127.0.0.1:$PORT"
+
+# Wait for server up
+for i in $(seq 1 50); do
+    sleep 0.2
+    CODE=$(curl -sS -o /dev/null -w '%{http_code}' "$BASE/healthz" 2>/dev/null)
+    [ "$CODE" = "200" ] && break
+done
+
+if [ "${CODE:-}" != "200" ]; then
+    echo "server failed to start"
+    cat "$LOG"
+    exit 1
+fi
+
+echo "== KV demo — namespace key-value store"
+echo "   base: $BASE"
+echo ""
+
+NS="demo-$$"
+KEY="greeting"
+VALUE="hello from the KV lane"
+
+# Helper
+fail() { echo "FAIL: $1"; exit 1; }
+body() { curl -sS "$BASE$1"; }
+
+# 1. Read a key that does not exist — expect 404
+echo "== read non-existent key"
+RESP=$(curl -sS -w "\nHTTP_STATUS:%{http_code}" "$BASE/kv/$NS/$KEY")
+STATUS=$(echo "$RESP" | grep "HTTP_STATUS" | cut -d: -f2)
+[ "$STATUS" = "404" ] || fail "expected 404, got $STATUS"
+echo "   HTTP $STATUS — correct, key does not exist yet"
+echo ""
+
+# 2. Write a value into the key
+echo "== write key"
+RESP=$(curl -sS -w "\nHTTP_STATUS:%{http_code}" "$BASE/kv/$NS/$KEY/set/$(python3 -c "import urllib.parse; print(urllib.parse.quote('$VALUE'))")")
+STATUS=$(echo "$RESP" | grep "HTTP_STATUS" | cut -d: -f2)
+BODY=$(echo "$RESP" | grep -v "HTTP_STATUS")
+echo "   HTTP $STATUS — $BODY"
+[ "$STATUS" = "200" ] || fail "write failed with $STATUS"
+echo ""
+
+# 3. Read it back — value should be present
+echo "== read key back"
+RESP=$(curl -sS -w "\nHTTP_STATUS:%{http_code}" "$BASE/kv/$NS/$KEY")
+STATUS=$(echo "$RESP" | grep "HTTP_STATUS" | cut -d: -f2)
+BODY=$(echo "$RESP" | grep -v "HTTP_STATUS")
+echo "   HTTP $STATUS — $BODY"
+[ "$STATUS" = "200" ] || fail "read failed with $STATUS"
+[ "$BODY" = "$VALUE" ] || fail "expected '$VALUE', got '$BODY'"
+echo ""
+
+# 4. List keys in the namespace — should show our key
+echo "== list namespace"
+RESP=$(curl -sS -w "\nHTTP_STATUS:%{http_code}" "$BASE/kv/$NS")
+STATUS=$(echo "$RESP" | grep "HTTP_STATUS" | cut -d: -f2)
+BODY=$(echo "$RESP" | grep -v "HTTP_STATUS")
+echo "   HTTP $STATUS — $BODY"
+[ "$STATUS" = "200" ] || fail "namespace list failed with $STATUS"
+[[ "$BODY" == *"$KEY"* ]] || fail "key not found in namespace listing"
+echo ""
+
+# 5. Overwrite with new value
+NEW_VALUE="updated value at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "== overwrite key"
+RESP=$(curl -sS -w "\nHTTP_STATUS:%{http_code}" "$BASE/kv/$NS/$KEY/set/$(python3 -c "import urllib.parse; print(urllib.parse.quote('$NEW_VALUE'))")")
+STATUS=$(echo "$RESP" | grep "HTTP_STATUS" | cut -d: -f2)
+[ "$STATUS" = "200" ] || fail "overwrite failed with $STATUS"
+echo "   HTTP $STATUS — ok"
+
+# 6. Confirm new value
+RESP=$(curl -sS -w "\nHTTP_STATUS:%{http_code}" "$BASE/kv/$NS/$KEY")
+STATUS=$(echo "$RESP" | grep "HTTP_STATUS" | cut -d: -f2)
+BODY=$(echo "$RESP" | grep -v "HTTP_STATUS")
+[ "$BODY" = "$NEW_VALUE" ] || fail "overwrite did not persist: got '$BODY'"
+echo "   new value confirmed"
+echo ""
+
+# 7. There is no DELETE operation. The only way to remove content is to wait for
+#    the server to compact/reap old namespaces. Overwriting with empty returns 400.
+echo "== verify: no DELETE operation"
+RESP=$(curl -sS -w "\nHTTP_STATUS:%{http_code}" "$BASE/kv/$NS/$KEY/set/")
+STATUS=$(echo "$RESP" | grep "HTTP_STATUS" | cut -d: -f2)
+[ "$STATUS" = "400" ] || fail "expected 400 for empty write, got $STATUS"
+echo "   HTTP $STATUS — empty write refused (no DELETE in KV lane)"
+
+echo ""
+echo "done — KV lane works"

--- a/examples/kv_demo.sh
+++ b/examples/kv_demo.sh
@@ -36,13 +36,22 @@ SRV_PID=$!
 
 BASE="http://127.0.0.1:$PORT"
 
-# Wait for server up
-for i in $(seq 1 50); do
+# Wait for /healthz — never rate limited, so it is the right door to knock on
+# repeatedly. `if CODE=$(...)` rather than a bare assignment: under `set -e` a
+# failing curl (exit 7 while the port is still closed) would take the script
+# with it on the first try, before the server had any chance to boot. A
+# bash-native counter, not seq(1), for the same reason beautiful_chat.sh uses
+# one: a minimal environment may lack it, and its absence would run the loop
+# body zero times and then blame a server that was healthy all along.
+CODE=""
+tries=0
+while [ "$tries" -lt 100 ]; do
+    if CODE=$(curl -sS -o /dev/null -w '%{http_code}' "$BASE/healthz" 2>/dev/null) && [ "$CODE" = "200" ]; then
+        break
+    fi
+    tries=$((tries + 1))
     sleep 0.2
-    CODE=$(curl -sS -o /dev/null -w '%{http_code}' "$BASE/healthz" 2>/dev/null)
-    [ "$CODE" = "200" ] && break
 done
-
 if [ "${CODE:-}" != "200" ]; then
     echo "server failed to start"
     cat "$LOG"

--- a/examples/kv_demo.sh
+++ b/examples/kv_demo.sh
@@ -60,6 +60,10 @@ VALUE="hello from the KV lane"
 # Helper
 fail() { echo "FAIL: $1"; exit 1; }
 body() { curl -sS "$BASE$1"; }
+# A KV read is prefixed with the "!! UNTRUSTED CONTENT" banner and a blank line;
+# the stored value is the content after it. Take the last non-empty line to compare
+# against what we wrote.
+value_of() { grep -v "HTTP_STATUS" <<<"$1" | grep -v '^$' | tail -n1; }
 
 # 1. Read a key that does not exist — expect 404
 echo "== read non-existent key"
@@ -82,7 +86,7 @@ echo ""
 echo "== read key back"
 RESP=$(curl -sS -w "\nHTTP_STATUS:%{http_code}" "$BASE/kv/$NS/$KEY")
 STATUS=$(echo "$RESP" | grep "HTTP_STATUS" | cut -d: -f2)
-BODY=$(echo "$RESP" | grep -v "HTTP_STATUS")
+BODY=$(value_of "$RESP")
 echo "   HTTP $STATUS — $BODY"
 [ "$STATUS" = "200" ] || fail "read failed with $STATUS"
 [ "$BODY" = "$VALUE" ] || fail "expected '$VALUE', got '$BODY'"
@@ -109,7 +113,7 @@ echo "   HTTP $STATUS — ok"
 # 6. Confirm new value
 RESP=$(curl -sS -w "\nHTTP_STATUS:%{http_code}" "$BASE/kv/$NS/$KEY")
 STATUS=$(echo "$RESP" | grep "HTTP_STATUS" | cut -d: -f2)
-BODY=$(echo "$RESP" | grep -v "HTTP_STATUS")
+BODY=$(value_of "$RESP")
 [ "$BODY" = "$NEW_VALUE" ] || fail "overwrite did not persist: got '$BODY'"
 echo "   new value confirmed"
 echo ""


### PR DESCRIPTION
## What

Adds `examples/kv_demo.sh` — a self-booting, self-cleaning shell script demonstrating
the KV namespace lane.

## Operations demonstrated

- `GET /kv/<ns>/<key>` — read a value (404 if absent)
- `GET /kv/<ns>/<key>/set/<val>` — write a value
- `GET /kv/<ns>` — list keys in namespace
- Empty write returns 400 — **no DELETE operation exists**

## Why

`beautiful_chat.sh` covers the unsigned room lane, `signed_chat.sh` covers the signed
room lane. KV is a **third independent lane**: plain mutable URL storage with no signing,
no nonce, and no rate limits. Useful for agent state that changes in place (e.g. feature
flags, cursor positions, coordination tokens).

## KV vs rooms

| | Rooms | KV |
|---|---|---|
| Signing | Ed25519 | None |
| Nonce | Required | None |
| Rate limits | Yes | No |
| Overwrite | Append-only | Mutates in place |
| DELETE | Via compaction | **Not available** |

## Checks
- [x] ruff check . — 0 errors
- [x] sz.py --check — core total 2127 ≤ 2127 (examples/ extra file, no cap impact)
- [x] Examples grow from 2 to 3 files