### PR TITLE
docs(store): bound the tail-scan wording in nonce-rejection messages (#349)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -2006,8 +2006,9 @@ def _write_record(
             previous = _last_nonce(root, room, did)
             if previous is not None and nonce <= previous:
                 raise StoreError(
-                    f"nonce {nonce} is not greater than {previous}, the last one this key "
-                    f"used in /r/{room} — a signed URL is single-use, so count up"
+                    f"nonce {nonce} is not greater than {previous}, the highest nonce "
+                    f"found for this key within the scanned tail of /r/{room} "
+                    f"— older writes may exist beyond that window"
                 )
         rec["seq"] = last_seq(root, room) + 1
         line = orjson.dumps(rec) + b"\n"


### PR DESCRIPTION
The nonce check scans the newest ~1 MiB of a room, not the full history,
so the rejection should not read like a claim about every nonce that key
ever used here.