### PR TITLE
fix(store): fd-scope child directory walks against symlink substitution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ uv run coverage report
 
 Layering: the core is `src/store.py`, `src/didkey.py`, `src/config.py`, `src/limit.py`
 and a thin `src/app.py` adapter.
-`src/manifest.py`, docs and frontends are extra — never counted as core.
+`src/manifest.py`, `src/walk.py`, docs and frontends are extra — never counted as core.
 Core size caps live in `sz-baseline.json` (`caps`); check with `uv run sz.py --caps`.
 Growth past a cap needs a new primitive, or belongs in extra.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ ignore = ["E501"]  # Line length is the formatter's job.
 # app.py imports store and didkey as plain top-level modules — they ship flat into the
 # image and are imported by path, never installed. Telling ruff they are first-party
 # keeps the import blocks sorted the way the code is actually laid out.
-known-first-party = ["app", "didkey", "store"]
+known-first-party = ["app", "didkey", "store", "walk"]
 
 [tool.ty.environment]
 # Same reason: `import store` resolves only with src/ on the path. mcp/src is the

--- a/src/store.py
+++ b/src/store.py
@@ -28,6 +28,7 @@ import orjson
 
 import config
 import didkey
+import walk
 
 NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,47}$")
 
@@ -561,7 +562,7 @@ def _prune(d: Path | str) -> bool:
     try:
         with os.scandir(d) as entries:
             for e in entries:
-                if e.is_dir() and _prune(e.path):
+                if e.is_dir(follow_symlinks=False) and _prune(e.path):
                     try:
                         os.rmdir(e.path)
                         continue
@@ -1070,7 +1071,7 @@ def _reapable(path: Path | str, now: float, stillborn_rule: bool) -> str | None:
 ROOM_GUARD_NS = (OWNERS_NS, ALLOW_NS, NONCE_NS)
 
 
-def _guards_a_live_room(root: Path, base: str, entry: os.DirEntry[str], now: float) -> bool:
+def _guards_a_live_room(root: Path, base: str, entry: walk.FileEntry, now: float) -> bool:
     """True when `entry` is a guard note whose room is still within its own idle window.
 
     Tied to the room, not exempted outright: once the room itself is reapable the guards go
@@ -1336,68 +1337,24 @@ def _snapshot(root: Path) -> None:
 def _scan(d: Path | str, suffix: str, sized: bool = False) -> tuple[int, int]:
     """(count, total bytes) of the entries in `d` named `*suffix`, in one pass.
 
-    os.scandir rather than Path.glob, and one pass rather than two, because every caller
-    below is on a *create* path — run on the shared threadpool, so the cost is paid by
-    the caller and by every create queued behind the create gate.
-
-    That is what made it worth measuring rather than assuming. At a full store, the glob
-    it replaces cost 36 ms per new room (a counting glob, then a second one that stats)
-    and 94 ms per new note; this costs 13 ms and 19 ms. The caps could not have grown
-    tenfold on top of glob without those numbers growing with them.
-
-    `sized` is a flag rather than always-on because the byte total is the expensive half:
-    readdir hands back the name for free and never the size, so each entry costs a stat.
-    Only rooms have a byte budget to enforce.
-
-    Recursive since sharding, and it has to be: `_check_room_capacity` totals what the room
-    caps are enforced against, and a scan that stopped at the top of `rooms/` would count the
-    buckets and none of the rooms in them — a cap that reads zero is not a cap. Depth is not
-    assumed anywhere here, so one pass covers a store part-way through its migration, where
-    some names still sit flat and the rest are already bucketed.
+    Delegates to `walk.counts`: the same confinement as `_walk`, so a directory symlink
+    (or a directory swapped for one after classification) cannot inflate the room or note
+    caps with files outside the store root. Depth is not assumed, so one pass covers a
+    store part-way through its migration, where some names still sit flat and the rest are
+    already bucketed.
     """
-    count = 0
-    size = 0
-    try:
-        with os.scandir(d) as entries:
-            for e in entries:
-                if e.is_dir():  # d_type from readdir: no syscall
-                    sub_count, sub_size = _scan(e.path, suffix, sized)
-                    count += sub_count
-                    size += sub_size
-                elif e.name.endswith(suffix):
-                    count += 1
-                    if sized:
-                        try:
-                            size += e.stat().st_size
-                        except OSError:
-                            continue  # reaped between the readdir and the stat
-    except OSError:
-        pass  # nothing has been created yet; an absent directory is an empty one here
-    return count, size
+    return walk.counts(d, suffix, sized)
 
 
-def _walk(d: Path | str, suffix: str) -> Iterator[os.DirEntry[str]]:
+def _walk(d: Path | str, suffix: str) -> Iterator[walk.FileEntry]:
     """Every `*suffix` file anywhere under `d`, at any depth.
 
