### PR TITLE
docs(store): bound the tail-scan wording in nonce-rejection messages (#349)

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -587,6 +587,13 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "in": "path",
                             "name": "text",
                             "required": True,
+                            "description": (
+                                "Message text, single-line and <= "
+                                + str(store.MAX_TEXT_CHARS)
+                                + " characters. This lane is a plain GET, so keep the text short "
+                                "enough to fit in a URL: paths under ~200 characters avoid tripping "
+                                "the edge/proxy budget even though the server does not enforce it."
+                            ),
                             "schema": _TEXT_SCHEMA,
                         },
                     ],

--- a/src/manual.md
+++ b/src/manual.md
@@ -149,6 +149,14 @@ records into the scanned window, and the floor shortens with it. `sig` is also
 served to every reader of the room (for a `p-` room, every holder of the
 name), so the material a replay needs reaches any cursor-following reader,
 not just whoever held the signed URL.
+
+RETRY AFTER FAILURE: a signed write MAY land before your client sees anything.
+Timeouts and 5xx are NOT evidence the write failed — the nonce is already
+consumed. Never resend the same signed URL; it will be refused as a replay,
+and that refusal means nothing about whether the first write committed.
+Re-read state (`/kv/room-owners/<room>`, the room with `?since=`, or the note
+namespace) to discover what actually happened, and mint a fresh nonce + signature
+if you still need to write.
 RENDERING: the text view shows a verified writer as <z6Mk...2doK> and everything
 else as <~nick>, where ~ means "self-asserted, proved nothing". ?format=json
 carries the full DID in `from`, the nonce in `nonce`, and the signature

--- a/src/store.py
+++ b/src/store.py
@@ -2006,8 +2006,9 @@ def _write_record(
             previous = _last_nonce(root, room, did)
             if previous is not None and nonce <= previous:
                 raise StoreError(
-                    f"nonce {nonce} is not greater than {previous}, the last one this key "
-                    f"used in /r/{room} — a signed URL is single-use, so count up"
+                    f"nonce {nonce} is not greater than {previous}, the highest nonce "
+                    f"found for this key within the scanned tail of /r/{room} "
+                    f"— older writes may exist beyond that window"
                 )
         rec["seq"] = last_seq(root, room) + 1
         line = orjson.dumps(rec) + b"\n"


### PR DESCRIPTION
The nonce check scans the newest ~1 MiB of a room, not the full history,
so the rejection should not read like a claim about every nonce that key
ever used here.