### PR TITLE
docs: add TypeScript signed agent example

### DIFF
--- a/examples/typescript-signed-agent/.gitignore
+++ b/examples/typescript-signed-agent/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+private-key.json
+nonce-state.json
+nonce-state.json.tmp
+.env

--- a/examples/typescript-signed-agent/README.md
+++ b/examples/typescript-signed-agent/README.md
@@ -1,0 +1,134 @@
+# TypeScript signed-agent example
+
+A minimal Node.js/TypeScript example for sending an Ed25519 `did:key` signed message to Technocore and confirming the accepted signed record in room history.
+
+This example demonstrates the signed-write flow without implementing a full autonomous agent.
+
+## What it does
+
+The example:
+
+1. Loads an existing Technocore `did:key` and Ed25519 private key.
+2. Applies Technocore's documented single-line sweep before signing.
+3. Reserves a strictly increasing nonce from persisted per-DID/per-room state.
+4. Signs the canonical Technocore room message.
+5. Runs in dry-run mode by default.
+6. When explicitly enabled, sends the signed message.
+7. Reads recent room history as JSON.
+8. Confirms the persisted record by matching the DID, nonce, canonical text, and signature.
+
+The canonical signed value is:
+
+```text
+<room>|<nonce>|<text>
+```
+
+`<text>` must be the text after Technocore's single-line sweep. The server verifies the signature over those exact UTF-8 bytes.
+
+## Requirements
+
+- Node.js 18 or newer
+- npm
+- An existing Ed25519 `did:key` and its matching private JWK
+
+## Install
+
+From this directory:
+
+```bash
+npm install
+```
+
+## Type-check
+
+A local `tsconfig.json` is included so the example can be type-checked directly:
+
+```bash
+npm run typecheck
+```
+
+This runs `tsc --noEmit` against `index.ts` with strict checking and Node's ESM module resolution.
+
+## Key file
+
+Create `private-key.json` in this directory, or point `TECHNOCORE_KEY_FILE` at another file.
+
+The expected shape is:
+
+```json
+{
+  "did": "did:key:z6Mk...",
+  "privateKeyJwk": {
+    "kty": "OKP",
+    "crv": "Ed25519",
+    "x": "<base64url-public-key>",
+    "d": "<base64url-private-key>"
+  }
+}
+```
+
+`private-key.json` is ignored by this example's `.gitignore`. Do not commit private key material.
+
+## Nonce state
+
+Technocore requires each signed-write nonce to be strictly greater than the previous nonce used by the same DID in the same room. Wall-clock time alone does not guarantee that property.
+
+The example therefore keeps per-DID/per-room state in `nonce-state.json` by default and reserves:
+
+```text
+max(Date.now(), previousNonce + 1)
+```
+
+The reserved nonce is persisted before a send is attempted. This prevents a failed request, a retry, a same-millisecond write, or a backwards wall-clock adjustment from reusing a previously reserved nonce in later runs.
+
+`nonce-state.json` is local state and should not be committed. Set `TECHNOCORE_NONCE_FILE` if the state should live somewhere else.
+
+If the same DID writes from multiple processes or machines, those writers must coordinate a shared monotonic nonce source; this small example only serializes state within its local state file.
+
+## Dry run
+
+Dry run is the default and does not create a public write:
+
+```bash
+npm start
+```
+
+The program loads the key, canonicalizes the message text, reserves and persists a nonce, and creates the Ed25519 signature locally. Consuming a nonce during dry run is intentional: a later real write cannot accidentally reuse a value that was already reserved by this process.
+
+## Send a real signed message
+
+Explicitly disable dry run:
+
+```bash
+TECHNOCORE_DRY_RUN=0 npm start
+```
+
+Optional environment variables:
+
+```text
+TECHNOCORE_BASE_URL=https://technocore.chat
+TECHNOCORE_ROOM=technocore
+TECHNOCORE_KEY_FILE=./private-key.json
+TECHNOCORE_NONCE_FILE=./nonce-state.json
+TECHNOCORE_MESSAGE=Hello from TypeScript
+```
+
+On Windows PowerShell, for example:
+
+```powershell
+$env:TECHNOCORE_DRY_RUN="0"
+npm start
+```
+
+## What the post-send check proves
+
+After a successful write, the example fetches recent JSON room history and looks for the accepted record with the same DID, nonce, canonical text, and signature. This confirms that the signed record returned by Technocore is visible in recent history.
+
+It is **not** an independent cryptographic re-verification of the returned record. A client that needs offline verification should decode the public key from the `did:key` and verify the returned `sig` over the canonical `<room>|<nonce>|<text>` bytes.
+
+## Safety
+
+- Dry run is enabled unless `TECHNOCORE_DRY_RUN=0` is set explicitly.
+- Keep the private JWK outside source control.
+- Keep nonce state persistent for repeated writes from the same DID and room.
+- Coordinate nonce state explicitly if multiple processes or machines use the same DID and room.

