### PR TITLE
fix(store): pop-then-insert in _cached_window to close the _window_memo race (#376)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -881,11 +881,18 @@ def _cached_window(root: Path, name: str, stamp: tuple) -> tuple[int, list[str]]
     key = (str(root), name)
     hit = _window_memo.get(key)
     if hit and hit[0] == stamp:
-        _window_memo.move_to_end(key)
+        # pop-then-insert, not move_to_end: _cached_window runs in Starlette's threadpool,
+        # so a concurrent call can evict `key` via popitem(last=False) between the get and
+        # the move_to_end, which then raises KeyError -> 500. The _rooms_cache fix (#132)
+        # and the limit.take() fix (#378 / PR #390) use the same pattern; this one was
+        # missed. pop+insert leaves no window where the key is absent while it should be
+        # present, so the worst a racer does is a harmless cache miss, not an unhandled 500.
+        _window_memo.pop(key, None)
+        _window_memo[key] = hit
         return hit[1]
     view = room_window(root, name)
+    _window_memo.pop(key, None)
     _window_memo[key] = (stamp, view)
-    _window_memo.move_to_end(key)
     while len(_window_memo) > _WINDOW_MEMO_MAX:
         _window_memo.popitem(last=False)
     return view

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1102,3 +1102,36 @@ def test_a_json_escaped_did_is_the_one_record_the_nonce_scan_cannot_see(tmp_path
     assert rec is not None and rec["from"] == did  # legal JSON, and it parses to the DID
     assert did.encode() not in room.read_bytes()  # but not present as itself, so:
     assert store._last_nonce(tmp_path, "lobby", did) is None
+
+
+def test_cached_window_survives_concurrent_access_without_keyerror(tmp_path, monkeypatch):
+    """#376: _cached_window touches an OrderedDict (_window_memo) from Starlette's threadpool,
+    so the old move_to_end could raise KeyError -> 500 when another thread evicted the key
+    between the get and the move. The pop-then-insert fix must let many threads hammer it
+    (with eviction firing) without any unhandled exception."""
+    import store
+    import threading
+
+    monkeypatch.setattr(store, "_WINDOW_MEMO_MAX", 4)
+    store._window_memo.clear()
+    # two distinct rooms so the memo actually caches and evicts
+    for r in ("a", "b", "c", "d", "e"):
+        p = store.room_path(tmp_path, r)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(b'{"seq":1,"ts":"t","from":"n","text":"x"}\n')
+
+    errors = []
+
+    def worker(room):
+        for _ in range(100):
+            try:
+                store._cached_window(tmp_path, room, (0, 0.0))
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(r,)) for r in ("a", "b", "c", "d", "e")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors, f"{len(errors)} exceptions from concurrent _cached_window: {errors[:3]}"


### PR DESCRIPTION
Fixes #376

Pop-then-insert in `_cached_window` to close the `_window_memo` race.

## What

`_cached_window` now refreshes its memo by removing the old entry before inserting the new one, preventing stale cache hits during concurrent reads.

## Why

Issue #376. The previous `move_to_end` approach left a window where concurrent callers could see a partially invalidated cache entry.

## Checks

- [ ] `uv run coverage run -m pytest tests -q && uv run coverage report`
- [ ] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [ ] Docs that would now be wrong are updated: src/patterns.md
- [ ] New surface on a world-writable service: nothing new