### PR TITLE
test: read repository text as UTF-8 on Windows

### DIFF
--- a/tests/http/test_config.py
+++ b/tests/http/test_config.py
@@ -25,7 +25,10 @@ SRC = Path(__file__).resolve().parents[2] / "src"
 # catch. Quoted names only, so the CHAT_* spelled out in the prose comments beside them
 # (there are dozens) do not count as knobs.
 KNOBS = frozenset(
-    re.findall(r"[\"'](CHAT_[A-Z_0-9]+|WEB_CONCURRENCY)[\"']", (SRC / "config.py").read_text())
+    re.findall(
+        r"[\"'](CHAT_[A-Z_0-9]+|WEB_CONCURRENCY)[\"']",
+        (SRC / "config.py").read_text(encoding="utf-8"),
+    )
 )
 
 

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -401,7 +401,7 @@ def test_skill_md_is_the_installable_skill_and_is_never_rate_limited(client, mon
 
     # Same bytes as the installable SKILL.md — one artifact, so the skill an agent
     # installs and the skill it fetches can never drift.
-    skill = (Path(__file__).resolve().parents[2] / "SKILL.md").read_text()
+    skill = (Path(__file__).resolve().parents[2] / "SKILL.md").read_text(encoding="utf-8")
     assert client.get("/skill.md").text == skill
     assert client.get("/skill.md").headers["content-type"].startswith("text/plain")
     assert "/llms.txt" in client.get("/skill.md").text  # points at the full reference
@@ -1202,7 +1202,7 @@ def test_openapi_limits_are_the_limits_the_server_enforces(client):
     room = next(p for p in say["parameters"] if p["name"] == "room")
     assert room["schema"]["pattern"] == store.NAME_RE.pattern
     # …and the version comes from the file that declares it, not a second copy.
-    pyproject = (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text()
+    pyproject = (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text(encoding="utf-8")
     assert doc["info"]["version"] in pyproject
 
 
@@ -1426,7 +1426,9 @@ def test_the_skill_the_image_and_the_wrapper_all_name_one_version(client):
     from pathlib import Path
 
     root = Path(__file__).resolve().parents[2]
-    service = tomllib.loads((root / "pyproject.toml").read_text())["project"]["version"]
+    service = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))["project"][
+        "version"
+    ]
 
     skill = client.get("/.well-known/agent-skills/index.json").json()["skills"][0]
     assert skill["version"] == service
@@ -1435,7 +1437,10 @@ def test_the_skill_the_image_and_the_wrapper_all_name_one_version(client):
     assert {"name", "type", "description", "url", "digest"} <= set(skill)
     assert client.get("/openapi.json").json()["info"]["version"] == service
     assert client.get("/.well-known/agent.json").json()["version"] == service
-    assert json_module.loads((root / "mcp" / "server.json").read_text())["version"] == service
+    assert (
+        json_module.loads((root / "mcp" / "server.json").read_text(encoding="utf-8"))["version"]
+        == service
+    )
 
 
 def test_the_api_catalog_only_links_paths_this_origin_answers(client):

--- a/tests/http/test_dupe_filter.py
+++ b/tests/http/test_dupe_filter.py
@@ -411,7 +411,7 @@ def test_the_first_action_skill_md_prescribes_survives_a_wave_of_new_agents(clie
     obeying it literally must all be heard. Under the floor is one way (the shipped
     example is), varying with the nick is another.
     """
-    skill = (Path(__file__).resolve().parents[2] / "SKILL.md").read_text()
+    skill = (Path(__file__).resolve().parents[2] / "SKILL.md").read_text(encoding="utf-8")
     example = re.search(r"`GET (/r/lobby/say/yourname/\S+?)`", skill)
     assert example, "SKILL.md no longer prescribes a first action in the form this gate reads"
     with _filter_on():

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -542,7 +542,9 @@ def test_an_empty_trusted_proxy_header_falls_back_to_the_socket_peer(client, mon
 
 def _dockerfile_cmd() -> list[str]:
     """The argv the shipped image actually runs, out of the CMD JSON array."""
-    raw = (Path(__file__).resolve().parents[2] / "docker" / "Dockerfile").read_text()
+    raw = (Path(__file__).resolve().parents[2] / "docker" / "Dockerfile").read_text(
+        encoding="utf-8"
+    )
     body = raw.split("\nCMD ", 1)[1].replace("\\\n", " ")
     return json.loads(body[: body.index("]") + 1])
 

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -787,7 +787,7 @@ def test_every_place_that_teaches_the_claim_teaches_the_signed_one(client):
     assert "/kv/room-owners/d-jobs/set-signed/" in patterns
     assert "share /kv/room-nonce/d-jobs as their replay counter" in patterns
 
-    readme = (Path(__file__).resolve().parents[2] / "README.md").read_text()
+    readme = (Path(__file__).resolve().parents[2] / "README.md").read_text(encoding="utf-8")
     for source in (manual, patterns, readme):
         assert unsigned not in source and "/set/<did>?if_absent=1" not in source
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1331,9 +1331,11 @@ def test_every_place_that_declares_a_version_agrees():
 
     from technocore_mcp import server as mcp_server
 
-    manifest = json.loads((ROOT / "mcp" / "server.json").read_text())
-    pyproject = (ROOT / "mcp" / "pyproject.toml").read_text()
-    service = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]["version"]
+    manifest = json.loads((ROOT / "mcp" / "server.json").read_text(encoding="utf-8"))
+    pyproject = (ROOT / "mcp" / "pyproject.toml").read_text(encoding="utf-8")
+    service = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"][
+        "version"
+    ]
     version = manifest["version"]
     assert manifest["packages"][0]["version"] == version
     assert mcp_server.VERSION == version
@@ -1361,8 +1363,8 @@ def test_the_registry_ownership_marker_is_present_and_matches():
     """The MCP registry proves we own the PyPI package by finding `mcp-name: <server name>`
     in the published README. Without it `mcp-publisher publish` is rejected — after the PyPI
     release is already public and unrepeatable at that version."""
-    manifest = json.loads((ROOT / "mcp" / "server.json").read_text())
-    readme = (ROOT / "mcp" / "README.md").read_text()
+    manifest = json.loads((ROOT / "mcp" / "server.json").read_text(encoding="utf-8"))
+    readme = (ROOT / "mcp" / "README.md").read_text(encoding="utf-8")
     assert f"mcp-name: {manifest['name']}" in readme
     assert manifest["name"].startswith("io.github.")  # the namespace OIDC can actually prove
 

--- a/tests/test_mcp_package.py
+++ b/tests/test_mcp_package.py
@@ -70,7 +70,7 @@ def test_distribution_verifier_rejects_nested_sdist_legal_files(tmp_path):
 
 
 def test_ci_verifies_the_mcp_artifacts_after_building_them():
-    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     build = workflow.index("uv build --project mcp")
     verify = workflow.index("uv run python tests/verify_mcp_dist.py")
     assert build < verify


### PR DESCRIPTION
## What

Tests now pass `encoding="utf-8"` when reading UTF-8 repository artifacts. On locale-encoded Windows this lets the tests reach their assertions instead of failing during file decoding. Runtime and public behavior are unchanged.

## Why

On native Japanese Windows with Python 3.12, UTF-8 mode disabled, and CP932 as the preferred encoding, three focused tests failed with `UnicodeDecodeError` while reading `mcp/server.json` or `.github/workflows/ci.yml`.

The same three tests pass after this change. The full suite cannot currently collect natively because the separate `fcntl` portability issue remains tracked in #255 / #122; the complete regression suite was therefore run on Linux. This PR is deliberately limited to repository-file test reads.

## Checks

- [x] Native Windows CP932: 3 focused tests passed (3 failed before)
- [x] `uv run coverage run -m pytest tests -q && uv run coverage report`: 463 passed, 97.31%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] `uv run sz.py --check`
- [x] Docs remain accurate; no product behavior changed
- [x] New world-writable surface: nothing new
