### PR TITLE
fix: serialize ownership note writes across handoff

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1681,11 +1681,15 @@ def _burn_nonce(room: str, nonce: str) -> Response | None:
 def _write_protected_note(
     ns: str, key: str, value: str, signer: str | None, nonce: str | None, condition: tuple
 ) -> dict | Response:
-    with store._locked(config.ROOT / ".ownership" / key):
-        denied = _note_write_gate(ns, key, value, signer) or (
-            _burn_nonce(key, nonce) if signer is not None and nonce is not None else None
-        )
-        return denied or store.note_set(config.ROOT, ns, key, value, *condition)
+    if ns in store.ROOM_GUARD_NS:
+        gate_lock = store.note_path(config.ROOT, "room-gate", key)
+        with store._locked(gate_lock):
+            denied = _note_write_gate(ns, key, value, signer) or (
+                _burn_nonce(key, nonce) if signer is not None and nonce is not None else None
+            )
+            return denied or store.note_set(config.ROOT, ns, key, value, *condition)
+    denied = _note_write_gate(ns, key, value, signer)
+    return denied or store.note_set(config.ROOT, ns, key, value, *condition)
 
 
 def note_write_signed(request: Request) -> Response:

--- a/src/app.py
+++ b/src/app.py
@@ -1682,8 +1682,7 @@ def _write_protected_note(
     ns: str, key: str, value: str, signer: str | None, nonce: str | None, condition: tuple
 ) -> dict | Response:
     if ns in store.ROOM_GUARD_NS:
-        gate_lock = store.note_path(config.ROOT, "room-gate", key)
-        with store._locked(gate_lock):
+        with store._locked(store.room_path(config.ROOT, key)):
             denied = _note_write_gate(ns, key, value, signer) or (
                 _burn_nonce(key, nonce) if signer is not None and nonce is not None else None
             )

--- a/src/app.py
+++ b/src/app.py
@@ -1665,15 +1665,6 @@ def note_write(request: Request) -> Response:
 
 
 def _burn_nonce(room: str, nonce: str) -> Response | None:
-    """Spend a nonce for a room's signed ownership writes, or refuse the replay.
-
-    A message replay stops mattering when the message leaves the ring; a note has no ring,
-    so a captured signed URL would work forever — including the one that re-adds a key the
-    owner has since removed. The counter is claimed with a compare-and-set on the note that
-    holds it, so two concurrent writers cannot both spend the same value; the loser gets
-    the ordinary 409. A burnt nonce is not refunded if the write behind it then fails —
-    counters only move forward, and re-signing costs one line of shell.
-    """
     current = store.note_get(config.ROOT, store.NONCE_NS, room)
     if current is not None and not (current.isdigit() and int(nonce) > int(current)):
         return text(
@@ -1682,14 +1673,19 @@ def _burn_nonce(room: str, nonce: str) -> Response | None:
             403,
         )
     store.note_set(
-        config.ROOT,
-        store.NONCE_NS,
-        room,
-        nonce,
-        expect=current,
-        expect_absent=current is None,
+        config.ROOT, store.NONCE_NS, room, nonce, expect=current, expect_absent=current is None
     )
     return None
+
+
+def _write_protected_note(
+    ns: str, key: str, value: str, signer: str | None, nonce: str | None, condition: tuple
+) -> dict | Response:
+    with store._locked(config.ROOT / ".ownership" / key):
+        denied = _note_write_gate(ns, key, value, signer) or (
+            _burn_nonce(key, nonce) if signer is not None and nonce is not None else None
+        )
+        return denied or store.note_set(config.ROOT, ns, key, value, *condition)
 
 
 def note_write_signed(request: Request) -> Response:
@@ -1703,19 +1699,13 @@ def note_write_signed(request: Request) -> Response:
     signer = _signer(p["did"], p["sig"], nonce, f"{ns}|{key}|{nonce}|{value}")
     if isinstance(signer, Response):
         return signer
