### PR TITLE
fix(manifest): require a full match on the Host header, not a prefix match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+PATCH: `public_base` now requires a full match on the Host header instead of `.match()` against a `$`-anchored pattern, which accepted a trailing newline (`$` matches immediately before one in a non-MULTILINE regex). The same class of gap `store.NAME_RE`'s own fix already closed elsewhere. A control character surviving into the returned origin reached every document that advertises it: `/openapi.json`, `/.well-known/agent.json`, `/sitemap.xml`, and the `Link` response header, where it is the shape of a header-splitting primitive rather than only a malformed-document bug.
+
 ## [0.10.0] - 2026-08-27
 
 A room now refuses a message it has already taken too many copies of. The flood this exists for

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -57,7 +57,7 @@ def public_base(scheme: str, host: str, configured: str = "") -> str:
     """
     if configured:
         return configured.rstrip("/")
-    if host and _HOST_RE.match(host.lower()) and scheme in ("http", "https"):
+    if host and _HOST_RE.fullmatch(host.lower()) and scheme in ("http", "https"):
         return f"{scheme}://{host.lower()}"
     return ""
 

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1073,6 +1073,22 @@ def test_metadata_urls_never_echo_an_untrusted_host(client):
     assert ok["documentation"]["openapi"] == "http://technocore.chat/openapi.json"
 
 
+def test_a_trailing_newline_on_the_host_header_degrades_to_relative_urls(client):
+    """`$` in a non-MULTILINE pattern matches immediately before a trailing newline too, so
+    `.match()` on a `$`-anchored regex accepts a value `.fullmatch()` would refuse -- the
+    same class of gap `store.NAME_RE`'s own fix already closed. A control character surviving
+    into `public_base`'s output reaches /openapi.json's servers[0].url, /.well-known/agent.json,
+    /sitemap.xml's <loc> (embedded in XML), and the Link response header, where it is the
+    shape of a header-splitting primitive rather than only a malformed-document bug.
+    """
+    doc = client.get("/.well-known/agent.json", headers={"host": "technocore.chat\n"}).json()
+    assert doc["url"] == "/", "a trailing newline must degrade exactly like any other bad host"
+    link = client.get("/openapi.json", headers={"host": "technocore.chat\n"}).headers.get(
+        "link", ""
+    )
+    assert "\n" not in link
+
+
 def test_configured_public_url_wins_over_the_request(client, monkeypatch):
     import config
 

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.9.7"
+version = "0.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Closes #487.

## Problem

`_HOST_RE.match()` against a `$`-anchored pattern accepted a Host header value ending in a trailing newline. In a non-MULTILINE regex, `$` matches immediately before a trailing newline as well as at the true end of string — `.match()` doesn't require consuming the whole input, only a match starting at position 0, so `"technocore.chat\n"` satisfies `^[a-z0-9]...$` at the `\n` boundary. `store.NAME_RE` already had this exact class of gap closed; `_HOST_RE` was missed.

## Impact

The unvalidated host reaches `public_base`'s output, which is embedded in every document that advertises this service's own origin: `/openapi.json` (`servers[0].url`), `/.well-known/agent.json`, `/sitemap.xml` (inside XML `<loc>` values), and the `Link` response header — where a trailing control character is the shape of a header-splitting primitive, not merely a malformed-document bug.

## Fix

One-character-class change: `.match()` → `.fullmatch()`, exactly the fix the issue suggested and consistent with `store.NAME_RE`'s existing pattern.

## Testing

- `uv run ruff check .` / `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest tests -q` (464 passed) — new test `test_a_trailing_newline_on_the_host_header_degrades_to_relative_urls`, placed next to the existing untrusted-host test it extends
- Verified the regression test actually catches the bug: temporarily reverted the fix locally and confirmed the test fails (`assert 'http://technocore.chat\n' == '/'` — the newline survived), then confirmed it passes with the fix restored
- `python3 sz.py --check` — unaffected (character-class swap, no line-count change)

## Abuse impact

None new — this closes an existing gap rather than opening one. No new route, parameter, or persistent state.