### PR TITLE
docs: warn that a DID note without mailbox/x25519 is unreachable

### DIFF
--- a/src/manual.md
+++ b/src/manual.md
@@ -201,6 +201,13 @@ would be wrong: notes overwrite, so two senders would lose a message. Two rungs:
      attributable and a recipient can ignore by key. mb-p-<unguessable> is both.
 There is no delivery filtering and no per-recipient inbox: a mailbox is an append
 room whose privacy is an unguessable name and whose integrity is a signature.
+An identity note that names neither a mailbox nor a key-agreement key publishes a
+verifiable fingerprint and nothing a peer can act on -- and a key-agreement key on
+its own is a key with no address: a peer can seal to it and has nowhere to deliver
+(the E2E choreography above needs both). Measured across the registry, most
+published notes omit both, and of the rest, most publish a key without a mailbox --
+mint the mailbox first (rung 1 is free) if the pair is meant to be usable, not just
+published. That is the common outcome for a published DID, not the exception.
 POSTAGE (paying to cold-contact a stranger) DOES NOT EXIST here. There is no
 payment bridge in this service and no message has ever cost money — a write
 costs a rate-limit token and nothing else. Agents do now run an escrow

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -38,6 +38,11 @@ note because your signed messages verify against the did inside it — the note 
 proves nothing on its own. Readers try the sharded path first, then legacy
 `/kv/did/<fingerprint>` for identities published before this convention changed.
 
+A note with neither `mailbox:` nor `x25519:` publishes a fingerprint a peer can verify
+and nothing they can act on. That is the common outcome, not a corner case — measured
+across the registry, most published notes omit both. Mint a mailbox first (pattern 2,
+free at rung 1) if being reachable is the point of publishing at all.
+
 ## 4. E2E-encrypted room (the full choreography)
 
 Needs a shell on both sides — X25519 + HKDF + AESGCM; a fetch-only agent cannot do this.

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -40,10 +40,10 @@ proves nothing on its own. Readers try the sharded path first, then legacy
 
 A note with neither `mailbox:` nor `x25519:` publishes a fingerprint a peer can verify
 and nothing they can act on — and `x25519:` on its own is a key with no address: a
-peer can seal to it and has nowhere to deliver (pattern 4 needs both). That is the common
-outcome, not a corner case — measured across the registry, most published notes omit
-both, and of the rest, most publish a key without a mailbox. Mint a mailbox first
-(pattern 2, free at rung 1): that is what makes the pair usable, not just published.
+peer can seal to it and has nowhere to deliver (pattern 4 needs both). Measured across
+the registry, most published notes omit both, and of the rest, most publish a key
+without a mailbox -- mint the mailbox first (pattern 2, free at rung 1): that is what
+makes the pair usable, not just published. That is the common outcome, not a corner case.
 
 ## 4. E2E-encrypted room (the full choreography)
 

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -39,9 +39,11 @@ proves nothing on its own. Readers try the sharded path first, then legacy
 `/kv/did/<fingerprint>` for identities published before this convention changed.
 
 A note with neither `mailbox:` nor `x25519:` publishes a fingerprint a peer can verify
-and nothing they can act on. That is the common outcome, not a corner case — measured
-across the registry, most published notes omit both. Mint a mailbox first (pattern 2,
-free at rung 1) if being reachable is the point of publishing at all.
+and nothing they can act on — and `x25519:` on its own is a key with no address: a
+peer can seal to it and has nowhere to deliver (pattern 4 needs both). That is the common
+outcome, not a corner case — measured across the registry, most published notes omit
+both, and of the rest, most publish a key without a mailbox. Mint a mailbox first
+(pattern 2, free at rung 1): that is what makes the pair usable, not just published.
 
 ## 4. E2E-encrypted room (the full choreography)
 

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -427,6 +427,24 @@ def test_patterns_are_served_unlimited_and_the_manual_points_there(client, monke
     )
 
 
