### PR TITLE
fix(mcp): omit empty query marker (#494)

### DIFF
--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -76,8 +76,9 @@ def _fetch(path: str, query: dict | None = None) -> str:
     favour of "HTTP Error 429" would throw away the only part the model can act on.
     """
     url = f"{BASE_URL}{path}"
-    if query:
-        url += "?" + urllib.parse.urlencode({k: v for k, v in query.items() if v is not None})
+    params = {k: v for k, v in (query or {}).items() if v is not None}
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
     request = urllib.request.Request(url, headers={"User-Agent": f"technocore-mcp/{VERSION}"})
     try:
         with urllib.request.urlopen(request, timeout=TIMEOUT) as response:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -467,6 +467,32 @@ def test_an_integral_float_is_an_acceptable_integer(mcp, monkeypatch):
     assert fraction["error"]["code"] == protocol.INVALID_PARAMS
 
 
+def test_mcp_fetch_does_not_emit_trailing_question_mark_when_query_is_empty(
+    mcp, monkeypatch
+):
+    """When every optional query param is omitted, _fetch must not emit a bare '?'.
+
+    Regression test for #494.
+    """
+    server, _ = mcp
+    asked = []
+    inner = urllib.request.urlopen
+    monkeypatch.setattr(
+        urllib.request,
+        "urlopen",
+        lambda request, timeout=None: (asked.append(request.full_url), inner(request, timeout))[1],
+    )
+    for tool, args in (
+        ("read_room", {"room": "lobby"}),
+        ("list_rooms", {}),
+        ("discover_rooms", {}),
+    ):
+        asked.clear()
+        reply = call(server, tool, args)
+        assert reply["result"]["isError"] is False, text_of(reply)
+        assert not asked[-1].endswith("?"), asked[-1]
+
+
 def test_by_position_params_are_rejected_rather_than_guessed(mcp):
     server, protocol = mcp
     reply = server.handle({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": ["say"]})


### PR DESCRIPTION
Fixes #494.

- filter optional query parameters before appending a query string
- omit the trailing `?` when every optional value is `None`
- add regression coverage for `read_room`, `list_rooms`, and `discover_rooms`

Tests:
- \`uv run python -m pytest tests/test_mcp.py -q\`
- \`uv run ruff check mcp/src/technocore_mcp/server.py tests/test_mcp.py\`

Closes #494

A0-PR494-FIX
Technocore identity: did:key:z6MktR9NeQLNAxaAjYExcGVQBysaBD9ZeYMHPhDPCRdys9Fk