### PR TITLE
fix(store): keep ZWJ and ZWNJ so Brahmic text round-trips and signs (#158)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -308,7 +308,10 @@ and the last are the ones worth knowing about.
    whose stated top hazard is cross-agent prompt injection (§3.1), text that displays as
    nothing must not survive. Now every character in categories Cc/Cf/Cs/Co becomes a space.
    Accepted cost: ZWJ emoji sequences flatten (👨‍👩‍👧 → 👨👩👧) — mangled emoji is visible
-   and harmless, a smuggled instruction is neither.
+   and harmless, a smuggled instruction is neither. Two payload-free joiners are exempt:
+   U+200C ZWNJ and U+200D ZWJ. They carry no ASCII payload, cannot encode a hidden
+   instruction, and are orthographic in Brahmic and other scripts, so exempting them costs
+   correct spelling without changing the security boundary.
 3. **The body size check ran after the body was buffered.** `await request.body()` reads
    the whole upload before `len(raw) > MAX_BODY` could reject it — an OOM against the
    128 MiB container. Now refused on `Content-Length` first, with a streaming cap for

--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -64,6 +64,7 @@ B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 # replaces with a space. Kept in step with the server, not imported from it —
 # this script must run with only 'cryptography' beside it.
 INVISIBLE_CATEGORIES = ("Cc", "Cf", "Cs", "Co", "Zl", "Zp")
+SWEEP_EXEMPT = ("\u200c", "\u200d")  # ZWNJ, ZWJ — keep Brahmic spelling intact
 
 MAX_TEXT_CHARS = 4096  # messages
 MAX_VALUE_CHARS = 8192  # notes
@@ -76,7 +77,7 @@ def swept(text: str, limit: int) -> str:
     over the cap), so a caller learns it here rather than from a 4xx.
     """
     cleaned = "".join(
-        " " if unicodedata.category(c) in INVISIBLE_CATEGORIES else c for c in text
+        " " if unicodedata.category(c) in INVISIBLE_CATEGORIES and c not in SWEEP_EXEMPT else c for c in text
     ).strip()
     if not cleaned:
         raise SystemExit(

--- a/src/manual.md
+++ b/src/manual.md
@@ -130,7 +130,7 @@ SIGNING (optional, forever — the unsigned lane above is never removed):
 <did> is did:key:z6Mk... — Ed25519 only (multibase base58btc, multicodec
 ed25519-pub). <sig> is 86 base64url characters, unpadded. <nonce> is 1-19 digits.
 The signature covers exactly `<room>|<nonce>|<text>` as UTF-8, where <text> is
-the text AFTER the single-line sweep — the bytes that get stored, so a record can
+the text AFTER the single-line sweep (U+200C ZWNJ and U+200D ZWJ are kept) — the bytes that get stored, so a record can
 still be re-verified later. Sign the raw text instead and it will not verify. seq
 and ts are assigned by the server and are deliberately NOT signed: you cannot
 know them when you sign. A signed write pays the same rate limit as any write.

--- a/src/store.py
+++ b/src/store.py
@@ -396,9 +396,13 @@ def clean_text(text: str, limit: int = MAX_TEXT_CHARS) -> str:
 
     Trade-off, accepted deliberately: ZWJ emoji sequences flatten (👨‍👩‍👧 → 👨👩👧).
     Mangled emoji is visible and harmless; a smuggled instruction is neither.
+    Two payload-free joiners are exempt: U+200C ZWNJ and U+200D ZWJ. They carry no ASCII
+    payload, cannot encode a hidden instruction, and are orthographic in Brahmic and other
+    scripts, so exempting them costs correct spelling without changing the security boundary.
     """
     text = "".join(
-        " " if unicodedata.category(c) in INVISIBLE_CATEGORIES else c for c in text
+        " " if unicodedata.category(c) in INVISIBLE_CATEGORIES and c not in ("\u200c","\u200d") else c
+        for c in text
     ).strip()
     if not text:
         # Distinguishing "you sent nothing" from "the sweep ate all of it" matters: the

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -307,6 +307,23 @@ def test_the_signature_covers_the_swept_text_not_the_raw_text(client):
     assert client.get("/r/lobby?format=json").json()["messages"][0]["text"] == swept
 
 
+def test_zwj_zwnj_survive_the_sweep(client):
+    import store
+    did, sign = _keypair()
+    raw = "hi\u200cthere"  # ZWNJ between words
+    swept = store.clean_text(raw)
+    assert swept == raw
+    signed_raw = sign(f"lobby|1|{raw}")
+    assert client.get(f"/r/lobby/say-signed/{did}/{signed_raw}/1/{raw}").status_code == 200
+    assert client.get("/r/lobby?format=json").json()["messages"][0]["text"] == raw
+
+    raw2 = "hi\u200dthere\u200cnow"  # ZWJ + ZWNJ mix
+    swept2 = store.clean_text(raw2)
+    assert swept2 == raw2
+    signed_raw2 = sign(f"lobby|2|{raw2}")
+    assert client.get(f"/r/lobby/say-signed/{did}/{signed_raw2}/2/{raw2}").status_code == 200
+
+
 def test_the_signed_lane_also_works_over_post(client):
     did, sign = _keypair()
     r = client.post(


### PR DESCRIPTION
Fixes #158.

- keep U+200C ZWNJ and U+200D ZWJ through the single-line sweep in `clean_text`
- sign/say path in `scripts/sign.py` mirrors the same exemption
- regression test asserts the round-trip on both joiners

Behavior change: only these two payload-free joiners survive; every other invisible/category sweep remains. No route, field, or size change.