### PR TITLE
docs(rooms): name the listed-room subset in /rooms head when unlisted rooms exist (#260)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -801,7 +801,9 @@ def rooms(request: Request) -> Response:
         head = (
             # Both caps, because either can be the one that refuses the next room and an
             # agent that hit one needs to know which: the count is not the disk budget.
-            f"# {len(view['rooms'])} of {view['total']} rooms "
+            # `view['total']` is the listed population; the cap counts every room file,
+            # including unlisted ones, so name both figures so the units cannot be misread.
+            f"# {len(view['rooms'])} of {view['total']} listed rooms "
             f"(cap {view['capacity']}, {_size(view['bytes'])} of "
             f"{_size(view['bytes_capacity'])} stored), newest first"
         )

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -357,7 +357,18 @@ def test_rooms_overview_carries_stats_newest_first(client, tmp_path):
     assert view["total"] == 3 and view["capacity"] == store.MAX_ROOMS and view["bytes"] > 0
 
     body = client.get("/rooms").text
-    assert "3 of 3 rooms" in body and "/r/busy" in body and "seq 2" in body and "ago" in body
+    assert "3 of 3 listed rooms" in body and "/r/busy" in body and "seq 2" in body and "ago" in body
+
+
+def test_rooms_header_names_listed_rooms_when_unlisted_rooms_exist(client):
+    """#260: when the store holds unlisted rooms alongside listed ones, the /rooms head
+    must say 'listed rooms' so the count cannot be misread as the population the cap
+    enforces."""
+    client.get("/r/p-only/say/bot/hi")
+    client.get("/r/listed/say/bot/hi")
+    body = client.get("/rooms").text
+    assert "listed rooms" in body
+    assert "(cap " in body
 
 
 def test_rooms_marks_the_caller_chosen_name_and_topic_as_untrusted(client):


### PR DESCRIPTION
Fixes #260

Change `/rooms`'s text head from `N of M rooms` to `N of M listed rooms` so the count cannot be misread as the population the cap enforces.

Why:
- the cap counts every room file, including unlisted `p-` rooms
- the listing only names the listed subset, so the two figures have different units
- the old wording invited the wrong inference whenever unlisted rooms existed

Verification:
- added HTTP test covering the unlisted-room case
- `tests/http/test_rooms.py`: 55 passed