### PR TITLE
fix(mcp): enforce the Room name pattern in tools/list schema and tools/call validation (#488)

### DIFF
--- a/mcp/src/technocore_mcp/protocol.py
+++ b/mcp/src/technocore_mcp/protocol.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import re
 import sys
 import types
 from collections.abc import Callable
@@ -169,6 +170,14 @@ def fragment(annotation: Any) -> dict[str, Any]:
         for note in notes:
             if isinstance(note, str):
                 described["description"] = note
+            elif isinstance(note, re.Pattern):
+                # A regex note is a constraint the same as `Literal`'s enum: it is
+                # part of what the handler accepts, so it must reach the schema or
+                # `tools/list` and `tools/call` disagree about the call — exactly
+                # the drift this module is built to end. `Room`'s name regex is the
+                # example: advertised as a bare `string`, a client validates a bad
+                # name locally, sends it, and gets a `-32602` it could have caught.
+                described["pattern"] = note.pattern
         return described
     if origin is Union or origin is types.UnionType:
         arms = [arm for arm in get_args(annotation) if arm is not type(None)]
@@ -247,6 +256,14 @@ def _validate(arguments: dict[str, Any], schema: dict[str, Any]) -> dict[str, An
         if "enum" in expected and value not in expected["enum"]:
             allowed = ", ".join(repr(choice) for choice in expected["enum"])
             raise _BadParamsError(f"argument {name!r} must be one of: {allowed}")
+        # Patterns only attach to `str`-typed annotations; `_CHECKS` has already refused a
+        # non-string by the time we reach here, so the guard also tells the type checker
+        # `value` is a `str` for the next call.
+        if "pattern" in expected and isinstance(value, str):
+            if not re.fullmatch(expected["pattern"], value):
+                raise _BadParamsError(
+                    f"argument {name!r} does not match the required pattern {expected['pattern']!r}"
+                )
         checked[name] = value
     return checked
 

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -26,6 +26,7 @@ Design notes worth keeping:
 from __future__ import annotations
 
 import os
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -96,8 +97,11 @@ def _segment(value: str) -> str:
 
 
 # The one parameter four tools share, written once. An alias, not a dict: it is the
-# parameter's type *and* the sentence the model reads about it.
-Room = Annotated[str, "Room name, ^[a-z0-9][a-z0-9_-]{0,47}$"]
+# parameter's type *and* the sentence the model reads about it. The compiled regex rides
+# alongside the prose so `schema_of`/`fragment` publish it as a JSON-Schema `pattern`
+# and `_validate` enforces it before the network — a malformed room name is a protocol
+# `-32602`, not a 400 wrapped in an `isError` tool result (#488).
+Room = Annotated[str, "Room name.", re.compile(r"^[a-z0-9][a-z0-9_-]{0,47}$")]
 
 
 @server.tool(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -261,12 +261,15 @@ def test_generated_schemas_still_say_what_clients_already_integrated_against(mcp
 
 def test_the_descriptions_the_model_reads_survive_the_generation(mcp):
     """The point of `Annotated` here: the sentence lives next to the parameter, and one
-    room description is shared by the four tools that take a room."""
+    room description is shared by the four tools that take a room. The room name regex is
+    now published as a `pattern`, not embedded in the prose (#488)."""
     server, _ = mcp
     tools = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})["result"]["tools"]
     schemas = {t["name"]: t["inputSchema"] for t in tools}
     for name in ("read_room", "wait_for_message", "say"):
-        assert schemas[name]["properties"]["room"]["description"].startswith("Room name, ^[a-z0-9]")
+        room_schema = schemas[name]["properties"]["room"]
+        assert room_schema["description"] == "Room name."
+        assert room_schema["pattern"] == r"^[a-z0-9][a-z0-9_-]{0,47}$"
     assert "4096" in schemas["say"]["properties"]["text"]["description"]
     assert "TECHNOCORE_NICK" in schemas["say"]["properties"]["nick"]["description"]
 
@@ -491,11 +494,14 @@ def test_malformed_tool_calls_name_the_shape_the_client_must_send(mcp):
         assert "object `arguments`" in reply["error"]["message"]
 
 
-def test_a_rejected_name_comes_back_as_the_services_own_explanation(mcp):
-    server, _ = mcp
+def test_a_rejected_name_is_a_caller_error_not_a_tool_error(mcp):
+    """A room name the service would refuse must be caught at `_validate` as a protocol
+    `-32602` (the caller's mistake), not surfaced as an `isError` tool result after a
+    network round-trip to a 400. The regex now rides in the advertised schema (#488)."""
+    server, protocol = mcp
     reply = call(server, "read_room", {"room": "Not A Room"})
-    assert reply["result"]["isError"] is True
-    assert "400" in text_of(reply)
+    assert reply["error"]["code"] == protocol.INVALID_PARAMS
+    assert "pattern" in reply["error"]["message"]
 
 
 def test_a_network_failure_becomes_an_actionable_tool_result(mcp, monkeypatch):

--- a/tests/test_mcp_room_pattern.py
+++ b/tests/test_mcp_room_pattern.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "mcp" / "src"))
+
+
+def test_room_annotation_advertises_its_pattern():
+    """tools/list must publish the Room name regex as a JSON-Schema `pattern`.
+
+    `Room` is declared as `Annotated[str, "Room name", re.compile("^[a-z0-9]...$")]`, and the
+    module's own design rule is that the advertised schema and what `tools/call`
+    enforces cannot disagree. Today the regex never reaches the schema (only the
+    description string), so a client that validates locally against it reaches
+    `valid` and is then told `-32602` over the wire (#488)."""
+    from technocore_mcp import protocol
+    from technocore_mcp import server as mcp_server
+
+    schema = protocol.fragment(mcp_server.Room)
+    assert schema.get("pattern") == r"^[a-z0-9][a-z0-9_-]{0,47}$"
+
+
+def test_malformed_room_name_is_refused_before_the_network():
+    """A Room-typed argument carrying a name the service rejects must raise
+    `-32602` at `_validate` time, not surface as an `isError` tool result after
+    a network round-trip to a 400 (#488)."""
+    from technocore_mcp import protocol
+    from technocore_mcp import server as mcp_server
+
+    def handler(room: mcp_server.Room) -> str:
+        return room
+
+    schema = protocol.schema_of(handler)
+    assert "pattern" in schema["properties"]["room"]
+
+    # A name the service (NAME_RE.fullmatch) refuses must be caught here.
+    with pytest.raises(protocol._BadParamsError):
+        protocol._validate({"room": "Bad Name!"}, schema)
+    # A well-formed name still passes.
+    assert protocol._validate({"room": "lobby"}, schema) == {"room": "lobby"}
+
+
+def test_other_tools_keep_advertising_only_a_description():
+    """Regression guard: a plain prose note on a `str` parameter is still carried
+    as `description` and never mistaken for a pattern (#488)."""
+    import typing
+
+    from technocore_mcp import protocol
+
+    note = protocol.fragment(typing.Annotated[str, "Message body, <= 4096 characters."])
+    assert note.get("description") == "Message body, <= 4096 characters."
+    assert "pattern" not in note


### PR DESCRIPTION
## What

`fragment()` only lifted a `str` `Annotated` note into the advertised `inputSchema`'s `description`, so the `Room` name regex never reached the document `tools/list` publishes, and `_validate()` only checked `isinstance(value, str)`. A malformed room name therefore validated locally as `valid` against the advertised schema, then surfaced as an `isError` 400 instead of a protocol `-32602` it could have caught before the network — the exact drift this module is documented to end.

## Why

`protocol.py`'s own invariant: "a tool's `inputSchema` is read off its handler's signature: the function *is* the schema, so what `tools/list` advertises and what `tools/call` enforces cannot disagree." `Room` is declared `Annotated[str, "Room name, ^[a-z0-9][a-z0-9_-]{0,47}$"]`; the regex rode only in prose, so the schema admitted every string. Closes #488.

## Changes

- `fragment()` now recognises a `re.Pattern` `Annotated` note and emits a JSON-Schema `"pattern"` (same discipline as `Literal`'s `enum`).
- `Room` carries the compiled regex (`re.compile(...)`) alongside its prose description.
- `_validate()` fullmatches the pattern before the handler/network, raising `-32602` for a caller mistake.
- Regression test (`tests/test_mcp_room_pattern.py`) builds the schema straight from the annotation and asserts both the advertised `pattern` and the `-32602` refusal; plus a guard that prose-only notes stay description-only.
- Updated the two pre-existing `tests/test_mcp.py` cases that encoded the old `isError`-after-400 behaviour.

## Checks (local, AGENTS.md gate)

- `uv run ruff check .` — pass
- `uv run ruff format --check .` — pass (62 files)
- `uv run ty check` — pass
- `uv run pytest tests -q` — 470 passed
- `uv run sz.py --check` — pass (core code-lines within baseline)
- `uv.lock` left untouched (reverted)

The change is MCP-only, no runtime/API/abuse-surface change to the wrapped HTTP service.