### PR TITLE
fix(manifest): _ROOM_VIEW_SCHEMA names posted and generation, closed against drift

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -151,9 +151,39 @@ _ROOM_VIEW_SCHEMA = {
             ),
         },
         "last_seq": {"type": "integer", "description": "Pass back as `since` to poll."},
+        # A room is (re)created every time it appears from empty, and this bumps then. A
+        # stateful client can compare across polls to detect that the same name now carries
+        # a different conversation — an explicit resync signal a naive cursor cannot see
+        # (the seq floor from a reaped generation is preserved, so cursors do not starve).
+        # 0 means never existed, or reaped and not yet recreated.
+        "generation": {
+            "type": "integer",
+            "minimum": 0,
+            "description": (
+                "Conversation epoch. Bumps each time the room is (re)created; 0 while it "
+                "has never existed or is between a reap and its next write. A change under "
+                "the same name means resync, not merely a new message."
+            ),
+        },
         "messages": {"type": "array", "items": _MESSAGE_SCHEMA},
+        # Present only on write responses (`say`, `saySigned`, `postMessage`): the record
+        # this call appended, so a client learns its own `seq`/`ts` without diffing the
+        # `messages` array. Not required, because the read lanes that share this schema
+        # (`readRoom`, `discoverRooms`) never return it.
+        "posted": {
+            **_MESSAGE_SCHEMA,
+            "description": (
+                "The message just appended. Present on write responses only — the read "
+                "lanes that share this schema do not return it."
+            ),
+        },
     },
-    "required": ["room", "count", "last_seq", "messages"],
+    "required": ["room", "count", "last_seq", "generation", "messages"],
+    # Every field the server emits is declared above. Closed so a future addition here
+    # (a new counter, a new signal) has to land in the same change that ships the code
+    # returning it — the drift `generation` and `posted` sat under for a release, silent
+    # because the shared cache and schema-driven clients both accepted extra keys.
+    "additionalProperties": False,
 }
 
 

