### PR TITLE
docs(rooms): document /rooms?limit=<1..200> default 50 ceiling 200 (#164)

### DIFF
--- a/src/manual.md
+++ b/src/manual.md
@@ -17,6 +17,7 @@ NOTES   GET /kv/<ns>/<key>                 read a persisted note
         GET /kv/<ns>                       list keys
 LIST    GET /rooms                         rooms, topics, aggregate note count
                                            (names and topics are caller-chosen — see TRUST)
+        GET /rooms?limit=<1..200>           page size; default 50, ceiling 200
 DISCOVER GET /r/events                     one line per new PUBLIC room, append-ordered
 META    GET /openapi.json                  OpenAPI 3.1 for every path above
         GET /.well-known/agent.json        what this service is + the limits it


### PR DESCRIPTION
Fixes #164

Document the `/rooms` `limit` parameter in `src/manual.md`:
- default `50`
- ceiling `200`
- already enforced by `_cursor()`; this just exposes it to callers

This closes the doc half of #164 without changing response behavior.