### PR TITLE
perf(store): cache unicodedata.category() in clean_text (#322)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -388,6 +388,11 @@ def ownable(name: str) -> bool:
 INVISIBLE_CATEGORIES = ("Cc", "Cf", "Cs", "Co", "Zl", "Zp")
 
 
+@lru_cache(maxsize=4096)
+def _category(c: str) -> str:
+    return unicodedata.category(c)
+
+
 def clean_text(text: str, limit: int = MAX_TEXT_CHARS) -> str:
     """Replace every character in INVISIBLE_CATEGORIES with a space, then trim.
 
@@ -398,7 +403,7 @@ def clean_text(text: str, limit: int = MAX_TEXT_CHARS) -> str:
     Mangled emoji is visible and harmless; a smuggled instruction is neither.
     """
     text = "".join(
-        " " if unicodedata.category(c) in INVISIBLE_CATEGORIES else c for c in text
+        " " if _category(c) in INVISIBLE_CATEGORIES else c for c in text
     ).strip()
     if not text:
         # Distinguishing "you sent nothing" from "the sweep ate all of it" matters: the

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1102,3 +1102,42 @@ def test_a_json_escaped_did_is_the_one_record_the_nonce_scan_cannot_see(tmp_path
     assert rec is not None and rec["from"] == did  # legal JSON, and it parses to the DID
     assert did.encode() not in room.read_bytes()  # but not present as itself, so:
     assert store._last_nonce(tmp_path, "lobby", did) is None
+
+
+def test_clean_text_is_identical_with_the_cached_category_lookup():
+    """#322: clean_text called unicodedata.category() per character; caching it on a hot
+    write path is a pure micro-optimisation with no behavioural change. Pin that the output
+    is byte-for-byte identical to a fresh, uncached sweep for ASCII, multibyte, zero-width
+    and emoji inputs."""
+    import store
+    import unicodedata
+
+    cases = [
+        "hello world",
+        "café déjà vu",
+        "ếớựữậ",                       # dense Vietnamese, multi-byte
+        "normal text with a ​ zero-width space",  # ZWSP is in INVISIBLE_CATEGORIES
+        "👨‍👩‍👧 family",                 # ZWJ sequence flattens
+        "tab\tand\nnewline",
+    ]
+    for s in cases:
+        out = store.clean_text(s)
+        # rebuild uncached to compare
+        manual = "".join(
+            " " if unicodedata.category(c) in store.INVISIBLE_CATEGORIES else c for c in s
+        ).strip()
+        assert out == manual, f"cached sweep diverged on {s!r}: {out!r} != {manual!r}"
+
+
+def test_clean_text_category_lookup_is_cached_on_repeat_chars():
+    """#322: the per-character category must come from a cache, not a fresh unicodedata call
+    each time. We can't easily monkeypatch unicodedata, but we can assert the cache is warm
+    and returns the same object for repeated code points."""
+    import store
+
+    store._category.cache_clear()
+    a = store._category("é")
+    b = store._category("é")
+    assert a is b, "repeated code point should hit the lru_cache"
+    assert store._category.cache_info().hits >= 1, "cache should register a hit"
+    store._category.cache_clear()


### PR DESCRIPTION
Fixes #322

Cache `unicodedata.category()` in `clean_text` to reduce per-call overhead.

## What

`clean_text` now reuses a local category lookup instead of calling into `unicodedata` on every character.

## Why

Issue #322. The hot path in `clean_text` was repeatedly invoking `unicodedata.category()` for common ASCII characters.

## Checks

- [ ] `uv run coverage run -m pytest tests -q && uv run coverage report`
- [ ] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [ ] Docs that would now be wrong are updated: none
- [ ] New surface on a world-writable service: nothing new