### PR TITLE
refactor(cache): retire the hand-rolled memo LRUs for validity-in-key lru_cache

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -16,8 +16,8 @@ import json
 import secrets
 import time
 import tomllib
-from collections import OrderedDict
 from contextlib import contextmanager
+from functools import lru_cache
 from pathlib import Path
 
 import orjson
@@ -650,9 +650,14 @@ def _size(n: int) -> str:
 
 
 # Keyed by limit, because the limit changes how much work the walk does and therefore what
-# the answer contains. Bounded by construction: _cursor clamps to 0..MAX_LIMIT, so this
-# holds at most a couple of hundred entries even if every caller asks for a different one.
-_rooms_cache: OrderedDict[int, tuple[tuple, float, dict]] = OrderedDict()
+# the answer contains — and by the stamp and the time bucket that say whether an entry is
+# still good, because an entry that is no longer valid is not one to find and invalidate,
+# it is a key nobody asks for (see _rooms_stamp, and store._time_bucket for the clock half).
+#
+# The limit alone was bounded by construction — _cursor clamps to 0..MAX_LIMIT — but the
+# stamp and the bucket both turn over, so the key space is now open and the LRU bound is
+# what closes it: at most MAX_ROOMS_CACHE walks, live and superseded mixed, and never more.
+# A superseded entry is not evicted when its stamp moves, it just stops being looked up.
 MAX_ROOMS_CACHE = 64
 
 
@@ -670,11 +675,18 @@ def _rooms_stamp() -> tuple:
     This is what makes the cache correct rather than merely quick, and the ordering is the
     whole argument: store.append, the create path and the reaper all bump these counters
     *after* the record is on disk (or gone from it), so a stamp read before the walk can
-    never be newer than the data the walk sees. A stale entry is therefore always detected,
+    never be newer than the data the walk sees. A stale view is therefore never served,
     whatever order two concurrent requests interleaved in — a /rooms request that walks the
     pre-write state while a writer is still in fsync, the reaper or the create lock caches
