### PR TITLE
Fix: room_stats topic cache thrashes under concurrent /rooms callers

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -15,6 +15,7 @@ import hashlib
 import os
 import re
 import tempfile
+import threading
 import time
 import unicodedata
 from collections import OrderedDict
@@ -1030,38 +1031,76 @@ def list_rooms(root: Path) -> list[str]:
 
 # (top, nicks) per room, validated against the (mtime_ns, size) stat the overview walk
 # already does — so a walk re-reads only the rooms a write actually changed. LRU-bounded.
+#
+# room_stats is reached through a sync `def` route (`rooms` in app.py), which Starlette
+# runs in a threadpool — so concurrent /rooms callers can be in this function on different
+# OS threads at once. Every mutation of _window_memo (get + move_to_end + insert + the
+# eviction loop) is a compound sequence, not one atomic operation, so it is guarded by a
+# lock. The lock is released before the actual tail read (room_window), which is the
+# expensive part: two threads racing on the same cold key both pay that cost once each
+# (redundant, not wrong) rather than one blocking on the other's disk IO.
 _WINDOW_MEMO_MAX = 512
+_window_lock = threading.Lock()
 _window_memo: OrderedDict[tuple, tuple] = OrderedDict()
 
 
 def _cached_window(root: Path, name: str, stamp: tuple) -> tuple[int, list[str]]:
     key = (str(root), name)
-    hit = _window_memo.get(key)
-    if hit and hit[0] == stamp:
-        _window_memo.move_to_end(key)
-        return hit[1]
+    with _window_lock:
+        hit = _window_memo.get(key)
+        if hit and hit[0] == stamp:
+            _window_memo.move_to_end(key)
+            return hit[1]
     view = room_window(root, name)
-    _window_memo[key] = (stamp, view)
-    _window_memo.move_to_end(key)
-    while len(_window_memo) > _WINDOW_MEMO_MAX:
-        _window_memo.popitem(last=False)
+    with _window_lock:
+        _window_memo[key] = (stamp, view)
+        _window_memo.move_to_end(key)
+        while len(_window_memo) > _WINDOW_MEMO_MAX:
+            _window_memo.popitem(last=False)
     return view
 
 
 # Topic previews, valid while topics_written holds (bumped only by a `topic` note); reaper
 # deletions age out with NOTE_STATS_CACHE_SECONDS, like the note gauge in app.py.
-_topics_memo: tuple = ((), 0.0, {})
+#
+# Keyed by stamp, LRU-bounded — not a single mutable slot. room_stats runs concurrently
+# across threads (see _window_memo above), and a single slot that gets unconditionally
+# replaced whenever a caller's stamp does not match the one currently sitting in it has a
+# real failure mode here, not just a missed optimization: two /rooms calls straddling one
+# `/kv/topic/<room>` write see different stamps, and because each call makes ~50 of these
+# lookups (one per shown room) rather than one, they do not just miss each other's cache
+# once — every remaining lookup in both loops re-triggers the reset, so the note reads this
+# cache exists to bound happen on every call instead of once. Keying by stamp lets the two
+# generations coexist instead of fighting over one slot; the bound keeps old generations
+# from accumulating if topics are written often.
+_TOPICS_MEMO_MAX = 4
+_topics_lock = threading.Lock()
+_topics_memo: OrderedDict[tuple, tuple[float, dict]] = OrderedDict()
 
 
 def _cached_topic(root: Path, room: str, stamp: tuple, now: float) -> str | None:
-    global _topics_memo
     ttl = config.NOTE_STATS_CACHE_SECONDS  # per call, so 0 disables an existing entry too