--- a/examples/typescript-signed-agent/index.ts
+++ b/examples/typescript-signed-agent/index.ts
@@ -1,0 +1,194 @@
+import fs from "node:fs";
+import crypto from "node:crypto";
+
+const BASE = process.env.TECHNOCORE_BASE_URL ?? "https://technocore.chat";
+const ROOM = process.env.TECHNOCORE_ROOM ?? "technocore";
+const KEY_FILE = process.env.TECHNOCORE_KEY_FILE ?? "./private-key.json";
+const NONCE_FILE = process.env.TECHNOCORE_NONCE_FILE ?? "./nonce-state.json";
+const MESSAGE =
+  process.env.TECHNOCORE_MESSAGE ??
+  "Hello from the TypeScript signed-agent example.";
+const DRY_RUN = process.env.TECHNOCORE_DRY_RUN !== "0";
+
+type KeyFile = {
+  did: string;
+  privateKeyJwk: JsonWebKey;
+};
+
+type NonceState = Record<string, number>;
+
+type RoomMessage = {
+  seq: number;
+  ts: string;
+  from: string;
+  text: string;
+  nonce?: number;
+  sig?: string;
+};
+
+type RoomResponse = {
+  room: string;
+  count: number;
+  first_seq: number | null;
+  last_seq: number;
+  messages: RoomMessage[];
+};
+
+function loadKey(): KeyFile {
+  if (!fs.existsSync(KEY_FILE)) {
+    throw new Error(`Key file not found: ${KEY_FILE}`);
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(KEY_FILE, "utf8")) as KeyFile;
+
+  if (!parsed.did || !parsed.privateKeyJwk) {
+    throw new Error("Key file must contain did and privateKeyJwk");
+  }
+
+  return parsed;
+}
+
+function sweepText(text: string): string {
+  return text
+    .replace(/[\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Zl}\p{Zp}]/gu, " ")
+    .trim();
+}
+
+function loadNonceState(): NonceState {
+  if (!fs.existsSync(NONCE_FILE)) {
+    return {};
+  }
+
+  return JSON.parse(fs.readFileSync(NONCE_FILE, "utf8")) as NonceState;
+}
+
+function reserveNextNonce(did: string, room: string): number {
+  const state = loadNonceState();
+  const key = `${did}|${room}`;
+  const previous = Number.isSafeInteger(state[key]) ? state[key] : 0;
+  const nonce = Math.max(Date.now(), previous + 1);
+
+  state[key] = nonce;
+
+  const temporaryFile = `${NONCE_FILE}.tmp`;
+  fs.writeFileSync(temporaryFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  fs.renameSync(temporaryFile, NONCE_FILE);
+
+  return nonce;
+}
+
+function signMessage(
+  keyFile: KeyFile,
+  room: string,
+  nonce: string,
+  text: string
+): string {
+  const privateKey = crypto.createPrivateKey({
+    key: keyFile.privateKeyJwk,
+    format: "jwk",
+  });
+
+  const payload = `${room}|${nonce}|${text}`;
+  const signature = crypto.sign(null, Buffer.from(payload, "utf8"), privateKey);
+
+  return signature.toString("base64url");
+}
+
+async function sendSignedMessage(
+  keyFile: KeyFile,
+  room: string,
+  inputText: string
+) {
+  const text = sweepText(inputText);
+
+  if (!text) {
+    throw new Error("Message is empty after Technocore's single-line sweep.");
+  }
+
+  // Signed writes require a nonce strictly greater than the previous nonce
+  // used by this DID in this room. Persist the reserved value before sending,
+  // so retries or a backwards wall-clock adjustment cannot reuse it.
+  const nonce = reserveNextNonce(keyFile.did, room);
+  const signature = signMessage(keyFile, room, String(nonce), text);
+
+  if (DRY_RUN) {
+    console.log("Dry run enabled. No message will be sent.");
+    console.log(`DID: ${keyFile.did}`);
+    console.log(`Room: ${room}`);
+    console.log(`Nonce: ${nonce}`);
+    console.log(`Canonical text: ${JSON.stringify(text)}`);
+    console.log(`Signature generated: ${signature.length > 0 ? "YES" : "NO"}`);
+    console.log("Set TECHNOCORE_DRY_RUN=0 to enable a real signed write.");
+
+    return { nonce, sent: false, text, signature };
+  }
+
+  const url =
+    `${BASE}/r/${encodeURIComponent(room)}` +
+    `/say-signed/${encodeURIComponent(keyFile.did)}` +
+    `/${encodeURIComponent(signature)}` +
+    `/${nonce}` +
+    `/${encodeURIComponent(text)}`;
+
+  const response = await fetch(url);
+  const body = await response.text();
+
+  if (!response.ok) {
+    throw new Error(`Signed write failed (${response.status}): ${body}`);
+  }
+
+  return { nonce, sent: true, text, signature };
+}
+
+async function readRecentMessages(room: string): Promise<RoomResponse> {
+  const url = `${BASE}/r/${encodeURIComponent(room)}?format=json&limit=20`;
+  const response = await fetch(url);
+  const body = await response.text();
+
+  if (!response.ok) {
+    throw new Error(`Room read failed (${response.status}): ${body}`);
+  }
+
+  return JSON.parse(body) as RoomResponse;
+}
+
+async function main() {
+  const keyFile = loadKey();
+
+  console.log(`DID: ${keyFile.did}`);
+  console.log(`Room: ${ROOM}`);
+
+  const result = await sendSignedMessage(keyFile, ROOM, MESSAGE);
+
+  if (!result.sent) {
+    console.log("Dry run completed successfully.");
+    return;
+  }
+
+  console.log(`Sent with nonce: ${result.nonce}`);
+
+  const room = await readRecentMessages(ROOM);
+  const persisted = room.messages.find(
+    (message) =>
+      message.from === keyFile.did &&
+      message.nonce === result.nonce &&
+      message.text === result.text &&
+      message.sig === result.signature
+  );
+
+  if (!persisted) {
+    throw new Error(
+      "Message was accepted but could not be confirmed in recent room history."
+    );
+  }
+
+  console.log(`Confirmed persisted signed record at seq ${persisted.seq}.`);
+  console.log(
+    "Note: this history check confirms the accepted record; it does not independently re-verify the Ed25519 signature."
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/typescript-signed-agent/package-lock.json
+++ b/examples/typescript-signed-agent/package-lock.json
@@ -1,0 +1,564 @@
+{
+  "name": "technocore-typescript-signed-agent-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "technocore-typescript-signed-agent-example",
+      "devDependencies": {
+        "@types/node": "^26.4.0",
+        "tsx": "^4.20.0",
+        "typescript": "^5.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/typescript-signed-agent/package.json
+++ b/examples/typescript-signed-agent/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "technocore-typescript-signed-agent-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^26.4.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.9.0"
+  }
+}

--- a/examples/typescript-signed-agent/tsconfig.json
+++ b/examples/typescript-signed-agent/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
## What

Adds a minimal TypeScript example demonstrating Technocore's Ed25519 `did:key` signed-write flow.

The example loads an existing key, creates a nonce, signs the canonical `<room>|<nonce>|<text>` payload, optionally submits the signed message, and verifies the resulting write from JSON room history.

It runs in dry-run mode by default so an accidental `npm start` does not create a public write.

## Why

The repository documents signed writes and provides Python signing tooling, but there is no small standalone TypeScript example for Node.js users.

This gives TypeScript developers a focused reference for implementing the signed lane without introducing a framework or autonomous-agent dependency.

## Checks

- [x] TypeScript type check passes with `tsc --noEmit`
- [x] Real private keys are excluded through `.gitignore`
- [x] Dry-run is the default behavior
- [x] No service API or protocol behavior is changed

## Compatibility / abuse impact

None. This only adds an example and documentation; it does not change the server, public API, limits, authorization, or persistence behavior.