### PR TITLE
Align signed replay protection with retained room history

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,12 @@ nonce, and `from` becomes the key. Verification is offline — the identifier *i
 is no resolver and no identity state on disk. The signature covers `<room>|<nonce>|<text>`, with
 `<text>` taken **after** the single-line sweep; `seq` and `ts` are server-assigned and unsigned.
 
-**Anti-replay expires early.** The nonce must exceed the last one that key used in that room, found
-by scanning the newest **1 MiB** of it rather than the whole ring — so a captured URL becomes
-replayable once that much newer traffic buries it, which a flooder can arrange. Deliberate, but a
-smaller guarantee than "until the ring forgets"; signatures still prove authorship.
+**Anti-replay follows retained room history.** The nonce must exceed the newest one that key has
+in the room's physically retained history. The lookup scans the retained room file rather than the
+ordinary 1 MiB tail-read window, so burying a signed record under newer traffic does not by itself
+make it replayable. A captured write can become replayable only after retention has forgotten that
+nonce and every later nonce from the same key that would still reject it. Signatures still prove
+authorship independently of that bounded replay lifetime.
 
 The text view shows `<z6Mk…2doK>` for a verified writer and `<~nick>` for self-asserted. Full DIDs
 are JSON-only: 50 lines of 56-character identifiers is ~1200 tokens of the agent's context.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,14 +65,15 @@ These are documented properties, not bugs. Reports about them will be closed wit
 - **A `p-` name is private only because it is unguessable.** The URL *is* the secret — as private as
   your transcript and the proxy's access log, no more. Store ciphertext if the operator must not
   read it.
-- **A captured signed-write URL becomes replayable once ~1 MiB of newer traffic buries the message
-  it wrote.** The last-nonce lookup scans the newest 1 MiB of the room, not the whole ~10 MiB ring,
-  so the single-use window is smaller than retention and an attacker can shorten it deliberately by
-  flooding the room. Signatures still prove authorship — only single-use expires. Narrowing this
-  needs per-(room, key) state that outlives the messages, which is the one unbounded thing this
-  design refuses; a bounded version is open work rather than a settled answer. `GET
-  /r/<room>/export` hands any reader the room's stored signed records in bulk — replay material
-  under exactly this window and the same retention model, not a new exposure.
+- **Signed-write replay protection is bounded by physical room retention, not by the ordinary
+  1 MiB tail-read window.** The last-nonce lookup scans the physically retained room file, so newer
+  traffic cannot make a captured write replayable while that nonce — or a later nonce from the same
+  key that would still reject it — remains retained. Flooding can still hasten actual compaction and
+  therefore physical forgetting; no separate per-(room, key) replay database outlives the room
+  history. In an `e-` room, TTL may hide a record from reads before compaction removes it, and that
+  hidden record still participates in replay protection while physically retained. `GET
+  /r/<room>/export` hands any reader the stored signed records in bulk — replay material under this
+  same retention model, not a new exposure.
 
 - **Every write is a `GET`, so anything that fetches a URL performs it.** Link unfurlers, prefetch,
   scanners, `<img src>`, and every agent `webfetch` are all writers. There are no cookies, so this

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -721,9 +721,9 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         "Verification is offline — the identifier is the key, so there is no "
                         "resolver and no identity state on disk. The signature covers "
                         "`<room>|<nonce>|<text>` with the text as stored. The nonce must "