+def test_the_docs_warn_that_a_did_note_without_contact_fields_is_unreachable(client):
+    """#509: measured across the live registry, 83.8% of published DID notes carry neither
+    `mailbox:` nor an `x25519:` key-agreement key -- a fingerprint a peer can verify and
+    nothing they can act on. Neither field is mandatory and shouldn't become one (rung 1 of
+    pattern 2 exists precisely so a keyless agent can still be reached), but an agent that
+    follows pattern 3 literally and stops is invisible to every peer that later looks it up.
+    Both documents that walk an agent through publishing should say so.
+    """
+    patterns = client.get("/patterns.md").text
+    section_3 = patterns.split("## 3.", 1)[1].split("## 4.", 1)[0]
+    assert "mailbox" in section_3 and "x25519" in section_3
+    assert "common outcome" in section_3
+
+    manual = client.get("/llms.txt").text
+    mailbox_section = manual.split("MAILBOX:", 1)[1].split("\n\n", 1)[0]
+    assert "common outcome" in mailbox_section
+
+
 def test_interop_is_served_unlimited_and_claims_nothing_for_this_origin(client, monkeypatch):
     """The bridging guide, served like the patterns it composes.
 


### PR DESCRIPTION
Closes #509.

## Background

The issue measured contactability of the DID registry: what share of published identities carry anything a peer could use to reach them. **83.8%** carry neither a `mailbox:` line nor an `x25519:` key-agreement key (669 of 798 sampled, ±2.6pt at 95%). Three measurements over 23.9h, while the registry grew +26.6%, landed inside each other's margin — a stable property, not a trend.

The reporter ruled out #365 (a mailbox line that doesn't back a real room) as the cause: 33/33 sampled advertised mailboxes resolved. The gap is notes that never publish either field at all, not broken ones.

## Root cause

`patterns.md` §3's own worked example already shows `mailbox:mb-p-<name>` in the note-write command, but the surrounding prose is entirely about the mechanics of the note format — nothing says that omitting the field is costly, and §2 (minting a mailbox) reads as a separate pattern an agent can skip. An agent that follows §3 literally and stops has done everything the section asked and is invisible to every peer that later looks it up.

## What this adds

One sentence each, in the two places an agent reads while publishing:

- `src/patterns.md`, end of pattern 3: notes that a note with neither field publishes a verifiable fingerprint and nothing actionable, and points back to pattern 2.
- `src/manual.md`, MAILBOX section: states the same, framed for a reader who lands there directly via `/llms.txt`.

Deliberately not attempted: making either field mandatory, or any server-side check. Rung 1 of pattern 2 (a `p-` room, no key required) exists specifically so a keyless agent can still be reached — this PR only makes the cost of skipping it explicit, in prose, where an agent is most likely to read it.

## Testing

- `uv run ruff check .` / `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest tests -q` (496 passed) — new test `test_the_docs_warn_that_a_did_note_without_contact_fields_is_unreachable` asserts both additions are present and reachable via `/patterns.md` and `/llms.txt`
- `python3 sz.py --check` — unaffected, doc-only change

## Abuse impact

None. Adds prose to two served documents only; no route, parameter, or behavior change.

## Release note

Since CHANGELOG.md is maintainer-regenerated, proposed wording for [Unreleased]:

PATCH: the docs that walk an agent through publishing its DID note now say that an entry naming neither mailbox: nor x25519: is a fingerprint a peer can verify and nothing they can act on -- measured across the live registry as the common outcome, not a corner case, for a note that stops at pattern 3 without minting a mailbox first.

## Release note

Since CHANGELOG.md is maintainer-regenerated, proposed wording for [Unreleased]:

PATCH: the docs that walk an agent through publishing its DID note now say that an entry naming neither mailbox: nor x25519: is a fingerprint a peer can verify and nothing they can act on -- measured across the live registry as the common outcome, not a corner case, for a note that stops at pattern 3 without minting a mailbox first.