-    that view under the *old* stamp and the next request rejects it. Nothing has to
-    invalidate anything for that to hold, which is why it survives a second worker.
+    that view under the *old* stamp, and the stamp is part of the cache key, so a request
+    that reads the new stamp is not looking it up. It does not have to be found and
+    rejected: it is simply not on the way to any later answer. Nothing has to invalidate
+    anything for that to hold, which is why it survives a second worker — and it is why
+    this is now the whole mechanism rather than half of one. Keying on the stamp instead of
+    storing it beside the value is also what leaves no read-then-validate window between
+    finding an entry and using it, so there is nothing here for a concurrent eviction to
+    race (the bug class of #376/#229). What it costs is that a superseded entry is not
+    reclaimed when its stamp moves; MAX_ROOMS_CACHE is what bounds that.
 
     That argument holds for every key here, and `messages` is deliberately not one of them.
     It is a single global lifetime counter, not per-room, so one message anywhere aged out
@@ -699,8 +711,11 @@ def _rooms_stamp() -> tuple:
 
     The clock is also the backstop under a lying stamp. `_bump` is best effort by design —
     an unwritable .counters must never fail a write that already landed — so a bump can go
-    missing, and a hit needs the stamp to match AND the entry to be inside the window. A
-    lost bump therefore costs at most one window, never a permanently stale listing.
+    missing, and a hit needs the stamp to match AND the time bucket to match — both of them
+    key material, so a miss on either is a miss. A lost bump therefore costs at most one
+    window, never a permanently stale listing. See store._time_bucket for why cutting the
+    window on a boundary can only expire an entry sooner than its own insertion would have,
+    which is the direction that keeps this docstring's promise rather than weakening it.
     """
     counted = store.counters(config.ROOT)
     # ROOT rides along for the reason _note_stats_cache stamps it: the entries are keyed by
@@ -735,19 +750,13 @@ def _note_stats() -> dict:
     return view
 
 
-def _rooms_view(limit: int) -> dict:
-    """The /rooms payload for `limit`, from cache when one is both fresh and still valid.
+def _rooms_payload(limit: int) -> dict:
+    """The /rooms walk for `limit`, uncached — everything a cache entry is made of.
 
-    Deliberately caching the *store walk* and not the rendered response: the text and JSON
-    renderings differ, and the budget footer is per-caller, so a response cache would have
-    to key on both and would still be wrong for the footer.
+    Split out so the cache is one decorator and the disabled path is one call: with
+    ROOMS_CACHE_SECONDS at 0 this runs and nothing is stored, which is the same "no reuse"
+    the old guarded read/insert pair gave and is now unmistakable at a glance.
     """
-    now = time.monotonic()
-    stamp = _rooms_stamp()  # before the walk, never after — see _rooms_stamp
-    if config.ROOMS_CACHE_SECONDS > 0:
-        hit = _rooms_cache.get(limit)
-        if hit and hit[0] == stamp and now - hit[1] < config.ROOMS_CACHE_SECONDS:
-            return hit[2]
     view = store.room_stats(config.ROOT, limit=limit)
     # Notes had no capacity surface at all: /kv/<ns> lists one namespace and namespaces are
     # unenumerable by design, so nothing showed how full the global note cap was. Aggregate
@@ -764,18 +773,42 @@ def _rooms_view(limit: int) -> dict:
     view["engagement"]["windowed_note_to_message_ratio"] = (
         round(view["notes"]["total"] / seen, 4) if seen else None
     )
-    if config.ROOMS_CACHE_SECONDS > 0:
-        # pop-then-insert, not move_to_end: assigning an existing key leaves the entry
-        # where it already was, which may be the front, and a concurrent evictor's popitem
-        # takes it from there — turning the move_to_end that used to follow into a
-        # KeyError. Reachable now that entries outlive a write: a caller cycling ?limit=
-        # keeps the cache full, so the evictor runs while another request is re-walking,
-        # and /rooms is sync, so two of them overlap in Starlette's threadpool.
-        _rooms_cache.pop(limit, None)
-        _rooms_cache[limit] = (stamp, now, view)
-        while len(_rooms_cache) > MAX_ROOMS_CACHE:
-            _rooms_cache.popitem(last=False)
     return view
+
+
+@lru_cache(maxsize=MAX_ROOMS_CACHE)
+def _rooms_walk(limit: int, stamp: tuple, bucket: int) -> dict:
+    """_rooms_payload under an LRU, keyed on everything that decides whether it is current.
+
+    There is no read-then-validate and no pop-then-insert here to get wrong. The pair that
+    used to bracket this function — a get, a stamp comparison, then a pop, an insert and an
+    eviction loop — was two unguarded read-modify-writes on shared state, and every fix for
+    them was a rearrangement of the same unguarded sequence. lru_cache is documented
+    threadsafe, so the bookkeeping stays coherent however Starlette's threadpool interleaves
+    two /rooms requests, and no part of the argument for that rests on GIL scheduling.
+
+    The dict it returns is shared by every caller that gets this entry, as it always was:
+    _rooms_payload finishes building it before it is stored, and `rooms` only reads it.
+    """
+    return _rooms_payload(limit)
+
+
+def _rooms_view(limit: int) -> dict:
+    """The /rooms payload for `limit`, from cache when one is both fresh and still valid.
+
+    Deliberately caching the *store walk* and not the rendered response: the text and JSON
+    renderings differ, and the budget footer is per-caller, so a response cache would have
+    to key on both and would still be wrong for the footer.
+
+    Zero means no reuse, and it means it for entries already in the cache too: the knob is
+    read here, per call, and at zero the walk goes straight past the cache rather than
+    trying to expire what is in it.
+    """
+    stamp = _rooms_stamp()  # before the walk, never after — see _rooms_stamp
+    ttl = config.ROOMS_CACHE_SECONDS
+    if ttl <= 0:
+        return _rooms_payload(limit)
+    return _rooms_walk(limit, stamp, store._time_bucket(time.monotonic(), ttl))
 
 
 def rooms(request: Request) -> Response:

--- a/src/store.py
+++ b/src/store.py
@@ -17,8 +17,7 @@ import re
 import tempfile
 import time
 import unicodedata
-from collections import OrderedDict
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from functools import lru_cache
@@ -974,7 +973,7 @@ def room_window(root: Path, room: str) -> tuple[int, list[str]]:
     return top, nicks
 
 
-def _unanswered(nicks: list[str]) -> int:
+def _unanswered(nicks: Sequence[str]) -> int:
     """How many of a window's messages nobody else spoke after (`nicks` is newest-first).
 
     A message is answered when some *later* message in the window carries a different nick.
@@ -988,7 +987,7 @@ def _unanswered(nicks: list[str]) -> int:
     return run
 
 
-def _engagement(nicks: list[str]) -> dict:
+def _engagement(nicks: Sequence[str]) -> dict:
     """Per-room §II.2.2 aggregates over one scanned window. `window` is how many messages the
     ratios are over, so a reader can tell 1.0-of-3 from 1.0-of-200."""
     n = len(nicks)
@@ -1001,7 +1000,7 @@ def _engagement(nicks: list[str]) -> dict:
     }
 
 
-def _rollup(windows: list[list[str]]) -> dict:
+def _rollup(windows: list[Sequence[str]]) -> dict:
     """Service-level §II.2.2 aggregates: one ratio pooled over every scanned window, not a mean
     of per-room ratios, so a three-message room cannot outweigh a two-hundred-message one.
     Nicks are pooled globally too — one bot talking to itself in forty rooms should read as low
@@ -1028,40 +1027,86 @@ def list_rooms(root: Path) -> list[str]:
     return sorted(n for n in names if _listable(n))
 
 
-# (top, nicks) per room, validated against the (mtime_ns, size) stat the overview walk
-# already does — so a walk re-reads only the rooms a write actually changed. LRU-bounded.
+def _time_bucket(now: float, ttl: float) -> int:
+    """A coarse clock for a cache whose validity window is part of its key.
+
+    The memo caches here and in app.py all answer "is this entry still good?" — and the way
+    they answer it is to put the answer in the key: an entry that is no longer valid is not
+    an entry that has to be found and invalidated, it is a key nobody asks for any more.
+    A stamp does that for structural change; this does it for a TTL. An entry keyed on
+    `int(now // ttl)` is valid until the next multiple of `ttl`, so it expires at or before
+    `now + ttl` and never after it: an entry that carried its own expiry got the whole
+    window measured from its own insertion, this one gets the tail of the window it landed
+    in. So the published staleness bound (ROOMS_CACHE_SECONDS, NOTE_STATS_CACHE_SECONDS)
+    still holds — a boundary can only move an expiry earlier, which costs a walk, never
+    later, which would cost correctness. What it costs is that an entry made just before a
+    boundary is thrown away almost at once: averaged over where insertions fall, an entry
+    lives half a window rather than a whole one. That is why the bucket is the whole window
+    and not a subdivision of it — halving the hit rate is the price already paid, and a
+    finer bucket would only pay it again for staleness nothing here asked to be tighter.
+
+    `ttl <= 0` is not this function's case: zero means "no cache at all", which every caller
+    handles by bypassing its cache entirely rather than by asking for a bucket here. Passing
+    it would be a division by zero, and that is deliberate — a caller that reaches this with
+    a disabled TTL has a bug, and a silent 0 would hand it one shared eternal bucket.
+    """
+    return int(now // ttl)
+
+
+# (top, nicks) per room, keyed on the (mtime_ns, size) stat the overview walk already does —
+# so a walk re-reads only the rooms a write actually changed.
+#
+# The stat is part of the KEY, not a stamp stored beside the value and checked against it.
+# That is what retires this cache's bug class (#376, #229): there is no get-then-promote and
+# no read-modify-write for a concurrent eviction to fall into, so no interleaving of two
+# threadpool threads can raise, lose an update, or serve a value against the wrong stat.
+# functools.lru_cache is documented threadsafe — its bookkeeping stays coherent under
+# concurrent calls — and nothing here relies on GIL scheduling for that.
+#
+# The accepted cost: an entry whose stat is dead is never deleted, only stopped being asked
+# for, so it lingers until the LRU evicts it. That is bounded by maxsize — the bound this
+# cache always needed — so a churning store holds up to _WINDOW_MEMO_MAX windows, live and
+# dead mixed, and never more. `root` is a str for the reason the old key stringified it: a
+# Path hashes case-insensitively on some platforms, and two stores must never share an entry.
 _WINDOW_MEMO_MAX = 512
-_window_memo: OrderedDict[tuple, tuple] = OrderedDict()
 
 
-def _cached_window(root: Path, name: str, stamp: tuple) -> tuple[int, list[str]]:
-    key = (str(root), name)
-    hit = _window_memo.get(key)
-    if hit and hit[0] == stamp:
-        _window_memo.move_to_end(key)
-        return hit[1]
-    view = room_window(root, name)
-    _window_memo[key] = (stamp, view)
-    _window_memo.move_to_end(key)
-    while len(_window_memo) > _WINDOW_MEMO_MAX:
-        _window_memo.popitem(last=False)
-    return view
+@lru_cache(maxsize=_WINDOW_MEMO_MAX)
+def _cached_window(root: str, name: str, stamp: tuple) -> tuple[int, tuple[str, ...]]:
+    top, nicks = room_window(Path(root), name)
+    # A tuple, not the list room_window builds: one entry is handed to every thread that
+    # asks for it and outlives all of them, so it must not be something a caller can mutate.
+    return top, tuple(nicks)
 
 
 # Topic previews, valid while topics_written holds (bumped only by a `topic` note); reaper
-# deletions age out with NOTE_STATS_CACHE_SECONDS, like the note gauge in app.py.
-_topics_memo: tuple = ((), 0.0, {})
+# deletions age out with NOTE_STATS_CACHE_SECONDS, like the note gauge in app.py — as a
+# bucket in the key, so validity is once again the key rather than a slot to be reset.
+#
+# One entry per room, where this was a single dict slot shared by every caller. The slot was
+# reset unconditionally by any caller whose stamp or expiry did not match, so two /rooms
+# requests straddling one topic write did not merely miss each other once: each of them
+# makes one lookup per shown room, and every one of those lookups reset the other's slot
+# again, so neither ever hit and both re-read all ~50 topics (#515). Per-room keys under one
+# LRU cannot thrash that way — a stamp the other caller is not using is a key it never
+# touches — and the bound is the same order the slot held, one walk's worth of rooms.
+_TOPICS_MEMO_MAX = 512
 
 
-def _cached_topic(root: Path, room: str, stamp: tuple, now: float) -> str | None:
-    global _topics_memo
+@lru_cache(maxsize=_TOPICS_MEMO_MAX)
+def _topics_memo(root: str, room: str, stamp: tuple, bucket: int) -> str | None:
+    return topic(Path(root), room)
+
+
+def _cached_topic(root: str, room: str, stamp: tuple, now: float) -> str | None:
     ttl = config.NOTE_STATS_CACHE_SECONDS  # per call, so 0 disables an existing entry too
-    if ttl <= 0 or _topics_memo[0] != stamp or now >= _topics_memo[1]:
-        _topics_memo = (stamp, now + ttl, {})
-    cache = _topics_memo[2]
-    if room not in cache:
-        cache[room] = topic(root, room)
-    return cache[room]
+    # ...and disables it by going round the cache, not by emptying it: an entry made while
+    # the knob was positive is never served once it is zero, which is the documented
+    # behaviour of reading the knob per call. Nothing is evicted for that, so flipping the
+    # knob back does not pay for a re-read either.
+    if ttl <= 0:
+        return topic(Path(root), room)
+    return _topics_memo(root, room, stamp, _time_bucket(now, ttl))
 
 
 def room_stats(root: Path, limit: int = 50) -> dict:
@@ -1086,10 +1131,11 @@ def room_stats(root: Path, limit: int = 50) -> dict:
     entries.sort(reverse=True)
     shown = []
     windows = []
-    topics_stamp = (counters(root)["topics_written"], str(root))
+    root_key = str(root)  # hoisted: it is the first element of both memo keys, per room
+    topics_stamp = (counters(root)["topics_written"], root_key)
     mono = time.monotonic()
     for mtime, size, name, mtime_ns in entries[: max(1, min(int(limit), MAX_LIMIT))]:
-        top, nicks = _cached_window(root, name, (mtime_ns, size))
+        top, nicks = _cached_window(root_key, name, (mtime_ns, size))
         windows.append(nicks)
         shown.append(
             {
@@ -1097,7 +1143,7 @@ def room_stats(root: Path, limit: int = 50) -> dict:
                 "last_seq": top,
                 "bytes": size,
                 "idle_seconds": max(0, int(now - mtime)),
-                "topic": _cached_topic(root, name, topics_stamp, mono),
+                "topic": _cached_topic(root_key, name, topics_stamp, mono),
                 **_engagement(nicks),
             }
         )

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,5 +1,5 @@
 {
-  "core_total": 2240,
+  "core_total": 2229,
   "caps": {
     "core/app.py": 1017,
     "core/config.py": 62,
@@ -10,10 +10,10 @@
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 1937,
-      "code_lines": 1017,
+      "raw_lines": 1970,
+      "code_lines": 1014,
       "comment_lines": 270,
-      "tokens_per_line": 7.75
+      "tokens_per_line": 7.74
     },
     "core/config.py": {
       "raw_lines": 353,
@@ -34,10 +34,10 @@
       "tokens_per_line": 8.48
     },
     "core/store.py": {
-      "raw_lines": 2206,
-      "code_lines": 933,
-      "comment_lines": 474,
-      "tokens_per_line": 7.35
+      "raw_lines": 2252,
+      "code_lines": 925,
+      "comment_lines": 503,
+      "tokens_per_line": 7.37
     },
     "extra/manifest.py": {
       "raw_lines": 1885,

--- a/tests/_client.py
+++ b/tests/_client.py
@@ -9,17 +9,31 @@ from starlette.testclient import TestClient
 
 
 @pytest.fixture()
-def client(tmp_path):
+def client(tmp_path, monkeypatch):
     """One shared app, a fresh ROOT per test: config.override re-binds the knob (and app's
     copy of it) for exactly this test, where the old fixture re-imported app against a
-    CHAT_ROOT env var. The limiter buckets and the /rooms cache are process state a fresh
-    import used to reset for free, so they are cleared here instead."""
+    CHAT_ROOT env var. The limiter buckets and the three memo caches behind /rooms are
+    process state a fresh import used to reset for free, so they are cleared here instead.
+
+    Their clock is pinned here too. Cache validity is part of the cache key now (see
+    store._time_bucket), so the boundary between one window and the next is a key change —
+    and unpinned those boundaries are cut on a free-running clock, which lands one inside
+    roughly one test in every ROOMS_CACHE_SECONDS of suite time. A test that pins a 60s
+    window "far above anything it spends" would still miss on those, for a reason no test
+    body could name. Anchoring the buckets to the moment the fixture ran puts a fast test
+    inside bucket 0 for the whole of it, and leaves a test that wants a window to pass
+    saying so out loud."""
     import app as app_module
     import config
     import limit
+    import store
 
+    origin = time.monotonic()
+    monkeypatch.setattr(store, "_time_bucket", lambda now, ttl: int((now - origin) // ttl))
     app_module._buckets.clear()
-    app_module._rooms_cache.clear()
+    app_module._rooms_walk.cache_clear()
+    store._cached_window.cache_clear()
+    store._topics_memo.cache_clear()
     app_module._identities.clear()
     app_module._proxy_evidence["proxied_requests"] = 0
     # The duplicate ring is the same kind of process state the buckets are: a fresh

--- a/tests/capacity_bench.py
+++ b/tests/capacity_bench.py
@@ -319,7 +319,7 @@ def rooms_cache_bench(root: Path, seconds: float = 6.0) -> None:
     is counted at the call, not inferred from a latency, so the figure is exact.
 
     It drives `app._rooms_view` rather than the route, so it measures the stamp alone. The
-    `_rooms_cache.clear()` that used to run on every write in `take` cost the same thing
+    `_rooms_walk` clear that used to run on every write in `take` cost the same thing
     per worker, and is gone for the same reason; a server-level run (`--port`) is what shows
     the two together.
     """
@@ -335,7 +335,7 @@ def rooms_cache_bench(root: Path, seconds: float = 6.0) -> None:
     def run(label: str, keys: tuple) -> None:
         walks, latencies, sent, served, noted = 0, [], 0, 0, 0
         last: dict | None = None
-        app._rooms_cache.clear()
+        app._rooms_walk.cache_clear()
         app.ROOMS_STAMP_KEYS = keys
         start = time.monotonic()
         while (now := time.monotonic() - start) < seconds:

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -240,10 +240,10 @@ def test_rooms_cache_can_be_disabled_and_never_grows_past_its_bound(client, monk
 
     monkeypatch.setattr(app_module.store, "room_stats", counted)
     with config.override(ROOMS_CACHE_SECONDS=0):
-        app_module._rooms_cache.clear()
+        app_module._rooms_walk.cache_clear()
         client.get("/rooms?limit=7")
         client.get("/rooms?limit=7")
-        assert calls == [7, 7] and app_module._rooms_cache == {}
+        assert calls == [7, 7] and app_module._rooms_walk.cache_info().currsize == 0
         # Zero is also the exactness escape hatch, now that message recency is otherwise
         # bounded by the clock rather than by the stamp: with the cache off, a message is
         # on the very next listing rather than up to ROOMS_CACHE_SECONDS later.
@@ -253,10 +253,13 @@ def test_rooms_cache_can_be_disabled_and_never_grows_past_its_bound(client, monk
         assert listed["first"]["last_seq"] == 2
 
     with config.override(ROOMS_CACHE_SECONDS=60):
-        monkeypatch.setattr(app_module, "MAX_ROOMS_CACHE", 2)
-        for limit in (1, 2, 3):
+        # The bound is the LRU's maxsize, fixed when the cache is built, so the flood is the
+        # real one rather than a shrunk stand-in: every distinct `limit` is a walk that
+        # wants an entry, and eight more of them than the cache can ever hold.
+        app_module._rooms_walk.cache_clear()
+        for limit in range(1, app_module.MAX_ROOMS_CACHE + 9):
             client.get(f"/rooms?limit={limit}")
-        assert list(app_module._rooms_cache) == [2, 3]
+        assert app_module._rooms_walk.cache_info().currsize == app_module.MAX_ROOMS_CACHE
 
 
 def test_a_lost_counter_bump_costs_one_window_and_not_the_listing(client, monkeypatch):
@@ -264,27 +267,28 @@ def test_a_lost_counter_bump_costs_one_window_and_not_the_listing(client, monkey
 
     `store._bump` is best effort on purpose — an unwritable `.counters` must not fail a
     write that already landed — so a bump can go missing and a create then moves no stamp.
-    A hit needs the stamp to match *and* the entry to be inside the window, so the cost of
-    that is one window, not a listing that is wrong until the next structural write.
+    A hit needs the stamp to match *and* the window to be the one the entry is keyed under,
+    so the cost of that is one window, not a listing that is wrong until the next structural
+    write.
     """
-    import app as app_module
     import config
     import store
 
     monkeypatch.setattr(store, "_bump", lambda *a, **k: None)  # every counter now lies
-    window = 60  # far above anything this test spends, so only the ageing below expires it
+    window = 60  # far above anything this test spends, so only the move below expires it
     with config.override(ROOMS_CACHE_SECONDS=window):
         client.get("/r/first/say/bot/hi")
         client.get("/rooms")  # populates the cache, under a stamp that will not move again
         client.get("/r/second/say/bot/hi")
         assert "second" not in client.get("/rooms").text, "the cost: the stamp did not move"
 
-        # Age the entry past the window rather than sleeping out a short one. The claim is
-        # that the clock releases it, and the clock is the one thing a loaded CI runner
-        # will not hold still for: a 0.25s window is a test that passes locally and fails
-        # on a runner that spends it before the assertion.
-        stamp, _, view = app_module._rooms_cache[50]  # 50 is the default `limit`
-        app_module._rooms_cache[50] = (stamp, time.monotonic() - window, view)
+        # Move the clock into the next window rather than sleeping out a short one. The
+        # claim is that the clock releases it, and the clock is the one thing a loaded CI
+        # runner will not hold still for: a 0.25s window is a test that passes locally and
+        # fails on a runner that spends it before the assertion. The window is key material
+        # now (store._time_bucket), so the next one is simply a key the entry is not under —
+        # and the fixture pins the buckets, so bucket 1 is exactly one window on.
+        monkeypatch.setattr(store, "_time_bucket", lambda now, ttl: 1)
         assert "second" in client.get("/rooms").text, "the clock must expire it regardless"
 
 
@@ -309,33 +313,46 @@ def test_a_cached_view_is_never_served_under_a_different_root(client, tmp_path):
         assert "/r/first" in client.get("/rooms").text  # and the first root still answers
 
 
-def test_a_rewalked_entry_is_the_newest_and_the_oldest_is_what_leaves(client, monkeypatch):
+def test_a_used_entry_is_the_newest_and_the_coldest_is_what_leaves(client, monkeypatch):
     """The eviction path, which entries outliving a write made reachable: a caller cycling
-    `?limit=` keeps the cache full, so the evictor now runs while other requests are still
-    walking. Re-walking an existing key is a pop and an insert rather than a write and a
-    `move_to_end` — the key can be evicted between the two, where `move_to_end` raises and
-    `pop` does not — and the entry it leaves behind is the newest, not the next to go.
+    `?limit=` keeps the cache full, so the evictor runs while other requests are still
+    walking. Nothing in that path promotes an entry after finding it any more — the key
+    already carries everything that decides whether the entry is current, and the ordering
+    is the LRU's own bookkeeping — so there is no window between a hit and a promotion for
+    an eviction to land in, which is what used to make this reachable path a 500.
 
-    Ordering is by last walk, not by last *hit*: a request served from the cache does not
-    reinsert, so a cycling caller can still push a hot `limit` out. Bounded (the key space
-    is one reply per clamped limit) and unchanged by this — noted so the next reader knows
-    it is the policy and not an oversight.
+    The policy that replaces it is the stricter one, and the change is deliberate: ordering
+    is by last *use*, where the hand-rolled memo ordered by last walk and a request served
+    from the cache did not reinsert. A cycling caller could push out a `limit` it was
+    hitting on every single request; it cannot now. Asserted so it stays the policy.
     """
     import app as app_module
     import config
+    import store
 
+    walked = []
+    real = store.room_stats
+    monkeypatch.setattr(
+        store, "room_stats", lambda *a, **k: (walked.append(k["limit"]), real(*a, **k))[1]
+    )
     client.get("/r/first/say/bot/hi")
     with config.override(ROOMS_CACHE_SECONDS=60):
-        monkeypatch.setattr(app_module, "MAX_ROOMS_CACHE", 2)
-        app_module._rooms_cache.clear()
-        for limit in (1, 2, 3):
-            client.get(f"/rooms?limit={limit}")
-        assert list(app_module._rooms_cache) == [2, 3]
-        client.get("/r/second/say/bot/hi")  # structural: every entry is now stale
-        client.get("/rooms?limit=2")  # so this one is re-walked, and lands at the end
-        assert list(app_module._rooms_cache) == [3, 2]
-        client.get("/rooms?limit=4")
-        assert list(app_module._rooms_cache) == [2, 4], "the oldest walk is what leaves"
+        # _rooms_view rather than the route: this needs more distinct limits than the read
+        # budget of one IP allows requests, and the cache sits under the route, not in it.
+        app_module._rooms_walk.cache_clear()
+        bound = app_module.MAX_ROOMS_CACHE
+        app_module._rooms_view(1)
+        for other in range(2, bound + 1):
+            app_module._rooms_view(other)
+            app_module._rooms_view(1)  # served from the cache, and that is what keeps it
+        assert app_module._rooms_walk.cache_info().currsize == bound, "full, and no fuller"
+        walked.clear()
+        for other in range(bound + 1, bound + 9):
+            app_module._rooms_view(other)  # eight entries in, eight of the coldest out
+        app_module._rooms_view(1)
+        assert 1 not in walked, "the one entry every cycle touched must not be the victim"
+        app_module._rooms_view(2)
+        assert 2 in walked, "and the coldest of them is what left"
 
 
 def test_rooms_overview_carries_stats_newest_first(client, tmp_path):
@@ -579,7 +596,7 @@ def test_one_reply_is_one_cache_entry_however_the_limit_was_spelled(client, monk
         walks += 1
         return real(*a, **k)
 
-    app._rooms_cache.clear()
+    app._rooms_walk.cache_clear()
     monkeypatch.setattr(store, "room_stats", counting)
     bodies = [client.get(f"/rooms?limit={n}").text for n in (200, 1000000, 1000001, 0, 1)]
     assert walks == 2, f"two distinct replies (>=200 and 1), {walks} walks"

--- a/tests/http/test_stats.py
+++ b/tests/http/test_stats.py
@@ -36,7 +36,7 @@ def stats_client(tmp_path, monkeypatch):
     # config.override now, not the environment.
     monkeypatch.setenv("CHAT_ROOT", str(tmp_path))
     app_module._buckets.clear()
-    app_module._rooms_cache.clear()
+    app_module._rooms_walk.cache_clear()
     app_module._identities.clear()
     app_module._proxy_evidence["proxied_requests"] = 0
     with config.override(  # every stats call recomputes, so a test can observe its writes

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -34,7 +34,7 @@ def mcp(tmp_path, monkeypatch):
     import config
 
     app_module._buckets.clear()
-    app_module._rooms_cache.clear()
+    app_module._rooms_walk.cache_clear()
     app_module._identities.clear()
     app_module._proxy_evidence["proxied_requests"] = 0
     with config.override(ROOT=tmp_path, DUPE_FILTER_SECONDS=0):

--- a/tests/unit/test_memo_caches.py
+++ b/tests/unit/test_memo_caches.py
@@ -1,0 +1,290 @@
+"""Run: uv run --group dev python -m pytest tests
+
+The three memo caches behind /rooms — store._cached_window, store._topics_memo and
+app._rooms_walk — under the conditions that used to break them. `rooms` is a sync `def`
+route, so Starlette runs it in a real thread pool, and every one of these caches is
+module-level state several OS threads reach at the same moment.
+
+All three answer "is this entry still current?" by putting the answer in the key: the
+room's stat, the counter stamp and the time bucket are key material, so a superseded entry
+is not something to find and invalidate, it is a key nobody looks up any more. That is what
+retires the bug class these tests are about. There is no promotion after a hit and no
+insert-then-evict after a miss for another thread to land in the middle of (#376, #229),
+and there is no single shared slot two callers can reset out from under each other (#515).
+What the LRU keeps coherent under concurrent calls, it keeps coherent itself — nothing here
+argues from GIL scheduling.
+
+The concurrency tests do not hope for an interleaving. They gate the *producer* — the
+function a cache calls on a miss — on a barrier, which parks every worker inside a miss
+before any of them returns, over a cache already filled to its bound so an eviction is in
+flight while the others insert. Once the workers stop arriving together the barrier breaks
+on its timeout and they carry on; that is the pass condition, not a failure, exactly as in
+tests/unit/test_token_bucket.py. Nothing here sleeps.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+import app  # noqa: E402
+import config  # noqa: E402
+import store  # noqa: E402
+
+WORKERS = 6
+# One timeout is the whole cost of the guarded path, because the gate arms once. It only
+# has to outlast the thread starts it is waiting on, never any I/O.
+GATE_TIMEOUT = 0.5
+# A stamp and a clock the tests choose, so nothing here depends on a counter file or on
+# what the machine's monotonic clock happened to read.
+STAMP = ("stamp", 1)
+NOW = 1_000.0
+
+
+class _Gated:
+    """A stub producer that returns only once every worker has reached it.
+
+    A miss is where a cache does its bookkeeping, so parking every worker inside one at the
+    same moment is what puts inserts and an eviction in flight together. `arm` opens that
+    window once, for the next WORKERS calls; the calls before it (the fill) and after it
+    (whatever the workers race through) run straight past. If one worker takes two of those
+    slots the barrier is never satisfied and breaks on its timeout instead, which is the
+    same pass condition and costs the timeout once, not once per call.
+    """
+
+    def __init__(self, value):
+        self._value = value
+        self._counting = threading.Lock()
+        self._barrier = threading.Barrier(WORKERS)
+        self.calls = 0
+        self._parking = 0
+
+    def arm(self) -> None:
+        self._parking = WORKERS
+
+    def __call__(self, *args):
+        with self._counting:
+            self.calls += 1
+            park = self._parking > 0
+            self._parking -= park
+        if park:
+            try:
+                self._barrier.wait(timeout=GATE_TIMEOUT)
+            except threading.BrokenBarrierError:
+                pass  # serialised, so the others are not coming: carry on
+        return self._value(*args)
+
+
+def _in_parallel(work) -> None:
+    """Run `work()` on WORKERS threads at once and re-raise whatever any of them raised."""
+    failures: list[Exception] = []
+    collecting = threading.Lock()
+    ready = threading.Barrier(WORKERS)
+
+    def run() -> None:
+        try:
+            ready.wait(timeout=GATE_TIMEOUT)
+        except threading.BrokenBarrierError:
+            pass
+        try:
+            work()
+        except Exception as exc:
+            with collecting:
+                failures.append(exc)
+
+    threads = [threading.Thread(target=run) for _ in range(WORKERS)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    if failures:
+        raise failures[0]
+
+
+# --------------------------------------------------------- eviction under contention
+
+
+def test_the_window_memo_answers_every_worker_while_it_is_evicting(tmp_path, monkeypatch):
+    """#376/#229: a valid hit whose key another thread evicted between the lookup and the
+    promotion that followed it. There is no promotion left to raise, and the check is not
+    merely that nothing raised — each worker asserts the window it got back belongs to the
+    key it asked for, because a bound that quietly swapped two entries would be the same
+    bug with a worse symptom.
+    """
+    store._cached_window.cache_clear()
+    root = str(tmp_path)
+    bound = store._WINDOW_MEMO_MAX
+    gate = _Gated(lambda _root, name: (int(name[1:]), [name]))
+    monkeypatch.setattr(store, "room_window", gate)
+    for n in range(bound):  # full, so every miss below has to evict something
+        store._cached_window(root, f"r{n}", (n, n))
+    gate.arm()
+
+    def work() -> None:
+        for n in range(bound + WORKERS * 4):
+            assert store._cached_window(root, f"r{n}", (n, n)) == (n, (f"r{n}",))
+
+    _in_parallel(work)
+    info = store._cached_window.cache_info()
+    assert info.currsize == bound, "the bound is what holds, and it held"
+    assert gate.calls > bound, "the workers asked for more windows than the cache can hold"
+
+
+def test_the_topic_memo_answers_every_worker_while_it_is_evicting(tmp_path, monkeypatch):
+    """The same pressure on the cache that used to be one mutable slot: what is bounded now
+    is a real LRU, so the interesting failure is eviction rather than a reset, and the
+    per-room key is what has to keep pointing at the right room through it."""
+    store._topics_memo.cache_clear()
+    root = str(tmp_path)
+    bound = store._TOPICS_MEMO_MAX
+    gate = _Gated(lambda _root, room: f"topic of {room}")
+    monkeypatch.setattr(store, "topic", gate)
+    for n in range(bound):
+        store._cached_topic(root, f"r{n}", STAMP, NOW)
+    gate.arm()
+
+    def work() -> None:
+        for n in range(bound + WORKERS * 4):
+            assert store._cached_topic(root, f"r{n}", STAMP, NOW) == f"topic of r{n}"
+
+    _in_parallel(work)
+    assert store._topics_memo.cache_info().currsize == bound
+    assert gate.calls > bound
+
+
+def test_the_rooms_cache_answers_every_worker_while_it_is_evicting(monkeypatch):
+    """And the one the pop-then-insert comment used to live on. The walk is stubbed because
+    what is under test is the cache, not the store: 64 entries of pressure would otherwise
+    be 64 directory walks, and the stub makes a mismatched answer visible instead of just
+    slow."""
+    app._rooms_walk.cache_clear()
+    bound = app.MAX_ROOMS_CACHE
+    gate = _Gated(lambda limit: {"limit": limit})
+    monkeypatch.setattr(app, "_rooms_payload", gate)
+    for n in range(bound):
+        app._rooms_walk(n, STAMP, 0)
+    gate.arm()
+
+    def work() -> None:
+        for n in range(bound + WORKERS * 4):
+            assert app._rooms_walk(n, STAMP, 0) == {"limit": n}
+
+    _in_parallel(work)
+    assert app._rooms_walk.cache_info().currsize == bound
+    assert gate.calls > bound
+
+
+# ------------------------------------------------------------------- the #515 thrash
+
+
+def test_concurrent_callers_share_the_topic_cache_instead_of_thrashing_it(tmp_path, monkeypatch):
+    """#515: the single slot was reset by any caller whose stamp did not match it.
+
+    Two /rooms requests straddling one topic write did not merely miss each other once.
+    Each makes one lookup per shown room, and every one of those lookups reset the slot the
+    other was using, so neither ever hit and both re-read every topic — the cost growing
+    with the room count and the caller count together. The measurement is a warm cache and
+    then a burst: with two generations already computed, a room's topic must not be read
+    again, however many threads ask for it and whichever generation they ask under.
+    """
+    store._topics_memo.cache_clear()
+    root = str(tmp_path)
+    rooms = [f"r{n}" for n in range(24)]
+    generations = (("stamp", 1), ("stamp", 2))
+    gate = _Gated(lambda _root, room: f"topic of {room}")
+    monkeypatch.setattr(store, "topic", gate)
+
+    def pass_over_both_generations() -> None:
+        for stamp in generations:
+            for room in rooms:
+                assert store._cached_topic(root, room, stamp, NOW) == f"topic of {room}"
+
+    pass_over_both_generations()
+    warm = gate.calls
+    assert warm == len(rooms) * len(generations), "one read per room per generation, cold"
+
+    _in_parallel(pass_over_both_generations)
+    assert gate.calls == warm, "a warm topic cache must not re-read one topic, ever"
+
+
+# ------------------------------------------------------------------------- staleness
+
+
+def test_a_write_moves_the_key_so_the_very_next_read_is_the_fresh_view(tmp_path):
+    """Validity-in-key does not soften the staleness contract, it is how it is kept: what
+    changes the answer changes the key, so the superseded entry is still sitting there and
+    is simply never asked for again. Both halves of that, since they are stamped by
+    different things — the window by the room's own stat, the topic by topics_written."""
+
+    def listed(field: str) -> dict:
+        return {r["room"]: r[field] for r in store.room_stats(tmp_path)["rooms"]}
+
+    store.append(tmp_path, "aaa", "bot", "one")
+    assert listed("last_seq")["aaa"] == 1
+    store.append(tmp_path, "aaa", "bot", "two")  # a new (mtime_ns, size)
+    assert listed("last_seq")["aaa"] == 2, "the changed room is re-read on the next walk"
+
+    assert listed("topic")["aaa"] is None
+    store.note_set(tmp_path, store.TOPIC_NS, "aaa", "what aaa is for")  # bumps topics_written
+    assert listed("topic")["aaa"] == "what aaa is for", "a topic is visible immediately"
+
+
+# ------------------------------------------------------------- the TTL, and its zero
+
+
+def test_a_zero_ttl_goes_round_the_topic_cache_including_an_entry_already_in_it(
+    tmp_path, monkeypatch
+):
+    """NOTE_STATS_CACHE_SECONDS is read per call, so zero disables an existing entry too —
+    documented behaviour, and the reason a reaper's deletion ages out at all. Zero disables
+    it by going round the cache rather than by emptying it (nothing is evicted, so putting
+    the knob back does not pay for a re-read) and never by asking for the bucket of a
+    window that is not open.
+    """
+    store._topics_memo.cache_clear()
+    root = str(tmp_path)
+    reads_the_note = store.topic
+    gate = _Gated(reads_the_note)  # the real read, counted: this test is about how often
+    monkeypatch.setattr(store, "topic", gate)
+    store.note_set(tmp_path, store.TOPIC_NS, "aaa", "what aaa is for")
+
+    assert store._cached_topic(root, "aaa", STAMP, NOW) == "what aaa is for"
+    assert store._cached_topic(root, "aaa", STAMP, NOW) == "what aaa is for"
+    assert gate.calls == 1, "the second read came from the cache"
+
+    store.note_path(tmp_path, store.TOPIC_NS, "aaa").unlink()  # a reaper-style deletion
+    with config.override(NOTE_STATS_CACHE_SECONDS=0):
+        assert store._cached_topic(root, "aaa", STAMP, NOW) is None
+        assert gate.calls == 2, "and it was read, not answered from the entry that is there"
+    assert store._cached_topic(root, "aaa", STAMP, NOW) == "what aaa is for"
+    assert gate.calls == 2, "the entry survived the zero: nothing was evicted for it"
+
+
+def test_a_bucket_boundary_can_only_expire_an_entry_sooner_than_its_own_window():
+    """The claim store._time_bucket makes, checked rather than argued.
+
+    An entry that carried its own expiry got the whole window measured from its insertion;
+    an entry keyed on a bucket gets the tail of the window it landed in. So the boundary can
+    only move an expiry earlier, which costs a walk, never later, which would cost the
+    published staleness bound (ROOMS_CACHE_SECONDS, NOTE_STATS_CACHE_SECONDS).
+    """
+    for ttl in (0.5, 3.0, 30.0):
+        for start in (0.0, ttl * 0.999, ttl * 7 + 0.25, 1_000_000.0):
+            bucket = store._time_bucket(start, ttl)
+            expiry = (bucket + 1) * ttl
+            assert expiry <= start + ttl, "an entry never outlives its own window"
+            assert store._time_bucket(expiry - ttl * 1e-6, ttl) == bucket, "valid until it"
+            assert store._time_bucket(expiry, ttl) != bucket, "and a new key at it"
+
+
+def test_a_disabled_ttl_is_a_bypass_at_the_call_site_and_never_a_bucket():
+    """Zero is "no cache", which every caller handles by going round its cache. Asking for
+    the bucket of a window that is not open is a bug, and it fails loudly rather than
+    quietly handing every entry one shared eternal bucket."""
+    with pytest.raises(ZeroDivisionError):
+        store._time_bucket(NOW, 0)

--- a/tests/unit/test_memo_caches.py
+++ b/tests/unit/test_memo_caches.py
@@ -200,8 +200,12 @@ def test_concurrent_callers_share_the_topic_cache_instead_of_thrashing_it(tmp_pa
     monkeypatch.setattr(store, "topic", gate)
 
     def pass_over_both_generations() -> None:
-        for stamp in generations:
-            for room in rooms:
+        # Room-major, so the two generations alternate on every single lookup rather than
+        # in two blocks. That is the order the reported thrash was in — two threadpool
+        # requests interleaving room by room — and the order in which one slot is at its
+        # worst: under the old cache this reset it 48 times in a pass and hit zero times.
+        for room in rooms:
+            for stamp in generations:
                 assert store._cached_topic(root, room, stamp, NOW) == f"topic of {room}"
 
     pass_over_both_generations()

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1084,6 +1084,7 @@ def test_room_windows_are_memoized_against_the_stat_the_walk_already_does(tmp_pa
     tail and reuses every other window from the memo — O(changed), not O(shown)."""
     import store
 
+    store._cached_window.cache_clear()  # module-level state; the counts below are exact
     store.append(tmp_path, "aaa", "bot", "one")
     store.append(tmp_path, "bbb", "bot", "two")
     calls = []
@@ -1103,10 +1104,15 @@ def test_room_windows_are_memoized_against_the_stat_the_walk_already_does(tmp_pa
     assert calls == ["aaa"], "only the changed room is re-read"
     assert {r["room"]: r["last_seq"] for r in view["rooms"]}["aaa"] == 2
 
-    monkeypatch.setattr(store, "_WINDOW_MEMO_MAX", 1)
+    held = store._cached_window.cache_info().currsize
     store.append(tmp_path, "aaa", "bot", "third-message")
     store.room_stats(tmp_path)
-    assert len(store._window_memo) == 1  # the bound holds under eviction
+    info = store._cached_window.cache_info()
+    # The stat is the key, so aaa's superseded window is not deleted when the room changes,
+    # it stops being asked for: the memo took the new stat and kept the old one, and maxsize
+    # is the only thing that ever reclaims it. tests/unit/test_memo_caches.py is where that
+    # bound is exercised past its limit, under threads.
+    assert (info.currsize, info.maxsize) == (held + 1, store._WINDOW_MEMO_MAX)
 
 
 def test_topic_previews_ride_the_notes_counter_not_only_a_clock(tmp_path):


### PR DESCRIPTION
## What

The three memo caches behind `/rooms` — `store._window_memo`, `store._topics_memo` and `app._rooms_cache` — stop being hand-rolled `OrderedDict` LRUs and become `functools.lru_cache` with the validity stamp moved **into the key**. Nothing a caller of the service or the MCP wrapper sees changes: responses are byte-identical, `ROOMS_STAMP_KEYS` is untouched, and the knobs behave as documented (including `0` still disabling an entry that already exists).

## Why

All three validated a stamp stored *beside* the value, unlocked, from Starlette's threadpool — so all three carried the same two bugs (KeyError promoting a concurrently evicted key; lost update on insert), and each was being fixed site by site with a rearrangement of the same unguarded read-modify-write. With the stamp in the key there is nothing to find and invalidate: a superseded entry is a key nobody looks up, so the get-then-promote and pop-then-insert sequences are gone rather than reordered. No correctness claim rests on GIL scheduling. Stdlib only — no new dependency.

Supersedes #376, #229, #515, and the `_window_memo` half of #451/#458. Deliberately leaves `limit._buckets` (#519/#486) and `limit._dupes` (#358) alone — different primitives, different bugs.

Two judgment calls worth a line each. The TTL'd caches encode the clock as a coarse bucket (`store._time_bucket`): a boundary can only expire an entry *earlier* than its own insertion would have, so the published staleness bound holds — checked at the boundary rather than argued. And `test_a_rewalked_entry_is_the_newest_and_the_oldest_is_what_leaves` is rewritten, not adapted: its subject was the pop-then-insert convention, and the eviction policy genuinely changed (ordering is by last *use* now, so a cycling caller can no longer evict a hot `limit`). Every other test touching the deleted internals is a mechanical adaptation, itemised in the commit message.

Net core code lines −11, and `sz-baseline.json` carries the new floor via `uv run sz.py --update-baseline`. The caps are untouched by that and now have headroom; tightening them is a policy call, not this change's to make.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 495 passed, 97.32%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [ ] Docs — nothing to update: no manual, `/skill.md`, README, `src/patterns.md` or `mcp/README.md` surface changed, and `_time_bucket` is private so the store ISA doc is unaffected
- [ ] New surface on a world-writable service — nothing new: all three caches are private, reached only through `/rooms`, and the bounds that cap them as process state are unchanged (512 / 512 / 64)