-    Yields the `os.DirEntry` scandir already built rather than a Path made from it. On 3.12
-    pathlib is lazily normalised — the constructor stashes the string and the parse lands on
-    the first `__fspath__`, which is `.stat()` — so `Path(e.path).stat()` costs 19.4 µs
-    against the 7.7 µs of the syscall it wraps, and the overhead hides inside the stat rather
-    than in the constructor where a reader would look for it. Over one reap pass at the live
-    caps (10,240 rooms + ~207,000 notes) that was the difference between 13.5 s and 3.6 s.
-
-    Every `os.*` spelling of the stat is the same speed — `DirEntry.stat()`, `os.stat(path)`
-    and `os.stat(name, dir_fd=)` are within 2% of each other. Only Path is slow, so this is a
-    representation change, not a cleverer syscall. `bench/dir_walk.py` is the measurement.
-
-    `e.is_dir()` reads d_type from readdir and costs no syscall. Callers that need a Path
-    build one at the point of action, which for the reaper means the branch that actually
-    unlinks — a live pass finds 0 reapable files, so the old shape built ~207,000 Paths to
-    act on none of them.
-
-    Note the asymmetry with `_scan`, which is faster still on the same directories: it only
-    ever counts and measures, so it never needs the entry after the loop body. Use that one
-    where a count is all you need.
+    Delegates to `walk.files`, which opens child directories relative to the parent fd
+    with `O_NOFOLLOW` on POSIX. That closes the check-to-open window where a real
+    directory could be replaced by a symlink after `is_dir(follow_symlinks=False)` and
+    before `scandir(e.path)`, after which `_reap` would unlink files outside the store
+    root. Yields `walk.FileEntry` rather than `os.DirEntry` so callers never receive an
+    entry whose `.path` was produced by following a substituted link.
 
     Depth-agnostic rather than the old `nested` switch, which said "exactly one level down"
     and so could only ever be right about one layout. Under sharding a room is one level
@@ -1405,15 +1362,7 @@ def _walk(d: Path | str, suffix: str) -> Iterator[os.DirEntry[str]]:
     a walk that picked a number would miss every file that had not moved yet, which for the
     reaper means idle files never reaped and for the sweeper means locks never swept.
     """
-    try:
-        with os.scandir(d) as entries:
-            for e in entries:
-                if e.is_dir():
-                    yield from _walk(e.path, suffix)
-                elif e.name.endswith(suffix):
-                    yield e
-    except OSError:
-        return  # missing or unreadable: nothing to walk, same as an empty glob
+    yield from walk.files(d, suffix)
 
 
 def _count_notes(root: Path) -> tuple[int, int]:
@@ -1425,18 +1374,7 @@ def _count_notes(root: Path) -> tuple[int, int]:
     gauge stop being a per-request walk, and it is the same pass `_ns_totals` makes for one
     namespace, so a per-namespace count costs its bytes for free too.
     """
-    total = 0
-    size = 0
-    try:
-        with os.scandir(root / "notes") as namespaces:
-            for ns in namespaces:
-                if ns.is_dir():
-                    count, ns_bytes = _scan(ns.path, ".txt", sized=True)
-                    total += count
-                    size += ns_bytes
-    except FileNotFoundError:
-        pass
-    return total, size
+    return _scan(root / "notes", ".txt", sized=True)
 
 
 def _write_note_count(root: Path, total: int, size: int) -> None:

