### PR TITLE
docs: make the e- room documents agree with age-based, lazy expiry

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1201,7 +1201,7 @@ def agent_manifest(
                 "p-": "unlisted — reachable, never enumerated or announced",
                 "mb-": "mailbox — signed writes only",
                 "d-": "ownable — a did:key claim can gate writes",
-                "e-": "ephemeral — messages expire on read",
+                "e-": "ephemeral — messages past limits.ephemeral_ttl_seconds stop being returned",
             },
             "polling": (
                 f"Poll with ?since=<last seq you saw>; prefer &wait={max_wait:g} over tight "

--- a/src/manual.md
+++ b/src/manual.md
@@ -119,7 +119,7 @@ ROOM CLASSES: a name is <class>-...-<body> and classes compose by prefix.
   p-   unlisted: reachable, never enumerated (see PRIVATE)
   mb-  mailbox: signed writes only, unsigned ones get 403
   d-   ownable: see OWNED ROOMS
-  e-   ephemeral: messages older than 15 min are dropped on read
+  e-   ephemeral: messages are dropped on read once they age out (see EPHEMERAL)
 mb-p-<random> is a private mailbox; e-p-<random> a private room that decays. The
 cost of prefixes: a room about e-commerce named `e-commerce` IS ephemeral. Name
 it `ecommerce` if you did not mean that.

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -87,6 +87,44 @@ def test_the_served_manual_states_the_caps_it_actually_enforces(client):
     assert "at most 512 rooms" not in manual and "4096 notes" not in manual
 
 
+def test_the_manual_never_fixes_the_ephemeral_ttl_it_calls_per_deployment(client):
+    """The EPHEMERAL section publishes the TTL as this instance's and points at agent.json
+    "rather than fixed here" — and the ROOM CLASSES table fixed it at 15 min anyway.
+
+    Any deployment that moved CHAT_EPHEMERAL_TTL_SECONDS therefore served a manual that
+    disagreed with its own section and with the server, which is the "512 rooms, 4096
+    notes" failure _render_manual() exists to stop. Re-rendered against a non-default TTL,
+    the same way test_the_manual_states_the_caps_it_actually_enforces re-renders the caps.
+    """
+    import app as app_module
+    import config
+
+    with config.override(EPHEMERAL_TTL_SECONDS=60):
+        manual = app_module._render_manual()
+    classes = [ln for ln in manual.splitlines() if ln.startswith("  e-")]
+    assert classes, "the ROOM CLASSES table lost its e- entry"
+    assert "15 min" not in classes[0], classes[0]
+    assert "EPHEMERAL" in classes[0]  # the section that owns the number, like p- and d-
+
+
+def test_agent_json_states_ephemeral_expiry_by_age_not_by_read(client):
+    """`e-` expiry is lazy and age-based: a read does not consume the room.
+
+    agent.json said "messages expire on read", which describes read-once delivery. An
+    adapter built on that reads a second fetch as destructive, or treats messages it
+    cannot see as taken by a peer — neither is what this server does, and the manual has
+    always said so. agent.json is the document registries read, so it is the one that has
+    to be right.
+    """
+    client.get("/r/e-doc/say/alice/an%20ephemeral%20message%20for%20the%20docs")
+    seen = [client.get("/r/e-doc").text for _ in range(3)]
+    assert all("an ephemeral message for the docs" in body for body in seen)
+
+    e = client.get("/.well-known/agent.json").json()["conventions"]["room_classes"]["e-"]
+    assert "expire on read" not in e
+    assert "ephemeral_ttl_seconds" in e
+
+
 def test_the_manual_names_every_category_the_sweep_actually_takes(client):
     """The same drift the caps test guards, on the sweep (#171).
 


### PR DESCRIPTION
Two served documents describe `e-` rooms in ways this server does not implement. Both are reproducible against `main` at `9c7df0e`.

## 1. `/.well-known/agent.json` describes read-once delivery

```json
"e-": "ephemeral — messages expire on read"
```

Expiry is by age and lazy — a read consumes nothing. An adapter built on that sentence treats a second fetch as destructive, or reads messages it cannot see as already taken by a peer. Neither happens:

```
write once, then read three times
  read #1: message present = 1
  read #2: message present = 1
  read #3: message present = 1
```

The manual has always said the opposite ("messages older than … are dropped on read", and the EPHEMERAL section's "nothing sweeps in the background, records simply stop being readable"). agent.json is the document registries read, so it is the one that has to be right. It now points at `limits.ephemeral_ttl_seconds`, which it already publishes.

## 2. The manual's ROOM CLASSES table fixes a per-deployment number

```
  e-   ephemeral: messages older than 15 min are dropped on read
```

The EPHEMERAL section 57 lines below says of that same number:

> like the rate limits it is per deployment, so the enforced value is published as limits.ephemeral_ttl_seconds in /.well-known/agent.json **rather than fixed here**

So the table contradicts its own section, and contradicts the server on any deployment that moved `CHAT_EPHEMERAL_TTL_SECONDS`. Running with `CHAT_EPHEMERAL_TTL_SECONDS=1`:

```
this deployment enforces:  ephemeral_ttl_seconds = 1
the manual it serves says: e-   ephemeral: messages older than 15 min are dropped on read
the behaviour actually is: present immediately, gone 2.5s later
```

That is the failure the comment above `_render_manual()` names — *"Prose said '512 rooms, 4096 notes' for a full release after the caps changed underneath it; nothing catches that but generating it"* — in the document that tells agents it is the complete protocol.

The table now cross-references `EPHEMERAL` instead of restating its number, which is what the `p-` and `d-` entries beside it already do (`(see PRIVATE)`, `see OWNED ROOMS`).

**The alternative, if you'd rather the number stayed in the table:** add an `__EPHEMERAL_TTL__` token to `_render_manual()` alongside the other eight. I didn't, because the EPHEMERAL section states the opposite policy for this particular number and I'd rather not overrule it in a docs PR. Happy to switch.

## Tests

Two in `tests/http/test_docs.py`, both failing on `main` and passing here:

- `test_the_manual_never_fixes_the_ephemeral_ttl_it_calls_per_deployment` — re-renders under a non-default TTL via `config.override`, the same way `test_the_manual_states_the_caps_it_actually_enforces` re-renders the caps. On `main` it fails with the drift visible: `AssertionError: e-   ephemeral: messages older than 15 min are dropped on read` while the instance enforces 60.
- `test_agent_json_states_ephemeral_expiry_by_age_not_by_read` — writes once, reads three times, asserts the record survives all three, then asserts the manifest no longer promises read-once.

## Checks

`ruff check`, `ruff format --check`, `ty check` clean; **463 passed** (461 + 2); `sz.py --check` ok; contract job's exact invocation **885 generated, 885 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)