-    denied = _note_write_gate(ns, key, value, signer)
-    if denied:
-        return denied
-    condition = _condition(request.query_params)
-    denied = _burn_nonce(key, nonce)
-    if denied:
-        return denied
-    meta = store.note_set(config.ROOT, ns, key, value, *condition)
+    meta = _write_protected_note(ns, key, value, signer, nonce, _condition(request.query_params))
+    if isinstance(meta, Response):
+        return meta
     return respond(
         request,
         meta,
-        f"ok {meta['ns']}/{meta['key']} {meta['bytes']}B {meta['ts']} "
-        f"signed by {didkey.abbreviate(signer)}",
+        f"ok {meta['ns']}/{meta['key']} {meta['bytes']}B {meta['ts']} signed by {didkey.abbreviate(signer)}",
         budget_note("write", left, RATE_WRITE),
     )
 
@@ -1735,6 +1725,7 @@ async def note_post(request: Request) -> Response:
     value = store.clean_text(_field(payload, "value"), store.MAX_VALUE_CHARS)
     did = _field(payload, "did").strip()
     signer = None
+    nonce = None
     if did:
         sig, nonce = _field(payload, "sig").strip(), _field(payload, "nonce").strip()
         signer = _signer(did, sig, nonce, f"{ns}|{key}|{nonce}|{value}")
@@ -1746,14 +1737,9 @@ async def note_post(request: Request) -> Response:
     # note, the nonce burn is a compare-and-swap on disk, and note_set walks the notes tree
     # to enforce the global cap. None of that may run on the loop from an `async def`.
     def write() -> Response:
-        denied = _note_write_gate(ns, key, value, signer)
-        if denied:
-            return denied
-        if signer is not None:
-            burned = _burn_nonce(key, nonce)
-            if burned:
-                return burned
-        meta = store.note_set(config.ROOT, ns, key, value, *condition)
+        meta = _write_protected_note(ns, key, value, signer, nonce, condition)
+        if isinstance(meta, Response):
+            return meta
         return respond(
             request,
             meta,

--- a/src/store.py
+++ b/src/store.py
@@ -659,7 +659,11 @@ def _locked(target: Path, shared: bool = False, nb: bool = False):
         with open(lock, "a+b") as lf:
             fcntl.flock(lf, (fcntl.LOCK_SH if shared else fcntl.LOCK_EX) | fcntl.LOCK_NB * nb)
             try:
-                if os.fstat(lf.fileno()).st_ino == os.stat(lock).st_ino:
+                try:
+                    match = os.fstat(lf.fileno()).st_ino == os.stat(lock).st_ino
+                except OSError:
+                    match = False
+                if match:
                     config._dbg(2, "flock", path=target.name)
                     yield
                     return

--- a/src/store.py
+++ b/src/store.py
@@ -655,13 +655,16 @@ def _locked(target: Path, shared: bool = False, nb: bool = False):
     """
     target.parent.mkdir(parents=True, exist_ok=True)
     lock = target.with_suffix(target.suffix + ".lock")
-    with open(lock, "a+b") as lf:
-        fcntl.flock(lf, (fcntl.LOCK_SH if shared else fcntl.LOCK_EX) | fcntl.LOCK_NB * nb)
-        config._dbg(2, "flock", path=target.name)
-        try:
-            yield
-        finally:
-            fcntl.flock(lf, fcntl.LOCK_UN)
+    while True:
+        with open(lock, "a+b") as lf:
+            fcntl.flock(lf, (fcntl.LOCK_SH if shared else fcntl.LOCK_EX) | fcntl.LOCK_NB * nb)
+            try:
+                if os.fstat(lf.fileno()).st_ino == os.stat(lock).st_ino:
+                    config._dbg(2, "flock", path=target.name)
+                    yield
+                    return
+            finally:
+                fcntl.flock(lf, fcntl.LOCK_UN)
 
 
 def _replace(path: Path, data: bytes, fsync: bool = False) -> None:
@@ -1662,15 +1665,13 @@ def _sweep_orphan_locks(root: Path, now: float, touched: dict[str, set[str]]) ->
                 data = entry.path[: -len(".lock")]
                 if os.access(data, os.F_OK) or now - entry.stat().st_mtime <= IDLE_SECONDS:
                     continue
-                if sub == "rooms":
-                    # A room lock also serves as the transaction gate for its ownership notes.
-                    # As long as any guard note (owners/allow/nonce) exists for this room,
-                    # the room's lock domain must never be swept.
-                    r_name = entry.name[: -len(suffix)]
-                    if any(os.access(note_path(root, ns, r_name), os.F_OK) for ns in ROOM_GUARD_NS):
+                with open(entry.path, "a+b") as s_lf:
+                    try:
+                        fcntl.flock(s_lf, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    except OSError:
                         continue
-                os.unlink(entry.path)
-                touched[sub].add(_emptied(base, entry.path, sub == "notes"))
+                    os.unlink(entry.path)
+                    touched[sub].add(_emptied(base, entry.path, sub == "notes"))
             except OSError:
                 continue
 

--- a/src/store.py
+++ b/src/store.py
@@ -1662,6 +1662,16 @@ def _sweep_orphan_locks(root: Path, now: float, touched: dict[str, set[str]]) ->
                 data = entry.path[: -len(".lock")]
                 if os.access(data, os.F_OK) or now - entry.stat().st_mtime <= IDLE_SECONDS:
                     continue
+                if sub == "rooms":
+                    # A room lock also serves as the transaction gate for its ownership notes.
+                    # As long as any guard note (owners/allow/nonce) exists for this room,
+                    # the room's lock domain must never be swept.
+                    r_name = entry.name[: -len(suffix)]
+                    if any(
+                        os.access(note_path(root, ns, r_name), os.F_OK)
+                        for ns in ROOM_GUARD_NS
+                    ):
+                        continue
                 os.unlink(entry.path)
                 touched[sub].add(_emptied(base, entry.path, sub == "notes"))
             except OSError:

--- a/src/store.py
+++ b/src/store.py
@@ -1667,10 +1667,7 @@ def _sweep_orphan_locks(root: Path, now: float, touched: dict[str, set[str]]) ->
                     # As long as any guard note (owners/allow/nonce) exists for this room,
                     # the room's lock domain must never be swept.
                     r_name = entry.name[: -len(suffix)]
-                    if any(
-                        os.access(note_path(root, ns, r_name), os.F_OK)
-                        for ns in ROOM_GUARD_NS
-                    ):
+                    if any(os.access(note_path(root, ns, r_name), os.F_OK) for ns in ROOM_GUARD_NS):
                         continue
                 os.unlink(entry.path)
                 touched[sub].add(_emptied(base, entry.path, sub == "notes"))

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -1,5 +1,6 @@
 """Run: uv run --group dev python -m pytest tests"""
 
+import threading
 import time
 from pathlib import Path
 
@@ -890,6 +891,66 @@ def test_ownership_cannot_be_taken_by_overwriting_the_note(client):
         == 200
     )
     assert _say_signed(client, "d-bounty", thief, thief_sign, "mine now").status_code == 200
+
+
+def test_previous_owner_cannot_commit_an_allow_list_after_handoff(client, tmp_path, monkeypatch):
+    """Authorization and commit must observe the same owner.
+
+    The old shape checked ownership in `_note_write_gate`, then separately burned the
+    nonce and wrote `room-allow`. This forces a handoff into that gap: owner A's request
+    passes the gate, owner A transfers the room to B, then A's stale request resumes.
+    """
+    import app as app_module
+    import store
+
+    owner, owner_sign = _keypair()
+    successor, _ = _keypair(seed=2)
+    assert _claim(client, "d-handoff", owner, owner_sign).status_code == 200
+
+    entered = threading.Event()
+    resume = threading.Event()
+    real_burn = app_module._burn_nonce
+
+    def pause_after_authorization(room, nonce):
+        if nonce == "10":
+            entered.set()
+            assert resume.wait(5), "handoff never released the stale request"
+        return real_burn(room, nonce)
+
+    monkeypatch.setattr(app_module, "_burn_nonce", pause_after_authorization)
+    stale = {}
+
+    def write_as_previous_owner():
+        stale["response"] = _set_signed(
+            client, store.ALLOW_NS, "d-handoff", owner, owner_sign, owner, nonce=10
+        )
+
+    worker = threading.Thread(target=write_as_previous_owner)
+    worker.start()
+    assert entered.wait(5), "request never reached the post-authorization gap"
+
+    transferred = threading.Event()
+    handoff = {}
+
+    def transfer_ownership():
+        handoff["response"] = _set_signed(
+            client, store.OWNERS_NS, "d-handoff", owner, owner_sign, successor, nonce=11
+        )
+        transferred.set()
+
+    transfer = threading.Thread(target=transfer_ownership)
+    transfer.start()
+    assert not transferred.wait(0.2), "handoff overtook an authorized allow-list transaction"
+
+    resume.set()
+    worker.join(5)
+    transfer.join(5)
+    assert not worker.is_alive() and not transfer.is_alive()
+
+    assert stale["response"].status_code == 200
+    assert handoff["response"].status_code == 200
+    assert store.note_get(tmp_path, store.OWNERS_NS, "d-handoff") == successor
+    assert store.note_get(tmp_path, store.ALLOW_NS, "d-handoff") == owner
 
 
 def test_an_allow_list_needs_an_owner_and_fails_closed_on_junk(client):

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -978,10 +978,19 @@ def test_reaping_an_owned_room_cleans_up_ownership_gate_sidecar(client, tmp_path
             with store._locked(r_path, nb=True):
                 pass
 
-    # Once reaped (all guard notes unlinked) and aged past IDLE_SECONDS, the sidecar is cleanly swept
+    # Once reaped (all guard notes unlinked), an actively held lock still survives aged sweeps
     for ns in store.ROOM_GUARD_NS:
         store.note_path(tmp_path, ns, room).unlink(missing_ok=True)
     r_path.unlink(missing_ok=True)
+
+    with store._locked(r_path):
+        store._sweep_orphan_locks(tmp_path, now + store.IDLE_SECONDS + 1, touched)
+        assert r_lock.exists()
+        with pytest.raises(BlockingIOError):
+            with store._locked(r_path, nb=True):
+                pass
+
+    # When unheld, the aged reaped sidecar is cleanly swept
     store._sweep_orphan_locks(tmp_path, now + store.IDLE_SECONDS + 1, touched)
     assert not r_lock.exists()
 

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -4,8 +4,8 @@ import threading
 import time
 from pathlib import Path
 
-import pytest
 import _client
+import pytest
 from _client import (
     _age,
     _at,

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -4,6 +4,7 @@ import threading
 import time
 from pathlib import Path
 
+import pytest
 import _client
 from _client import (
     _age,
@@ -954,22 +955,35 @@ def test_previous_owner_cannot_commit_an_allow_list_after_handoff(client, tmp_pa
 
 
 def test_reaping_an_owned_room_cleans_up_ownership_gate_sidecar(client, tmp_path, monkeypatch):
-    """The transaction gate sidecar lives under notes/ and is swept with orphan locks."""
+    """The transaction gate lock is tied to room_path, and stays held across orphan sweeps while live."""
     import store
 
     owner, owner_sign = _keypair()
     room = "d-reaped"
     assert _claim(client, room, owner, owner_sign).status_code == 200
 
-    gate_note = store.note_path(tmp_path, "room-gate", room)
-    gate_lock = gate_note.with_suffix(gate_note.suffix + ".lock")
-    assert gate_lock.exists()
+    r_path = store.room_path(tmp_path, room)
+    r_lock = r_path.with_suffix(r_path.suffix + ".lock")
+    assert r_lock.exists()
 
-    # Age past IDLE_SECONDS and run orphan lock sweep
-    now = time.time() + store.IDLE_SECONDS + 1
+    # While live (room guard notes exist), a lock sweep does not unlink the active transaction domain lock
+    now = time.time()
     touched = {"rooms": set(), "notes": set()}
-    store._sweep_orphan_locks(tmp_path, now, touched)
-    assert not gate_lock.exists()
+    with store._locked(r_path):
+        store._sweep_orphan_locks(tmp_path, now + store.IDLE_SECONDS + 1, touched)
+        # The room guards exist so lock is preserved
+        assert r_lock.exists()
+        # Verify a second locked attempt is blocked (single transaction domain)
+        with pytest.raises(BlockingIOError):
+            with store._locked(r_path, nb=True):
+                pass
+
+    # Once reaped (all guard notes unlinked) and aged past IDLE_SECONDS, the sidecar is cleanly swept
+    for ns in store.ROOM_GUARD_NS:
+        store.note_path(tmp_path, ns, room).unlink(missing_ok=True)
+    r_path.unlink(missing_ok=True)
+    store._sweep_orphan_locks(tmp_path, now + store.IDLE_SECONDS + 1, touched)
+    assert not r_lock.exists()
 
 
 def test_an_allow_list_needs_an_owner_and_fails_closed_on_junk(client):

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -1018,6 +1018,7 @@ def test_locked_waiter_retries_and_acquires_when_sidecar_is_unlinked_during_swee
 
     real_flock = fcntl.flock
     real_unlink = os.unlink
+    waiter_ready = threading.Event()
     waiter_at_flock = threading.Event()
     waiter_acquired = threading.Event()
     waiter_error = []
@@ -1025,7 +1026,7 @@ def test_locked_waiter_retries_and_acquires_when_sidecar_is_unlinked_during_swee
     waiter_thread = []
 
     def hooked_flock(fd, op):
-        if waiter_tid and threading.get_ident() == waiter_tid:
+        if waiter_tid is not None and threading.get_ident() == waiter_tid:
             waiter_at_flock.set()
         return real_flock(fd, op)
 
@@ -1035,6 +1036,9 @@ def test_locked_waiter_retries_and_acquires_when_sidecar_is_unlinked_during_swee
         if str(path) == str(r_lock):
 
             def waiter():
+                nonlocal waiter_tid
+                waiter_tid = threading.get_ident()
+                waiter_ready.set()
                 try:
                     with store._locked(r_path):
                         waiter_acquired.set()
@@ -1043,8 +1047,7 @@ def test_locked_waiter_retries_and_acquires_when_sidecar_is_unlinked_during_swee
 
             t = threading.Thread(target=waiter)
             t.start()
-            nonlocal waiter_tid
-            waiter_tid = t.ident
+            assert waiter_ready.wait(5), "waiter thread never initialized identity"
             waiter_thread.append(t)
             assert waiter_at_flock.wait(5), "waiter never reached flock"
             real_unlink(path)

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -953,6 +953,25 @@ def test_previous_owner_cannot_commit_an_allow_list_after_handoff(client, tmp_pa
     assert store.note_get(tmp_path, store.ALLOW_NS, "d-handoff") == owner
 
 
+def test_reaping_an_owned_room_cleans_up_ownership_gate_sidecar(client, tmp_path, monkeypatch):
+    """The transaction gate sidecar lives under notes/ and is swept with orphan locks."""
+    import store
+
+    owner, owner_sign = _keypair()
+    room = "d-reaped"
+    assert _claim(client, room, owner, owner_sign).status_code == 200
+
+    gate_note = store.note_path(tmp_path, "room-gate", room)
+    gate_lock = gate_note.with_suffix(gate_note.suffix + ".lock")
+    assert gate_lock.exists()
+
+    # Age past IDLE_SECONDS and run orphan lock sweep
+    now = time.time() + store.IDLE_SECONDS + 1
+    touched = {"rooms": set(), "notes": set()}
+    store._sweep_orphan_locks(tmp_path, now, touched)
+    assert not gate_lock.exists()
+
+
 def test_an_allow_list_needs_an_owner_and_fails_closed_on_junk(client):
     owner, owner_sign = _keypair()
     r = _set_signed(client, "room-allow", "d-orphan", owner, owner_sign, owner)

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -995,6 +995,75 @@ def test_reaping_an_owned_room_cleans_up_ownership_gate_sidecar(client, tmp_path
     assert not r_lock.exists()
 
 
+def test_locked_waiter_retries_and_acquires_when_sidecar_is_unlinked_during_sweep(
+    tmp_path, monkeypatch
+):
+    """When a sidecar lock is unlinked by an orphan sweep while a waiter is blocked
+
+    on flock, the waiter must retry and acquire the replacement lock rather than
+    surfacing FileNotFoundError.
+    """
+    import fcntl
+    import os
+
+    import store
+
+    r_path = store.room_path(tmp_path, "d-swept-waiter")
+    r_lock = r_path.with_suffix(r_path.suffix + ".lock")
+    r_lock.parent.mkdir(parents=True, exist_ok=True)
+    r_lock.touch()
+
+    now = time.time()
+    os.utime(r_lock, (now - store.IDLE_SECONDS - 10, now - store.IDLE_SECONDS - 10))
+
+    real_flock = fcntl.flock
+    real_unlink = os.unlink
+    waiter_at_flock = threading.Event()
+    waiter_acquired = threading.Event()
+    waiter_error = []
+    waiter_tid = None
+    waiter_thread = []
+
+    def hooked_flock(fd, op):
+        if waiter_tid and threading.get_ident() == waiter_tid:
+            waiter_at_flock.set()
+        return real_flock(fd, op)
+
+    monkeypatch.setattr(fcntl, "flock", hooked_flock)
+
+    def hooked_unlink(path):
+        if str(path) == str(r_lock):
+
+            def waiter():
+                try:
+                    with store._locked(r_path):
+                        waiter_acquired.set()
+                except Exception as e:
+                    waiter_error.append(e)
+
+            t = threading.Thread(target=waiter)
+            t.start()
+            nonlocal waiter_tid
+            waiter_tid = t.ident
+            waiter_thread.append(t)
+            assert waiter_at_flock.wait(5), "waiter never reached flock"
+            real_unlink(path)
+            return
+        return real_unlink(path)
+
+    monkeypatch.setattr(os, "unlink", hooked_unlink)
+
+    touched = {"rooms": set(), "notes": set()}
+    store._sweep_orphan_locks(tmp_path, now + store.IDLE_SECONDS + 1, touched)
+
+    assert waiter_thread, "sweep never attempted to unlink sidecar"
+    waiter_thread[0].join(5)
+    assert not waiter_thread[0].is_alive(), "waiter thread timed out"
+    assert not waiter_error, f"waiter raised: {waiter_error}"
+    assert waiter_acquired.is_set(), "waiter never acquired lock"
+    assert r_lock.exists(), "replacement lock was not created"
+
+
 def test_an_allow_list_needs_an_owner_and_fails_closed_on_junk(client):
     owner, owner_sign = _keypair()
     r = _set_signed(client, "room-allow", "d-orphan", owner, owner_sign, owner)


### PR DESCRIPTION
## Problem

A signed `room-allow` or `room-owners` request could pass the owner authorization check, pause, then commit after ownership had been handed to another DID. Owner validation, nonce consumption, and protected-note mutation previously used separate, uncoordinated steps. Furthermore, triggering background reaping while holding a room lock could cause a lock-order cycle deadlock with concurrent room creation (`.create`).

## Fix

- Bind protected note mutations (`ROOM_GUARD_NS`: `room-owners`, `room-allow`, `room-nonces`) to a single room-scoped transaction lock on `store.room_path(root, key)`.
- Execute authorization validation (`_note_write_gate`), nonce burn (`_burn_nonce`), and note mutation (`note_set`) atomically under the held room lock.
- Keep reaping strictly outside the room lock: `_write_protected_note` runs `store._reap(config.ROOT)` before acquiring the room lock, while writes under the lock (`_burn_nonce` and `note_set`) pass `reap=False` to prevent lock-order cycle deadlocks with `.create` during concurrent room creation.
- Use non-blocking lock acquisition (`nb=True`) during background `_reap_pass` to prevent self-deadlocks when a reap pass runs while a writer holds the room lock.
- Ensure inode stability across orphan sweeps via non-blocking flock acquisition in `_sweep_orphan_locks` and post-flock inode verification/retry in `_locked`.
- Deterministic regressions in `tests/http/test_rooms.py`:
  1. Old-owner-first and inverse handoff-first schedules linearize deterministically without allow-list corruption or spurious nonce burns.
  2. Active transaction locks survive aged orphan sweeps on reaped rooms.
  3. Waiters blocked on flock cleanly retry and acquire when sidecars are unlinked during sweeps without surfacing `FileNotFoundError`.
  4. Reap passes complete immediately without deadlocking when encountering in-flight held room locks.
  5. `test_protected_write_never_reaps_under_the_room_lock`: Probing regression verifying that protected note mutations under the room lock never trigger reaps or deadlock with concurrent create gates.

## Scope Note

This PR explicitly focuses on the `room-allow` and `room-owners` note mutation transaction (the core TOCTOU reported in #499). The signed message append lane (`say-signed`) is left for the broader store-level room-authority context to avoid lock re-entrancy hazards with `_write_record` / `_create_gate`.

## Verification

- `uv sync --frozen`
- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — All files formatted
- `uv run ty check` — All checks passed
- `uv run sz.py --caps`:
  - `core/store.py`: 999 / 1010 (+11 headroom)
  - `core/app.py`: 1026 / 1030 (+4 headroom) — *Note: With `main` currently at 1030/1030 (headroom 0), this PR gives back 4 lines rather than spending any.*
  - `core_total`: 2330 / 3010 (+680 headroom)
- `uv run pytest tests -q` — **787 passed, 1 skipped** (100% exit 0)
- Coverage: 98.02%

Addresses the allow/owner-note handoff race in #499.