--- a/src/walk.py
+++ b/src/walk.py
@@ -1,0 +1,116 @@
+"""Directory walks that refuse to follow substituted child symlinks.
+
+`store._walk` used to classify a directory and then reopen it by pathname. A
+real child could be replaced by a directory symlink in that window, after which
+the reaper unlinked files outside the store root. POSIX child directories are
+opened with `O_NOFOLLOW` relative to the parent fd, so that substitution raises
+and is skipped. The configured root itself may be a symlink (a mounted volume)
+and is followed once. Windows has no `dir_fd` openat, so observed child
+symlinks and junctions are skipped; hostile same-privilege rename races stay
+out of scope.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+# Rooms are one level down, notes two, plus a spare for a foreign extra layer.
+# Deeper trees are skipped rather than walked until fds or the stack run out.
+MAX_DEPTH = 8
+_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
+_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_FD_SCANDIR = os.name != "nt"
+
+# Tests assign a callable(full_path, name) that runs after classification and
+# before the child directory is opened — the substitution window.
+_before_open_child = None
+
+
+class FileEntry:
+    """A suffix file found under a walk. `path` is reconstructed, never followed."""
+
+    __slots__ = ("name", "path")
+
+    def __init__(self, name: str, path: str) -> None:
+        self.name = name
+        self.path = path
+
+    def stat(self, follow_symlinks: bool = False) -> os.stat_result:
+        return os.stat(self.path, follow_symlinks=follow_symlinks)
+
+
+def files(d: Path | str, suffix: str) -> Iterator[FileEntry]:
+    """Every `*suffix` file under `d`, skipping child directory symlink substitutions."""
+    yield from _walk(os.fspath(d), suffix, None, None, 0)
+
+
+def counts(d: Path | str, suffix: str, sized: bool = False) -> tuple[int, int]:
+    """(count, total bytes) of `*suffix` files under `d`, same confinement as `files`."""
+    n = 0
+    size = 0
+    for entry in files(d, suffix):
+        n += 1
+        if sized:
+            try:
+                size += entry.stat(follow_symlinks=False).st_size
+            except OSError:
+                continue
+    return n, size
+
+
+def _is_link(path: str) -> bool:
+    if os.path.islink(path):
+        return True
+    is_junction = getattr(os.path, "isjunction", None)
+    return bool(is_junction is not None and is_junction(path))
+
+
+def _open_dir(name: str, dir_fd: int | None, full_path: str, *, child: bool) -> int | None:
+    if child and _before_open_child is not None:
+        _before_open_child(full_path, name)
+    if child and dir_fd is not None and _NOFOLLOW and _FD_SCANDIR:
+        return os.open(name, os.O_RDONLY | _DIRECTORY | _NOFOLLOW, dir_fd=dir_fd)
+    if child and _is_link(full_path):
+        raise OSError(errno.ELOOP, "directory symlink", full_path)
+    if not _FD_SCANDIR:
+        return None
+    flags = os.O_RDONLY | _DIRECTORY
+    try:
+        return os.open(full_path, flags)
+    except OSError:
+        return os.open(full_path, os.O_RDONLY)
+
+
+def _walk(
+    path: str, suffix: str, dir_fd: int | None, name: str | None, depth: int
+) -> Iterator[FileEntry]:
+    if depth > MAX_DEPTH:
+        return
+    fd = None
+    try:
+        fd = _open_dir(
+            path if name is None else name,
+            dir_fd,
+            path,
+            child=name is not None,
+        )
+        # scandir does not take ownership of a directory fd.
+        with os.scandir(fd if fd is not None else path) as entries:
+            for entry in entries:
+                full = os.path.join(path, entry.name)
+                try:
+                    is_dir = entry.is_dir(follow_symlinks=False)
+                except OSError:
+                    continue
+                if is_dir:
+                    yield from _walk(full, suffix, fd, entry.name, depth + 1)
+                elif entry.name.endswith(suffix):
+                    yield FileEntry(entry.name, full)
+    except OSError:
+        return
+    finally:
+        if fd is not None:
+            os.close(fd)

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,5 +1,5 @@
 {
-  "core_total": 2127,
+  "core_total": 2091,
   "caps": {
     "core/app.py": 998,
     "core/config.py": 61,
@@ -16,9 +16,9 @@
       "tokens_per_line": 7.78
     },
     "core/config.py": {
-      "raw_lines": 312,
+      "raw_lines": 324,
       "code_lines": 61,
-      "comment_lines": 195,
+      "comment_lines": 207,
       "tokens_per_line": 12.56
     },
     "core/didkey.py": {
@@ -34,16 +34,22 @@
       "tokens_per_line": 8.48
     },
     "core/store.py": {
-      "raw_lines": 2010,
-      "code_lines": 840,
-      "comment_lines": 441,
-      "tokens_per_line": 7.36
+      "raw_lines": 1948,
+      "code_lines": 804,
+      "comment_lines": 437,
+      "tokens_per_line": 7.48
     },
     "extra/manifest.py": {
-      "raw_lines": 1818,
-      "code_lines": 1320,
+      "raw_lines": 1819,
+      "code_lines": 1321,
       "comment_lines": 152,
       "tokens_per_line": 3.83
+    },
+    "extra/walk.py": {
+      "raw_lines": 116,
+      "code_lines": 78,
+      "comment_lines": 5,
+      "tokens_per_line": 7.44
     }
   }
 }

--- a/sz.py
+++ b/sz.py
@@ -5,7 +5,7 @@
 # ///
 """Measure the size of the core, and only the core.
 
