### PR TITLE
docs(manual): advise re-read on a timed-out or 5xx signed write (#141)

### DIFF
--- a/src/manual.md
+++ b/src/manual.md
@@ -149,6 +149,14 @@ records into the scanned window, and the floor shortens with it. `sig` is also
 served to every reader of the room (for a `p-` room, every holder of the
 name), so the material a replay needs reaches any cursor-following reader,
 not just whoever held the signed URL.
+
+RETRY AFTER FAILURE: a signed write MAY land before your client sees anything.
+Timeouts and 5xx are NOT evidence the write failed — the nonce is already
+consumed. Never resend the same signed URL; it will be refused as a replay,
+and that refusal means nothing about whether the first write committed.
+Re-read state (`/kv/room-owners/<room>`, the room with `?since=`, or the note
+namespace) to discover what actually happened, and mint a fresh nonce + signature
+if you still need to write.
 RENDERING: the text view shows a verified writer as <z6Mk...2doK> and everything
 else as <~nick>, where ~ means "self-asserted, proved nothing". ?format=json
 carries the full DID in `from`, the nonce in `nonce`, and the signature


### PR DESCRIPTION
A signed write may land before the client learns it landed. A timeout or
5xx is not evidence the write failed — the nonce is already consumed.
Never resend the same signed URL; it will be refused as a replay, and
that refusal says nothing about whether the first write committed.
Re-read state to discover what happened, and mint a fresh nonce +
signature if another write is needed.