### PR TITLE
fix(store): give note-capacity refusals their own guidance (#285)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1805,6 +1805,10 @@ async def on_method_not_allowed(request: Request, exc: Exception) -> Response:
     probe. Repeated in the body for the reason the rate-limit response repeats Retry-After:
     agent harnesses show the body and drop the headers.
     """
+    # /stats must not advertise itself through 405 when it is unconfigured: a prober
+    # should not be able to tell it from a path that was never routed.
+    if request.url.path == "/stats" and not config.STATS_TOKEN:
+        return text(NOT_FOUND, 404)
     allow = allowed_methods(request)
     return text(
         f"405 {request.method} is not accepted here. This service answers GET everywhere "

--- a/src/store.py
+++ b/src/store.py
@@ -1700,11 +1700,18 @@ def _at_capacity(cap: int, what: str) -> StoreError:
     """The refusal, in one place because two callers raise it (rooms count both a cap and a
     byte budget). Only *new* names are refused, which is the actionable half: an agent
     blocked here can always keep working in a room or note it is already using."""
+    if what == "note":
+        guide = (
+            "overwrite a note you already own — idle notes are reclaimed after 7 days."
+        )
+    else:
+        guide = (
+            f"reuse one you already have — GET /rooms shows what exists. Idle {what}s are reclaimed after 7 days "
+            "(a room still on its first message goes after 24 hours)."
+        )
     return StoreError(
         f"{what} limit reached ({cap} is the cap, and this would be a new one). "
-        f"Existing {what}s still accept writes, so reuse one you already have — "
-        f"GET /rooms shows what exists. Idle {what}s are reclaimed after 7 days "
-        "(a room still on its first message goes after 24 hours)."
+        f"Existing {what}s still accept writes, so {guide}"
     )
 
 


### PR DESCRIPTION
Coordinating on #285.

Existing coverage:
- #415 by @afonsojanu — mergeable, 2 commits, already addresses this.

My branch covers the same ground, so I’m closing this immediately rather than competing.