-    if ttl <= 0 or _topics_memo[0] != stamp or now >= _topics_memo[1]:
-        _topics_memo = (stamp, now + ttl, {})
-    cache = _topics_memo[2]
-    if room not in cache:
-        cache[room] = topic(root, room)
-    return cache[room]
+    if ttl <= 0:
+        return topic(root, room)
+    with _topics_lock:
+        entry = _topics_memo.get(stamp)
+        if entry is None or now >= entry[0]:
+            entry = (now + ttl, {})
+            _topics_memo[stamp] = entry
+        _topics_memo.move_to_end(stamp)
+        cache = entry[1]
+        if room in cache:
+            return cache[room]
+    value = topic(root, room)
+    with _topics_lock:
+        # Store only if this generation is still the one live under `stamp`: if it aged
+        # out or was evicted while topic() ran, the value returned above is still correct,
+        # it is just not memoized — a miss next time, never a wrong answer.
+        if _topics_memo.get(stamp) is entry:
+            cache[room] = value
+        while len(_topics_memo) > _TOPICS_MEMO_MAX:
+            _topics_memo.popitem(last=False)
+    return value
 
 
 def room_stats(root: Path, limit: int = 50) -> dict:

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1128,6 +1128,51 @@ def test_topic_previews_ride_the_notes_counter_not_only_a_clock(tmp_path):
         assert topics()["aaa"] is None  # visible once the clock (here: disabled) expires
 
 
+def test_cached_topic_survives_interleaved_generations_without_thrashing(tmp_path, monkeypatch):
+    """room_stats is reached through a sync `def` route that Starlette runs in a
+    threadpool, so two /rooms callers straddling one topic write are not a hypothetical:
+    they see different stamps and their per-room lookups can land on the cache in any
+    order relative to each other. Before this cache was keyed per stamp, it was a single
+    mutable slot any mismatched stamp reset unconditionally — so two interleaved
+    generations did not just miss each other's entries once, every remaining lookup in
+    both loops re-triggered a reset, and the note reads this cache exists to bound
+    happened on every call instead of once per (stamp, room).
+
+    This reproduces the interleaving directly (no real threads needed: the bug is in the
+    cache's logic, not in the GIL) and checks the discriminating property — a second,
+    identical pass over both generations must be served entirely from cache. Revert
+    _cached_topic to a single slot and this fails: the second pass re-reads everything,
+    because the two generations were still fighting over one slot.
+    """
+    import store
+
+    reads = []
+
+    def counted_topic(root, room):
+        reads.append(room)
+        return f"topic-for-{room}"
+
+    monkeypatch.setattr(store, "topic", counted_topic)
+    store._topics_memo.clear()
+
+    rooms = [f"room{i}" for i in range(5)]
+    stamp_a, stamp_b = ((1,), str(tmp_path)), ((2,), str(tmp_path))
+    now = 1_000_000.0
+
+    # Two /rooms loops, interleaved room-by-room — the order a threadpool executing both
+    # requests concurrently can produce.
+    for room in rooms:
+        store._cached_topic(tmp_path, room, stamp_a, now)
+        store._cached_topic(tmp_path, room, stamp_b, now)
+    assert len(reads) == len(rooms) * 2  # first pass: everything is a genuine miss
+
+    reads.clear()
+    for room in rooms:
+        store._cached_topic(tmp_path, room, stamp_a, now)
+        store._cached_topic(tmp_path, room, stamp_b, now)
+    assert reads == [], "a second identical pass over both generations must hit cache"
+
+
 def test_a_json_escaped_did_is_the_one_record_the_nonce_scan_cannot_see(tmp_path):
     """The stated boundary of `_last_nonce`'s bytes-level reject, not a wish.
 


### PR DESCRIPTION
## What

`_cached_topic` and `_cached_window` (used by `room_stats`, behind `/rooms`) now guard their read/insert/evict sequences with a lock, and the topic cache is keyed per stamp (bounded LRU) instead of being a single mutable slot. No externally visible behavior changes — same responses, just correct under concurrent callers.

## Why

`rooms` is a sync `def` route, which Starlette runs in a threadpool, so concurrent `/rooms` callers can be in these functions on different OS threads at once. `_topics_memo` was one shared slot that any mismatched stamp reset unconditionally: two `/rooms` calls straddling a single `/kv/topic/<room>` write see different stamps, and since each call makes ~50 of these lookups (one per shown room), they don't just miss each other's cache once, every remaining lookup in both loops re-triggers a reset. Reproduced this directly in the added test: a second, identical pass over two interleaved generations still re-reads every topic under the old single-slot version, instead of hitting cache.

Doesn't touch or overlap with #486, #487, #488, #489, or #499.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 488 passed, coverage 97.18%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [ ] Docs — nothing new: internal caching detail, no manual/skill.md/README/patterns.md surface changed
- [ ] New surface on a world-writable service — nothing new: both functions are private, called only internally by `room_stats`; no new externally reachable behavior