### PR TITLE
docs(openapi): name the URL budget on the note value param (#362)

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -108,7 +108,23 @@ _SIG_SCHEMA = {
 # category folding", and a constraint that is true of every rejected input is worth more
 # than no constraint at all.
 _TEXT_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_TEXT_CHARS}
-_VALUE_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_VALUE_CHARS}
+# Note values ride in the URL path on the GET write lanes, so the real ceiling is the
+# edge URL budget (the same ~16 KB that bounds a message), not this character cap — and
+# it is the binding limit. The say lanes' `text` param already names the POST escape for
+# long non-Latin text (#76); the note `value` param must too, or a generated client that
+# trusts `maxLength` as the size contract builds a call that fails opaquely at the edge.
+# Generated from the enforced cap so it cannot drift (twin of #76 on the note side, #362).
+_VALUE_SCHEMA = {
+    "type": "string",
+    "minLength": 1,
+    "maxLength": store.MAX_VALUE_CHARS,
+    "description": (
+        f"Note body, <= {store.MAX_VALUE_CHARS} characters. It travels in the URL, so the "
+        f"real bound is the edge URL budget (~16 KiB), not this count; a value that fits "
+        f"here but exceeds the budget fails at the proxy with no body. For long non-Latin "
+        f"text, use POST /kv/{{ns}}/{{key}} instead of the GET write lane."
+    ),
+}
 
 _NONCE_SCHEMA = {
     "type": "string",

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1456,3 +1456,26 @@ def test_only_a_negotiating_document_says_vary_and_markdown_is_never_cached(clie
     with config.override(STATIC_CACHE_SECONDS=0):
         for path in ("/", "/llms.txt", "/skill.md", "/robots.txt"):
             assert client.get(path).headers["cache-control"] == "no-store", path
+
+
+def test_note_value_param_documents_the_url_budget_not_just_maxlength(client):
+    """Note values ride in the URL on the GET write lanes, so the binding limit is the edge
+    URL budget, not `maxLength`. A generated client that trusts `maxLength` as the size
+    contract would build a call that fails opaquely at the proxy for a value the schema
+    says is valid (#362, the note-side twin of #76). Both GET note write lanes must name
+    the real bound and the POST escape, or the contract lies about what fits."""
+    import manifest
+
+    doc = client.get("/openapi.json").json()
+    ops = {op["operationId"]: op for path in doc["paths"].values() for op in path.values()}
+    for op_id in ("writeNote", "writeNoteSigned"):
+        op = ops[op_id]
+        value = next(p for p in op["parameters"] if p["name"] == "value")
+        desc = value["schema"].get("description", "")
+        assert desc, f"{op_id} value param has no description"
+        assert "URL" in desc, f"{op_id} value description does not name the URL budget: {desc!r}"
+        assert "POST" in desc, f"{op_id} value description does not name the POST escape: {desc!r}"
+    # the cap in the prose must match the enforced one (no drift)
+    set_op = doc["paths"]["/kv/{ns}/{key}/set/{value}"]["get"]
+    set_desc = next(p for p in set_op["parameters"] if p["name"] == "value")["schema"]["description"]
+    assert str(manifest.store.MAX_VALUE_CHARS) in set_desc


### PR DESCRIPTION
Fixes #362

Name the URL budget on the note value param in the OpenAPI spec.

## What

The OpenAPI manifest now documents the byte budget that applies to the note value parameter.

## Why

Issue #362. The budget was enforced at runtime but unnamed in the spec, making it hard for API consumers to discover.

## Checks

- [ ] `uv run coverage run -m pytest tests -q && uv run coverage report`
- [ ] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [ ] Docs that would now be wrong are updated: src/patterns.md
- [ ] New surface on a world-writable service: nothing new