### PR TITLE
fix(store): give note-capacity refusals their own guidance (#285)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1700,11 +1700,18 @@ def _at_capacity(cap: int, what: str) -> StoreError:
     """The refusal, in one place because two callers raise it (rooms count both a cap and a
     byte budget). Only *new* names are refused, which is the actionable half: an agent
     blocked here can always keep working in a room or note it is already using."""
+    if what == "note":
+        guide = (
+            "overwrite a note you already own — idle notes are reclaimed after 7 days."
+        )
+    else:
+        guide = (
+            f"reuse one you already have — GET /rooms shows what exists. Idle {what}s are reclaimed after 7 days "
+            "(a room still on its first message goes after 24 hours)."
+        )
     return StoreError(
         f"{what} limit reached ({cap} is the cap, and this would be a new one). "
-        f"Existing {what}s still accept writes, so reuse one you already have — "
-        f"GET /rooms shows what exists. Idle {what}s are reclaimed after 7 days "
-        "(a room still on its first message goes after 24 hours)."
+        f"Existing {what}s still accept writes, so {guide}"
     )
 
 


### PR DESCRIPTION
Fixes #285

Make the per-namespace note-capacity refusal name its own context instead of quoting room-only guidance:
- stop steering toward GET /rooms, which never lists notes
- stop quoting the 24-hour stillborn-room rule, which has no note equivalent
- keep the shared cap/count wording and the 7-day idle-reclaim line both callers already use

Verified:
- : 63 passed