### PR TITLE
fix(mcp): build Docker image from checkout

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,12 @@
 !SKILL.md
 !pyproject.toml
 !uv.lock
+# The MCP image installs the checkout's package rather than silently pulling an older
+# release from PyPI. Keep only the package metadata and sources in the context.
+!mcp/
+!mcp/pyproject.toml
+!mcp/README.md
+!mcp/LICENSE
+!mcp/NOTICE
+!mcp/src/
+!mcp/src/technocore_mcp/

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -9,15 +9,12 @@ FROM python:3.12.13-slim@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad
 ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1 \
     TECHNOCORE_URL=https://technocore.chat
 
-# From PyPI rather than the source beside it, so the image runs the same artifact
-# `uvx technocore-mcp` does — unpinned, for the same reason that one is. The package
-# declares no dependencies (the service it wraps needs no client library), so this
-# resolves exactly one first-party wheel and there is no third party under it for a
-# floating version to break. A literal here would instead leave this the one install
-# lane frozen behind a release while `uvx` and `claude mcp add` follow it, and it would
-# be the third copy of a version number pyproject.toml keeps dynamic on purpose. The
-# interpreter is the real third-party surface, and it is pinned by digest above.
-RUN pip install --no-cache-dir technocore-mcp \
+# Install the package from this checkout so the image contains the code being built. The
+# release workflow publishes the same source to PyPI; local Docker validation must not
+# silently resolve an older published release. The package has no runtime dependencies.
+COPY mcp /tmp/technocore-mcp
+RUN pip install --no-cache-dir /tmp/technocore-mcp \
+    && rm -rf /tmp/technocore-mcp \
     && useradd --uid 10001 --no-create-home --shell /usr/sbin/nologin mcp
 
 USER 10001


### PR DESCRIPTION
## Summary

Fixes #475.

`mcp/Dockerfile` previously ran `pip install technocore-mcp`, so a checkout at source version `0.10.0` built an image containing the latest published PyPI release (`0.9.4`). The image therefore did not validate or run the checked-out MCP source.

This change:

- includes only the MCP package metadata and source in the Docker build context;
- installs `/tmp/technocore-mcp` from that checkout;
- removes the temporary source after installation;
- leaves the runtime image dependency-free and keeps the pinned Python base image.

## Validation

- `uv build --project mcp` — source distribution and wheel built successfully at `0.10.0`
- `docker build --no-cache -f mcp/Dockerfile -t technocore-mcp-fix:475 .` — passed
- resulting image package version — `0.10.0`
- Linux MCP tests: `45 passed in 2.88s`
- `git diff --check` — clean

The native Windows MCP test run remains blocked by the pre-existing `fcntl` import issue tracked in #122; the same tests passed in the Linux container.