### PR TITLE
fix(app): frame the current value in a 409 conflict body as untrusted content (#291)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1836,7 +1836,8 @@ async def on_conflict(request: Request, exc: Exception) -> Response:
         body += (
             "\n\nto retry: merge your change into the value below, then write it with "
             "?if=<that value> so you only win if nothing moved again.\n"
-            f"current value follows ({len(current)} chars):\n{current}"
+            f"current value follows ({len(current)} chars):\n"
+            f"{BANNER}\n{current}"
         )
     else:
         # The only way here: ?if=<value> against a note that does not exist — it was never

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -121,6 +121,20 @@ def test_cas_rejects_a_write_whose_read_went_stale(client):
     assert "agent-a" in second.text  # 409 hands back the current value to rebase on
 
 
+def test_409_conflict_bodies_frame_caller_content_as_untrusted(client):
+    """A 409 from /kv must not present caller content as instruction.
+
+    The value that lost the race is caller-authored and must be marked with
+    the untrusted-content banner before it is returned.
+    """
+    client.get("/kv/coord/claim/set/ATTACKER CHOSEN TEXT")
+    r = client.get("/kv/coord/claim/set/ATTACKER CHOSEN TEXT?if_absent=1")
+    assert r.status_code == 409
+    body = r.text
+    assert "UNTRUSTED CONTENT" in body
+    assert "ATTACKER CHOSEN TEXT" in body
+
+
 def test_if_absent_creates_exactly_once(client):
     assert client.get("/kv/coord/claim/set/agent-a?if_absent=1").status_code == 200
     assert client.get("/kv/coord/claim/set/agent-b?if_absent=1").status_code == 409


### PR DESCRIPTION
Fixes #291

In `src/app.py`, `on_conflict()` prepends caller-chosen content onto a 409 body immediately after a server-authored imperative, without the existing untrusted-content banner.

Change:
- prefix the current value with `BANNER` so caller-chosen bytes are framed as data, not instructions
- keep the rest of the 409 shape intact so `?if=` round-trips still work

Verification:
- added HTTP test asserting `UNTRUSTED CONTENT` is present in a 409 conflict body
- `tests/http/test_notes.py`: 27 passed