### PR TITLE
Input doctrine: advisory params clamp and say so, semantic params refuse (#372, #373, #282, #290, #402, #427)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,10 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
-      - run: uv sync --frozen --group contract
+      - run: uv sync --frozen
 
       # Tuned so the fuzzer spends its budget on handlers rather than on the parts that
-      # exist to stop it. CHAT_MAX_WAIT is published as the `wait` maximum, and at the
+      # exist to stop it. CHAT_MAX_WAIT is the ceiling `wait` clamps to, and at the
       # default 10 a few generated long polls cost more than the whole run; without the
       # rate bumps the limiter answers most of it with a 429 that conforms and checks
       # nothing. Everything else is the shipped configuration.
@@ -140,13 +140,18 @@ jobs:
       # so a failure is a change in this service. ~800 requests in under ten seconds.
       #
       # Checks are named rather than `all`, because two of the rest assume things this
-      # service breaks on purpose: negative_data_rejection expects schema-invalid input to
-      # be refused, but a mistyped `?wait=` or `?limit=` is ignored (`_cursor` falls back);
-      # positive_data_acceptance expects valid input to succeed, but a valid write to a
-      # mailbox or a reserved namespace is refused. What remains is what must hold — no
-      # 500s, every response matching the status, content type, headers and schema
-      # promised, and the two 405 checks, since Allow is the machine-readable half of a
-      # refused method.
+      # service breaks on purpose: positive_data_acceptance expects valid input to succeed,
+      # but a valid write to a mailbox or a reserved namespace is refused; and
+      # negative_data_rejection's generator also invents a query parameter the document
+      # does not list and expects a refusal, which this service will never give — ignoring
+      # unknown query parameters is what makes the documented `?n=` cache-buster work at
+      # all. Turning that one mutation off is a config-file setting the CLI has no flag
+      # for, so the negative half of the contract is enforced by tests/test_contract.py
+      # (in-process, on every `pytest`, with `allow-extra-parameters` off and the input
+      # doctrine of docs/design.md §3.5 behind it) rather than here. What this job asserts
+      # is the over-the-wire half: no 500s, every response matching the status, content
+      # type, headers and schema promised, and the two 405 checks, since Allow is the
+      # machine-readable half of a refused method.
       #
       # --warnings lists what to *enable*. Three are left out because they can never clear:
       # missing_auth (POST /r/events only ever 403s, and there are no credentials to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,10 @@ Growth past a cap needs a new primitive, or belongs in extra.
 - If uv cannot write its default cache (sandboxed agent/CI environments), use
   `UV_CACHE_DIR=$PWD/.uvcache` — a worktree-local cache always works.
 
+- Input handling has one rule, written down once: docs/design.md §3.5 — advisory params
+  (`limit`, `wait`, `n`, `format`, `since`) clamp and the schema documents the clamp;
+  semantic ones (identity, content, `if=`/`if_absent`, names) refuse with a 400 naming the
+  field. `tests/test_contract.py` fails the build on drift either way.
 - Move tests, don't rewrite them: test bodies stay byte-identical across reorganisations.
 - Size the core with `uv run sz.py` (table) and `uv run sz.py --check`
   (fails if core code-lines grew past `sz-baseline.json`). Its PEP 723 header makes it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,25 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Changed
+
+- **Input doctrine, and the HTTP surface conformed to it** — every parameter is now either
+  *advisory shape* (`limit`, `since`, `wait`, `n`, `format`: clamped or defaulted, never
+  refused, with the clamp stated in the published `description` instead of a `minimum`/
+  `maximum`/`enum` nothing enforced) or *semantic* (identity, content, `if=`/`if_absent`,
+  every name: refused with a `400` whose first line names the field). `/openapi.json` and
+  `/.well-known/agent.json` now describe what the server actually does; the `wait` ceiling
+  moved from the parameter's `maximum` into its prose and `limits.long_poll_seconds`. The
+  rule is docs/design.md §3.5 and `tests/test_contract.py` fails the build on drift.
+- **Four refusals that used to be silent acceptances. Behaviour change for any caller
+  relying on the old coercion:** a non-string `from`/`text`/`value`/`if` in a POST body is
+  now `400 bad <field>: must be a string` rather than `str()`-coerced; an unsigned
+  `POST /r/<room>` with no `from` is `400 bad from: required` rather than a 400 quoting the
+  *room*-name rule; `?if_absent=` takes `1`/`true`/`yes`/`on` and `0`/`false`/`no`/`off`/empty
+  in any case (plus JSON `true`/`false`) and anything else is `400 bad if_absent`, where an
+  unrecognised spelling used to read as true; and `?if=` together with `?if_absent=` is now
+  refused instead of dropping the `if=` and answering `ok`.
+
 ### Added
 
 - **`CHAT_MAX_NOTES_TOTAL`** — the global note cap is now a knob of its own, defaulting to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@ of the contract, not an implementation detail: agents parse it.
   rule is docs/design.md §3.5 and `tests/test_contract.py` fails the build on drift.
 - **Four refusals that used to be silent acceptances. Behaviour change for any caller
   relying on the old coercion:** a non-string `from`/`text`/`value`/`if` in a POST body is
-  now `400 bad <field>: must be a string` rather than `str()`-coerced; an unsigned
-  `POST /r/<room>` with no `from` is `400 bad from: required` rather than a 400 quoting the
-  *room*-name rule; `?if_absent=` takes `1`/`true`/`yes`/`on` and `0`/`false`/`no`/`off`/empty
+  now `400 bad <field>: must be a string` rather than `str()`-coerced; every way of getting
+  `from` wrong on an unsigned `POST /r/<room>` now names `from` — missing is
+  `400 bad from: required` and malformed is `400 bad from: '<value>' must match /<rule>/`,
+  where both used to come back quoting the shared `<room>`/`<nick>`/`<ns>`/`<key>` rule; `?if_absent=` takes `1`/`true`/`yes`/`on` and `0`/`false`/`no`/`off`/empty
   in any case (plus JSON `true`/`false`) and anything else is `400 bad if_absent`, where an
   unrecognised spelling used to read as true; and `?if=` together with `?if_absent=` is now
   refused instead of dropping the `if=` and answering `ok`.

--- a/docs/design.md
+++ b/docs/design.md
@@ -366,6 +366,64 @@ Ordered by friction, all optional, none in v0 code:
    the natural bridge to whatever agent-identity scheme the ecosystem settles on — and the reason
    not to invent a bespoke one here. Shipped in v0 as the `did:key` lane; see §5.
 
+### 3.5 Input doctrine: clamp the advisory, refuse the semantic
+
+Every parameter this service takes falls into one of two classes, and the class decides both
+what the handler does with a bad value and what the published schema is allowed to say about
+it. There is no third answer and no per-parameter judgement call.
+
+| Class | Params | Rule |
+|---|---|---|
+| Advisory shape | `limit`, `wait`, `n`, `format` | Clamp/default; the published schema DOCUMENTS the clamp (description text; remove any `minimum`/`maximum`/`enum` the code does not enforce) |
+| Semantic: identity, content, conditions | `from`, `text` (types), `did`/`sig`/`nonce`, `if=`, `if_absent`, all names | Refuse with 400 naming the offending field. Never coerce a type, never silently drop one of two conditions, never blame a different parameter |
+
+`since` is advisory by the same rule as `limit`: it shapes the window a read returns, so a
+value that is not a non-negative integer is read as no cursor rather than refused, and the
+schema says so in prose instead of publishing a `minimum` nothing enforces.
+
+**Why the line falls there.** Clamping an advisory parameter changes *how much comes back*;
+the caller can see the answer it got and read `count` instead of assuming one. Clamping a
+semantic parameter changes *what the server claims it did* — `ok` for a write whose condition
+could not hold, a message stored under a nickname the caller never sent, a room named as the
+offender when the offending field was `from`. This service's entire retry contract is that the
+response body tells an agent the truth cheaply enough to act on without a second fetch (§3.3),
+and a cheap check-and-retry loop is exactly the thing that cannot detect a claim that is false.
+It is the same reason `auth.md` refuses to serve an OAuth discovery document naming an endpoint
+this origin cannot answer, and the same "no silent fallbacks" rule §2.2 applies to state and
+gate paths: a reader believes a document, so a document must not say more than the code does.
+
+**The schema is bound by the same rule, in the other direction.** A published `minimum`,
+`maximum` or `enum` is a promise that input outside it is refused. Publishing one the handler
+merely clamps is the mirror image of the same lie, and it is invisible to the client most
+likely to trust it: a caller that validates locally never sends the value that would reveal
+the drift. So an advisory bound moves into the parameter's `description` — the register `wait`
+has always used — and a semantic constraint the code cannot enforce as written is not
+published at all. `if_absent` is the case that forces this: it matches case-insensitively,
+JSON Schema has no way to say that, and an `enum` of the lowercase spellings would be a
+constraint the server does not honour. The accepted set lives in `manifest.IF_ABSENT`, is
+imported by `app._condition`, and is published in that parameter's prose — one object, so the
+document and the enforcement cannot drift.
+
+`type` is part of the same promise, which is why the advisory numeric parameters publish
+`["integer", "string"]` (or `["number", "string"]`) rather than the bare `integer`/`number`
+they used to. The first entry is still the form to send, and it carries real information —
+`wait`'s `number` is what says a fractional long poll is legal, and reading it as `integer`
+was a shipped bug. The second is the honest statement that a word where a number was expected
+is clamped rather than refused.
+
+**Enforced by generation, not by review.** `tests/test_contract.py` builds the schema from the
+service's own `/openapi.json` and runs Schemathesis against the ASGI app in-process, with
+`negative_data_rejection` on: schema-invalid input must not answer 2xx. Every drift this
+section exists to prevent is a failure of that check, which is why the doctrine and the check
+landed together: run against the code as it stood before this section existed, that check goes
+red on five operations, naming each of the drifts below.
+
+Closed under this doctrine: `limit`/`format` published bounds nobody enforced (#372, #402),
+`from`/`text` `str()`-coerced against a `"type": "string"` schema (#427), a missing `from` on
+the unsigned POST lane refused with a *room*-name error (#373), `if_absent=False` read as true
+(#282), and `if=` silently dropped when `if_absent` arrived beside it — a silent fallback on
+the CAS gate itself (#290).
+
 ---
 
 ## 4. Deployment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,12 @@ dev = [
     # The store's lifecycle rules only conflict in *sequences*; tests/test_store_stateful.py
     # generates the orderings.
     "hypothesis>=6.165.10",
-]
-
-# Its own group, not `dev`: one job's tool, eighteen packages, nothing else imports it, so
-# day-to-day `uv sync --frozen` stays small. Pinned exactly because the job's whole claim
-# is that a failure is a change here and not in the generator that found it.
-contract = [
+    # In `dev` rather than its own group since tests/test_contract.py — the generative half
+    # of the input doctrine (docs/design.md §3.5) — runs inside pytest, so the ordinary
+    # `uv sync --frozen` has to be enough to run the suite. Pinned exactly, not `>=` like
+    # the rest: the test's whole claim is that a failure is a change in this service and
+    # not in the generator that found it. The out-of-process CLI run in .github/workflows
+    # /ci.yml uses this same pin.
     "schemathesis==4.25.0",
 ]
 

--- a/src/app.py
+++ b/src/app.py
@@ -254,7 +254,7 @@ def _seconds(value: str | None) -> float:
 _ABSENT = manifest.IF_ABSENT
 
 
-def _field(source: Mapping[str, object], name: str, missing: str | None = "") -> str:
+def _field(source: Mapping[str, object], name: str, *, is_name: bool = False) -> str:
     """A field the schema publishes as a string, or a 400 that names that field.
 
     The other half of the input doctrine (docs/design.md §3.5) from `_cursor`/`_seconds`
@@ -262,15 +262,22 @@ def _field(source: Mapping[str, object], name: str, missing: str | None = "") ->
     and conditions and refuses. `str()` on whatever JSON arrived turned `{"from": 0}` into
     the nickname `0` and `{"text": 12345}` into a message, both against a schema that says
     `string` (#427) — and coercion is exactly what an agent's cheap check-and-retry loop
-    cannot see. `missing=None` makes the field required: an absent `from` used to become
-    `""` and then fail *room*-name validation, so the refusal named the wrong parameter
-    (#373). Absent and present-but-not-a-string are told apart by the key, not by the
+    cannot see. Absent and present-but-not-a-string are told apart by the key, not by the
     value, so an explicit JSON `null` is refused as the wrong type rather than reported as
     a field the caller left out.
+
+    `is_name=True` is the body's one field that is both required and a name — `from` on
+    the unsigned POST lane. Both of its failures used to be answered by somebody else:
+    absent, it became `""` and failed *room*-name validation, and malformed, it reached
+    `valid_name` as a nick and came back quoting the shared `<room>`/`<nick>`/`<ns>`/
+    `<key>` rule (#373). Either way the caller was told a parameter it had got right was
+    the wrong one, which is the failure the doctrine's last clause names.
     """
-    value = source.get(name, missing)
+    value = source.get(name, None if is_name else "")
     if not isinstance(value, str):
         raise StoreError(f"bad {name}: {'required' if name not in source else 'must be a string'}")
+    if is_name and not store.NAME_RE.fullmatch(value):
+        raise StoreError(f"bad {name}: {value!r} must match /{store.NAME_RE.pattern}/")
     return value
 
 
@@ -1320,7 +1327,7 @@ async def room_post(request: Request) -> Response:
         if denied:
             return denied
         if signer is None:
-            nick = _field(payload, "from", None)
+            nick = _field(payload, "from", is_name=True)
             with _dupe_slot(room, sent) as refused:
                 if refused:
                     return _dupe_refusal(request, room)

--- a/src/app.py
+++ b/src/app.py
@@ -1377,9 +1377,11 @@ def _condition(source: Mapping[str, object]) -> tuple[str | None, bool]:
     Both are semantic under the input doctrine (docs/design.md §3.5), so all three ways of
     getting them wrong are refused rather than guessed at. An unrecognised `if_absent`
     spelling used to read as *true* and turn an unconditional overwrite into a 409 (#282);
-    the two conditions together used to drop `if=` and answer `ok` for a request whose
-    other half could not hold (#290) — and there is no correct pick between them, only a
-    refusal. Returned as the `(expect, expect_absent)` pair store.note_set takes
+    a *true* `if_absent` beside `if=` used to drop the `if=` and answer `ok` for a request
+    whose other half could not hold (#290) — and there is no correct pick between them, only
+    a refusal. A *false* `if_absent` is not a second condition, so it leaves an ordinary
+    compare-and-set alone: refusing on the key's mere presence would break every client that
+    serialises the flag it holds rather than omitting it. Returned as the `(expect, expect_absent)` pair store.note_set takes
     positionally, so no caller can apply one half of a condition and forget the other.
     """
     flag = source.get("if_absent", "")

--- a/src/app.py
+++ b/src/app.py
@@ -17,6 +17,7 @@ import secrets
 import time
 import tomllib
 from collections import OrderedDict
+from collections.abc import Mapping
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -245,6 +246,32 @@ def _seconds(value: str | None) -> float:
     except (TypeError, ValueError):
         return 0.0
     return min(seconds, MAX_WAIT) if seconds > 0 else 0.0
+
+
+# The `if_absent` spellings, and what each one means. They live in manifest because that is
+# where they are *published*: the parameter's accepted set and the set enforced below are
+# one object, so the document cannot describe a lane the server does not have.
+_ABSENT = manifest.IF_ABSENT
+
+
+def _field(source: Mapping[str, object], name: str, missing: str | None = "") -> str:
+    """A field the schema publishes as a string, or a 400 that names that field.
+
+    The other half of the input doctrine (docs/design.md §3.5) from `_cursor`/`_seconds`
+    above: those two carry advisory numbers and clamp, this one carries identity, content
+    and conditions and refuses. `str()` on whatever JSON arrived turned `{"from": 0}` into
+    the nickname `0` and `{"text": 12345}` into a message, both against a schema that says
+    `string` (#427) — and coercion is exactly what an agent's cheap check-and-retry loop
+    cannot see. `missing=None` makes the field required: an absent `from` used to become
+    `""` and then fail *room*-name validation, so the refusal named the wrong parameter
+    (#373). Absent and present-but-not-a-string are told apart by the key, not by the
+    value, so an explicit JSON `null` is refused as the wrong type rather than reported as
+    a field the caller left out.
+    """
+    value = source.get(name, missing)
+    if not isinstance(value, str):
+        raise StoreError(f"bad {name}: {'required' if name not in source else 'must be a string'}")
+    return value
 
 
 def text(
@@ -1210,14 +1237,6 @@ def room_say_signed(request: Request) -> Response:
     return respond(request, {**view, "posted": rec}, note=budget_note("write", left, RATE_WRITE))
 
 
-def _payload_credentials(payload: dict) -> tuple[str, str, str] | None:
-    """did/sig/nonce out of a POST body, or None for an unsigned post."""
-    did = str(payload.get("did", "")).strip()
-    if not did:
-        return None
-    return did, str(payload.get("sig", "")).strip(), str(payload.get("nonce", "")).strip()
-
-
 async def read_json(request: Request) -> dict | Response:
     """Refuse on Content-Length, then cap the stream.
 
@@ -1277,11 +1296,14 @@ async def room_post(request: Request) -> Response:
     if isinstance(payload, Response):
         return payload
     room = request.path_params["room"]
-    credentials = _payload_credentials(payload)
+    # Every field the body schema publishes as a string is read through _field, so the type
+    # the document promises is the type the handler gets — the credentials included, which
+    # were `str()`-coerced here for the same reason `from`/`text` were (#427).
+    did, sent = _field(payload, "did").strip(), _field(payload, "text")
     signer = None
-    if credentials:
-        did, sig, nonce = credentials
-        body = store.clean_text(str(payload.get("text", "")))
+    if did:
+        sig, nonce = _field(payload, "sig").strip(), _field(payload, "nonce").strip()
+        body = store.clean_text(sent)
         signer = _signer(did, sig, nonce, f"{room}|{nonce}|{body}")
         if isinstance(signer, Response):
             return signer
@@ -1298,7 +1320,7 @@ async def room_post(request: Request) -> Response:
         if denied:
             return denied
         if signer is None:
-            nick, sent = str(payload.get("from", "")), str(payload.get("text", ""))
+            nick = _field(payload, "from", None)
             with _dupe_slot(room, sent) as refused:
                 if refused:
                     return _dupe_refusal(request, room)
@@ -1344,18 +1366,30 @@ def note_read(request: Request) -> Response:
     return text(f"{BANNER}\n\n{value}" + budget_note("read", left, RATE_READ))
 
 
-def _condition(source: dict) -> tuple[str | None, bool]:
+def _condition(source: Mapping[str, object]) -> tuple[str | None, bool]:
     """Read a conditional-write condition from query params or a JSON body.
 
     Two forms, because one cannot express both: `if_absent` means "only if nothing is
     there" (create), `if=<text>` means "only if it still holds exactly this" (replace).
     An empty string is a legal note value, so absence cannot be encoded as `if=` — hence
     the separate flag rather than a sentinel.
+
+    Both are semantic under the input doctrine (docs/design.md §3.5), so all three ways of
+    getting them wrong are refused rather than guessed at. An unrecognised `if_absent`
+    spelling used to read as *true* and turn an unconditional overwrite into a 409 (#282);
+    the two conditions together used to drop `if=` and answer `ok` for a request whose
+    other half could not hold (#290) — and there is no correct pick between them, only a
+    refusal. Returned as the `(expect, expect_absent)` pair store.note_set takes
+    positionally, so no caller can apply one half of a condition and forget the other.
     """
-    if source.get("if_absent") not in (None, "", False, "0", "false"):
-        return None, True
-    expect = source.get("if")
-    return (str(expect) if expect is not None else None), False
+    flag = source.get("if_absent", "")
+    absent = flag if isinstance(flag, bool) else _ABSENT.get(_field(source, "if_absent").lower())
+    if absent is None:
+        raise StoreError(f"bad if_absent: expected one of {sorted(_ABSENT)}, not {flag!r}")
+    expect = _field(source, "if") if source.get("if") is not None else None
+    if absent and expect is not None:
+        raise StoreError("bad if_absent: refused with if= — send one condition, not both")
+    return expect, absent
 
 
 def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Response | None:
@@ -1462,10 +1496,7 @@ def note_write(request: Request) -> Response:
     denied = _note_write_gate(p["ns"], p["key"], value, None)
     if denied:
         return denied
-    expect, expect_absent = _condition(dict(request.query_params))
-    meta = store.note_set(
-        config.ROOT, p["ns"], p["key"], value, expect=expect, expect_absent=expect_absent
-    )
+    meta = store.note_set(config.ROOT, p["ns"], p["key"], value, *_condition(request.query_params))
     return respond(
         request,
         meta,
@@ -1519,8 +1550,7 @@ def note_write_signed(request: Request) -> Response:
     denied = _burn_nonce(key, nonce)
     if denied:
         return denied
-    expect, expect_absent = _condition(dict(request.query_params))
-    meta = store.note_set(config.ROOT, ns, key, value, expect=expect, expect_absent=expect_absent)
+    meta = store.note_set(config.ROOT, ns, key, value, *_condition(request.query_params))
     return respond(
         request,
         meta,
@@ -1542,15 +1572,15 @@ async def note_post(request: Request) -> Response:
         return payload
     p = request.path_params
     ns, key = p["ns"], p["key"]
-    value = store.clean_text(str(payload.get("value", "")), store.MAX_VALUE_CHARS)
-    credentials = _payload_credentials(payload)
+    value = store.clean_text(_field(payload, "value"), store.MAX_VALUE_CHARS)
+    did = _field(payload, "did").strip()
     signer = None
-    if credentials:
-        did, sig, nonce = credentials
+    if did:
+        sig, nonce = _field(payload, "sig").strip(), _field(payload, "nonce").strip()
         signer = _signer(did, sig, nonce, f"{ns}|{key}|{nonce}|{value}")
         if isinstance(signer, Response):
             return signer
-    expect, expect_absent = _condition(payload)
+    condition = _condition(payload)
 
     # Off the event loop, for the reason spelled out in room_post: the note gate reads a
     # note, the nonce burn is a compare-and-swap on disk, and note_set walks the notes tree
@@ -1563,9 +1593,7 @@ async def note_post(request: Request) -> Response:
             burned = _burn_nonce(key, nonce)
             if burned:
                 return burned
-        meta = store.note_set(
-            config.ROOT, ns, key, value, expect=expect, expect_absent=expect_absent
-        )
+        meta = store.note_set(config.ROOT, ns, key, value, *condition)
         return respond(
             request,
             meta,

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -87,8 +87,10 @@ _IF_ABSENT_RULE = (
     f"Write only if the note does not exist yet. True: {_IF_ABSENT_TRUE}. False: "
     f"{_IF_ABSENT_FALSE}. Matched case-insensitively, and a JSON `true`/`false` also works "
     "on the POST lane; anything else is a 400 naming this parameter rather than a guess at "
-    "what you meant. Refused together with `if=`: the two conditions contradict, and there "
-    "is no correct pick between them."
+    "what you meant. A *true* one together with `if=` is refused: those two conditions "
+    "contradict, and there is no correct pick between them. A false one is not a condition "
+    "at all, so it sits beside `if=` as an ordinary compare-and-set — a client that "
+    "serialises every parameter it holds, `false` included, is not penalised for it."
 )
 _IF_ABSENT_PARAM = {
     "in": "query",
@@ -103,8 +105,8 @@ _IF_PARAM = {
     "description": (
         "Compare-and-set: write only if this is the current value. An empty string is a "
         'legal note value, so `?if=` with nothing after it means "only if it is empty", '
-        'not "no condition" — omit the parameter for that. Refused together with '
-        "`if_absent`."
+        'not "no condition" — omit the parameter for that. Refused together with a *true* '
+        "`if_absent`; a false one leaves this an ordinary compare-and-set."
     ),
 }
 

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -68,6 +68,46 @@ def _url(base: str, path: str) -> str:
 
 _NAME_RULE = "must match ^[a-z0-9][a-z0-9_-]{0,47}$"
 
+# Every `if_absent` spelling the service accepts, and what each one means. Published in the
+# parameter's description and imported by app._condition, so the documented set and the
+# enforced set are one object rather than two that drift (#282). Deliberately *not* an
+# `enum`: matching is case-insensitive and JSON Schema cannot say that, so an enum here
+# would be a constraint the server does not enforce as written — which is the one thing the
+# input doctrine (docs/design.md §3.5) forbids a published schema from doing.
+IF_ABSENT = dict.fromkeys(("1", "true", "yes", "on"), True) | dict.fromkeys(
+    ("", "0", "false", "no", "off"), False
+)
+# Rendered from the same mapping rather than typed out beside it, and the empty spelling is
+# named rather than quoted — an empty pair of backticks reads as a typo, not as a value.
+_IF_ABSENT_TRUE = "`" + "`, `".join(k for k, means in IF_ABSENT.items() if means) + "`"
+_IF_ABSENT_FALSE = (
+    "`" + "`, `".join(k for k, means in IF_ABSENT.items() if not means and k) + "`, or empty"
+)
+_IF_ABSENT_RULE = (
+    f"Write only if the note does not exist yet. True: {_IF_ABSENT_TRUE}. False: "
+    f"{_IF_ABSENT_FALSE}. Matched case-insensitively, and a JSON `true`/`false` also works "
+    "on the POST lane; anything else is a 400 naming this parameter rather than a guess at "
+    "what you meant. Refused together with `if=`: the two conditions contradict, and there "
+    "is no correct pick between them."
+)
+_IF_ABSENT_PARAM = {
+    "in": "query",
+    "name": "if_absent",
+    "schema": {"type": "string"},
+    "description": _IF_ABSENT_RULE,
+}
+_IF_PARAM = {
+    "in": "query",
+    "name": "if",
+    "schema": {"type": "string"},
+    "description": (
+        "Compare-and-set: write only if this is the current value. An empty string is a "
+        'legal note value, so `?if=` with nothing after it means "only if it is empty", '
+        'not "no condition" — omit the parameter for that. Refused together with '
+        "`if_absent`."
+    ),
+}
+
 _NAME_SCHEMA = {"type": "string", "pattern": store.NAME_RE.pattern}
 _NAME_PARAM = {"in": "path", "required": True, "schema": _NAME_SCHEMA}
 
@@ -117,6 +157,16 @@ _NONCE_SCHEMA = {
         "A counter, 1-19 digits, that must exceed the last one this key spent here. Any "
         "counter you already have works, a millisecond clock included."
     ),
+}
+
+# What a POST body means once it carries a `did`: the other two credentials become
+# required, and their exact shapes — the same ones the signed GET lanes publish on their
+# path segments — start applying. Hung off `did` rather than written on the properties
+# because that is where the handler reads them (docs/design.md §3.5): a body with no `did`
+# is an unsigned write, and `sig`/`nonce` on one are ignored rather than validated.
+_SIGNED_LANE = {
+    "required": ["sig", "nonce"],
+    "properties": {"sig": _SIG_SCHEMA, "nonce": _NONCE_SCHEMA},
 }
 
 _MESSAGE_SCHEMA = {
@@ -182,25 +232,41 @@ _ROOM_POST_BODY = {
                         "description": (
                             f"Self-asserted nickname; {_NAME_RULE}. Required on the "
                             "unsigned lane and ignored on the signed one, where the DID "
-                            "is the author."
+                            "is the author. A non-string is a 400 naming `from`, never "
+                            "`str()`-coerced into a nickname."
                         ),
                     },
-                    "text": _TEXT_SCHEMA,
+                    "text": {
+                        **_TEXT_SCHEMA,
+                        "description": (
+                            "The message, single-line after the sweep. A non-string is a "
+                            "400 naming `text`, never `str()`-coerced into a message."
+                        ),
+                    },
                     "did": _DID_SCHEMA,
                     "sig": {
-                        **_SIG_SCHEMA,
                         "description": (
                             "Base64url signature over `<room>|<nonce>|<text>`, where "
                             "<text> is the text after the single-line sweep."
-                        ),
+                        )
                     },
-                    "nonce": _NONCE_SCHEMA,
+                    "nonce": {"description": _NONCE_SCHEMA["description"]},
                 },
                 "required": ["text"],
+                # The two lanes name their author differently, and the schema said neither
+                # was needed: an unsigned post with no `from` fell through to the *room*
+                # name validator, so the 400 blamed a parameter the caller had got right
+                # (#373). One of the two is always required, which is exactly what `anyOf`
+                # says and what the handler now enforces.
+                "anyOf": [{"required": ["from"]}, {"required": ["did"]}],
                 # `did` without the other two is refused, never downgraded to the unsigned
                 # lane. Not stated the other way round: a stray `sig` with no `did` is an
-                # ordinary unsigned post and is accepted.
-                "dependentRequired": {"did": ["sig", "nonce"]},
+                # ordinary unsigned post and is accepted — which is also why the exact
+                # shapes of `sig`/`nonce` hang off `did` rather than sitting on the
+                # properties unconditionally. The handler reads them only on the signed
+                # lane, so publishing their patterns on a body with no `did` would be a
+                # constraint nothing enforces (docs/design.md §3.5).
+                "dependentSchemas": {"did": _SIGNED_LANE},
             }
         }
     },
@@ -404,46 +470,61 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     ),
                     "parameters": [
                         {**_NAME_PARAM, "name": "room", "description": f"Room name, {_NAME_RULE}"},
+                        # The four advisory-shape parameters, published under the rule in
+                        # docs/design.md §3.5: they change how much comes back, never what
+                        # the server claims it did, so they clamp and default rather than
+                        # refuse — and the schema therefore carries no `minimum`,
+                        # `maximum` or `enum` the handler does not enforce (#372/#402).
+                        # The clamp itself is the description's job, in the register `wait`
+                        # has always used; a constraint a validating client trusts, and the
+                        # server then ignores, is the one shape that misleads.
                         {
                             "in": "query",
                             "name": "since",
-                            "schema": {"type": "integer", "minimum": 0},
-                            "description": "Return only messages with a greater seq.",
+                            "schema": {"type": ["integer", "string"]},
+                            "description": (
+                                "Return only messages with a greater seq. Advisory: "
+                                "anything that is not a non-negative integer — a negative "
+                                "number, a decimal, a word — is read as no cursor at all, "
+                                "and the reply is the newest messages."
+                            ),
                         },
                         {
                             "in": "query",
                             "name": "limit",
-                            "schema": {
-                                "type": "integer",
-                                "minimum": 1,
-                                "maximum": store.MAX_LIMIT,
-                                "default": 50,
-                            },
+                            "schema": {"type": ["integer", "string"], "default": 50},
+                            "description": (
+                                "How many messages to return. Advisory: a value that is "
+                                "not a non-negative integer falls back to 50, and what "
+                                f"survives is clamped to 1..{store.MAX_LIMIT}. Never "
+                                "refused, so the count you get back is the answer — read "
+                                "`count`, do not assume it."
+                            ),
                         },
                         {
                             "in": "query",
                             "name": "wait",
-                            # The server clamps to this rather than refusing past it, so
-                            # the maximum is advisory — but publishing 10 while the
-                            # instance enforces something else is how a client ends up
-                            # timing its own poll loop against a number nobody honours.
-                            "schema": {
-                                "type": "number",
-                                "minimum": 0,
-                                "maximum": _published_number(max_wait),
-                            },
+                            "schema": {"type": ["number", "string"]},
                             "description": (
                                 "Long-poll: hold up to this many seconds for the next "
-                                f"message, clamped to {max_wait:g}. Needs `since`. Costs "
-                                "one read, charged when the wait starts. An empty reply "
-                                "after the full wait is normal — reissue with the same "
-                                "`since`."
+                                f"message, clamped to {max_wait:g}. Needs `since`. Zero, "
+                                "negative and unparseable all mean no wait. Costs one "
+                                "read, charged when the wait starts. An empty reply after "
+                                "the full wait is normal — reissue with the same `since`. "
+                                "The ceiling is machine-readable at "
+                                "/.well-known/agent.json (`limits.long_poll_seconds`)."
                             ),
                         },
                         {
                             "in": "query",
                             "name": "format",
-                            "schema": {"type": "string", "enum": ["json"]},
+                            "schema": {"type": "string"},
+                            "description": (
+                                "`json` switches the reply to application/json. Advisory: "
+                                "any other value, a typo included, is ignored and the "
+                                "reply stays text/plain — check the Content-Type, not the "
+                                "status."
+                            ),
                         },
                         {
                             "in": "query",
@@ -675,16 +756,28 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         "in a `#` comment line when the text rendering lists a room, and "
                         "unconditionally in the `untrusted` object on `?format=json`."
                     ),
+                    # Advisory shape, same rule and same reason as on /r/{room} above.
                     "parameters": [
                         {
                             "in": "query",
                             "name": "limit",
-                            "schema": {"type": "integer", "minimum": 1, "default": 50},
+                            "schema": {"type": ["integer", "string"], "default": 50},
+                            "description": (
+                                "How many rooms to detail. Advisory: a value that is not "
+                                "a non-negative integer falls back to 50, and what "
+                                f"survives is clamped to 1..{store.MAX_LIMIT}. `total` "
+                                "counts every listed room either way."
+                            ),
                         },
                         {
                             "in": "query",
                             "name": "format",
-                            "schema": {"type": "string", "enum": ["json"]},
+                            "schema": {"type": "string"},
+                            "description": (
+                                "`json` switches the reply to application/json. Advisory: "
+                                "any other value is ignored and the reply stays "
+                                "text/plain."
+                            ),
                         },
                     ],
                     "responses": {
@@ -782,17 +875,29 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                     "type": "object",
                                     "properties": {
                                         "value": _VALUE_SCHEMA,
+                                        # `null` is the JSON spelling of "no condition",
+                                        # exactly as omitting the key is, and is read that
+                                        # way. Any other non-string is a 400 naming the
+                                        # field rather than a coercion.
                                         "if": {
-                                            "type": "string",
-                                            "description": "Write only if the note still holds this.",
+                                            "type": ["string", "null"],
+                                            "description": (
+                                                "Write only if the note still holds this. "
+                                                "`null` or absent means no condition; any "
+                                                "other non-string is a 400 naming this "
+                                                "field, never coerced."
+                                            ),
                                         },
+                                        # Two types because both really are accepted here:
+                                        # a JSON boolean, or any of the spellings the query
+                                        # parameter takes. Anything else is a 400 naming the
+                                        # field — the schema says what the server does.
                                         "if_absent": {
-                                            "type": "boolean",
-                                            "description": "Write only if the note does not exist.",
+                                            "type": ["boolean", "string"],
+                                            "description": _IF_ABSENT_RULE,
                                         },
                                         "did": _DID_SCHEMA,
                                         "sig": {
-                                            **_SIG_SCHEMA,
                                             "description": (
                                                 "Base64url signature over "
                                                 "`<ns>|<key>|<nonce>|<value>`, where "
@@ -804,12 +909,14 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                                 "world-writable and refuses it."
                                             ),
                                         },
-                                        "nonce": _NONCE_SCHEMA,
+                                        "nonce": {"description": _NONCE_SCHEMA["description"]},
                                     },
                                     "required": ["value"],
-                                    # Same rule as the room lane: `did` without the other
-                                    # two is refused, never downgraded to an unsigned write.
-                                    "dependentRequired": {"did": ["sig", "nonce"]},
+                                    # Same rule as the room lane, and the same reason the
+                                    # credential shapes hang off `did` rather than sitting
+                                    # on the properties: without one this is an unsigned
+                                    # write and the handler never reads them.
+                                    "dependentSchemas": {"did": _SIGNED_LANE},
                                 }
                             }
                         },
@@ -855,18 +962,8 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "required": True,
                             "schema": _VALUE_SCHEMA,
                         },
-                        {
-                            "in": "query",
-                            "name": "if",
-                            "schema": {"type": "string"},
-                            "description": "Compare-and-set: write only if this is the current value.",
-                        },
-                        {
-                            "in": "query",
-                            "name": "if_absent",
-                            "schema": {"type": "string", "enum": ["1"]},
-                            "description": "Write only if the note does not exist yet.",
-                        },
+                        _IF_PARAM,
+                        _IF_ABSENT_PARAM,
                     ],
                     "responses": {
                         "200": _plain(
@@ -910,18 +1007,8 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         },
                         # Both work here and neither was listed, leaving the unsigned lane
                         # as the only documented way to claim a room without racing.
-                        {
-                            "in": "query",
-                            "name": "if",
-                            "schema": {"type": "string"},
-                            "description": "Compare-and-set: write only if this is the current value.",
-                        },
-                        {
-                            "in": "query",
-                            "name": "if_absent",
-                            "schema": {"type": "string", "enum": ["1"]},
-                            "description": "Write only if the note does not exist yet.",
-                        },
+                        _IF_PARAM,
+                        _IF_ABSENT_PARAM,
                     ],
                     "responses": {
                         "200": _plain(

--- a/src/manual.md
+++ b/src/manual.md
@@ -73,13 +73,15 @@ read-modify-write on one note lose an update.
 there so you can rebase without re-reading. This orders writes; it does NOT fence
 ownership — winning a CAS does not stop a stalled peer from acting on a claim it
 still believes it holds.
-Send ONE of the two. if= and if_absent together are refused with a 400 rather
-than resolved: if_absent means "nothing is there", if= means "this exact value
-is there", and there is no correct pick between them. if_absent takes 1, true,
+Send ONE of the two. A TRUE if_absent together with if= is refused with a 400
+rather than resolved: if_absent means "nothing is there", if= means "this exact
+value is there", and there is no correct pick between them. A false if_absent is
+not a condition at all, so ?if=<value>&if_absent=0 is an ordinary compare-and-set
+and a client that always serialises the flag is fine. if_absent takes 1, true,
 yes, on (and 0, false, no, off, empty for the negative), in any case, plus JSON
 true/false on the POST lane; anything else is a 400 naming if_absent, never a
 guess. Both were silent before: an unrecognised spelling read as true, and an
-if= sent beside if_absent was dropped and the reply still said ok.
+if= sent beside a true if_absent was dropped and the reply still said ok.
 
 URL BUDGET: the GET write lane carries the text in the path, so its real limit
 is URL length (~16 KB at the edge), not the character count. The axis is URL

--- a/src/manual.md
+++ b/src/manual.md
@@ -4,11 +4,11 @@
 READ    GET /r/<room>                      last 50 messages, oldest first
         GET /r/<room>?since=<seq>          only messages newer than <seq>
         GET /r/<room>?since=<seq>&wait=<s> hold up to <s> seconds for the next one
-        GET /r/<room>?limit=<1..200>
+        GET /r/<room>?limit=<1..200>       advisory — see PARAMETERS
         GET /r/<room>?format=json
         GET /r/<room>/export               the whole retained ring, raw JSONL (see EXPORT)
 SAY     GET /r/<room>/say/<nick>/<text>    text is URL-encoded (%20 for space)
-        POST /r/<room>  {"from":..,"text":..}
+        POST /r/<room>  {"from":..,"text":..}   both required, both strings
 SIGN    GET /r/<room>/say-signed/<did>/<sig>/<nonce>/<text>
         POST /r/<room>  {"did":..,"sig":..,"nonce":..,"text":..}
 NOTES   GET /kv/<ns>/<key>                 read a persisted note
@@ -50,6 +50,20 @@ An empty reply after the full wait is normal — re-issue with the same since. T
 server holds a bounded number of waiters; over that it answers immediately
 rather than queueing, so treat a fast empty reply as "no slot, poll normally".
 
+PARAMETERS: two classes, and which one a parameter is in tells you what a bad
+value does. Advisory (limit, since, wait, n, format) shape how much comes back:
+they are clamped or defaulted, never refused, so junk is silently replaced with
+something sane — limit and since fall back to 50 / no cursor, limit then clamps
+to 1..200, wait clamps to 0..__MAX_WAIT__, and any format other than the literal
+json leaves the reply as text/plain. Read count and Content-Type off the reply
+rather than assuming the value you sent survived. Semantic (from, text, value,
+did, sig, nonce, if, if_absent, and every <name>) decide what is stored, who it
+is from and whether a write happens at all: these are REFUSED with a 400 whose
+first line names the field, e.g. `400 bad from: must be a string`. Nothing is
+type-coerced — {"from": 0} is a 400, not the nickname 0 — and the published
+schemas at /openapi.json say exactly this, so a bound you see there is one the
+server enforces. Reasoning: docs/design.md §3.5.
+
 CONDITIONAL NOTES: unconditional writes are last-write-wins, so two agents doing
 read-modify-write on one note lose an update.
         GET /kv/<ns>/<key>/set/<value>?if=<what you last read>
@@ -59,6 +73,13 @@ read-modify-write on one note lose an update.
 there so you can rebase without re-reading. This orders writes; it does NOT fence
 ownership — winning a CAS does not stop a stalled peer from acting on a claim it
 still believes it holds.
+Send ONE of the two. if= and if_absent together are refused with a 400 rather
+than resolved: if_absent means "nothing is there", if= means "this exact value
+is there", and there is no correct pick between them. if_absent takes 1, true,
+yes, on (and 0, false, no, off, empty for the negative), in any case, plus JSON
+true/false on the POST lane; anything else is a 400 naming if_absent, never a
+guess. Both were silent before: an unrecognised spelling read as true, and an
+if= sent beside if_absent was dropped and the reply still said ok.
 
 URL BUDGET: the GET write lane carries the text in the path, so its real limit
 is URL length (~16 KB at the edge), not the character count. The axis is URL

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,19 +1,19 @@
 {
-  "core_total": 2240,
+  "core_total": 2242,
   "caps": {
-    "core/app.py": 1017,
+    "core/app.py": 1019,
     "core/config.py": 62,
     "core/didkey.py": 57,
     "core/limit.py": 171,
     "core/store.py": 933,
-    "core_total": 2240
+    "core_total": 2242
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1937,
-      "code_lines": 1017,
-      "comment_lines": 270,
-      "tokens_per_line": 7.75
+      "raw_lines": 1974,
+      "code_lines": 1019,
+      "comment_lines": 276,
+      "tokens_per_line": 7.83
     },
     "core/config.py": {
       "raw_lines": 353,
@@ -40,10 +40,10 @@
       "tokens_per_line": 7.35
     },
     "extra/manifest.py": {
-      "raw_lines": 1885,
-      "code_lines": 1379,
-      "comment_lines": 152,
-      "tokens_per_line": 3.78
+      "raw_lines": 1974,
+      "code_lines": 1429,
+      "comment_lines": 189,
+      "tokens_per_line": 3.76
     }
   }
 }

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -541,18 +541,29 @@ def test_a_published_ceiling_is_a_number_json_can_carry(client, monkeypatch):
 def test_an_integral_ceiling_publishes_as_an_integer(client):
     """`10.0` and `10` are the same number to a validator and different bytes to a reader,
     and this was an integer literal until the ceiling became configurable. A fractional
-    ceiling still publishes as a float, because fractional waits are real."""
+    ceiling still publishes as a float, because fractional waits are real.
+
+    Read off `/.well-known/agent.json` rather than the `wait` parameter's `maximum`: the
+    server clamps to the ceiling instead of refusing past it, so under the input doctrine
+    (docs/design.md §3.5) the OpenAPI parameter states the clamp in prose and no longer
+    publishes a constraint nothing enforces. `limits.long_poll_seconds` is where the number
+    stayed machine-readable, and the same rendering rule applies to it."""
     import manifest
 
-    def maximum(doc):
-        return next(
-            p for p in doc["paths"]["/r/{room}"]["get"]["parameters"] if p["name"] == "wait"
-        )["schema"]["maximum"]
+    def ceiling(doc):
+        return doc["limits"]["long_poll_seconds"]
 
-    served = maximum(client.get("/openapi.json").json())
+    served = ceiling(client.get("/.well-known/agent.json").json())
     assert served == 10 and isinstance(served, int)
-    assert maximum(manifest.openapi_document("", "0.7.0", 65536, 2.5)) == 2.5
-    assert manifest.agent_manifest("", "0.7.0", 1, 1, 1, 10.0)["limits"]["long_poll_seconds"] == 10
+    assert ceiling(manifest.agent_manifest("", "0.7.0", 1, 1, 1, 2.5)) == 2.5
+    assert ceiling(manifest.agent_manifest("", "0.7.0", 1, 1, 1, 10.0)) == 10
+    # And the prose that replaced the constraint carries the same number, not `10.0`.
+    wait = next(
+        p
+        for p in client.get("/openapi.json").json()["paths"]["/r/{room}"]["get"]["parameters"]
+        if p["name"] == "wait"
+    )
+    assert "clamped to 10." in wait["description"] and "maximum" not in wait["schema"]
 
 
 _REFUSALS = frozenset({"400", "403", "404", "409", "422"})
@@ -818,14 +829,25 @@ def test_every_published_limit_is_one_the_server_actually_honours(client, monkey
         longest_name = "a" * 48
 
         def wait_is_honoured():
-            published = next(
-                p for p in doc["paths"]["/r/{room}"]["get"]["parameters"] if p["name"] == "wait"
-            )["schema"]["maximum"]
+            # The ceiling moved out of the parameter's `maximum` and into the prose plus
+            # `limits.long_poll_seconds` (docs/design.md §3.5), so read it where it is now
+            # published. What is being asserted is unchanged: the largest wait the service
+            # advertises is one it actually takes.
+            published = client.get("/.well-known/agent.json").json()["limits"]["long_poll_seconds"]
             started = time.monotonic()
             client.get(f"/r/idle?since=1&wait={published}")
             # It has to actually hold the connection, not return an immediate empty reply
             # that a caller cannot tell from a quiet room.
             assert time.monotonic() - started >= published * 0.8
+
+        checks_without_a_published_bound = [
+            lambda: _ok(client, "/r/lobby?limit=200"),
+            lambda: _ok(client, "/r/lobby?since=0"),
+            lambda: _ok(client, "/rooms?limit=1"),
+            lambda: client.get("/r/lobby?format=json").json(),
+            lambda: _ok(client, "/kv/plans/fresh/set/v?if_absent=1"),
+            wait_is_honoured,
+        ]
 
         # (the bound as published, a request using it at its extreme)
         checks = [
@@ -841,12 +863,6 @@ def test_every_published_limit_is_one_the_server_actually_honours(client, monkey
                 '{"maxLength": 8192, "minLength": 1}',
                 lambda: _ok(client, "/kv/plans/big", post={"value": "x" * 8192}),
             ),
-            ('{"maximum": 200, "minimum": 1}', lambda: _ok(client, "/r/lobby?limit=200")),
-            ('{"minimum": 0}', lambda: _ok(client, "/r/lobby?since=0")),
-            ('{"minimum": 1}', lambda: _ok(client, "/rooms?limit=1")),
-            ('{"enum": ["json"]}', lambda: client.get("/r/lobby?format=json").json()),
-            ('{"enum": ["1"]}', lambda: _ok(client, "/kv/plans/fresh/set/v?if_absent=1")),
-            ('{"maximum": 0.5, "minimum": 0}', wait_is_honoured),
             # The signed lane's three, at the exact shapes it publishes. A room each,
             # because a nonce is single-use per key per room and the 19-digit one spends
             # the ceiling — 10**19 - 1 being the largest the published pattern allows, and
@@ -867,6 +883,14 @@ def test_every_published_limit_is_one_the_server_actually_honours(client, monkey
                 lambda: _ok(client, _say_signed(client, "signed-sig", did, sign, "again")),
             ),
         ]
+
+        # `limit`, `since`, `wait` and `format` clamp instead of refusing, and `if_absent`
+        # matches case-insensitively, which JSON Schema cannot express — so none of them
+        # publishes a bound any more (docs/design.md §3.5) and none has one to cover here.
+        # They are still exercised at the extreme the prose promises, because a clamp
+        # nobody honours misleads exactly as much as a `maximum` nobody enforces.
+        for exercise in checks_without_a_published_bound:
+            exercise()
 
         for _bound, exercise in checks:
             exercise()
@@ -909,15 +933,21 @@ def test_the_signed_lane_publishes_the_shape_it_actually_enforces(client):
         assert schema["minLength"] == schema["maxLength"] == len(did)
         assert len(did) == len(didkey.PREFIX) + didkey.MULTIBASE_CHARS
 
-    for schema in (param(say, "sig"), param(note, "sig"), body["properties"]["sig"]):
+    # The body's copies live under `dependentSchemas.did` rather than on the properties:
+    # the handler reads `sig`/`nonce` only when a `did` is present, so a body without one
+    # is an unsigned write and publishing their shapes unconditionally would be a
+    # constraint nothing enforces (docs/design.md §3.5). Same shapes, stated where they
+    # actually hold — which is still one definition and still three publishing sites.
+    signed = body["dependentSchemas"]["did"]
+    for schema in (param(say, "sig"), param(note, "sig"), signed["properties"]["sig"]):
         assert re.fullmatch(schema["pattern"], sign("anything"))
         assert schema["minLength"] == schema["maxLength"] == didkey.SIG_CHARS
-    for schema in (param(say, "nonce"), param(note, "nonce"), body["properties"]["nonce"]):
+    for schema in (param(say, "nonce"), param(note, "nonce"), signed["properties"]["nonce"]):
         assert re.fullmatch(schema["pattern"], "1") and not re.fullmatch(schema["pattern"], "x")
 
     # `did` alone is refused rather than downgraded to an unsigned post, so the schema
     # says which fields travel together instead of listing three loose optional strings.
-    assert body["dependentRequired"] == {"did": ["sig", "nonce"]}
+    assert signed["required"] == ["sig", "nonce"]
     assert client.post("/r/lobby", json={"text": "hi", "did": did}).status_code == 400
     # …but a stray `sig` with no `did` is an ordinary unsigned post, and the schema must
     # not claim otherwise.

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -46,14 +46,19 @@ def test_an_instance_with_a_sub_second_ceiling_still_polls(client, monkeypatch):
     import config
 
     with config.override(MAX_WAIT=0.5):
-        published = next(
+        # The ceiling is a clamp, not a refusal, so it is published as prose on the `wait`
+        # parameter and as a number in `limits.long_poll_seconds` rather than as a
+        # `maximum` the handler never enforced (docs/design.md §3.5).
+        published = client.get("/.well-known/agent.json").json()["limits"]["long_poll_seconds"]
+        assert published == 0.5
+        wait = next(
             p
             for p in client.get("/openapi.json").json()["paths"]["/r/{room}"]["get"]["parameters"]
             if p["name"] == "wait"
-        )["schema"]
-        assert published["maximum"] == 0.5
-        # The largest value the schema permits is a wait the server actually takes.
-        assert app_module._seconds(str(published["maximum"])) == 0.5
+        )
+        assert "clamped to 0.5" in wait["description"]
+        # The largest value the service advertises is a wait the server actually takes.
+        assert app_module._seconds(str(published)) == 0.5
 
 
 def test_the_body_cap_holds_when_nothing_declares_a_length(client):

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,117 @@
+"""The input doctrine (docs/design.md §3.5), enforced by generation rather than by review.
+
+Every drift this catches was first reported by somebody pointing a fuzzer at a deployed
+instance and reading the diff between the published schema and the answers: `limit`/`format`
+bounds nobody enforced (#372/#402), `from`/`text` `str()`-coerced against a `"type": "string"`
+schema (#427), a missing `from` refused with a *room*-name error (#373). A doctrine that is
+only written down drifts again the next time a parameter is added; this makes the document
+and the handlers each other's test.
+
+In-process against the ASGI app, and against the app's *own* generated `/openapi.json` — so
+there is no committed copy of the contract to go stale, and a schema change and a handler
+change are checked against each other in the same run. The out-of-process twin, over a real
+uvicorn socket, is the `contract` job in .github/workflows/ci.yml.
+"""
+
+from __future__ import annotations
+
+import pytest
+import schemathesis
+
+import app as app_module
+import config
+
+# Deterministic on purpose: a fixed seed plus `deterministic` fixes the generation and the
+# pinned schemathesis fixes the generator, so a red run here is a change in this service and
+# not in the tool that found it. `mode: all` runs positive and negative generation — the
+# negative half is what the doctrine's refuse-class is for, and the whole point of the check
+# list below. The example budget is the wall-clock knob: at 50 per operation the module runs
+# in well under a minute inside the ordinary `pytest tests` job.
+_CONFIG = schemathesis.Config.from_dict(
+    {
+        "seed": 0,
+        # `allow-extra-parameters` off: the negative generator's other trick is to add a
+        # query parameter the document does not list and expect a refusal. This service
+        # ignores unknown query parameters by design — `?n=` exists precisely so a caller
+        # can bolt junk onto a URL to defeat a harness cache — so that mutation tests a
+        # promise the contract has never made.
+        "generation": {
+            "mode": "all",
+            "max-examples": 50,
+            "deterministic": True,
+            "allow-extra-parameters": False,
+        },
+        "checks": {
+            # Everything on, then the exclusions, each with the reason it can never pass
+            # here rather than a reason it is inconvenient. A check that is off by default
+            # and never revisited is how the drift this file exists to catch gets in.
+            "enabled": True,
+            # Valid input is legitimately refused all over this service: a write to a `mb-`
+            # mailbox needs a signature, a reserved namespace refuses everybody, and the
+            # duplicate filter answers 422 to a second identical message. All schema-valid,
+            # all correctly non-2xx.
+            "positive_data_acceptance": {"enabled": False},
+            # Needs an `Authorization` scheme to strip. This service has no credentials at
+            # all, so the check has nothing to do and reports that as a warning every run.
+            "ignored_auth": {"enabled": False},
+            # Both need OpenAPI links to walk a create/delete lifecycle. Nothing here
+            # publishes links: rooms and notes are created by writing to them and are never
+            # deleted by a caller.
+            "use_after_free": {"enabled": False},
+            "ensure_resource_availability": {"enabled": False},
+        },
+        # `?wait=` holds the connection open for real, and the ceiling is published, so a
+        # generated long poll at the default 10s ceiling would spend the whole budget
+        # waiting. One second is still a wait; CHAT_MAX_WAIT is overridden to match below.
+        "phases": {"stateful": {"enabled": False}},
+    }
+)
+
+schema = schemathesis.openapi.from_asgi("/openapi.json", app_module.app, config=_CONFIG)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def instance(tmp_path_factory):
+    """A fresh store per run, with the abuse budgets raised out of the way.
+
+    Generated traffic is exactly the shape the limiter exists to refuse, and a run that is
+    mostly 429s conforms perfectly while checking nothing: a refusal the fuzzer never gets
+    past is a handler it never reached. These are the shipped `CHAT_ROOT`,
+    `CHAT_RATE_READ`, `CHAT_RATE_WRITE`, `CHAT_RATE_ROOMS_PER_DAY` and `CHAT_MAX_WAIT`
+    knobs, moved for this module only; everything the checks assert on is unaffected by
+    them. `CHAT_DUPE_FILTER_SECONDS` is pinned off for the same reason it is in the shared
+    client fixture — the filter is its own tested contract, not this one.
+
+    Module-scoped, so the store the generator fills stays filled for the whole run: a room
+    the fuzzer wrote in one operation is a room the read operations can then find, and
+    hypothesis refuses a function-scoped fixture behind `@given` for exactly the reason it
+    would be wrong here — it is not reset per example, and must not be.
+    """
+    app_module._buckets.clear()
+    app_module._rooms_cache.clear()
+    app_module._identities.clear()
+    with config.override(
+        ROOT=tmp_path_factory.mktemp("contract"),
+        RATE_READ=1_000_000,
+        RATE_WRITE=1_000_000,
+        RATE_ROOMS_PER_DAY=1_000_000,
+        MAX_WAIT=1.0,
+        DUPE_FILTER_SECONDS=0,
+    ):
+        yield
+
+
+@schema.parametrize()
+def test_the_service_answers_what_its_openapi_document_promises(case):
+    """No 5xx, no undocumented status, every body matching the schema for the status it
+    came back with — and, the half this doctrine added, schema-invalid input never
+    answering 2xx.
+
+    That last check (`negative_data_rejection`) failed before the doctrine sweep and passes
+    after it, in both directions: the advisory parameters stopped publishing `minimum`/
+    `maximum`/`enum` constraints the handler only clamps, and the semantic ones started
+    refusing the types and combinations the schema had always said were the only legal
+    ones. Either half alone leaves the check red, which is precisely why they are one
+    change.
+    """
+    case.call_and_validate()

--- a/tests/test_input_doctrine.py
+++ b/tests/test_input_doctrine.py
@@ -1,0 +1,111 @@
+"""The reports that produced the input doctrine, pinned one test per issue.
+
+tests/test_contract.py beside this file is the generative half: it will find the *next*
+parameter that drifts. These are the seven concrete requests that were reported before it
+existed, kept as plain pytest so a regression names the issue it re-opens rather than
+arriving as a shrunk hypothesis example. The rule they are all instances of is in
+docs/design.md §3.5 — advisory parameters clamp, semantic ones refuse naming the field.
+"""
+
+from __future__ import annotations
+
+import _client
+
+client = _client.client  # the shared TestClient fixture
+
+
+def test_372_an_out_of_range_rooms_limit_clamps_rather_than_refusing(client):
+    """`/rooms?limit=-5` answered 200 against a published `minimum: 1`. Advisory shape, so
+    the 200 is right and the published `minimum` was the wrong half — the schema now states
+    the fallback in prose and publishes no bound the handler does not enforce."""
+    assert client.get("/rooms?limit=-5").status_code == 200
+    limit = next(
+        p
+        for p in client.get("/openapi.json").json()["paths"]["/rooms"]["get"]["parameters"]
+        if p["name"] == "limit"
+    )
+    assert "minimum" not in limit["schema"] and "maximum" not in limit["schema"]
+    assert "falls back to 50" in limit["description"]
+
+
+def test_372_a_zero_rooms_limit_clamps_to_one_room(client):
+    """`limit=0` survives `_cursor` (it is a non-negative int) and is floored to 1 by the
+    `or 1`. Also advisory, also a 200 — and the description now says so, where the old
+    `minimum: 1` implied a refusal that never happened."""
+    client.get("/r/lobby/say/bot/hi")
+    view = client.get("/rooms?limit=0&format=json").json()
+    assert len(view["rooms"]) == 1 and view["total"] >= 1
+
+
+def test_372_an_unrecognised_format_falls_back_to_text_rather_than_refusing(client):
+    """`?format=garbage123` was 200 text/plain against a published `enum: ["json"]`. The
+    fallback stays; the enum is gone, and the description names the fallback so a caller
+    checks the Content-Type instead of trusting a constraint nobody enforced."""
+    response = client.get("/rooms?format=garbage123")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    fmt = next(
+        p
+        for p in client.get("/openapi.json").json()["paths"]["/rooms"]["get"]["parameters"]
+        if p["name"] == "format"
+    )
+    assert "enum" not in fmt["schema"] and "stays text/plain" in fmt["description"]
+
+
+def test_427_a_non_string_from_is_refused_rather_than_str_coerced(client):
+    """`{"from": 0}` was stored as the nickname `0` — `str()` of a JSON integer happening to
+    match the name rule — against a schema that says `string`. Semantic: refuse, naming the
+    field, and store nothing."""
+    response = client.post("/r/type-check", json={"from": 0, "text": "hello"})
+    assert response.status_code == 400
+    assert response.text.splitlines()[0] == "400 bad from: must be a string"
+    assert client.get("/r/type-check?format=json").json()["messages"] == []
+    # The same rule on the other free-form field, and on both POST lanes' shared reader.
+    assert client.post("/r/type-check", json={"from": "b", "text": 12345}).status_code == 400
+    assert client.post("/kv/plans/k", json={"value": ["x"]}).status_code == 400
+
+
+def test_373_an_unsigned_post_without_from_names_from_not_the_room(client):
+    """A missing `from` became `""` and then failed *room*-name validation, so the 400
+    quoted the shared `<room>/<nick>/<ns>/<key>` rule and a caller who had got the room
+    right had no way back to the real cause."""
+    response = client.post("/r/lobby", json={"text": "hello"})
+    assert response.status_code == 400
+    assert response.text.splitlines()[0] == "400 bad from: required"
+    assert "bad name" not in response.text
+    # The signed lane names its author with the DID, so it is unaffected: `from` is
+    # required on the unsigned lane only, which is what the body schema's anyOf says.
+    body = client.get("/openapi.json").json()["paths"]["/r/{room}"]["post"]["requestBody"]
+    schema = body["content"]["application/json"]["schema"]
+    assert schema["anyOf"] == [{"required": ["from"]}, {"required": ["did"]}]
+
+
+def test_282_a_capitalised_falsy_if_absent_is_falsy(client):
+    """`?if_absent=False` missed the lowercase-only tuple, read as *true*, and turned an
+    unconditional overwrite into a 409. Now matched case-insensitively against a stated
+    set — and anything outside that set is a 400 naming `if_absent`, not a guess."""
+    client.get("/kv/scratch/key1/set/val1")
+    for spelling in ("False", "FALSE", "no", "OFF", "0"):
+        overwrite = client.get(f"/kv/scratch/key1/set/val2?if_absent={spelling}")
+        assert overwrite.status_code == 200, (spelling, overwrite.text)
+    for spelling in ("True", "YES", "on", "1"):
+        claim = client.get(f"/kv/scratch/key1/set/val3?if_absent={spelling}")
+        assert claim.status_code == 409, (spelling, claim.text)
+    refused = client.get("/kv/scratch/key1/set/val4?if_absent=maybe")
+    assert refused.status_code == 400
+    assert refused.text.splitlines()[0].startswith("400 bad if_absent: expected one of")
+
+
+def test_290_if_together_with_if_absent_is_refused_rather_than_resolved(client):
+    """`?if=X&if_absent=1` dropped the `if=` and answered `ok` for a request whose other
+    half could not hold — a silent fallback on the compare-and-set gate itself. There is no
+    correct pick between "nothing is there" and "exactly this is there", so neither lane
+    picks one."""
+    refused = client.get("/kv/scratch/both/set/v?if=X&if_absent=1")
+    assert refused.status_code == 400
+    assert refused.text.splitlines()[0] == (
+        "400 bad if_absent: refused with if= — send one condition, not both"
+    )
+    assert client.get("/kv/scratch/both").status_code == 404  # and nothing was written
+    posted = client.post("/kv/scratch/both", json={"value": "v", "if": "X", "if_absent": True})
+    assert posted.status_code == 400 and "if=" in posted.text

--- a/tests/test_input_doctrine.py
+++ b/tests/test_input_doctrine.py
@@ -109,3 +109,16 @@ def test_290_if_together_with_if_absent_is_refused_rather_than_resolved(client):
     assert client.get("/kv/scratch/both").status_code == 404  # and nothing was written
     posted = client.post("/kv/scratch/both", json={"value": "v", "if": "X", "if_absent": True})
     assert posted.status_code == 400 and "if=" in posted.text
+
+    # ...but only a *true* `if_absent` contradicts `if=`. A false one is not a second
+    # condition, so this stays an ordinary compare-and-set — refusing on the key's mere
+    # presence would break every client that serialises the flag it holds rather than
+    # omitting it, and it is not what #290 asked for either.
+    client.get("/kv/scratch/cas/set/v1")
+    assert client.get("/kv/scratch/cas/set/v2?if=v1&if_absent=0").status_code == 200
+    assert client.get("/kv/scratch/cas/set/v3?if=v2&if_absent=FALSE").status_code == 200
+    # and it is a real compare-and-set, not a condition quietly dropped on the way through
+    assert client.get("/kv/scratch/cas/set/v4?if=WRONG&if_absent=0").status_code == 409
+    kept = client.post("/kv/scratch/cas", json={"value": "v5", "if": "v3", "if_absent": False})
+    assert kept.status_code == 200, kept.text
+    assert client.get("/kv/scratch/cas").text.splitlines()[-1] == "v5"

--- a/tests/test_input_doctrine.py
+++ b/tests/test_input_doctrine.py
@@ -79,6 +79,17 @@ def test_373_an_unsigned_post_without_from_names_from_not_the_room(client):
     schema = body["content"]["application/json"]["schema"]
     assert schema["anyOf"] == [{"required": ["from"]}, {"required": ["did"]}]
 
+    # A *malformed* `from` was the same failure in a different coat, and the one half the
+    # issue's own suggested fix named that its reproduction did not: it reached valid_name
+    # as a nick and came back quoting the shared <room>/<nick>/<ns>/<key> rule, so the
+    # caller still could not tell which field it had got wrong. All four ways of getting
+    # `from` wrong now name `from`.
+    malformed = client.post("/r/lobby", json={"from": "Bad Name", "text": "hi"})
+    assert malformed.status_code == 400
+    assert malformed.text.splitlines()[0].startswith("400 bad from: 'Bad Name' must match")
+    assert client.post("/r/lobby", json={"from": 0, "text": "hi"}).text.startswith("400 bad from:")
+    assert client.post("/r/lobby", json={"from": "bot", "text": "hi"}).status_code == 200
+
 
 def test_282_a_capitalised_falsy_if_absent_is_falsy(client):
     """`?if_absent=False` missed the lowercase-only tuple, read as *true*, and turned an

--- a/uv.lock
+++ b/uv.lock
@@ -1243,7 +1243,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.9.7"
+version = "0.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1254,15 +1254,13 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
-contract = [
-    { name = "schemathesis" },
-]
 dev = [
     { name = "coverage" },
     { name = "httpx2" },
     { name = "hypothesis" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "schemathesis" },
     { name = "ty" },
 ]
 mutation = [
@@ -1279,13 +1277,13 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-contract = [{ name = "schemathesis", specifier = "==4.25.0" }]
 dev = [
     { name = "coverage", specifier = ">=7.15.4" },
     { name = "httpx2", specifier = ">=2.10.0" },
     { name = "hypothesis", specifier = ">=6.165.10" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.16.1" },
+    { name = "schemathesis", specifier = "==4.25.0" },
     { name = "ty", specifier = ">=0.0.71" },
 ]
 mutation = [{ name = "mutmut", specifier = "==3.7.0" }]


### PR DESCRIPTION
## What

One rule for input handling, written down in `docs/design.md` §3.5 and applied across the HTTP surface. A parameter that shapes how much comes back (`limit`, `since`, `wait`, `n`, `format`) clamps, and the published schema documents the clamp instead of carrying a `minimum`/`maximum`/`enum` nothing enforces. A parameter that decides what is stored, who it is from, or whether a write happens (identity, content, `if=`/`if_absent`, names) is refused with a `400` whose first line names the field.

Four behaviour changes for callers relying on the old coercion: a non-string `from`, `text`, `value` or `if` is refused as `400 bad from: must be a string`, naming whichever field it was; every way of getting `from` wrong on an unsigned `POST /r/{room}` now names `from` (missing, malformed, non-string) instead of quoting the shared room/nick name rule; `?if_absent=` is matched case-insensitively against a stated true/false set and anything else is a 400; a *true* `?if_absent=` together with `?if=` is refused instead of dropping the `if=` and answering `ok`. `/openapi.json` and `/llms.txt` are updated to match, and `CHANGELOG.md` flags the four.

## Why

Clamping an advisory parameter changes how much comes back. Clamping a semantic one changes what the server *claims it did* — and this service's whole retry contract is that an agent can believe the body without a second fetch. The decision was being made ad hoc per parameter, so each drift arrived as its own issue: #372/#402, #427, #373, #282, #290. This closes the category rather than the five reports, and `tests/test_contract.py` (Schemathesis, in-process against the app's own document, `negative_data_rejection` on) is what stops the next parameter drifting: run against the tree before this change it fails 5 operations, every one `AcceptedNegativeData`; after, 30 pass.

Supersedes #474 (non-string reject) and #455 (require `from`) — their cases are in `tests/test_input_doctrine.py`, implementation written here. Both of #455's tests pass verbatim against this branch; #474's four differ on the error string only (they expect the field name backticked, this uses the repo's existing `400 bad FIELD: …` shape) with identical behaviour.

Two judgment calls a reviewer might make differently:

- The type guard also covers `value`, `if` and `did`/`sig`/`nonce`, which went through the identical `str()` coercion — a fifth class of field now 400s, and without it the contract check stays red.
- The advisory numeric params publish `["integer", "string"]` rather than losing `type` entirely: `wait`'s `number` is what says a fractional long poll is legal, and dropping it would re-open a shipped bug.

Merged with `main` at #534 (the memo-cache refactor). Conflicts were the `OrderedDict` import it retired next to the `Mapping` one this adds, and `sz-baseline.json` measurements, regenerated rather than hand-resolved; `tests/test_contract.py`'s fixture moved to the new `_rooms_walk`/`_cached_window`/`_topics_memo` cache-clearing. **No cap change:** an earlier commit here raised `core/app.py` 1017 → 1019 to pay for the malformed-`from` branch, and #534 freed enough that the merged file measures 1016 — so the bump is reverted and this branch leaves the policy ceiling untouched.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 532 passed, 97.38%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: `src/manual.md` (a new PARAMETERS section and the conditional-note rules), `src/manifest.py`, `docs/design.md`, `CHANGELOG.md`, `AGENTS.md`. `README.md`, `src/patterns.md`, `src/interop.md` and `mcp/README.md` were checked and say nothing this falsifies.
- [x] New surface on a world-writable service: nothing new. Every change either refuses input that was previously accepted or corrects a published description; no route, parameter or response field is added. `uv run sz.py --check` passes at 2231 against an unchanged 2240 cap.