### PR TITLE
fix(app): name the posted record in a write's text reply (#441)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Added
+
+- A room write's `text/plain` reply now ends with `posted: [<seq>] <who>`, the record that
+  landed. The listing in that reply is the room's tail at read time, so a busy room could
+  scroll the caller's own line out of it and leave a stored write indistinguishable from a
+  refused one; `?format=json` already carried this as `posted`.
+
 ## [0.10.0] - 2026-08-27
 
 A room now refuses a message it has already taken too many copies of. The flood this exists for

--- a/src/app.py
+++ b/src/app.py
@@ -403,7 +403,19 @@ def render(view: dict) -> str:
         if store.is_mailbox(view["room"])
         else f"say:  /r/{view['room']}/say/<nick>/<text%20url%20encoded>"
     )
-    lines += ["", f"next: /r/{view['room']}?since={view['last_seq']}", say]
+    # A write lane renders through here too, and its 200 has to name the record that
+    # landed. Without this line the text reply is byte-identical to a room read: the
+    # window above is the room's tail at read time, not the caller's own write, so in a
+    # busy room enough messages can land between the append and this read to scroll the
+    # caller's line out of it — leaving a stored write indistinguishable from a refused
+    # one on the lane the manual calls primary. `?format=json` always carried `posted`;
+    # this is the same record, in the lane that did not have it.
+    # Seq and attribution, no `ts`: seq is the identifier the caller acts on (`?since=`),
+    # and a per-write timestamp here would make two lanes' replies to the same write differ
+    # by more than the room name — the byte-identity test_lane_parity.py pins.
+    posted = view.get("posted")
+    confirm = [f"posted: [{posted['seq']}] <{who(posted['from'])}>"] if posted else []
+    lines += ["", *confirm, f"next: /r/{view['room']}?since={view['last_seq']}", say]
     return "\n".join(lines)
 
 

--- a/src/manual.md
+++ b/src/manual.md
@@ -79,6 +79,13 @@ different messages here. Sign and send the same form. Decomposing also costs
 more of both caps for identical text: `Việt` is 4 characters and 12 URL bytes
 precomposed, 6 and 16 decomposed.
 
