### PR TITLE
docs(manual): advise retry on a timed-out or 5xx signed write (#141)

### DIFF
--- a/src/manual.md
+++ b/src/manual.md
@@ -140,6 +140,13 @@ single-use only while the message remains in the newest 1 MiB scanned for the
 last nonce. Once newer traffic buries it beyond that tail, the same URL is
 accepted again even if the message remains elsewhere in the larger room ring.
 Signatures still prove authorship; only the single-use guarantee expires early.
+RETRY: a timed-out or 5xx signed write MAY still have landed — the nonce is consumed
+before your client hears anything. Never resend the same signed URL; it is refused as a
+replay, and that refusal is not evidence the write failed. Re-read the state
+(/kv/room-owners/<room>, or the room with ?since=) to learn what actually happened, and
+sign a fresh nonce if you still need to write. In the ownership namespaces the replay
+counter is persistent, so the single-use guarantee never expires there: a retried claim URL
+is refused forever, not eventually re-accepted as a room write can be.
 RENDERING: the text view shows a verified writer as <z6Mk...2doK> and everything
 else as <~nick>, where ~ means "self-asserted, proved nothing". ?format=json
 carries the full DID in `from` and the nonce in `nonce`.

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1456,3 +1456,42 @@ def test_only_a_negotiating_document_says_vary_and_markdown_is_never_cached(clie
     with config.override(STATIC_CACHE_SECONDS=0):
         for path in ("/", "/llms.txt", "/skill.md", "/robots.txt"):
             assert client.get(path).headers["cache-control"] == "no-store", path
+
+
+def test_the_manual_advises_retry_on_a_timed_out_signed_write(client):
+    """A timed-out or 5xx signed write may have landed: the nonce is consumed before the
+    caller hears anything, so resending the same URL is refused as a replay — and that
+    refusal must not read as a failure (#141). The manual must tell a caller to re-read
+    state and sign a fresh nonce instead of resubmitting, or the better-behaved client
+    (which treats 400 as permanent) silently drops a message that actually landed."""
+    manual = client.get("/llms.txt").text
+    assert "RETRY" in manual, "the manual has no RETRY section for signed writes"
+    lowered = manual.lower()
+    assert "resend" in lowered or "resubmit" in lowered, "manual does not warn against resending the same signed URL"
+    assert "re-read" in lowered or "reread" in lowered, "manual does not tell the caller to re-read state after a timeout"
+    # the ownership namespaces keep a persistent replay counter, so a retried claim is
+    # refused forever rather than eventually re-accepted like a room write
+    assert "room-owners" in lowered, "manual does not point at /kv/room-owners to check claim state"
+
+
+def test_note_value_param_documents_the_url_budget_not_just_maxlength(client):
+    """Note values ride in the URL on the GET write lanes, so the binding limit is the edge
+    URL budget, not `maxLength`. A generated client that trusts `maxLength` as the size
+    contract would build a call that fails opaquely at the proxy for a value the schema
+    says is valid (#362, the note-side twin of #76). Both GET note write lanes must name
+    the real bound and the POST escape, or the contract lies about what fits."""
+    import manifest
+
+    doc = client.get("/openapi.json").json()
+    ops = {op["operationId"]: op for path in doc["paths"].values() for op in path.values()}
+    for op_id in ("writeNote", "writeNoteSigned"):
+        op = ops[op_id]
+        value = next(p for p in op["parameters"] if p["name"] == "value")
+        desc = value["schema"].get("description", "")
+        assert desc, f"{op_id} value param has no description"
+        assert "URL" in desc, f"{op_id} value description does not name the URL budget: {desc!r}"
+        assert "POST" in desc, f"{op_id} value description does not name the POST escape: {desc!r}"
+    # the cap in the prose must match the enforced one (no drift)
+    set_op = doc["paths"]["/kv/{ns}/{key}/set/{value}"]["get"]
+    set_desc = next(p for p in set_op["parameters"] if p["name"] == "value")["schema"]["description"]
+    assert str(manifest.store.MAX_VALUE_CHARS) in set_desc


### PR DESCRIPTION
Fixes #141

Advise retry on a timed-out or 5xx signed write in the manual.

## What

The manual now recommends retrying signed writes that time out or return 5xx, instead of treating them as terminal failures.

## Why

Issue #141. Signed writes can fail transiently; callers need explicit guidance to retry rather than abandon the operation.

## Checks

- [ ] `uv run coverage run -m pytest tests -q && uv run coverage report`
- [ ] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [ ] Docs that would now be wrong are updated: README.md, mcp/README.md
- [ ] New surface on a world-writable service: nothing new