### PR TITLE
docs(patterns): give pattern 4 the HKDF parameters it needs

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -48,16 +48,23 @@ Server involvement: zero. It stores ciphertext, serves ciphertext, never sees a 
       2. publish the DID note (pattern 3) with the X25519 public key and a mailbox name
     B (sender):
       3. fetch A's note; make an EPHEMERAL X25519 keypair
-      4. shared = HKDF-SHA256(X25519(eph_priv, A_static_pub), info="technocore-e2e-v1")
+      4. shared = HKDF-SHA256(X25519(eph_priv, A_static_pub), salt=empty, length=32,
+                             info="technocore-e2e-v1")
       5. pick a fresh 32-byte room key K and a room name p-<unguessable>
       6. sealed = AESGCM(shared).encrypt(nonce12, K || room_name)
       7. deliver to A's mailbox through the signed lane, one line:
              e2e1 <eph_pub_b64url> <nonce12_b64url> <sealed_b64url>
-         where sealed = AESGCM(HKDF-SHA256(X25519(eph, A_static), info=technocore-e2e-v1)).encrypt(nonce12, K || room_name)
+         where sealed is step 6 and shared is step 4
     A: reverse steps 4-6 with its static private key and B's ephemeral public key;
        recover K and the room name.
     Both: write AESGCM(K) ciphertext lines into the p- room (no AAD):
              <nonce12_b64url>.<ct_b64url>
+
+An empty salt is RFC 5869's default and is the same key as 32 zero bytes, because HMAC
+zero-pads a key shorter than its block size; a library that spells the default `salt=None`
+already does this. nonce12 must be fresh for every encryption under a given key -- the
+fixture in the test suite is a constant only because a test has to be deterministic, and
+reusing one costs both confidentiality and authenticity.
 
 Mailbox-notify convention (not a server feature): if you published mailbox:, long-poll that
 room with ?since=<last_seq>&wait=10 (wait= only takes effect together with a real since=).


### PR DESCRIPTION
Pattern 4 gives the HKDF info string but not its length or salt. Both are needed to reach the same key, so an implementer working from `patterns.md` alone derives something the counterpart cannot open — and AES-GCM fails closed, so the only symptom is a write that does not verify, with nothing to say why.

The values exist, in `test_the_e2e_pattern_round_trips_within_the_caps`:

```python
HKDF(algorithm=hashes.SHA256(), length=32, salt=None, info=b"technocore-e2e-v1")
```

That is the one place a second implementation is least likely to look, and the file itself says the executable version lives there — which reads as "the test is the reference" rather than "the test holds parameters the prose omits".

I hit this writing a Node implementation of pattern 4 and only resolved it by reading the test.

## What changed

- Step 4 states `salt=empty, length=32` alongside the info string.
- A note explains that an empty salt and 32 zero bytes are the same key, because HMAC zero-pads a key shorter than its block size. A reader coming from a library that spells the default `salt=None` otherwise has to derive that to be sure the two agree.
- Step 7 restated the whole derivation inline. Two copies of one formula drift, so it now points at step 4.
- A line on `nonce12`. The fixture is a constant because a test has to be deterministic; copied into real code it reuses a nonce under one AES-GCM key, which costs confidentiality and authenticity at once. Worth naming at the place it will be copied from.

## Verification

Documentation only — no behaviour change.

```
uv run pytest -q      459 passed
uv run ruff check .   All checks passed!
uv run ruff format --check .   61 files already formatted
```

No test asserts the lines this touches; the strings pinned in `tests/http/test_rooms.py` are in pattern 5 and are untouched.