### PR TITLE
fix(mcp): omit empty query marker

### DIFF
--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -76,8 +76,9 @@ def _fetch(path: str, query: dict | None = None) -> str:
     favour of "HTTP Error 429" would throw away the only part the model can act on.
     """
     url = f"{BASE_URL}{path}"
-    if query:
-        url += "?" + urllib.parse.urlencode({k: v for k, v in query.items() if v is not None})
+    params = {key: value for key, value in (query or {}).items() if value is not None}
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
     request = urllib.request.Request(url, headers={"User-Agent": f"technocore-mcp/{VERSION}"})
     try:
         with urllib.request.urlopen(request, timeout=TIMEOUT) as response:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -443,6 +443,32 @@ def test_an_integer_is_an_acceptable_number(mcp):
         assert "no new messages" in text_of(reply)
 
 
+@pytest.mark.parametrize(
+    ("tool", "arguments", "path"),
+    [
+        ("read_room", {"room": "lobby"}, "/r/lobby"),
+        ("list_rooms", {}, "/rooms"),
+        ("discover_rooms", {}, "/r/events"),
+    ],
+)
+def test_empty_optional_query_params_do_not_add_query_marker(
+    mcp, monkeypatch, tool, arguments, path
+):
+    server, _ = mcp
+    asked = []
+    inner = urllib.request.urlopen
+
+    def capture(request, timeout=None):
+        asked.append(request.full_url)
+        return inner(request, timeout)
+
+    monkeypatch.setattr(urllib.request, "urlopen", capture)
+
+    call(server, tool, arguments)
+
+    assert asked[-1].endswith(path)
+
+
 def test_an_integral_float_is_an_acceptable_integer(mcp, monkeypatch):
     """JSON Schema reads `integer` by value, not by spelling, so `1.0` satisfies the schema
     this server advertised and a client that validated locally against it must not then be


### PR DESCRIPTION
## Summary

- filter optional query parameters before deciding whether to append a query string
- omit the trailing `?` when every optional value is `None`
- add regression coverage for `read_room`, `list_rooms`, and `discover_rooms`

## Tests

- `uv run python -m pytest tests/test_mcp.py -q` (48 passed)
- `uv run ruff check mcp/src/technocore_mcp/server.py tests/test_mcp.py`
- `uv run ruff format --check mcp/src/technocore_mcp/server.py tests/test_mcp.py`

Closes #494