### PR TITLE
fix(mcp): omit query string when all optional params are None

### DIFF
--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -76,8 +76,9 @@ def _fetch(path: str, query: dict | None = None) -> str:
     favour of "HTTP Error 429" would throw away the only part the model can act on.
     """
     url = f"{BASE_URL}{path}"
-    if query:
-        url += "?" + urllib.parse.urlencode({k: v for k, v in query.items() if v is not None})
+    params = {k: v for k, v in (query or {}).items() if v is not None}
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
     request = urllib.request.Request(url, headers={"User-Agent": f"technocore-mcp/{VERSION}"})
     try:
         with urllib.request.urlopen(request, timeout=TIMEOUT) as response:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -639,3 +639,28 @@ def test_the_registry_ownership_marker_is_present_and_matches():
     readme = (ROOT / "mcp" / "README.md").read_text()
     assert f"mcp-name: {manifest['name']}" in readme
     assert manifest["name"].startswith("io.github.")  # the namespace OIDC can actually prove
+
+
+def test_fetch_omits_trailing_question_mark_when_all_optional_params_are_none(mcp, monkeypatch):
+    """read_room, list_rooms and discover_rooms must not append a bare '?'
+    when optional parameters are left at their None defaults.
+
+    Regression for the _fetch bug where `if query:` was True for a
+    non-empty dict whose values were all None, causing urlencode({}) == ""
+    to be appended after '?'."""
+    server, _ = mcp
+    asked = []
+    inner = urllib.request.urlopen
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda request, timeout=None: (asked.append(request.full_url), inner(request, timeout))[1],
+    )
+    call(server, "read_room", {"room": "lobby"})
+    assert not asked[-1].endswith("?"), f"trailing ? in {asked[-1]!r}"
+
+    call(server, "list_rooms", {})
+    assert not asked[-1].endswith("?"), f"trailing ? in {asked[-1]!r}"
+
+    call(server, "discover_rooms", {})
+    assert not asked[-1].endswith("?"), f"trailing ? in {asked[-1]!r}"


### PR DESCRIPTION
Fixes #494.

`_fetch` filtered `None` values inside the `if query:` guard, so a dict like `{"since": None, "limit": None}` passed the guard (non-empty dict is truthy), then `urlencode({})` returned `""`, appending a bare `?` to every no argument call to `read_room`, `list_rooms`, and `discover_rooms`.

## Fix

Filter first, then guard on the filtered result:

```python
params = {k: v for k, v in (query or {}).items() if v is not None}
if params:
    url += "?" + urllib.parse.urlencode(params)
```

## Test

Added a regression test that monkeypatches `urlopen` and asserts `request.full_url` has no trailing `?` for all three affected tools same pattern as the existing `test_float_since_is_narrowed_to_int_before_hitting_the_wire`.