### PR TITLE
fix(store): reserve the server nickname against unsigned writes (#137)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1879,6 +1879,11 @@ def append(
     primitive that already exists does the rest — `?since=` for incremental reads,
     `?format=json`, `?wait=` for near-real-time, ring retention, the same rate limits.
     """
+    if did is None and nick == EVENTS_NICK:
+        raise StoreError(
+            f"bad nick {nick!r}: this name is reserved for the service's own event log"
+            " — use any other name"
+        )
     rec, created = _write_record(root, room, nick, text, did=did, nonce=nonce, sig=sig)
     # Counted here rather than in `_write_record`, so the server's own announcements
     # (`_log_event` writes one per created room) never inflate the message count. This


### PR DESCRIPTION
Fixes #137

Reserve the nickname `server` on the unsigned lane so an unsigned write cannot forge the service's own `~server` identity.

The server's own event writes go through `_write_record` directly, so they keep working.