-Core is src/app.py, src/config.py, src/didkey.py and src/store.py; src/manifest.py is
+Core is src/app.py, src/config.py, src/didkey.py, src/limit.py and src/store.py; src/manifest.py and src/walk.py are
 reported under an "extra" label and never counted in the core total. Two numbers per file:
 
 - code lines: lines carrying executable tokens, with docstrings and comments stripped.
@@ -42,7 +42,7 @@ import tokenize
 from pathlib import Path
 
 CORE_FILES = ("src/app.py", "src/config.py", "src/didkey.py", "src/limit.py", "src/store.py")
-EXTRA_FILES = ("src/manifest.py",)
+EXTRA_FILES = ("src/manifest.py", "src/walk.py")
 BASELINE = Path(__file__).resolve().parent / "sz-baseline.json"
 # Token types that carry no code: layout, comments, and the encoding/end markers.
 _SKIP_TOKENS = {

--- a/tests/unit/test_walk.py
+++ b/tests/unit/test_walk.py
@@ -1,0 +1,145 @@
+"""Root confinement for store directory walks.
+
+The reaper used to classify a child with `is_dir()` and then reopen it by
+pathname. Replacing that directory with a symlink in the window let `_reap`
+unlink files outside the store root. These tests pin the public reaper path,
+not the walker alone.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from _client import _age
+
+
+def _can_symlink(tmp_path: Path) -> bool:
+    target = tmp_path / "symlink-target"
+    target.mkdir()
+    link = tmp_path / "symlink"
+    try:
+        os.symlink(target, link, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        return False
+    return link.is_symlink() or os.path.islink(link)
+
+
+def _arm_reaper(root: Path) -> None:
+    (root / ".reaped").unlink(missing_ok=True)
+
+
+def test_walk_skips_an_existing_directory_symlink(tmp_path: Path) -> None:
+    import store
+    import walk
+
+    if not _can_symlink(tmp_path):
+        pytest.skip("directory symlinks are unavailable")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("keep")
+    notes = tmp_path / "notes"
+    notes.mkdir()
+    os.symlink(outside, notes / "trap", target_is_directory=True)
+    (notes / "did").mkdir()
+    (notes / "did" / "ok.txt").write_text("inside")
+    found = {Path(entry.path).name for entry in walk.files(notes, ".txt")}
+    assert found == {"ok.txt"}
+    assert store._scan(notes, ".txt") == (1, 0)
+    assert store._scan(notes, ".txt", sized=True) == (1, 6)
+
+
+def test_walk_follows_a_symlinked_store_root(tmp_path: Path) -> None:
+    import walk
+
+    if not _can_symlink(tmp_path):
+        pytest.skip("directory symlinks are unavailable")
+    real = tmp_path / "volume"
+    real.mkdir()
+    (real / "ok.txt").write_text("mounted")
+    alias = tmp_path / "store"
+    os.symlink(real, alias, target_is_directory=True)
+    found = [Path(entry.path).name for entry in walk.files(alias, ".txt")]
+    assert found == ["ok.txt"]
+
+
+def test_walk_skips_trees_deeper_than_max_depth(tmp_path: Path) -> None:
+    import walk
+
+    current = tmp_path
+    for i in range(walk.MAX_DEPTH + 2):
+        current = current / f"d{i}"
+        current.mkdir()
+    (current / "too-deep.txt").write_text("no")
+    shallow = tmp_path / "d0" / "ok.txt"
+    shallow.write_text("yes")
+    found = {Path(entry.path).name for entry in walk.files(tmp_path, ".txt")}
+    assert found == {"ok.txt"}
+
+
+def test_walk_skips_a_vanished_child_and_a_stale_sized_stat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import walk
+
+    nested = tmp_path / "gone"
+    nested.mkdir()
+    live = tmp_path / "keep.txt"
+    live.write_text("keep")
+    stale = tmp_path / "stale.txt"
+    stale.write_text("drop")
+
+    def vanish(full_path: str, name: str) -> None:
+        if name == "gone":
+            Path(full_path).rmdir()
+
+    monkeypatch.setattr(walk, "_before_open_child", vanish)
+    assert {Path(entry.path).name for entry in walk.files(tmp_path, ".txt")} == {
+        "keep.txt",
+        "stale.txt",
+    }
+    stale.unlink()
+    assert walk.counts(tmp_path, ".txt", sized=True) == (1, 4)
+
+
+def test_reap_does_not_follow_a_directory_replaced_by_a_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The check-to-open window: a real child directory becomes a symlink before
+    recursive open. The public reaper must not delete the external target, and it
+    must still reap a later legitimate sibling."""
+    import store
+    import walk
+
+    if not _can_symlink(tmp_path):
+        pytest.skip("directory symlinks are unavailable")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "keep-me.txt"
+    victim.write_text("external")
+    _age(victim, store.IDLE_SECONDS + 60)
+    store.note_set(tmp_path, "did", "keep", "live")
+    trap = tmp_path / "notes" / "trap"
+    trap.mkdir()
+    (trap / "decoy.txt").write_text("decoy")
+    stale = store.note_path(tmp_path, "old", "gone")
+    stale.parent.mkdir(parents=True, exist_ok=True)
+    stale.write_text("stale")
+    _age(stale, store.IDLE_SECONDS + 60)
+
+    def swap(full_path: str, name: str) -> None:
+        if name != "trap":
+            return
+        decoy = Path(full_path) / "decoy.txt"
+        decoy.unlink(missing_ok=True)
+        Path(full_path).rmdir()
+        os.symlink(outside, full_path, target_is_directory=True)
+
+    monkeypatch.setattr(walk, "_before_open_child", swap)
+    _arm_reaper(tmp_path)
+    store._reap(tmp_path)
+    assert victim.exists() and victim.read_text() == "external"
+    assert not stale.exists()
+    assert store.note_get(tmp_path, "did", "keep") == "live"
+    assert (tmp_path / "notes" / "trap").is_symlink()


### PR DESCRIPTION
## Problem

`store._walk` classified a child with `DirEntry.is_dir(follow_symlinks=False)` and then reopened it by pathname. Replacing that real directory with a directory symlink in the window let the public reaper follow the new link and unlink aged files outside the store root.

This is the pre-existing check-to-open race reported on #330. It is not introduced by that PR, and it still reproduces on exact current main:

```
MAIN_swapped True
MAIN_external_exists False
```

Static `follow_symlinks=False` only blocks a symlink that is already present. It does not bind the later recursive open to the directory that was classified.

## Fix

Add `src/walk.py` as an extra primitive and delegate `_walk` / `_scan` to it.

- POSIX child directories are opened with `O_NOFOLLOW` relative to the parent fd (`openat`).
- The configured store root itself may be a symlink (a mounted volume) and is followed once.
- Observed Windows child symlinks and junctions are skipped; Windows has no `dir_fd` openat, so hostile same-privilege rename races stay out of scope there.
- Trees deeper than 8 levels are skipped rather than walked until fds or the stack run out.

`store.py` shrinks because the walker moved out of core. The size ratchet records that: core code-lines 2127 -> 2091, with `store.py` 840 -> 804 against an unchanged 841 cap.

## Tests

`tests/unit/test_walk.py` pins the public reaper path, not just the walker:

- existing directory symlink is not descended;
- directory-to-symlink substitution does not delete the external target, and a later legitimate sibling is still reaped;
- a symlinked store root is followed once;
- vanished children and stale sized stats are skipped;
- depth above `MAX_DEPTH` is skipped.

On the patched tree the same public-reaper substitution now keeps the external file:

```
PATCHED_victim_exists True external
PATCHED_stale_exists False
```

## Validation on exact main `9c7df0e3616cf28d17e7c8ebeb0c05de6adf117c`

| Gate | Result |
|---|---:|
| Focused store/walk/sharding/note-count | **107 passed** |
| Ruff lint | Passed |
| Ruff formatting | Passed |
| `ty` | Passed |
| Size check / caps | **2091/2128** (`store.py` 804/841) |
| Full suite | **464 passed** |
| Coverage | **97.14%** |

## Out of scope

`_prune()` still recurses empty directories by pathname. That path only removes empty dirs, not aged file contents, and is not this PR's deletion-capable race. Fd-scoping prune can follow separately if wanted.

Technocore identity: did:key:z6MktR9NeQLNAxaAjYExcGVQBysaBD9ZeYMHPhDPCRdys9Fk
