### PR TITLE
fix(store): name the sharded path in did namespace note-capacity refusals (#165)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -460,6 +460,11 @@ def clean_text(text: str, limit: int = MAX_TEXT_CHARS) -> str:
 # the string: 350 ns of hashing becomes a 36 ns cache hit, which is how the whole resolution
 # lands under the budget rather than over it. Sized like `_listable`, and for the same reason
 # — names are caller-supplied, so a flood of fresh ones must cost misses and never memory.
+def _is_did_note_namespace(ns_dir: Path) -> bool:
+    """Return True only for the `did` namespace directory directly under `notes/`."""
+    return ns_dir.name == "did" and ns_dir.parent.name == "notes"
+
+
 @lru_cache(maxsize=MAX_ROOMS)
 def _shard(name: str, key: bytes | None = None) -> str:
     """The directory component `name` hashes into — two hex characters, `00` to `ff`."""
@@ -535,6 +540,11 @@ def _resolve(d: Path, name: str, suffix: str) -> Path:
 def room_path(root: Path, room: str) -> Path:
     """Where a room's JSONL lives — `rooms/<shard>/<room>.jsonl`."""
     return _resolve(root / "rooms", valid_name(room), ".jsonl")
+
+
+def _is_did_note_namespace(ns_dir: Path) -> bool:
+    """Return True only for the `did` namespace directory directly under `notes/`."""
+    return ns_dir.name == "did" and ns_dir.parent.name == "notes"
 
 
 def _note_ns_dir(root: Path, ns: str) -> Path:
@@ -1803,6 +1813,21 @@ def _check_note_capacity(root: Path, ns_dir: Path, path: Path) -> None:
     # key's bucket now, and counting that would both compare the cap against ~1 note and drop
     # the namespace's `.notes-count` two levels below where every other reader looks for it.
     if _note_totals(ns_dir, _ns_totals, persist=True)[0] >= MAX_NOTES_PER_NS:
+        if ns_dir.name == "did" and _is_did_note_namespace(ns_dir):
+            key = path.name.removesuffix(".txt")
+            try:
+                shard = _shard(ns_dir.name, key.encode("utf-8"))
+            except Exception:
+                shard = None
+            guide = (
+                f"publish at /kv/did-{shard}/{key} instead — the same fingerprint, sharded."
+                if shard
+                else "overwrite a note you already own — idle notes are reclaimed after 7 days."
+            )
+            raise StoreError(
+                f"note limit reached ({MAX_NOTES_PER_NS} is the cap, and this would be a new one). "
+                f"Existing notes still accept writes, but a fresh identity has nothing to reuse — {guide}"
+            )
         raise _at_capacity(MAX_NOTES_PER_NS, "note")
     _check_note_total(root)
 

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -285,6 +285,22 @@ def test_notes_are_capped_across_namespaces(tmp_path, monkeypatch):
     assert not (tmp_path / "notes" / "ns-fresh").exists()  # rejection creates no namespace
 
 
+def test_note_capacity_refusal_names_sharded_path_for_did(tmp_path, monkeypatch):
+    """When the per-namespace cap is hit for a 16-hex key in `did`, the refusal must
+    point at the sharded path, not at GET /rooms or the room-only 24-hour rule."""
+    import store
+
+    monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 1)
+    store.note_set(tmp_path, "did", "0123456789abcdef", "v")
+    with pytest.raises(store.StoreError, match=r"note limit reached \(1 is the cap") as refused:
+        store.note_set(tmp_path, "did", "fedcba9876543210", "v")
+    message = str(refused.value)
+    assert "publish at /kv/did-" in message
+    assert "sharded." in message
+    assert "GET /rooms" not in message
+    assert "24 hours" not in message
+
+
 def test_note_cap_holds_under_concurrent_creates(tmp_path, monkeypatch):
     """Sync handlers run in a threadpool: a cap counted across files needs one gate.
 


### PR DESCRIPTION
Fixes #165

When the per-namespace note cap is hit for a 16-hex key in the `did` namespace, point the refusal at the sharded path instead of repeating room-only guidance.

Changes:
- add `_is_did_note_namespace(ns_dir)` to identify the sharded `did` namespace under `notes/`
- in `_check_note_capacity`, when the cap is hit for `did`, emit a `StoreError` that names `/kv/did-<shard>/<key>` instead of `GET /rooms`
- other namespaces keep the shared `_at_capacity()` message; room refusals are unchanged

Verification:
- added unit test for the new `did` refusal wording
- `tests/unit/test_store.py`: 64 passed