-                        "exceed the last one that key used in this room, where 'last' is "
-                        "found by scanning the newest 1 MiB of the room: single-use expires "
-                        "when the message falls out of that tail, authorship does not."
+                        "exceed the newest one that key has in this room's physically retained "
+                        "history. Single-use lasts while that nonce, or a later nonce from the "
+                        "same key that would reject it, remains retained; authorship does not expire."
                     ),
                     "parameters": [
                         {**_NAME_PARAM, "name": "room"},

--- a/src/manual.md
+++ b/src/manual.md
@@ -171,18 +171,20 @@ the text AFTER the single-line sweep — the bytes that get stored, so a record 
 still be re-verified later. Sign the raw text instead and it will not verify. seq
 and ts are assigned by the server and are deliberately NOT signed: you cannot
 know them when you sign. A signed write pays the same rate limit as any write.
-NONCE: it must be greater than the last nonce that key used in that room. A
-counter or a millisecond clock both work. That makes a captured signed URL
-single-use only while the message remains in the newest __READ_BUDGET__ scanned for the
-last nonce. Once newer traffic buries it beyond that tail, the same URL is
-accepted again even if the message remains elsewhere in the larger room ring.
-Signatures still prove authorship; only the single-use guarantee expires early.
-The tail is a byte budget, not a message count: `sig` adds 95 bytes to every
-signed record, so a room of short signed messages fits roughly a third fewer
-records into the scanned window, and the floor shortens with it. `sig` is also
-served to every reader of the room (for a `p-` room, every holder of the
-name), so the material a replay needs reaches any cursor-following reader,
-not just whoever held the signed URL.
+NONCE: it must be greater than the newest nonce that key has in the room's
+physically retained history. A counter or a millisecond clock both work. The
+replay lookup deliberately does not use the ordinary __READ_BUDGET__ tail-read
+budget: it scans the physically retained room file, so burying a signed record
+under newer traffic does not by itself make the captured URL reusable. It can
+become replayable only after retention has forgotten that nonce and every later
+nonce from the same key that would still reject it. In an `e-` room,
+TTL can hide a record from reads before compaction physically removes it; while retained
+on disk it still participates in this nonce check. Replay state therefore stays
+bounded by room retention rather than by permanent per-(room, key) state.
+Signatures still prove authorship after replay state is forgotten. `sig` is also
+served to every reader of the room (for a `p-` room, every holder of the name),
+so the material a replay needs reaches any cursor-following reader, not just
+whoever held the signed URL.
 RENDERING: the text view shows a verified writer as <z6Mk...2doK> and everything
 else as <~nick>, where ~ means "self-asserted, proved nothing". ?format=json
 carries the full DID in `from`, the nonce in `nonce`, and the signature

--- a/src/store.py
+++ b/src/store.py
@@ -2252,32 +2252,27 @@ def _log_event(root: Path, line: str) -> None:
 
 
 def _last_nonce(root: Path, room: str, did: str) -> int | None:
-    """The newest nonce this DID used in this room, within the tail READ_BUDGET covers.
+    """The newest nonce this DID used in the physically retained room history.
 
-    Bounded on purpose. A signed URL is a bearer token for one message: replaying it must
-    fail while the message is still there to be seen, which is what this gives. Once the
-    record has aged out of the scanned window — or out of the ring entirely — a replay is
-    accepted again as a fresh message. That is the retention model doing what it says, not
-    a gap: this store forgets, and an anti-replay set that outlived the messages it guards
-    would be the one piece of unbounded state on a service whose whole design is bounded.
+    Replay authority follows the retained room file rather than the ordinary tail-read
+    budget. The normal write and compaction path bounds room storage, so replay protection
+    remains coupled to retained history without introducing state that outlives it.
     """
     path = room_path(root, room)
     if not path.exists():
         return None
     # Reject on bytes before parsing. This is a predicate scan, not a tail read: when the DID
-    # has not posted recently, every record in the budget is parsed only to be discarded, and
+    # has not posted recently, every retained record is examined only to be discarded, and
     # that is most signed writes on a busy room. A false positive — the DID quoted in message
     # text — falls through to the parse, which is the only thing that tells `from` from a
     # mention. No false negatives, on one precondition: the DID is in the line as itself.
     # Both encoders this store has ever written rooms with put it there literally, which
     # test_json_backend.py pins byte-for-byte. A foreign writer that escaped it as \uXXXX
-    # would be parsed correctly and skipped here, narrowing the replay window for that record
-    # to nothing; test_store.py states that boundary. Testing for the escape as well costs a
-    # second scan of every line — 2.1 ms -> 3.7 ms against a 4.1 ms baseline, i.e. most of
-    # what this buys — to cover files this store did not write, so it stays out of the loop.
+    # would be parsed correctly and skipped here, narrowing replay protection for that record
+    # to nothing; test_store.py states that separate boundary.
     did_b = did.encode()
     with path.open("rb") as f:
-        for raw in reverse_lines(f):
+        for raw in reverse_lines(f, max_bytes=os.fstat(f.fileno()).st_size):
             if did_b not in raw:
                 continue
             rec = _parse(raw)

--- a/tests/capacity_bench.py
+++ b/tests/capacity_bench.py
@@ -261,10 +261,10 @@ def _build_nonce_room(root: Path, room: str, records: int, mention: str | None =
 
 
 def _parse_every(root: Path, room: str, did: str) -> int | None:
-    """`_last_nonce` before the bytes-level reject. Kept here because a baseline that only
-    exists in git history stops being run."""
+    """`_last_nonce` without the bytes-level reject, over the same retained-file bound."""
     with store.room_path(root, room).open("rb") as f:
-        for raw in store.reverse_lines(f):
+        size = os.fstat(f.fileno()).st_size
+        for raw in store.reverse_lines(f, max_bytes=size):
             rec = store._parse(raw)
             if rec is not None and rec.get("from") == did and isinstance(rec.get("nonce"), int):
                 return rec["nonce"]
@@ -272,23 +272,26 @@ def _parse_every(root: Path, room: str, did: str) -> int | None:
 
 
 def _scan_only(root: Path, room: str) -> None:
-    """The floor: read the window backwards and parse nothing."""
+    """The floor: read the physically retained file backwards and parse nothing."""
     with store.room_path(root, room).open("rb") as f:
-        for _ in store.reverse_lines(f):
+        size = os.fstat(f.fileno()).st_size
+        for _ in store.reverse_lines(f, max_bytes=size):
             pass
 
 
 def nonce_bench(root: Path, records: int) -> None:
-    """A predicate scan, not a tail read: a DID that has NOT posted lately costs the whole
-    READ_BUDGET, which is the common case (lobby: 826 signed writes/min, 770 distinct DIDs,
-    a ~5,400-record window). It holds the room lock, so every signed write pays it. Both
-    loops run over one file, so only the loop differs."""
+    """A predicate scan, not an ordinary tail read.
+
+    An absent DID is the worst case and scans the physically retained room file while the
+    room lock is held. A recent DID still returns newest-first after only a short scan.
+    The comparison loops use the same retained-file byte bound as `_last_nonce`.
+    """
     room, absent = "nonce-bench", _did(records + 5_000)
     path = _build_nonce_room(root, room, records)
     size = path.stat().st_size
     print(
         f"\nsigned-write path — _last_nonce over {records} records, {size >> 10} KiB "
-        f"({size // records} B each); READ_BUDGET covers ~{store.READ_BUDGET // (size // records)}"
+        f"({size // records} B each); retained scan bound {size >> 10} KiB"
     )
     assert didkey.is_did(absent), absent  # the shape claim, not a hope
     assert store._last_nonce(root, room, absent) is None

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1328,8 +1328,10 @@ def test_the_manual_defines_every_convention_it_names(client):
     assert "/kv/did-<first 2>/<remaining 14>" in manual
     assert "legacy /kv/did/<fingerprint>" in manual
     assert "`<room>|<nonce>|<text>`" in manual or "<room>|<nonce>|<text>" in manual
-    assert "newest 1 MiB" in manual
-    assert "even if the message remains elsewhere in the larger room ring" in manual
+    assert "physically retained history" in manual
+    assert "TTL can hide a record from reads" in manual
+    assert "newest 1 MiB scanned for the" not in manual
+    assert "even if the message remains elsewhere in the larger room ring" not in manual
     # …and the source, so a reader who wants their own instance does not have to search
     # for it. This is also the only outbound link the manual carries.
     assert "https://github.com/flop-labs/technocore-chat" in manual

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -225,15 +225,14 @@ def test_a_replayed_signed_url_is_refused_while_the_message_is_still_there(clien
     assert client.get("/r/lobby?format=json").json()["count"] == 2
 
 
-def test_a_replay_is_accepted_once_traffic_buries_the_record_past_the_scan_tail(client, tmp_path):
-    """The far side of test_a_replayed_signed_url_is_refused_while_the_message_is_still_there.
+def test_a_replay_is_refused_while_the_original_signed_record_is_physically_retained(
+    client, tmp_path
+):
+    """Replay authority follows physical room retention, not only the newest READ_BUDGET bytes.
 
-    `_last_nonce` scans the newest READ_BUDGET bytes of tail for the DID, and its
-    docstring is explicit that the bound is the retention model working as designed:
-    once newer traffic buries the record past that tail, the same signed URL is
-    accepted again, even while the record remains in the room ring. That boundary was
-    stated in prose only - pin it, so a change that moves it (record-size growth such
-    as the `sig` field, a budget change) fails here instead of shipping silently.
+    Newer traffic may bury a signed record beyond the ordinary tail-read budget while that
+    record still exists in the room ring. The captured signed URL must remain single-use for
+    as long as that authoritative record is physically retained.
     """
     import orjson
 
@@ -242,24 +241,116 @@ def test_a_replay_is_accepted_once_traffic_buries_the_record_past_the_scan_tail(
     did, sign = _keypair()
     url = f"/r/lobby/say-signed/{did}/{sign('lobby|7|once')}/7/once"
     assert client.get(url).status_code == 200
+
     path = store.room_path(tmp_path, "lobby")
     original = path.read_bytes()
+
     seq = 2
     with path.open("ab") as f:
         written = 0
         while written < store.READ_BUDGET + 65536:
             line = (
-                orjson.dumps({"seq": seq, "ts": store._now(), "from": "~bury", "text": "x" * 200})
+                orjson.dumps(
+                    {
+                        "seq": seq,
+                        "ts": store._now(),
+                        "from": "~bury",
+                        "text": "x" * 200,
+                    }
+                )
                 + b"\n"
             )
             f.write(line)
             written += len(line)
             seq += 1
+
+    before = path.read_bytes()
+    before_seq = store.last_seq(tmp_path, "lobby")
+
     assert path.stat().st_size > store.READ_BUDGET
-    r = client.get(url)
-    assert r.status_code == 200
-    # buried past the scan tail, not reaped: the original record is still in the ring
-    assert path.read_bytes().startswith(original)
+    assert path.stat().st_size < store.MAX_ROOM_BYTES
+    assert before.startswith(original)
+
+    replay = client.get(url)
+
+    assert replay.status_code == 400
+    assert "not greater than 7" in replay.text
+    assert path.read_bytes() == before
+    assert store.last_seq(tmp_path, "lobby") == before_seq
+
+
+def test_replay_authority_survives_compaction_and_ends_when_the_record_is_removed(
+    client, tmp_path, monkeypatch
+):
+    """A nonce stays spent exactly as long as its signed room record is retained."""
+    import orjson
+
+    import store
+
+    cap = 8192
+    monkeypatch.setattr(store, "MAX_ROOM_BYTES", cap)
+
+    room = "replay-compact"
+    path = store.room_path(tmp_path, room)
+
+    while not path.exists() or path.stat().st_size < cap - 2500:
+        store.append(tmp_path, room, "bury", "x" * 300)
+
+    did, sign = _keypair()
+    url = f"/r/{room}/say-signed/{did}/{sign(f'{room}|7|once')}/7/once"
+    assert client.get(url).status_code == 200
+
+    store.append(tmp_path, room, "bury", "x" * 3000)
+
+    def retained_records():
+        return [orjson.loads(line) for line in path.read_bytes().splitlines()]
+
+    records = retained_records()
+    assert records[0]["seq"] > 1, "the room must actually have compacted"
+    assert any(r.get("from") == did and r.get("nonce") == 7 for r in records)
+
+    replay = client.get(url)
+    assert replay.status_code == 400
+    assert "not greater than 7" in replay.text
+
+    for _ in range(6):
+        if not any(r.get("from") == did and r.get("nonce") == 7 for r in retained_records()):
+            break
+        store.append(tmp_path, room, "bury", "x" * 3000)
+
+    records = retained_records()
+    assert not any(r.get("from") == did and r.get("nonce") == 7 for r in records)
+
+    replay_after_removal = client.get(url)
+    assert replay_after_removal.status_code == 200
+
+
+def test_ephemeral_replay_authority_follows_physical_not_visible_retention(
+    client, tmp_path, monkeypatch
+):
+    """TTL may hide a signed record before physical retention forgets its nonce."""
+    import store
+
+    room = "e-replay-retention"
+    did, sign = _keypair()
+    url = f"/r/{room}/say-signed/{did}/{sign(f'{room}|7|once')}/7/once"
+
+    real_now = store._now
+    monkeypatch.setattr(store, "_now", lambda: "2020-01-01T00:00:00.000000Z")
+    assert client.get(url).status_code == 200
+    monkeypatch.setattr(store, "_now", real_now)
+
+    path = store.room_path(tmp_path, room)
+    view = client.get(f"/r/{room}?format=json").json()
+
+    assert view["messages"] == []
+    raw = path.read_bytes()
+    assert did.encode() in raw
+    assert b'"nonce":7' in raw
+
+    replay = client.get(url)
+    assert replay.status_code == 400
+    assert "not greater than 7" in replay.text
 
 
 def test_a_did_quoted_in_another_agents_text_is_not_that_agents_nonce(client):

--- a/tests/test_signed_lane_stateful.py
+++ b/tests/test_signed_lane_stateful.py
@@ -2,71 +2,33 @@
 
 Run: uv run --group dev python -m pytest tests/test_signed_lane_stateful.py
 
-`tests/test_store_stateful.py` models the store's lifecycle — append, read, expire, compact,
-reap, note CAS — and never touches a signature. This models the part of the store whose
-correctness is a *security* property: `_last_nonce`, which decides whether a captured signed
-URL still works.
+`tests/test_store_stateful.py` models the store lifecycle. This file models the signed
+lane property whose correctness is security-sensitive: `_last_nonce`, which decides
+whether a previously accepted nonce may be used again.
 
-The contract is deliberately bounded. A signed URL is a bearer token for exactly one message,
-so replaying it must fail while the message is still there to be seen; once the record has aged
-out the replay is accepted again as a fresh message, and `_last_nonce`'s docstring says so. The
-bound is the retention model doing what it says rather than a hole.
+The contract is bounded by physical room retention. Ordinary `read_messages` remains
+bounded by READ_BUDGET, while `_last_nonce` may scan deeper: a signed nonce remains spent
+while that nonce, or a later nonce from the same key that would reject it, survives in
+the retained room file. Once retention forgets all such history, the old nonce may be
+accepted again.
 
-WHY THE BOUND IS SAFE, which is not where it looks
---------------------------------------------------
-"Refused while the original is readable" is not established by anything in `_write_record`. It
-holds because of a coincidence of two default arguments:
+The safety ordering is therefore:
 
-    read_messages    for raw in reverse_lines(f):        <- default max_bytes
-    _last_nonce      for raw in reverse_lines(f):        <- default max_bytes
+    guard depth >= visible depth
 
-Those are the *only* two call sites in the module that take `reverse_lines`' default budget.
-Every other one names its own and narrower (`last_seq` 64 KiB, the tripwire window 64 KiB) or is
-a write path (`_compact`, MAX_ROOM_BYTES).
+Equality is neither required nor desired. A record may leave the ordinary read window,
+or become invisible through an ephemeral TTL, while still participating in replay
+protection. Physical retention is the replay authority.
 
-The property that follows, stated carefully, is an ORDERING and not an equality:
+The state machine deliberately asks `_last_nonce` for the current guard rather than
+reimplementing the scan. It then checks that the write path agrees with that guard,
+that every visible signed record remains guarded, and that the guard equals the newest
+physically retained canonical record for the key.
 
-    guard depth  >=  visible depth
-
-Today the two are the same 1 MiB, which satisfies it with no slack. But equality is not what
-safety needs, and asserting equality would be asserting the mechanism: the guard is *allowed* to
-reach further back than a reader can see, and in two places it already does — an expired `e-`
-record still guards its nonce, and a MAX_LIMIT tail can run out of records before it runs out of
-budget. Stricter-than-visible costs nothing and hides nothing. Only the reverse is a hole.
-
-So the thing to hold onto is the direction, not the coincidence. `a_visible_record_is_always_
-still_guarded` asserts it over the whole state machine, and
-`test_the_guard_scans_at_least_as_deep_as_a_reader_can_see` measures both depths directly by
-giving every record its own key. Neither one counts bytes or restates the scan.
-
-Widen the reader's budget and not the guard's and the ordering is gone.
-`test_narrowing_only_the_guards_budget…` below constructs that state on purpose: a record a
-reader can still see, whose nonce is no longer guarded, so the replay lands as a second visible
-record with the same signature, nonce and text as the first. That is what a "let readers page
-further back" change costs if it touches `read_messages`' budget alone, and it is the state
-these tests exist to keep unreachable. Nothing in the repo records that this is load-bearing,
-which is the gap this file closes.
-
-The retention ring is a red herring here, and worth naming because it looks relevant: records
-survive on disk for 5-10 MiB (COMPACT_KEEP_BYTES, MAX_ROOM_BYTES), far past the 1 MiB either
-window reaches. So a room file legitimately holds records no reader can ever retrieve, and
-*disk* contents say nothing about what is guarded.
-
-Three notes on the model:
-
-- **It asks the implementation for the boundary, then holds it to the consequence.** Rather
-  than re-deriving what `_last_nonce` should return — which would test a copy of the scan —
-  each rule reads the guard value and asserts `append` refuses at or below it and accepts
-  above. What is checked is the *agreement* between two functions called one line apart under
-  the same lock, which is where a real bug would live.
-- **There is no ordering invariant on nonces on disk.** "One key's nonces ascend by seq" is the
-  obvious property and it is FALSE — see `surviving_nonces_may_repeat` for the counterexample
-  the model produced within three steps. Anything reading `from` + `nonce` off disk as an
-  ordering has to be shown this.
-- **The window is tuned down, and it takes a patch to do it.** `READ_BUDGET` is bound into
-  `reverse_lines`' default argument, so re-binding the module attribute does nothing — see
-  `_window`. That is why this file did not exist sooner: the boundary is unreachable in a test
-  without writing a megabyte.
+READ_BUDGET is patched down in tests so the ordinary visibility boundary is reachable
+without writing a megabyte. That patch changes the default used by ordinary readers;
+the retained-history replay scan deliberately supplies its own explicit byte bound and
+therefore does not shrink with the reader.
 """
 
 from __future__ import annotations
@@ -90,10 +52,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 import didkey  # noqa: E402
 import store  # noqa: E402
 
-# Production has READ_BUDGET (1 MiB) < COMPACT_KEEP_BYTES (5 MiB) < MAX_ROOM_BYTES (10 MiB), so
-# the byte window binds before the ring and records outlive their own readability. The ratio is
-# preserved rather than the values: a model where the ring bound first would be exercising an
-# ordering the service does not have, and would hide the whole point of the coupling above.
+# Production has READ_BUDGET (1 MiB) < COMPACT_KEEP_BYTES (5 MiB) < MAX_ROOM_BYTES (10 MiB).
+# Preserve that ordering here so a record can leave ordinary visibility while remaining physically
+# retained and therefore still guarded. This is the deliberate slack in guard depth >= visible depth.
 WINDOW_BYTES = 512  # ~3 records: a key falls out of the window after a few others post
 KEEP_BYTES = 2560
 RING_BYTES = 5120
@@ -139,21 +100,14 @@ DIDS = (_did(1), _did(2))
 
 @contextlib.contextmanager
 def _window(size: int):
-    """Shrink the tail that `reverse_lines` scans by default, for the length of one test.
+    """Shrink `reverse_lines`' default budget, which controls ordinary tail reads.
 
-    `reverse_lines(f, chunk_size=65536, max_bytes=READ_BUDGET)` binds the budget as a *default
-    argument*, evaluated once at import. So `setattr(store, "READ_BUDGET", n)` — how
-    `test_store_stateful.py` tunes every other threshold, and how `config.override` reaches the
-    rest of the module — has no effect, and both scans keep reading 1 MiB.
+    `reverse_lines(f, chunk_size=65536, max_bytes=READ_BUDGET)` binds READ_BUDGET as a
+    default argument at import time, so rebinding `store.READ_BUDGET` would not move it.
 
-    Patching `__defaults__` is the only way in from a test, and it is why the bounded half of
-    the replay contract has never had one: reaching the boundary honestly costs ~250 full-size
-    records. A one-line change (`max_bytes: int | None = None`, resolved to `READ_BUDGET` in the
-    body) would make this helper unnecessary.
-
-    Note that it moves the budget for `read_messages` and `_last_nonce` *together*, which is
-    exactly the coupling the module docstring describes. Tuning them apart is the failure this
-    file is about, and only one test does it, deliberately.
+    `_last_nonce` no longer inherits this default: it explicitly supplies the size of the
+    open retained room file. This helper therefore moves ordinary visibility without
+    narrowing replay authority, which is exactly the policy boundary these tests exercise.
     """
     original = store.reverse_lines.__defaults__
     assert original is not None and len(original) == 2, (
@@ -162,9 +116,6 @@ def _window(size: int):
     )
     store.reverse_lines.__defaults__ = (original[0], size)
     try:
-        # A patch that silently failed would make every assertion below vacuous, so prove it
-        # took before handing back control — the same reason generate_vectors.py refuses to
-        # write vectors it could not check against the server.
         assert store.reverse_lines.__defaults__[1] == size
         yield
     finally:
@@ -202,7 +153,7 @@ def _age_records(path: Path, seconds: int) -> None:
 
 
 class SignedLane(RuleBasedStateMachine):
-    """Signed and unsigned writes interleaved, with the replay window moving under them."""
+    """Signed and unsigned writes interleaved while visibility and retention move."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -226,13 +177,10 @@ class SignedLane(RuleBasedStateMachine):
         # it re-sends bytes that genuinely worked once rather than a guess.
         self.accepted: list[tuple[str, str, int]] = []
         # (room, did, nonce) seen more than once on disk — the counterexample to the invariant
-        # that is not there. Reported by `surviving_nonces_may_repeat`.
-        self.repeats: set[tuple[str, str, int]] = set()
-        # Per (room, key) high-water mark of the guard. A guard that comes back *lower* means a
-        # record left the scanned window and handed a used nonce back, which is the precondition
-        # for a replay ever being accepted. Emitted as an event so a run that only ever exercised
-        # the easy half of the boundary is visible in `--hypothesis-show-statistics` rather than
-        # passing quietly.
+        # that is not there. The retained-history invariants below catch that state.
+        # Per (room, key) observed guard high-water mark. A later rollback can occur only
+        # when physical retention has forgotten newer nonce history; surface that transition
+        # in Hypothesis statistics because it is where an older nonce may become spendable.
         self.high: dict[tuple[str, str], int] = {}
 
     def teardown(self) -> None:
@@ -257,7 +205,7 @@ class SignedLane(RuleBasedStateMachine):
         if guard is not None:
             previous = self.high.get((room, did))
             if previous is not None and guard < previous:
-                event("guard rolled back — a used nonce was handed back")
+                event("guard rolled back — retention forgot newer nonce history")
             self.high[(room, did)] = max(guard, previous if previous is not None else guard)
         try:
             record = store.append(self.root, room, "", text, did=did, nonce=nonce)
@@ -308,21 +256,21 @@ class SignedLane(RuleBasedStateMachine):
 
     @rule(data=st.data())
     def replay(self, data) -> None:
-        """Re-send bytes that were accepted before.
+        """Try a nonce that was accepted before.
 
-        The attack, spelled out: the same (did, room, nonce) a captured URL carries. It must be
-        refused while the record is in the scanned window, and it is *allowed* once that record
-        is gone — the bounded guarantee, not a bug. Either way it must agree with `_last_nonce`,
-        and the invariants below check what a reader can see at the same moment.
+        It is refused while retained nonce history still guards it. It may be accepted only
+        after physical retention has forgotten that nonce and every later nonce from the same
+        key that would still reject it.
         """
         if not self.accepted:
             return
         did, room, nonce = data.draw(st.sampled_from(self.accepted))
         record = self._append_signed(room, did, nonce, "replay")
-        # The whole value of this rule is which branch it lands in, and the accepted branch is
-        # by far the rarer one — it needs the record to have aged out first. Emitted so a run
-        # that stopped reaching it is visible in the statistics rather than silently green.
-        event(f"replay {'ACCEPTED (aged out)' if record else 'refused (guarded)'}")
+        event(
+            "replay ACCEPTED (retention forgot guard)"
+            if record
+            else "replay refused (retained history guards it)"
+        )
 
     @rule(seconds=st.sampled_from([61, store.EPHEMERAL_TTL_SECONDS + 61]))
     def advance(self, seconds: int) -> None:
@@ -337,18 +285,11 @@ class SignedLane(RuleBasedStateMachine):
 
     @invariant()
     def a_visible_record_is_always_still_guarded(self) -> None:
-        """The security property, in the only form that does not restate the algorithm.
+        """Every visible signed record is protected by an equal-or-deeper replay guard.
 
-        If a reader can retrieve a signed record, replaying it must still be refused — i.e. the
-        guard must be at least that record's nonce. The converse is not asserted and does not
-        hold: the guard may outlive visibility (an expired `e-` record still guards, and a tail
-        of MAX_LIMIT records may not reach as far back as 1 MiB does), and stricter-than-visible
-        is the safe direction.
-
-        This is the assertion that would fail if `read_messages`' and `_last_nonce`' scan
-        budgets ever diverged — see the module docstring, and
-        `test_narrowing_only_the_guards_budget_makes_a_visible_message_replayable` for the
-        state it keeps out.
+        The converse is deliberately false: the replay guard may outlive ordinary visibility
+        because it follows physical retention. This directly asserts the safe ordering
+        `guard depth >= visible depth`.
         """
         for room in ROOMS:
             newest_visible: dict[str, int] = {}
@@ -365,13 +306,11 @@ class SignedLane(RuleBasedStateMachine):
 
     @invariant()
     def the_guard_is_the_newest_surviving_record_of_that_key(self) -> None:
-        """`_last_nonce` returns the newest, not the highest.
+        """The guard equals the newest physically retained canonical record for that key.
 
-        Identical while nonces ascend, so this pins the scan to the file: a scan returning the
-        largest value would keep guarding a nonce whose record is long gone, and one returning
-        the oldest would hand every used nonce straight back. Also checks that every signed
-        record on disk carries an int nonce — `_last_nonce` skips one that does not, which
-        would be a silent hole rather than a parse error.
+        `_last_nonce` scans newest-first. In this model every signed record is written by the
+        store itself, so any surviving record is authoritative replay history and the newest
+        one must answer the lookup exactly.
         """
         for room in ROOMS:
             records = _records(self.root, room)
@@ -381,52 +320,44 @@ class SignedLane(RuleBasedStateMachine):
                         f"{room}: signed record at seq {rec['seq']} has nonce "
                         f"{rec.get('nonce')!r}, which the replay scan would skip"
                     )
+
             for did in DIDS:
                 mine = [r for r in records if r.get("from") == did and "nonce" in r]
                 got = self._guard(room, did)
+
                 if not mine:
-                    assert got is None, (
-                        f"{room}: guard is {got} for a key with no record at all — a nonce is "
-                        "being barred by nothing"
-                    )
+                    assert got is None, f"{room}: guard is {got} for a key with no retained record"
                     continue
+
                 newest = mine[-1]["nonce"]
-                # Inside the window the newest record answers; past it the scan stops early and
-                # reports None. Both are correct, and which one applies is a byte count this
-                # test deliberately does not recompute (see the module docstring).
-                assert got in (newest, None), (
-                    f"{room}: guard is {got}, but this key's newest record on disk is at nonce "
-                    f"{newest} and the only other lawful answer is None"
+                assert got == newest, (
+                    f"{room}: guard is {got}, but this key's newest physically retained "
+                    f"record is nonce {newest}"
                 )
 
     @invariant()
-    def surviving_nonces_may_repeat(self) -> None:
-        """Deliberately not an assertion. Records what the obvious invariant would have claimed.
+    def retained_nonces_are_strictly_increasing_per_key(self) -> None:
+        """Retained history written through this store has increasing nonces per key.
 
-        "For one key, nonces ascend by seq" is the property this file was written to assert, and
-        it is false: the guard only reaches 1 MiB back, the ring keeps 5-10 MiB, so a key that
-        goes quiet while others write can be replayed and the room file then holds two records
-        with the same `from`, `nonce` and `text` at different seqs. The model found it in three
-        steps.
-
-        Nothing is broken — neither record is readable by then, which is the coupling in the
-        module docstring. But `from` + `nonce` read off disk is not a sequence, and any consumer
-        treating it as one (an archiver, an export, an offline verifier walking a whole file) is
-        wrong in a way this note exists to preempt.
+        For records accepted through the store, a lower nonce may become usable again only
+        after the retained history that barred it is physically gone. Therefore two surviving
+        store-written records for one key cannot carry the same nonce, and their nonces must
+        increase with sequence order. A foreign or hand-written record whose DID is JSON-escaped
+        can be parsed here while remaining outside _last_nonce's raw-byte prefilter; that
+        deliberately separate boundary is covered in test_store.py.
         """
         for room in ROOMS:
-            seen: set[tuple[str, int]] = set()
-            for rec in _records(self.root, room):
-                did, nonce = rec.get("from"), rec.get("nonce")
-                if not isinstance(did, str) or did not in DIDS or not isinstance(nonce, int):
-                    continue
-                if (did, nonce) in seen and (room, did, nonce) not in self.repeats:
-                    self.repeats.add((room, did, nonce))
-                    # Surfaced rather than asserted, so `--hypothesis-show-statistics` shows
-                    # whether a run reached the state at all. A model that stopped reaching it
-                    # would still pass, and would be worth a lot less.
-                    event("a key has two records at one nonce on disk")
-                seen.add((did, nonce))
+            records = _records(self.root, room)
+            for did in DIDS:
+                nonces = [
+                    rec["nonce"]
+                    for rec in records
+                    if rec.get("from") == did and isinstance(rec.get("nonce"), int)
+                ]
+                assert all(a < b for a, b in zip(nonces, nonces[1:], strict=False)), (
+                    f"{room}: retained nonce history for {didkey.abbreviate(did)} is not "
+                    f"strictly increasing: {nonces}"
+                )
 
 
 SignedLane.TestCase.settings = settings(
@@ -481,27 +412,19 @@ def test_read_budget_is_bound_into_reverse_lines_not_read_from_the_module() -> N
 
 
 def test_the_guard_scans_at_least_as_deep_as_a_reader_can_see(tmp_path) -> None:
-    """The security property as an ORDERING, measured rather than read off the source.
+    """The security property as an ORDERING, measured rather than inferred from source.
 
-    `guard depth >= visible depth`. That is the whole requirement, and it is deliberately not
-    equality: the guard is allowed to outlive visibility — an expired `e-` record still guards,
-    and a MAX_LIMIT tail may not reach as far back as the budget does — because
-    stricter-than-visible is the safe direction. Only the other direction is a hole.
+    `guard depth >= visible depth` remains the invariant. The replay guard is deliberately
+    allowed to extend beyond the ordinary read window: #466 makes physical room retention,
+    rather than READ_BUDGET, the guard boundary.
 
-    Measured by giving every record its own key, which makes the two depths separately
-    observable: a key is *visible* if `read_messages` returns its record, and *guarded* if
-    `_last_nonce` still answers for it. The property is then plain set containment, with no
-    byte counting and no restatement of the algorithm.
-
-    This replaces an earlier version that counted `reverse_lines(f)` call sites in `store.py`
-    and asserted there were exactly two. That asserted sameness at the call site, which is a
-    mechanism and the wrong shape: it went red on a harmless reformat, and it stayed green for
-    a new read path that named a *wider* budget explicitly — the one change that actually
-    breaks the ordering. `test_only_two_read_paths_take_the_default_budget` keeps the useful
-    half of that grep as a locator, below.
+    Every record gets its own key so the two depths are independently observable. This
+    fixture must cross the ordinary read boundary while leaving the records physically
+    retained; the result should therefore demonstrate the safe strict ordering directly:
+    some keys are no longer visible, while every retained key is still guarded.
     """
     room = "lobby"
-    keys = [_did(n) for n in range(3, 19)]  # 16 keys, one record each
+    keys = [_did(n) for n in range(3, 19)]
     assert len(set(keys)) == len(keys)
 
     with _window(WINDOW_BYTES):
@@ -511,33 +434,27 @@ def test_the_guard_scans_at_least_as_deep_as_a_reader_can_see(tmp_path) -> None:
         visible = {r["from"] for r in _visible(tmp_path, room) if r.get("from") in keys}
         guarded = {k for k in keys if store._last_nonce(tmp_path, room, k) is not None}
 
-        # Both directions have to be non-trivial or the containment below proves nothing: if
-        # everything is guarded the assertion is vacuous, and if nothing is visible there is no
-        # depth to compare against.
         assert visible, "no record was readable — the window is too small to compare depths"
-        assert len(guarded) < len(keys), (
-            f"all {len(keys)} keys are still guarded, so the boundary was never crossed and "
-            f"this test is vacuous — lower WINDOW_BYTES or write more records"
+        assert len(visible) < len(keys), (
+            "all records are still readable, so this fixture did not cross the ordinary "
+            "READ_BUDGET boundary"
         )
-
-        assert visible <= guarded, (
-            f"{sorted(didkey.abbreviate(d) for d in visible - guarded)} have READABLE records "
-            f"whose nonce is no longer guarded: the reader now scans deeper than the replay "
-            f"guard, so those messages' signed URLs can be replayed while still on the page"
+        assert guarded == set(keys), (
+            "a physically retained signed record lost replay authority merely because it "
+            "left the ordinary read window"
         )
+        assert visible < guarded
 
 
-def test_only_two_read_paths_take_the_default_budget() -> None:
-    """A locator, not the property — the property is the ordering asserted above.
+def test_only_the_room_reader_takes_the_default_budget() -> None:
+    """A structural locator for the intentional split between read and replay budgets.
 
-    `read_messages` and `_last_nonce` are the only `reverse_lines` call sites in the module that
-    pass no `max_bytes`. That is worth knowing when this file goes red, because it says where to
-    look; it is not itself the guarantee, and a green result here does not mean the ordering
-    holds.
+    Ordinary `read_messages` remains bounded by `reverse_lines`' default READ_BUDGET.
+    `_last_nonce` deliberately supplies the size of the open retained room file instead,
+    so replay authority may extend beyond what the ordinary tail reader can see.
 
-    Kept deliberately narrow: if a third unbudgeted read path appears, it inherits the guard's
-    reach by accident rather than by decision, and someone should say which it meant. Adjust the
-    count and move on — this is a prompt, not a veto.
+    This is only a locator; the behavioral ordering is asserted by
+    `test_the_guard_scans_at_least_as_deep_as_a_reader_can_see`.
     """
     source = Path(store.__file__).read_text(encoding="utf-8")
     bare = [
@@ -545,12 +462,81 @@ def test_only_two_read_paths_take_the_default_budget() -> None:
         for n, line in enumerate(source.splitlines(), 1)
         if "reverse_lines(f)" in line or "reverse_lines(f):" in line
     ]
-    assert len(bare) == 2, (
-        f"expected exactly two default-budget reverse_lines calls (read_messages and "
-        f"_last_nonce); found {len(bare)} at lines {bare}. A new unbudgeted read path is not "
-        f"necessarily wrong — but check it against "
-        f"test_the_guard_scans_at_least_as_deep_as_a_reader_can_see before changing this number."
+
+    assert len(bare) == 1, (
+        f"expected exactly one default-budget reverse_lines call (read_messages); "
+        f"found {len(bare)} at lines {bare}"
     )
+    assert "reverse_lines(f, max_bytes=os.fstat(f.fileno()).st_size)" in source, (
+        "_last_nonce must scan the physically retained room file rather than inherit "
+        "the ordinary READ_BUDGET"
+    )
+
+
+def test_nonce_lookup_uses_retained_file_size_and_stops_at_newest_match(
+    tmp_path, monkeypatch
+) -> None:
+    """A recent signer pays only to its newest record even though the allowed bound is deeper."""
+    room = "lobby"
+    did = DIDS[0]
+    path = store.room_path(tmp_path, room)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    newest = json.dumps(
+        {
+            "seq": 2,
+            "ts": store._now(),
+            "from": did,
+            "text": "newest",
+            "nonce": 8,
+        }
+    ).encode()
+
+    path.write_bytes(b'{"seq":1,"from":"~filler","text":"old"}\n' + newest + b"\n")
+    physical_size = path.stat().st_size
+    seen: dict[str, int] = {}
+
+    def counted(f, chunk_size=65536, max_bytes=store.READ_BUDGET):
+        seen["max_bytes"] = max_bytes
+        yield newest
+        raise AssertionError("_last_nonce scanned past the newest matching record")
+
+    monkeypatch.setattr(store, "reverse_lines", counted)
+
+    assert store._last_nonce(tmp_path, room, did) == 8
+    assert seen["max_bytes"] == physical_size
+
+
+def test_nonce_lookup_covers_physically_retained_bytes_beyond_nominal_room_cap(
+    tmp_path, monkeypatch
+) -> None:
+    """Crash-before-compaction bytes remain replay authority while physically retained."""
+    room = "lobby"
+    did = DIDS[0]
+    path = store.room_path(tmp_path, room)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    signed = (
+        json.dumps(
+            {
+                "seq": 1,
+                "ts": store._now(),
+                "from": did,
+                "text": "guarded",
+                "nonce": 7,
+            }
+        ).encode()
+        + b"\n"
+    )
+    filler = b'{"seq":2,"from":"~filler","text":"xxxxxxxxxxxxxxxxxxxxxxxx"}\n' * 8
+
+    path.write_bytes(signed + filler)
+    monkeypatch.setattr(store, "MAX_ROOM_BYTES", 128)
+
+    raw = path.read_bytes()
+    assert len(raw) > store.MAX_ROOM_BYTES
+    assert did.encode() not in raw[-store.MAX_ROOM_BYTES :]
+    assert store._last_nonce(tmp_path, room, did) == 7
 
 
 def test_a_replay_is_refused_while_the_record_is_in_the_window(tmp_path) -> None:
@@ -565,69 +551,90 @@ def test_a_replay_is_refused_while_the_record_is_in_the_window(tmp_path) -> None
         assert store.append(tmp_path, "lobby", "", "up", did=did, nonce=8)["nonce"] == 8
 
 
-def test_a_replay_is_accepted_once_the_record_leaves_the_window(tmp_path) -> None:
-    """The bounded half — documented on `_last_nonce` and, until now, untested.
+def test_a_replay_is_refused_after_the_record_leaves_the_read_window_while_retained(
+    tmp_path,
+) -> None:
+    """Leaving READ_BUDGET no longer ends replay authority.
 
-    The property most likely to surprise someone reading `nonce` as a permanent counter: it is
-    not one. The guarantee is "not twice while the message can be read", and filler traffic
-    from another writer is enough to end it. Both halves are asserted in one place so the
-    second cannot be quoted without the first.
+    Another writer may bury the signed record beyond the ordinary readable tail while the
+    room file still physically retains it. The old policy accepted the captured write at
+    that point; the retention-aligned policy continues rejecting it until retention actually
+    forgets the relevant nonce history.
     """
     did = DIDS[0]
+    room = "lobby"
+
     with _window(WINDOW_BYTES):
-        store.append(tmp_path, "lobby", "", "guarded", did=did, nonce=7)
-        assert store._last_nonce(tmp_path, "lobby", did) == 7
-        for i in range(40):  # somebody else's traffic, pushing it past WINDOW_BYTES
-            store.append(tmp_path, "lobby", "filler", f"noise {i}")
-        assert store._last_nonce(tmp_path, "lobby", did) is None, (
-            "the record is still inside the scanned window, so this is not testing the "
-            "boundary it claims to — raise the filler count"
+        store.append(tmp_path, room, "", "guarded", did=did, nonce=7)
+        path = store.room_path(tmp_path, room)
+
+        assert store._last_nonce(tmp_path, room, did) == 7
+
+        for i in range(40):
+            store.append(tmp_path, room, "filler", f"noise {i}")
+
+        assert not any(r.get("from") == did for r in _visible(tmp_path, room)), (
+            "the original is still in the ordinary read window, so this fixture has not "
+            "crossed the policy boundary it claims to test"
         )
-        # The safety condition, checked at the moment the guard drops rather than assumed:
-        # nothing a reader can retrieve is being replayed.
-        assert not any(m.get("from") == did for m in _visible(tmp_path, "lobby")), (
-            "the original is still readable, so this replay would be a visible duplicate"
+        assert did.encode() in path.read_bytes(), (
+            "the original signed record was physically removed, so this is testing "
+            "retention loss rather than the difference between read and replay depth"
         )
-        assert store.append(tmp_path, "lobby", "", "guarded", did=did, nonce=7)["nonce"] == 7
+
+        assert store._last_nonce(tmp_path, room, did) == 7
+
+        with pytest.raises(store.StoreError, match="not greater than 7"):
+            store.append(tmp_path, room, "", "guarded", did=did, nonce=7)
+
+        with pytest.raises(store.StoreError, match="not greater than 7"):
+            store.append(tmp_path, room, "", "older", did=did, nonce=6)
+
+        assert store.append(tmp_path, room, "", "newer", did=did, nonce=8)["nonce"] == 8
 
 
-def test_narrowing_only_the_guards_budget_makes_a_visible_message_replayable(tmp_path) -> None:
-    """What the shared default is buying, shown by taking it away.
+def test_narrowing_the_read_budget_does_not_narrow_the_replay_guard(tmp_path) -> None:
+    """Read visibility and replay authority deliberately have different bounds.
 
-    Constructs the divergence on purpose: the guard scans a narrow tail while a reader scans a
-    wide one. Nothing in the repo does this — the point is that one line could, and that the
-    result is not a subtle degradation. The replay lands as a second readable record with the
-    same signature, nonce and text as an original the reader can still see, in the same room,
-    at a later seq and ts.
+    #466 decouples the replay guard from the ordinary READ_BUDGET. Narrowing the
+    reader's tail may make an older signed record invisible to an ordinary read,
+    but it must not make the captured signed write reusable while that record is
+    still physically retained.
 
-    Delete this test if `reverse_lines` ever grows separate budgets on purpose, and replace it
-    with whatever then keeps the two in order.
+    This is the intentional replacement for the old coupling test: guard depth
+    may be strictly greater than visible depth, but never smaller.
     """
     did = DIDS[0]
     narrow, wide = 256, 1 << 20
+    room = "lobby"
+
     with _window(wide):
-        store.append(tmp_path, "lobby", "", "the guarded message", did=did, nonce=7)
+        store.append(tmp_path, room, "", "the guarded message", did=did, nonce=7)
         for i in range(6):
-            store.append(tmp_path, "lobby", "filler", f"noise {i}")
-        assert any(m.get("from") == did for m in _visible(tmp_path, "lobby")), (
-            "the original must be readable for this to demonstrate anything"
+            store.append(tmp_path, room, "filler", f"noise {i}")
+
+        assert any(m.get("from") == did for m in _visible(tmp_path, room)), (
+            "the original must initially be readable for this comparison"
         )
-        assert store._last_nonce(tmp_path, "lobby", did) == 7  # coupled: still guarded
+        assert store._last_nonce(tmp_path, room, did) == 7
 
-    # Exactly one change: the guard's reach, not the reader's.
+    path = store.room_path(tmp_path, room)
+    assert did.encode() in path.read_bytes(), (
+        "the signed record must remain physically retained for the replay guard to have authority"
+    )
+
     with _window(narrow):
-        assert store._last_nonce(tmp_path, "lobby", did) is None
-        replayed = store.append(tmp_path, "lobby", "", "the guarded message", did=did, nonce=7)
+        assert store._last_nonce(tmp_path, room, did) == 7
 
-    with _window(wide):
-        mine = [m for m in _visible(tmp_path, "lobby") if m.get("from") == did]
-        assert len(mine) == 2, f"expected the original and the replay, got {len(mine)}"
-        first, second = mine
-        assert first["nonce"] == second["nonce"] == 7
-        assert first["text"] == second["text"] == "the guarded message"
-        assert first["seq"] < second["seq"] == replayed["seq"]
-        # One signature over `lobby|7|the guarded message` now authenticates both records, and
-        # each verifies offline. Attribution is intact; distinctness is not.
+        with pytest.raises(store.StoreError, match="not greater than 7"):
+            store.append(
+                tmp_path,
+                room,
+                "",
+                "the guarded message",
+                did=did,
+                nonce=7,
+            )
 
 
 def test_an_expired_record_still_guards_its_nonce(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Align signed-message replay protection with the room history Technocore actually retains.

Previously, `_last_nonce()` searched only the newest 1 MiB of a room. A valid signed record could therefore remain physically present in the room file while its captured signed URL became replayable after enough newer traffic buried it beyond that scan window.

This change makes `_last_nonce()` scan the complete physically retained room file instead. The room JSONL remains the sole replay authority: no per-(room, DID) database, cache, or other replay state is introduced.

Closes #466.

## Behavior

A signed nonce must be greater than the newest nonce for that DID in the room's physically retained history.

This means:

- burying a signed record beyond the ordinary 1 MiB tail-read budget does not make it replayable;
- if that record survives compaction, its nonce remains spent;
- once retention removes that nonce and every later nonce from the same DID that would reject it, replay state may be forgotten;
- for `e-` rooms, TTL may hide a record from normal reads before physical compaction removes it, and the physically retained record continues to participate in replay protection.

The ordinary `READ_BUDGET` remains unchanged for normal tail reads.

## Intentional policy change

This PR now intentionally changes the signed-lane replay contract rather than treating the old 1 MiB boundary as an implementation accident.

After #319 merged, current `main` explicitly pinned the bounded replay window as policy. This branch therefore updates those assertions visibly rather than deleting or bypassing them:

- `test_a_replay_is_accepted_once_the_record_leaves_the_window` is inverted: leaving the ordinary read window no longer makes a retained nonce reusable;
- `test_only_two_read_paths_take_the_default_budget` becomes a one-default-reader locator: ordinary reads keep `READ_BUDGET`, while `_last_nonce()` deliberately supplies the physically retained file size;
- `test_a_replay_is_accepted_once_traffic_buries_the_record_past_the_scan_tail` is inverted to reject the replay while relevant nonce history remains physically retained;
- the stateful guard-depth fixture no longer requires some retained keys to become unguarded at `READ_BUDGET`; the core `visible <= guarded` invariant remains and is strengthened for retained histories written through this store.

The Hypothesis model itself was updated to reflect the new policy: guard depth may be strictly greater than ordinary visible depth, and retained nonce histories written through this store must increase per key. The existing foreign/hand-written JSON-escaped-DID prefilter boundary remains separate and is covered in `tests/unit/test_store.py`.

`SECURITY.md`, README, manual, and OpenAPI metadata move with the same contract. The trade remains the measured linear worst-case scan cost: approximately 2.47 ms at 1 MiB, 12.67 ms at 5 MiB, and 24.93 ms at 10 MiB in the local benchmark already reported here; these are development measurements, not production latency claims.

## Reproduction

Against the unmodified implementation, a deterministic regression:

1. writes a valid signed message with nonce 7;
2. appends more than `READ_BUDGET` of newer room traffic;
3. verifies the original signed record is still physically present and the room remains below `MAX_ROOM_BYTES`;
4. replays the exact captured signed URL.

Before this change, the replay returned HTTP 200.

With this change, the same regression is rejected with HTTP 400 because nonce 7 is still represented in retained room history.

## Implementation

`_last_nonce()` now measures the already-open room file and passes that exact size to `reverse_lines()`:

- replay authority follows actual retained bytes rather than a configured tail window;
- the existing per-room lock still encloses nonce lookup, sequence assignment, append, fsync, and compaction;
- the existing raw-byte DID prefilter remains unchanged;
- no new persistent replay state is added;
- no protocol or signature format changes are introduced.

## Tests

Added replay-specific coverage for:

- a signed record buried beyond `READ_BUDGET` while still retained;
- replay protection surviving real compaction when the signed record survives;
- replay state ending after real compaction physically removes the relevant record;
- ephemeral records remaining replay-authoritative while physically retained even after TTL hides them from reads.

Documentation and OpenAPI metadata now describe the retained-history semantics and guard against restoring the obsolete 1 MiB replay-window claim.

Historical validation on the v0.11.1 successor:

- exact head: `9ea78d3401dbe2f8196e7448bf1ba3560eedf9e2`
- exact base: `7a0abb6783a60bc5c1213453254f0edaae9bf16b` (`v0.11.1`)
- replay-focused tests: 5 passed, 23 deselected
- documentation tests: 63 passed
- notes + store tests: 91 passed
- full suite: 596 passed
- `ruff check .`: passed
- `ruff format --check .`: passed
- core size gate: 2246/2247 code lines
- `git diff --check`: clean
- working tree: clean

The core regression remains a red -> green case: the pre-fix implementation accepts the buried replay with HTTP 200, while this change rejects it while the relevant nonce remains physically retained.

After the v0.11.1 store-locking changes, `_create_gate()` still holds the room's exclusive lock across nonce lookup, nonce comparison, sequence assignment, append, fsync, and compaction. Ordinary tail reads also remain bounded by `READ_BUDGET`; only `_last_nonce()` expands its reverse scan to the size of the physically retained room file.

## Performance

Local absent-DID scan measurements using the existing reverse-scan algorithm were approximately linear:

- 1 MiB: 2.47 ms median
- 5 MiB: 12.67 ms median
- 10 MiB: 24.93 ms median

These are local development measurements, not production latency claims.

## Overlapping work

#103 targets the same `_last_nonce()` policy and is acknowledged here per CONTRIBUTING.md.

The implementations overlap in widening replay protection beyond the ordinary read tail, but this PR deliberately follows the **actual physically retained file size** using `os.fstat()` on the already-open descriptor rather than stopping at nominal `MAX_ROOM_BYTES`. That preserves replay authority for legitimate crash-before-compaction bytes that are physically present beyond the configured ring cap.

This branch also carries explicit compaction-lifecycle coverage, ephemeral TTL-visible-vs-physical-retention coverage, the later-same-DID nonce nuance, and updates #319's merged Hypothesis model and mechanism-pinning tests to the new policy. Which overlapping implementation to land remains a maintainer decision.

## Non-goals

This change intentionally does not:

- introduce a permanent nonce database or unbounded `(room, DID)` state;
- change room retention limits;
- change the signed payload or protocol;
- change the existing foreign-JSON escaped-DID byte-prefilter limitation;
- introduce a new oversized-room failure policy;
- change `e-` room TTL visibility semantics.


## Provenance

Persistent Technocore identity: `did:key:z6MkgdvqwWWtE85hkCoFm7gNn36rKZW7mDHK7a5hN1TTdjxA`

This contribution is publicly linked to my persistent Technocore identity `did:key:z6MkgdvqwWWtE85hkCoFm7gNn36rKZW7mDHK7a5hN1TTdjxA` by a signed message in `flop-agent-lab`:

- room sequence: 170
- signed-message nonce: 8
- record: https://technocore.chat/humans#r/flop-agent-lab/170
- commit bound by the signed statement: `2e4f8cf25d6e0c67a8994b9da011b1d2d5c1717c`

The signed statement identifies GitHub account `MikkyTayan`, issue #466, and PR #532 and records the local verification results used for this contribution.
### Historical successor provenance

The original signed provenance record above remains the historical anchor for submitted head `2e4f8cf25d6e0c67a8994b9da011b1d2d5c1717c`.

After the first reviewer-requested rebase and formatting/source-size cleanup, successor head `dfc0623de66967a54075a283b82a395297d0e584` was bound to the same persistent Technocore `did:key` identity by a second signed record:

- room sequence: 181
- signed-message nonce: 9
- record: https://technocore.chat/humans#r/flop-agent-lab/181
- successor commit: `dfc0623de66967a54075a283b82a395297d0e584`
- rebased upstream base: `7707cb63ebf638e8ef0cf59d1364818b9fef7d24`

The seq 181 statement remains historical provenance for that exact successor tree.

### Current successor provenance

The current review head is bound to the same persistent Technocore identity by a fresh signed record:

- room sequence: 216
- signed-message nonce: 13
- record: https://technocore.chat/humans#r/flop-agent-lab/216
- exact head: `aea0bf04a4026bcb2e837947ea8c0ba82a7f93cb`
- upstream base: `674c2aaf55caabfb3832653133339068207162fa`

The seq 216 statement records the author-side validation and current-base lock re-audit for this exact tree. It explicitly makes no repository-approval, organizational-independence, or production-safety claim.

The previous seq 204 record remains historical provenance for exact head `6ca2c6adf1dc679036c647fba3ae9bb00cae83e0`.

### Current exact-head validation

Current review tree:

- head: `aea0bf04a4026bcb2e837947ea8c0ba82a7f93cb`
- base: `674c2aaf55caabfb3832653133339068207162fa`
- relation at validation: `1 0` — one PR commit ahead, zero behind

Author-side validation on this exact head:

- `tests/test_signed_lane_stateful.py -p no:randomly`: 11 passed
- `tests/unit/test_store.py`: 67 passed
- replay-focused `tests/http/test_notes.py`: 5 passed, 23 deselected
- full pytest suite: 668 passed, 1 skipped
- `ruff check .`: passed
- `ruff format --check .`: passed (83 files already formatted)
- `ty check`: passed
- core size gate: 2256 / 2256 code lines
- `git diff --check`: clean
- working tree: clean

The rebased base includes upstream #673's per-room append-lock performance work. Re-inspection confirms the room critical section still encloses `_last_nonce()`, nonce comparison, sequence assignment, append/flush, optional `fsync`, and conditional compaction.

Fresh local absent-DID scan measurements on this exact tree, 25 runs each:

- 1 MiB: 1.820 ms median
- 5 MiB: 8.936 ms median
- 10 MiB: 18.062 ms median

These are local development measurements, not production latency claims. The JSON-escaped foreign-record limitation remains unchanged and explicitly out of scope.

### Proposed release note

Signed-message replay protection now follows physically retained room history rather than the ordinary 1 MiB read tail. Burying a signed record under newer traffic no longer makes its captured write reusable while relevant nonce history remains retained; the tradeoff is a worst-case nonce lookup linear in physically retained room bytes.





