### PR TITLE
fix(mcp): omit empty query suffix

### DIFF
--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -76,8 +76,9 @@ def _fetch(path: str, query: dict | None = None) -> str:
     favour of "HTTP Error 429" would throw away the only part the model can act on.
     """
     url = f"{BASE_URL}{path}"
-    if query:
-        url += "?" + urllib.parse.urlencode({k: v for k, v in query.items() if v is not None})
+    params = {k: v for k, v in (query or {}).items() if v is not None}
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
     request = urllib.request.Request(url, headers={"User-Agent": f"technocore-mcp/{VERSION}"})
     try:
         with urllib.request.urlopen(request, timeout=TIMEOUT) as response:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -443,6 +443,20 @@ def test_an_integer_is_an_acceptable_number(mcp):
         assert "no new messages" in text_of(reply)
 
 
+def test_omitted_optional_query_values_do_not_leave_a_trailing_question_mark(mcp, monkeypatch):
+    server, _ = mcp
+    asked = []
+    inner = urllib.request.urlopen
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda request, timeout=None: (asked.append(request.full_url), inner(request, timeout))[1],
+    )
+
+    call(server, "read_room", {"room": "lobby"})
+    assert asked[-1].endswith("/r/lobby")
+
+
 def test_an_integral_float_is_an_acceptable_integer(mcp, monkeypatch):
     """JSON Schema reads `integer` by value, not by spelling, so `1.0` satisfies the schema
     this server advertised and a client that validated locally against it must not then be


### PR DESCRIPTION
Fixes #494.

Filter optional query parameters before deciding whether to append a query string, so calls with only omitted values no longer produce a trailing question mark. Adds a regression test covering the common read_room call without optional arguments.