### PR TITLE
fix: pop-then-insert on _buckets and _window_memo (#378, #376)

### DIFF
--- a/src/limit.py
+++ b/src/limit.py
@@ -280,8 +280,11 @@ def take(request, kind, per_min, burst=None, *, ip_header="", max_buckets=MAX_BU
         wait = 0.0
     else:
         wait = (1.0 - tokens) * 60.0 / per_min
+    # pop-then-insert, not move_to_end: assigning an existing key leaves the entry
+    # where it already was, which may be the front, and a concurrent evictor's popitem
+    # takes it from there — turning the move_to_end that used to follow into a KeyError.
+    _buckets.pop((ip, kind), None)
     _buckets[(ip, kind)] = (tokens, now)
-    _buckets.move_to_end((ip, kind))
     while len(_buckets) > max_buckets:
         _buckets.popitem(last=False)
     # Counted at the one point every rate-limited route already funnels through, so a new

--- a/src/store.py
+++ b/src/store.py
@@ -1036,13 +1036,14 @@ _window_memo: OrderedDict[tuple, tuple] = OrderedDict()
 
 def _cached_window(root: Path, name: str, stamp: tuple) -> tuple[int, list[str]]:
     key = (str(root), name)
-    hit = _window_memo.get(key)
+    # pop-then-insert, not get + move_to_end: a concurrent evictor's popitem can take the
+    # key between the two, turning move_to_end into a KeyError. Same fix as _rooms_cache.
+    hit = _window_memo.pop(key, None)
     if hit and hit[0] == stamp:
-        _window_memo.move_to_end(key)
+        _window_memo[key] = hit
         return hit[1]
     view = room_window(root, name)
     _window_memo[key] = (stamp, view)
-    _window_memo.move_to_end(key)
     while len(_window_memo) > _WINDOW_MEMO_MAX:
         _window_memo.popitem(last=False)
     return view

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -909,3 +909,35 @@ def test_waiter_slots_are_bounded_per_ip(client):
                 assert other is True  # a different IP is unaffected
     assert app._waiters_total == 0  # every slot released
     assert app._waiters_by_ip == {}  # and the table does not grow per distinct IP
+
+
+def test_take_survives_eviction_of_the_key_it_just_reinserted(client, monkeypatch):
+    """A refill for an existing IP re-assigns its bucket, which leaves the entry where it
+    already was — possibly at the front — and the follow-up that used to keep it hot was a
+    `move_to_end`. Starlette runs sync handlers in a threadpool, so a concurrent evictor's
+    `popitem(last=False)` can take that key in the gap between the assignment and the move,
+    and `move_to_end` on a missing key raises KeyError — a 500 on an ordinary throttled
+    read. `_rooms_cache` had the same shape and the same fix; this pins it for `_buckets`.
+
+    Discriminating rather than timed: the bucket dict's `move_to_end` is booby-trapped to
+    raise, standing in for the key being gone by the time it runs. The pop-then-insert path
+    never calls it, so `take` must not raise; the old `assign`-then-`move_to_end` path did.
+    """
+    from collections import OrderedDict
+    from types import SimpleNamespace
+
+    import limit
+
+    class MoveToEndRaises(OrderedDict):
+        def move_to_end(self, key, last=True):  # noqa: FBT002 - mirrors OrderedDict
+            raise KeyError(key)  # the key an evictor took in the gap is no longer here
+
+    racy = MoveToEndRaises()
+    key = ("203.0.113.7", "read")
+    racy[key] = (5.0, 0.0)  # the IP already has a bucket, so this is the refill path
+    monkeypatch.setattr(limit, "_buckets", racy)
+
+    request = SimpleNamespace(headers={}, client=SimpleNamespace(host="203.0.113.7"))
+    left, wait = limit.take(request, "read", 120)  # must not touch move_to_end
+    assert isinstance(left, int) and wait == 0.0
+    assert key in racy  # and the fresh bucket is the one that survived

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1157,3 +1157,34 @@ def test_a_json_escaped_did_is_the_one_record_the_nonce_scan_cannot_see(tmp_path
     assert rec is not None and rec["from"] == did  # legal JSON, and it parses to the DID
     assert did.encode() not in room.read_bytes()  # but not present as itself, so:
     assert store._last_nonce(tmp_path, "lobby", did) is None
+
+
+def test_cached_window_survives_eviction_between_read_and_reinsert(tmp_path, monkeypatch):
+    """A memo hit re-inserts the entry to keep it hot; the code that did so was a `get`
+    followed by `move_to_end`. A concurrent evictor's `popitem(last=False)` can take the
+    key in the gap between the two — `room_stats` runs in Starlette's threadpool — and
+    `move_to_end` on a missing key raises KeyError, turning an overview read into a 500.
+    Same shape and same fix as `_buckets` and `_rooms_cache`: pop on read, reinsert on hit.
+
+    Deterministic rather than timed: a memo whose `pop` evicts a *second* time in the gap
+    would break the old `get`+`move_to_end`; the new `pop`-then-reinsert takes the key out
+    itself and so has nothing left for a racing evictor to miss on.
+    """
+    from collections import OrderedDict
+
+    import store
+
+    class MoveToEndRaises(OrderedDict):
+        def move_to_end(self, key, last=True):  # noqa: FBT002 - mirrors OrderedDict
+            raise KeyError(key)  # the key an evictor took in the gap is no longer here
+
+    racy = MoveToEndRaises()
+    monkeypatch.setattr(store, "_window_memo", racy)
+
+    store.append(tmp_path, "aaa", "bot", "one")
+    store.room_stats(tmp_path)  # populates the memo for "aaa"
+
+    # A second overview hits the memo. The old get+move_to_end path would call the
+    # booby-trapped move_to_end and raise; the pop-then-reinsert path never does.
+    view = store.room_stats(tmp_path)
+    assert {r["room"] for r in view["rooms"]} >= {"aaa"}


### PR DESCRIPTION
Closes #378. Closes #376.

## What

Both call sites carried the same `OrderedDict` race that was already fixed in `_rooms_cache` (`app.py`): assigning an existing key leaves the entry where it already was — possibly at the front — so a concurrent evictor's `popitem(last=False)` can remove it, and the `move_to_end` that follows raises `KeyError` → HTTP 500.

Starlette runs sync route handlers in a threadpool, so both `take()` and `_cached_window()` genuinely overlap.

## Changes

`limit.py` `take()` — pop the key before reinserting, drop `move_to_end`:

```python
_buckets.pop((ip, kind), None)
_buckets[(ip, kind)] = (tokens, now)
while len(_buckets) > max_buckets:
    _buckets.popitem(last=False)
```

`store.py` `_cached_window()` — pop on read, reinsert on hit; both `move_to_end` calls go away:

```python
hit = _window_memo.pop(key, None)
if hit and hit[0] == stamp:
    _window_memo[key] = hit
    return hit[1]
view = room_window(root, name)
_window_memo[key] = (stamp, view)
```

The pop-on-read shape also means a stale-stamp entry is dropped rather than left in place, which is what the miss path wanted anyway.

## Size

Core code-lines **2127 → 2126** (net **-1**). No `sz-baseline.json` change needed.

## Verification

- `uv run python sz.py --check` → `check ok: core code-lines <= baseline (2127)`
- `uv run ruff check .` → clean
- `uv run ruff format --check .` → clean
- `uv run ty check` → clean
- `uv run pytest tests/ -q` → **467 passed**
- Re-ran `tests/unit tests/test_store_stateful.py tests/http/test_limits.py tests/http/test_rooms.py` after the final refactor → **260 passed**