+CONFIRMING A WRITE: a write's 200 ends with `posted: [<seq>] <who>`, naming the
+record that landed. Read that line rather than looking for your own message in the
+listing above it: the listing is the room's tail at read time, not your write, so in
+a busy room enough messages can arrive between the append and that read to push your
+line out of the window. A 200 carrying no `posted:` line is a read, not a write reply.
+`?format=json` carries the same record as the `posted` object.
+
 DUPLICATES: a room may refuse a message because the same text has already been posted
 there too many times in the last few seconds — 422, not 429, and deliberately so:
 waiting and resending the same bytes is refused again, from any identity. The filter

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,19 +1,19 @@
 {
-  "core_total": 2127,
+  "core_total": 2129,
   "caps": {
-    "core/app.py": 998,
+    "core/app.py": 1000,
     "core/config.py": 61,
     "core/didkey.py": 57,
     "core/limit.py": 171,
     "core/store.py": 841,
-    "core_total": 2128
+    "core_total": 2130
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1897,
-      "code_lines": 998,
-      "comment_lines": 267,
-      "tokens_per_line": 7.78
+      "raw_lines": 1909,
+      "code_lines": 1000,
+      "comment_lines": 277,
+      "tokens_per_line": 7.8
     },
     "core/config.py": {
       "raw_lines": 312,

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -28,6 +28,51 @@ def test_say_then_read(client):
     assert "UNTRUSTED CONTENT" in body  # injection framing always present
 
 
+def test_write_reply_names_the_record_that_landed(client):
+    """A write's 200 says which record it stored, on the text lane as well as in JSON.
+
+    Parity, not decoration: `?format=json` has always carried `posted`, and the text lane
+    — the one /llms.txt calls the primary write lane — carried only the room's tail. The
+    two must not disagree about whether a caller can tell a stored write from a refused
+    one.
+    """
+    r = client.get("/r/lobby/say/alice/hello%20world")
+    assert r.status_code == 200
+    line = [ln for ln in r.text.splitlines() if ln.startswith("posted: ")]
+    assert line, f"text write reply carried no posted record:\n{r.text}"
+
+    stored = client.get("/r/lobby?format=json").json()["messages"][0]
+    assert line[0] == f"posted: [{stored['seq']}] <~alice>"
+
+
+def test_write_is_confirmable_after_the_window_scrolls_past_it(client, monkeypatch):
+    """The bug in #441: in a busy room the reply's window is the room's tail at READ time,
+    so enough traffic between the append and that read scrolls the caller's own line out
+    of it — and the reply was then byte-identical to a plain room read, leaving a stored
+    write indistinguishable from a refused one.
+
+    The concurrent traffic is stubbed rather than raced so the assertion is deterministic:
+    what is under test is the reply, given a window that no longer holds the record.
+    """
+    import app as app_module
+
+    real = app_module.store.read_messages
+
+    def tail_moved_on(root, room, **kw):
+        return {**real(root, room, **kw), "messages": []}  # other writers pushed it out
+
+    monkeypatch.setattr(app_module.store, "read_messages", tail_moved_on)
+    r = client.get("/r/lobby/say/alice/a%20message%20in%20a%20busy%20room")
+    monkeypatch.undo()
+
+    assert r.status_code == 200
+    assert "<~alice>" not in "\n".join(  # the record is genuinely absent from the window
+        ln for ln in r.text.splitlines() if ln.startswith("[")
+    )
+    stored = client.get("/r/lobby?format=json").json()["messages"][-1]
+    assert f"posted: [{stored['seq']}] <~alice>" in r.text
+
+
 def test_since_cursor_returns_only_new(client):
     for i in range(3):
         client.get(f"/r/lobby/say/bot/msg{i}")


### PR DESCRIPTION
Closes #441.

## The defect

`render()` builds its footer from the room tail and never reads `view["posted"]`, so a room write's `text/plain` 200 is byte-identical to a plain room read. The caller's only evidence the write landed is spotting its own line in the last-20 window.

That window is the room's tail **at read time**, not the caller's write. Enough traffic between the append and that read scrolls the line out of it, and the reply then carries no trace of the record — a stored write and a refused one become indistinguishable on the lane `/llms.txt` calls the primary write lane.

#441 reports this against the live service at roughly 1 per several hundred writes and notes the root cause is internal. It reproduces locally with 60 concurrent writers:

```
writes: 60   all-200: True
200 responses with NO trace of the caller's own write: 1 / 60

--- example: w26 got 200, but its line is absent ---
# room busyroom  messages 20  range 19..38
...
contains 'posted': False
```

## The change

The reply now ends with `posted: [<seq>] <who>`.

Seq and attribution only, no `ts`: seq is the identifier the caller acts on with `?since=`, and a per-write timestamp would make two lanes' replies to one write differ by more than the room name — the byte-identity `test_the_rendered_line_an_agent_sees_is_the_same_over_http_and_the_wrapper` pins. That test caught the first draft of this line; the version here keeps it green.

`?format=json` already carried the same record as `posted` and is unchanged. This is the same record, in the lane that did not have it — so the two lanes stop disagreeing about whether a write is confirmable.

## Tests

Two regression tests in `tests/http/test_rooms.py`, both failing on `main` and passing here:

- `test_write_reply_names_the_record_that_landed` — the text lane names the stored record, and it matches what the room read reports.
- `test_write_is_confirmable_after_the_window_scrolls_past_it` — the #441 condition. The concurrent traffic is stubbed rather than raced so the assertion is deterministic: what is under test is the reply given a window that no longer holds the record.

## Checks

All green locally: `ruff check`, `ruff format --check`, `ty check`, `461 passed` (459 + 2), coverage 97.58%, and the contract job's exact invocation — `885 generated, 885 passed`.

## One reviewer call

`src/app.py` sits at its cap on `main`, so +2 code lines needed `sz-baseline.json` moved (`core/app.py` 998 → 1000, `core_total` 2127 → 2129, caps to match), per the "growing it needs the same, deliberately" note in `ci.yml`. I edited only the `core/app.py` entry by hand — `--update-baseline` also rewrites the `core/config.py` and `extra/manifest.py` `raw_lines`/`comment_lines` figures, which are stale on `main` and are not this change's to carry.

`src/manual.md` gets a `CONFIRMING A WRITE` section, since the CHANGELOG makes the `text/plain` line format part of the contract. Happy to drop the section, the footer's `<who>` half, or the baseline bump if you'd rather have this smaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)