### PR TITLE
ci(mutation): copy README.md and scripts/ into the mutants tree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,15 +99,21 @@ only_mutate = ["src/app.py", "src/store.py", "src/didkey.py", "src/limit.py"]
 # mutmut runs the suite in a copy of the project, so anything the tests read from the repo
 # root has to come along: the cross-checked version lives in three files, the Dockerfile is
 # asserted against, and app.py reads SKILL.md at import.
-also_copy = ["SKILL.md", "docker", "mcp"]
+also_copy = ["README.md", "SKILL.md", "docker", "mcp", "scripts"]
 # test_mcp.py is excluded, not forgotten: nothing in scope is reachable through the wrapper
 # that the HTTP tests do not already reach, and it is time paid once per mutant.
 # test_app.py was split into tests/http/ and tests/unit/; every shard selects the same
 # suite the monolith did, and test_mcp.py stays excluded for the reason above.
+# test_store_doc.py is excluded for a different reason than test_mcp.py: it asserts that
+# docs/store.md still lists store.py's public functions, and mutmut rewrites those very
+# names (`_at_capacity` becomes `x__at_capacity__mutmut_1`). It cannot pass in a mutated
+# tree by construction, and it judges a generated document rather than behaviour — nothing
+# in SCOPE reaches it.
 pytest_add_cli_args_test_selection = [
     "tests/http",
     "tests/unit",
     "tests/test_store_stateful.py",
+    "--ignore=tests/unit/test_store_doc.py",
 ]
 
 # Not an installable package: src/ is copied into the image and imported by path.

--- a/tests/unit/test_mutation_harness.py
+++ b/tests/unit/test_mutation_harness.py
@@ -1,0 +1,51 @@
+"""The mutation run's copied tree has to hold what the suite it runs there reads.
+
+Run: uv run --group dev python -m pytest tests
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+# The two forms the suite uses to reach out of tests/ and into the repo root.
+_ROOT_READ = re.compile(r'(?:ROOT|parents\[2\])\s*/\s*"([^"/]+)"')
+
+# mutmut builds these into the copy itself: the mutated sources, the suite it selects from,
+# and the config it re-reads inside the tree.
+_ALWAYS_PRESENT = frozenset({"src", "tests", "pyproject.toml"})
+
+
+def test_every_root_path_the_mutation_suite_reads_is_copied_into_the_tree():
+    """mutmut runs the suite in a copy of the project, so anything a selected test reads
+    from the repo root has to be in `also_copy` — the rule stated in the comment above it.
+
+    It stopped holding. README.md (tests/http/test_rooms.py) and scripts/ (test_signer.py)
+    both arrived after `also_copy` was last touched, and the weekly run has been dying in
+    its own baseline — FileNotFoundError on mutants/README.md — before generating a single
+    mutant. A scoped mutation suite that cannot start is worse than not having one: the
+    report is empty either way, and only one of them looks like it ran.
+    """
+    with (ROOT / "pyproject.toml").open("rb") as fh:
+        cfg = tomllib.load(fh)["tool"]["mutmut"]
+    copied = set(cfg["also_copy"]) | _ALWAYS_PRESENT
+    selection = cfg["pytest_add_cli_args_test_selection"]
+    ignored = {arg.split("=", 1)[1] for arg in selection if arg.startswith("--ignore=")}
+
+    missing: dict[str, set[str]] = {}
+    for entry in (t for t in selection if not t.startswith("-")):
+        target = ROOT / entry
+        for f in sorted(target.rglob("*.py")) if target.is_dir() else [target]:
+            if str(f.relative_to(ROOT)) in ignored:
+                continue
+            for name in _ROOT_READ.findall(f.read_text(encoding="utf-8")):
+                if name not in copied:
+                    missing.setdefault(name, set()).add(str(f.relative_to(ROOT)))
+
+    assert not missing, (
+        "read from the repo root by the mutation suite, but absent from "
+        f"[tool.mutmut] also_copy: { ({k: sorted(v) for k, v in missing.items()}) }"
+    )


### PR DESCRIPTION
The weekly mutation run has been dying in its own baseline, before generating a single mutant.

## Evidence

The last scheduled run on record — `mutation.yml`, 2026-08-23 — failed:

```
FileNotFoundError: [Errno 2] No such file or directory:
  '/home/runner/work/technocore-chat/technocore-chat/mutants/README.md'
FAILED tests/test_app.py::test_every_place_that_teaches_the_claim_teaches_the_signed_one
1 failed, 149 passed in 19.36s
failed to collect stats. runner returned 1
```

It fails identically on `main` at `9c7df0e` today (same test, now at `tests/http/test_rooms.py:773` after the #52 split).

## Cause

mutmut runs the suite in a copy of the project, so anything a selected test reads from the repo root has to be in `also_copy` — the rule the comment directly above it already states. Two entries are missing:

| Path | Read by |
|---|---|
| `README.md` | `tests/http/test_rooms.py` — `test_every_place_that_teaches_the_claim_teaches_the_signed_one` |
| `scripts/` | `tests/http/test_signer.py` — runs `scripts/sign.py` as a subprocess |

Both arrived after `also_copy` was last touched (`f992e96`, 2026-08-23); the README read landed the next day in `d239df9`. Each was hidden behind the previous — fixing `README.md` surfaced `scripts/`, and `ci.yml` already anticipates this shape: *"Failing here is a missing entry in `also_copy`, not a mutation finding."*

## `test_store_doc.py`

Excluded from the mutation selection, for a different reason than `test_mcp.py`. It asserts `docs/store.md` still lists `store.py`'s public functions, and mutmut rewrites those very names (`_at_capacity` → `x__at_capacity__mutmut_1`). It cannot pass in a mutated tree by construction, and it judges a generated document rather than behaviour — nothing in `SCOPE` reaches it. That is also why `docs/` is not added to `also_copy`: it was only ever needed by this file.

## Verified working

With the fix, the harness completes end to end and judges mutants for the first time:

```
Running mutation testing
2/4331  🎉 2
🎉 store.x__cutoff__mutmut_1
🎉 store.x__cutoff__mutmut_2
```

Both killed — the `ttl` theme's first two mutants, which is what `mutation_scope.py` says the run is for.

## The test

`tests/unit/test_mutation_harness.py` derives the requirement rather than restating it: it reads `[tool.mutmut]` from `pyproject.toml`, scans the selected suites for repo-root reads, and fails naming any `also_copy` misses. On `main` it reports exactly the drift, attributed:

```
AssertionError: read from the repo root by the mutation suite, but absent from
[tool.mutmut] also_copy: {'README.md': ['tests/http/test_rooms.py'],
                          'scripts': ['tests/http/test_signer.py', 'tests/unit/test_store_doc.py'],
                          'docs': ['tests/unit/test_store_doc.py']}
```

It passes with the fix, and it lives in `tests/unit/` so it runs on every PR — the mutation workflow itself never does.

A scoped mutation suite that cannot start is worse than not having one: the report is empty either way, and only one of them looks like it ran.

## Checks

`ruff check`, `ruff format --check`, `ty check` clean; **460 passed** (459 + 1); `sz.py --check` ok (no core lines touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)