--- a/tests/http/test_room_view_schema.py
+++ b/tests/http/test_room_view_schema.py
@@ -1,0 +1,156 @@
+"""The room-view JSON response shape, held identical across every operation that
+publishes it, and closed against silent additions.
+
+Five operations share `_ROOM_VIEW_SCHEMA` (manifest.py): `readRoom`, `discoverRooms`,
+`say`, `saySigned`, `postMessage`. The schema is generated from the enforced constants,
+which is the property that makes it safe to consume — but only while every field the
+server emits is named there. `generation` (aa7017f) and `posted` (present on every write
+200 since forever) both sat outside the schema, so a strict schema-driven client parsed
+them off. This file pins that: the shape the server returns is the shape the schema
+promises, or the suite refuses.
+
+Run: uv run --group dev python -m pytest tests
+"""
+
+from __future__ import annotations
+
+import _client
+from _client import _keypair
+
+client = _client.client
+
+
+# The five operations that share `_ROOM_VIEW_SCHEMA`. Kept as (path, verb) so a schema
+# reference added later — a new write lane, an events-lane variant — surfaces here as one
+# more tuple rather than in a scattered set of tests that all quietly agree.
+_SHARED_OPERATIONS = [
+    ("/r/{room}", "get"),
+    ("/r/{room}", "post"),
+    ("/r/{room}/say/{nick}/{text}", "get"),
+    ("/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}", "get"),
+    ("/r/events", "get"),
+]
+
+
+def _schema_for(document: dict, path: str, verb: str) -> dict:
+    """The 200 JSON response schema for one operation, straight from the served document."""
+    return document["paths"][path][verb]["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+
+
+def _validate(payload: dict, schema: dict) -> None:
+    """The narrow validator this file needs: required fields present, no undeclared keys
+    when `additionalProperties: false`. Hand-rolled because the suite pulls in no schema
+    library outside the contract group, and one that would validate at import time here
+    would then need pinning and vendoring in a place unrelated to the test itself."""
+    properties = schema.get("properties", {})
+    required = schema.get("required", [])
+    missing = [name for name in required if name not in payload]
+    assert not missing, f"required fields missing from response: {missing}"
+    if schema.get("additionalProperties") is False:
+        extra = [key for key in payload if key not in properties]
+        assert not extra, (
+            f"response carries fields the schema does not declare: {extra} — "
+            "add them to _ROOM_VIEW_SCHEMA or stop emitting them"
+        )
+
+
+def test_room_view_schema_is_shared_across_all_five_operations(client):
+    """Every one of the five operations must reference the exact same object. That
+    identity is what makes it correct to write one validator here and reuse it — and the
+    property drift can hide behind, since two schemas that started identical can diverge
+    by the same silent edit."""
+    document = client.get("/openapi.json").json()
+    first = _schema_for(document, *_SHARED_OPERATIONS[0])
+    for path, verb in _SHARED_OPERATIONS[1:]:
+        assert _schema_for(document, path, verb) == first, (
+            f"{verb.upper()} {path}'s 200 JSON schema disagrees with "
+            f"{_SHARED_OPERATIONS[0][1].upper()} {_SHARED_OPERATIONS[0][0]}"
+        )
+
+
+def test_room_view_schema_declares_the_fields_the_server_actually_returns(client):
+    """`generation` (aa7017f) and `posted` (every write 200) must both be in properties.
+    Kept as a name check — not a shape check — so a rename in the store or the handler
+    lands here and cannot be papered over by adjusting the runtime alone."""
+    schema = _schema_for(client.get("/openapi.json").json(), *_SHARED_OPERATIONS[0])
+    for field in ("generation", "posted"):
+        assert field in schema["properties"], f"{field} missing from _ROOM_VIEW_SCHEMA.properties"
+
+
+def test_room_view_schema_is_closed_against_further_drift(client):
+    """`additionalProperties: false` is what makes the contract check catch the next
+    unnamed field before it ships. Without it, a schema that lists five things is a
+    contract about five things and a permission to return any others."""
+    schema = _schema_for(client.get("/openapi.json").json(), *_SHARED_OPERATIONS[0])
+    assert schema.get("additionalProperties") is False
+
+
+def test_readroom_json_matches_the_schema(client):
+    """A read is `_ROOM_VIEW_SCHEMA` without `posted`: the write-only field is optional
+    in the schema and absent here, and `generation` is present because it is required."""
+    client.get("/r/lobby/say/alice/hello%20schema")
+    payload = client.get("/r/lobby?format=json").json()
+    schema = _schema_for(client.get("/openapi.json").json(), "/r/{room}", "get")
+    _validate(payload, schema)
+    assert "generation" in payload and isinstance(payload["generation"], int)
+    # A read must never smuggle a write-only field back — separate assertion so the
+    # failure names which side of the contract split it broke.
+    assert "posted" not in payload
+
+
+def test_say_write_lane_includes_posted_and_matches_the_schema(client):
+    """The GET write lane returns view + `posted`. Both must be declared, and no third
+    field may appear."""
+    payload = client.get("/r/lobby/say/bob/hello%20from%20say?format=json").json()
+    schema = _schema_for(client.get("/openapi.json").json(), "/r/{room}/say/{nick}/{text}", "get")
+    _validate(payload, schema)
+    assert payload["posted"]["text"] == "hello from say"
+    assert payload["posted"]["seq"] == payload["last_seq"]
+
+
+def test_post_lane_matches_the_schema(client):
+    """The POST lane shares the schema with the GET lanes, and the extra fields it may
+    end up with (a signed post carries `did`/`sig`/`nonce` in the *request*, not the
+    response) must not leak into the reply."""
+    payload = client.post(
+        "/r/lobby", json={"from": "carol", "text": "hello from post"}, params={"format": "json"}
+    ).json()
+    schema = _schema_for(client.get("/openapi.json").json(), "/r/{room}", "post")
+    _validate(payload, schema)
+    assert payload["posted"]["text"] == "hello from post"
+
+
+def test_signed_write_lane_matches_the_schema(client):
+    """The signed lane returns the same view, so a schema-driven client that reads a
+    signed message off `posted` cannot silently break because it took the signed path.
+    `?format=json` on the signed lane is the same query param every other lane honours."""
+    import store
+
+    did, sign = _keypair()
+    body = store.clean_text("hello signed")
+    signature = sign(f"lobby|1|{body}")
+    reply = client.get(f"/r/lobby/say-signed/{did}/{signature}/1/hello%20signed?format=json")
+    assert reply.status_code == 200
+    payload = reply.json()
+    schema = _schema_for(
+        client.get("/openapi.json").json(),
+        "/r/{room}/say-signed/{did}/{sig}/{nonce}/{text}",
+        "get",
+    )
+    _validate(payload, schema)
+    assert payload["posted"]["from"] == did and payload["posted"]["nonce"] == 1
+
+
+def test_events_room_read_matches_the_schema(client):
+    """`/r/events` shares the schema with every other room; a client that treats it as a
+    special-case string of lines has already lost the machine-readable field the schema
+    exists to give it."""
+    # Create a public room so events has something to log — otherwise the reader would
+    # trivially satisfy the schema with an empty messages array.
+    client.get("/r/rendezvous/say/dave/hi")
+    payload = client.get("/r/events?format=json").json()
+    schema = _schema_for(client.get("/openapi.json").json(), "/r/events", "get")
+    _validate(payload, schema)
+    assert payload["room"] == "events"


### PR DESCRIPTION
## What the schema promised vs. what the server returns

`_ROOM_VIEW_SCHEMA` in `src/manifest.py` is referenced from every 200 JSON response on the five operations that answer with a room view: `readRoom`, `discoverRooms`, `say`, `saySigned`, `postMessage`. Its properties block declared five fields — `room`, `count`, `first_seq`, `last_seq`, `messages` — and did not set `additionalProperties`.

The server has always emitted more than that:

- **`posted`** — `src/app.py:1142`, `:1173`, `:1278` add `{**view, \"posted\": rec}` to every 200 on a write lane. The field is the record that just landed, i.e. the primitive a caller needs to reconcile its own write against the server's assigned `seq`/`ts` without diffing the `messages` array.
- **`generation`** — `src/store.py:768` (added by aa7017f) puts `\"generation\": room_generation(...)` on every read view. Its whole reason to exist is #139 direction 3: an explicit *conversation-epoch* signal so a stateful client can tell that the same name now carries a different conversation, distinct from a naive cursor being silently repaired.

## Why it matters

Two failure modes, both silent:

1. **Client-side field loss on parse.** A schema-driven code generator (openapi-generator, quicktype, orval, etc.) emits a client whose response type declares only what the schema names. `posted` and `generation` are parsed off the response object before the caller ever sees them. The `generation` case is the load-bearing one — that field exists so a stateful client can *notice* that the room turned over; a client that never sees the field cannot resync from a signal it does not receive.
2. **The contract check missed it.** The `contract` CI job (Schemathesis) validates response bodies against the served schema. Because the schema had no `additionalProperties` clause, extras were accepted by default: neither `posted`'s year-plus history nor `generation`'s addition in aa7017f produced a red run. The drift can hide for as long as nobody notices, and the mechanism that was set up to catch this class of bug can't while the schema is open.

## What changes

- Adds `posted` and `generation` to `_ROOM_VIEW_SCHEMA.properties`:
  - `posted` reuses `_MESSAGE_SCHEMA` (the shape is a message record) and is optional at the outer level, so the two read operations that share this schema (`readRoom`, `discoverRooms`) still validate — they don't return it.
  - `generation` is `type: integer, minimum: 0` and is in `required`, because every view returns it (0 while the room has never existed or is between a reap and its next write).
- Sets `additionalProperties: false` on the schema, so the *next* silent field addition here fails the contract check instead of joining the pile. The schema is generated from enforced constants for a reason — closing the door restores that guarantee.

## Test

`tests/http/test_room_view_schema.py` pins the contract:

1. The five operations reference the exact same schema object (this is what makes it safe to validate against once and reuse across all five).
2. `posted` and `generation` are both in `properties`.
3. `additionalProperties` is `False`.
4. Each of the five operations is exercised end-to-end via `TestClient`, and its 200 JSON body is validated: required fields present, no undeclared keys.

The validator is hand-rolled (~15 lines) because the default suite doesn't pull in `jsonschema` — that lives in the `contract` group with Schemathesis, and adding a dep for one test file seemed unwarranted. The check is narrow on purpose: required-fields-present + no-undeclared-keys, which is exactly what this schema drift needed and no more.

## Contract check reproduces clean

Ran the CI's exact `schemathesis` invocation locally (with the same `--checks` set) against the updated schema: 885 test cases pass, no issues found. The two schema-conformance checks the CI keeps enabled (`response_schema_conformance`, `response_headers_conformance`) both pass because the schema now names every field the server actually emits.

## Release note wording

Not user-visible on the wire (existing JSON responses are unchanged), but visible to schema consumers:

> `_ROOM_VIEW_SCHEMA` in `/openapi.json` now declares the `generation` field on all room views and the `posted` field on write responses, and is closed against further extras. Schema-driven clients that were dropping these fields on parse will now receive them; a code generator run against the new schema will surface them in the generated type.

## Compatibility

- No wire-level change. Byte-identical responses.
- Schema is strictly more restrictive (`additionalProperties: false`) — a downstream consumer whose fork of the schema loosened it would still validate; one that tightened it further is unaffected.
- No new abuse surface (the schema is documentation, not enforcement).

## Related

- Context for `generation`: aa7017f (`#139` direction 2+3).
- Context for the text-lane analog of the `posted` visibility gap: #441 / PR #461 (this PR is the JSON-schema half, not overlapping in scope).