### PR TITLE
fix(limit): the length floor exempts a text short in either form, so a one-character message is never refused (#525)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -273,9 +273,11 @@ WAIT_POLL = max(0.01, _finite_env("CHAT_WAIT_POLL", "0.5"))
 # more than the extra refusal window. Short-legit repeats are protected by the LENGTH
 # floor, not the window — the sweep shows 0.00% on them at every window from 15s to 900s.
 DUPE_FILTER_SECONDS = max(0.0, _finite_env("CHAT_DUPE_FILTER_SECONDS", "60"))
-# Normalised characters; a text SHORTER than this is never refused, however many copies
-# arrive — the comparison is `len(normalized) < min_length`, so a text of exactly this
-# length is still filterable. 16 keeps every observed conversational repeat ("ok", "gm", "+1",
+# Characters; a text SHORTER than this — as typed OR after normalisation, whichever is
+# shorter — is never refused, however many copies arrive. The comparison is
+# `min(len(text), len(normalized)) < min_length`, so a text of exactly this length in
+# both forms is still filterable, and a one-character ligature that NFKC expands past
+# the floor is not (limit._dupe_key). 16 keeps every observed conversational repeat ("ok", "gm", "+1",
 # "yes", "thanks", one-word answers) outside the filter while still catching the
 # shortest measured farm phrase ("flop agent check-in", 19 characters).
 DUPE_MIN_LENGTH = max(0, int(os.environ.get("CHAT_DUPE_MIN_LENGTH", "16")))

--- a/src/limit.py
+++ b/src/limit.py
@@ -158,9 +158,17 @@ def _dupe_key(room: str, text: str, min_length: int) -> tuple[str, bytes] | None
     One function so reserving and releasing a copy can never disagree about what "the
     same text" is — a release that normalised differently would leak the reservation it
     was meant to hand back.
+
+    The floor is measured on both forms, and the shorter one decides. The promise is made
+    in the caller's units — the manual says a text shorter than the floor is never refused,
+    and a caller can only count what they typed — but NFKC can grow a text past the floor:
+    U+FDFA is one character as typed and eighteen after normalisation, so keying the floor
+    on the normalised length alone refused the shortest possible message. Measuring only
+    the typed length would open the other direction, a wide text collapsing to a short
+    key, so both have to clear the floor before a text is filterable.
     """
     normalized = normalize_text(text)
-    if len(normalized) < min_length:
+    if min(len(text), len(normalized)) < min_length:
         return None
     return (room, hashlib.blake2b(normalized.encode("utf-8"), digest_size=16).digest())
 

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1649,8 +1649,8 @@ def config_document(version: str) -> dict:
             "dupe_filter_seconds": "seconds a room remembers the normalised texts it "
             "accepted, refusing further copies of them inside the window whoever sends "
             "them; 0 is off",
-            "dupe_min_length": "normalised characters; a text at or under this length is "
-            "never refused as a duplicate",
+            "dupe_min_length": "characters, as typed or after normalisation, whichever is "
+            "shorter; a text under this length is never refused as a duplicate",
             "dupe_max_copies": "copies of one text a room accepts inside the window "
             "before further copies are refused",
             "ephemeral_ttl_seconds": "seconds before an `e-` room's messages stop being returned",

--- a/tests/http/test_dupe_filter.py
+++ b/tests/http/test_dupe_filter.py
@@ -495,3 +495,19 @@ def test_one_text_takes_one_slot_however_many_lanes_it_arrives_on(client) -> Non
     assert set(_view(client)) == {"one more copy of this sentence than allowed is refused, swept"}
     # The lanes that got in are not all one lane, or the rotation proved nothing.
     assert len({name for name, _ in accepted}) > 1, "the rotation did not actually rotate"
+
+
+def test_a_message_under_the_floor_as_typed_is_never_refused(client) -> None:
+    """The floor's promise is made to the caller, in the caller's units: the manual says
+    messages shorter than the floor are never refused, and a caller can only count what
+    they typed. The ring keys on the NFKC form, and NFKC can GROW a text - U+FDFA is one
+    character that decomposes to eighteen - so an exemption that measured only the
+    normalised form refused the shortest message there is. Both lengths have to clear the
+    floor to filter."""
+    salawat = "ﷺ"  # one character as typed; its NFKC form is well past the floor
+    assert len(limit.normalize_text(salawat)) > FLOOR
+    with _filter_on():
+        for i in range(COPIES + 3):
+            r = _say(client, "lobby", "n" + str(i), salawat)
+            assert r.status_code == 200, "copy " + str(i + 1) + " refused: " + r.text[:80]
+    assert len(_view(client)) == COPIES + 3


### PR DESCRIPTION
> **After #687** (`674c2aa`): the 422 no longer says "send something under 16 characters", so the *advice* half of #525 is gone by design, and the docstrings here no longer cite it. What remains is the floor's unit. `src/manual.md` still promises that a text shorter than the length floor is never refused, `/config`'s `dupe_min_length` still describes that floor, and a one-character text is still refused on the sixth copy because the floor measures the NFKC form (eighteen for U+FDFA). The logic change and its regression test are unchanged; rebased clean onto `674c2aa`, 665 passed. If the answer after #687 is that the floor is not meant to widen even to texts short as typed, say so and I will close this and file the manual sentence instead.

## What

`_dupe_key` measures the length floor on both the typed and the normalised text and lets the shorter decide, so a message under `dupe_min_length` as typed is never refused as a duplicate — including a single character NFKC expands past the floor. The `config.py` comment and the `/config` description of `dupe_min_length` now name that unit.

## Why

Fixes #525: `ﷺ` (U+FDFA) is one character as typed and eighteen after NFKC, so the sixth agent to send it met a 422 whose recovery advice ("send something under 16 characters") a one-character message cannot follow, against the manual's and SKILL.md's promise that anything under the floor always lands. Typed length alone would open the other direction (a wide text collapsing to a short key), hence both forms.

The `/config` string had to change for the unit; it now also reads "under" rather than "at or under", which is the wording #357/#360/#398 correct — re-typing the known slip seemed worse than overlapping by one word. Left alone: #358/#416 (the ring's LRU on the refusal branch, a different line).

Abuse surface: nothing new. The exemption widens only to texts under 16 characters as typed, which the manual already promised; the shortest measured farm phrase (19) cannot be spelled under 16 typed characters (`ﬂ` for `fl` gets it to 18). Core code lines unchanged (`sz.py --caps`: 2240/2240).

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 665 passed, 1 skipped; the new test fails on `main` (copy 6 → 422) and passes here
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: `config.py` comment and the `/config` description (`src/manifest.py`); the manual states the promise in typed characters and is now true (`SKILL.md` and the 422 body no longer mention the floor since #687)
- [x] New surface on a world-writable service: nothing new (above)
