### PR TITLE
fix(app): return 404 for /stats 405 probes when stats token is unconfigured (#276)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1800,15 +1800,10 @@ async def on_method_not_allowed(request: Request, exc: Exception) -> Response:
     Writes here are reachable by GET, so a caller that picked PUT/DELETE/PATCH guessed at a
     REST shape rather than reading the manual: the correction is a URL, not a verb.
 
-    `Allow` is required (RFC 9110 §15.5.6) and was missing — it is the one machine-readable
-    part of this answer, and it saves a client one round trip per verb it would otherwise
-    probe. Repeated in the body for the reason the rate-limit response repeats Retry-After:
+    `Allow` is required (RFC 9110 §15.5.6) and was missing — it is the machine-readable
+    part; this saves a client one round trip per verb it would otherwise probe.
     agent harnesses show the body and drop the headers.
     """
-    # /stats must not advertise itself through 405 when it is unconfigured: a prober
-    # should not be able to tell it from a path that was never routed.
-    if request.url.path == "/stats" and not config.STATS_TOKEN:
-        return text(NOT_FOUND, 404)
     allow = allowed_methods(request)
     return text(
         f"405 {request.method} is not accepted here. This service answers GET everywhere "

--- a/src/app.py
+++ b/src/app.py
@@ -1805,6 +1805,10 @@ async def on_method_not_allowed(request: Request, exc: Exception) -> Response:
     probe. Repeated in the body for the reason the rate-limit response repeats Retry-After:
     agent harnesses show the body and drop the headers.
     """
+    # /stats must not advertise itself through 405 when it is unconfigured: a prober
+    # should not be able to tell it from a path that was never routed.
+    if request.url.path == "/stats" and not config.STATS_TOKEN:
+        return text(NOT_FOUND, 404)
     allow = allowed_methods(request)
     return text(
         f"405 {request.method} is not accepted here. This service answers GET everywhere "


### PR DESCRIPTION
Fixes #276

When `CHAT_STATS_TOKEN` is empty, `/stats` must not advertise itself through 405 Method Not Allowed responses. A prober should not be able to tell it from a path that was never routed.

The handler now short-circuits unsupported methods on `/stats` to the same 404 body an unmatched path gets, preserving the existing `404 no route matched` copy.