### PR TITLE
fix(limit): guard _buckets read-modify-write under _buckets_lock

### DIFF
--- a/src/limit.py
+++ b/src/limit.py
@@ -53,6 +53,13 @@ FREE_PATHS = "/, /llms.txt, /skill.md, /patterns.md, /interop.md, /auth.md, /ope
 # limiter state — which is why the authoritative limit belongs in the proxy (see README).
 MAX_BUCKETS = 20_000
 _buckets: OrderedDict[tuple[str, str], tuple[float, float]] = OrderedDict()
+# Guards every read-modify-write on _buckets, in take() and in refund(): unlike a lost
+# update on _dupes (a fraction of a token, see below), a burst of concurrent callers on
+# one (ip, kind) can each read the same un-decremented balance and each grant
+# independently — the over-admission scales with concurrency, not with a fixed fraction.
+# A leaf lock, same discipline as _dupes_lock: held for a handful of dict operations,
+# never across client_ip(), the debug log, or any I/O.
+_buckets_lock = threading.Lock()
 
 # Request counters for /stats. Deliberately in-process (the store's counters are the
 # durable ones): traffic is only ever read as a rate, and a rate needs the uptime that
@@ -267,23 +274,35 @@ def take(request, kind, per_min, burst=None, *, ip_header="", max_buckets=MAX_BU
     the capacity is the whole day's allowance and `per_min` is only the rate that hands it
     back. Folded together, a 20-rooms-per-day budget would be a bucket holding 0.0139
     tokens, which never reaches the 1.0 a grant costs — the limit would refuse everything.
+
+    The balance is read, updated and written back under `_buckets_lock`: every write lane
+    reaches here from a threadpool, so an unlocked read-modify-write lets a burst of
+    concurrent callers on one (ip, kind) each read the same balance and each grant —
+    admitting more than the bucket ever held. `refund()` takes the same lock for the
+    same reason.
     """
     ip = client_ip(request, ip_header)
     if len(_identities) < MAX_IDENTITIES:
         _identities.add(ip)
     now = time.monotonic()
     cap = float(per_min if burst is None else burst)
-    tokens, last = _buckets.get((ip, kind), (cap, now))
-    tokens = min(cap, tokens + (now - last) * per_min / 60.0)
-    if tokens >= 1.0:  # granted: no wait, even when this was the last token
-        tokens -= 1.0
-        wait = 0.0
-    else:
-        wait = (1.0 - tokens) * 60.0 / per_min
-    _buckets[(ip, kind)] = (tokens, now)
-    _buckets.move_to_end((ip, kind))
-    while len(_buckets) > max_buckets:
-        _buckets.popitem(last=False)
+    with _buckets_lock:
+        tokens, last = _buckets.get((ip, kind), (cap, now))
+        tokens = min(cap, tokens + (now - last) * per_min / 60.0)
+        if tokens >= 1.0:  # granted: no wait, even when this was the last token
+            tokens -= 1.0
+            wait = 0.0
+        else:
+            wait = (1.0 - tokens) * 60.0 / per_min
+        # pop-then-insert, not move_to_end: assigning an existing key leaves the entry
+        # where it already was, and a concurrent evictor's popitem could take it from
+        # there, turning a plain move_to_end into a KeyError (#378). Redundant now that
+        # the lock rules that interleaving out, but keeps this block correct on its own
+        # if the lock is ever narrowed further.
+        _buckets.pop((ip, kind), None)
+        _buckets[(ip, kind)] = (tokens, now)
+        while len(_buckets) > max_buckets:
+            _buckets.popitem(last=False)
     # Counted at the one point every rate-limited route already funnels through, so a new
     # route cannot forget to count itself. In-process, so these reset on restart — /stats
     # reports them next to `uptime_seconds`, which is what makes them readable.
@@ -299,11 +318,16 @@ def refund(request, kind, per_min, burst=None, *, ip_header="") -> None:
 
     `last` is deliberately left alone: it is the refill clock, and moving it would either
     grant free time or discard earned time. Only the balance changes.
+
+    Takes `_buckets_lock`, the same one `take()` holds: this is a read-modify-write on the
+    same dict, and without the same lock a refund racing a take() on one (ip, kind) can
+    lose either side's update the same way two concurrent take() calls can.
     """
     ip = client_ip(request, ip_header)
     cap = float(per_min if burst is None else burst)
-    tokens, last = _buckets.get((ip, kind), (cap, time.monotonic()))
-    _buckets[(ip, kind)] = (min(cap, tokens + 1.0), last)
+    with _buckets_lock:
+        tokens, last = _buckets.get((ip, kind), (cap, time.monotonic()))
+        _buckets[(ip, kind)] = (min(cap, tokens + 1.0), last)
     config._dbg(1, "refund", ip=ip, kind=kind)
 
 

--- a/tests/unit/test_token_bucket.py
+++ b/tests/unit/test_token_bucket.py
@@ -1,0 +1,134 @@
+"""Run: uv run --group dev python -m pytest tests
+
+`take()` and `refund()`'s own rules, tested against `limit._buckets` directly. Every
+write lane reaches the token bucket from a threadpool — the GET lanes are sync
+endpoints, the POST goes through run_in_threadpool — so a burst of concurrent callers
+on one (ip, kind) is not a hypothetical, it is the ordinary shape of load. What matters
+is not the verdict on one call but the total admitted across every caller that raced
+the same bucket: a lock that is missing is invisible in a single-threaded test and only
+shows up as an over-admitted budget under a real burst.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+import threading
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+import limit  # noqa: E402
+
+
+class _FakeClient:
+    def __init__(self, host: str) -> None:
+        self.host = host
+
+
+class _FakeRequest:
+    """The only two things client_ip() reads off a request: .headers (for the
+    proxy-header check, unused with the default ip_header="") and .client.host."""
+
+    def __init__(self, host: str = "203.0.113.5") -> None:
+        self.headers: dict[str, str] = {}
+        self.client = _FakeClient(host)
+
+
+REQUEST = _FakeRequest()
+
+
+def _run(threads: list[threading.Thread]) -> None:
+    """Every thread started, then joined, at the fine-grained switch interval the
+    dupe-ring concurrency test already establishes as what makes this codebase's races
+    reproducible rather than merely possible."""
+    switch = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        sys.setswitchinterval(switch)
+
+
+def test_concurrent_take_never_admits_more_than_the_burst() -> None:
+    """Twenty threads hammer take() on the same (ip, kind) far past the burst. Unguarded,
+    a burst of callers can each read the same un-decremented balance and each grant
+    independently — the over-admission scales with how many raced the same snapshot, not
+    with a fixed fraction of a token (limit.py's own comment on the un-locked _dupes
+    case argues the latter, which does not hold here). `per_min` is set low enough that
+    refill during the run cannot itself explain an extra grant.
+    """
+    limit._buckets.clear()
+    key = (REQUEST.client.host, "burst-test")
+    per_min, burst = 1e-9, 50
+    threads_n, calls_per_thread = 20, 50
+    errors: list[BaseException] = []
+    granted = itertools.count()
+
+    def hammer() -> None:
+        try:
+            for _ in range(calls_per_thread):
+                _, wait = limit.take(REQUEST, "burst-test", per_min, burst=burst)
+                if wait == 0.0:
+                    next(granted)
+        except BaseException as exc:  # noqa: BLE001 - the exception IS what this asserts on
+            errors.append(exc)
+
+    _run([threading.Thread(target=hammer) for _ in range(threads_n)])
+
+    assert not errors, [repr(exc) for exc in errors[:3]]
+    admitted = next(granted)
+    assert admitted <= burst, f"admitted {admitted} calls against a burst of {burst}"
+    assert len(limit._buckets) >= 1 and key in limit._buckets
+    limit._buckets.clear()
+
+
+def test_concurrent_take_and_refund_never_lose_an_update() -> None:
+    """Half the threads spend tokens, half refund them, on the same (ip, kind), starting
+    and ending far from either the empty or the full boundary so every call is a plain
+    read-modify-write with a known effect. Locked, the net change has to equal
+    (refunds - takes) exactly, regardless of interleaving order — float addition and
+    subtraction by 1.0 is exact at these magnitudes. A lost update from either side
+    racing the other shows up as a final balance that does not match.
+    """
+    limit._buckets.clear()
+    key = (REQUEST.client.host, "take-refund-test")
+    per_min, burst = 1e-9, 100_000.0
+    start = 50_000.0
+    # `last` set to now, not 0.0: a stale `last` would let the very first call's own
+    # refill term (now - last) span real elapsed time since the epoch, adding a genuine
+    # if tiny balance the assertion below would then wrongly read as a lost update.
+    limit._buckets[key] = (start, time.monotonic())
+
+    threads_n, calls_per_thread = 10, 200  # 2000 takes, 2000 refunds
+    errors: list[BaseException] = []
+
+    def spend() -> None:
+        try:
+            for _ in range(calls_per_thread):
+                limit.take(REQUEST, "take-refund-test", per_min, burst=burst)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    def give_back() -> None:
+        try:
+            for _ in range(calls_per_thread):
+                limit.refund(REQUEST, "take-refund-test", per_min, burst=burst)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=spend) for _ in range(threads_n)] + [
+        threading.Thread(target=give_back) for _ in range(threads_n)
+    ]
+    _run(threads)
+
+    assert not errors, [repr(exc) for exc in errors[:3]]
+    final_tokens, _ = limit._buckets[key]
+    # threads_n * calls_per_thread takes and the same number of refunds started and
+    # ended at the same point, net zero, if — and only if — no update was lost.
+    assert final_tokens == start, f"expected {start}, got {final_tokens} — an update was lost"
+    limit._buckets.clear()


### PR DESCRIPTION
## What
`take()` and `refund()` in `src/limit.py` now read, update, and write back `_buckets` under a new `_buckets_lock`, and use pop-then-insert instead of `move_to_end`. No route, parameter, or response shape changes — callers only see the overdraft close.

## Why
Closes #476. Both functions ran the read-modify-write on `_buckets` unlocked; a burst of concurrent callers on one `(ip, kind)` could each read the same balance and each be admitted, over-admitting the rate-limit budget. `_dupes` already has `_dupes_lock` for the equivalent race.

This also subsumes the `#378` fix for `_buckets`: the `move_to_end` `KeyError` cannot occur inside a lock that rules out the interleaving, but pop-then-insert is kept as a documented invariant in case the lock is ever narrowed.

## Checks
- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 465 passed (463 existing + 2 new in `tests/unit/test_token_bucket.py`), 97.39% coverage
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — clean
- [x] Docs that would now be wrong are updated: none — no public-surface change
- [x] New surface on a world-writable service: nothing new — this narrows an existing overdraft, no new route/parameter/state