### PR TITLE
docs(interop): recover retained bridge cursor gaps (#481)

### DIFF
--- a/src/interop.md
+++ b/src/interop.md
@@ -19,11 +19,18 @@ Two loops against one room, and a durable cursor between them.
 ```python
 import json
 
-cursor = load_cursor(room)
-cold_start = cursor is None
-since = cursor or 0
+checkpoint = load_checkpoint(room)
+cold_start = checkpoint is None
+generation = None if cold_start else checkpoint["generation"]
+since = 0 if cold_start else checkpoint["last_delivered_seq"]
 while True:
     view = get(f"{BASE}/r/{room}", params={"since": since, "wait": 10, "format": "json"}).json()
+    if cold_start:
+        generation = view["generation"]
+    elif view["generation"] != generation:
+        raise RuntimeError(
+            f"room {room} was recreated: generation {generation} -> {view['generation']}"
+        )
     messages = view["messages"]
 
     # A normal read is the newest window, not the oldest records after `since`. If the
@@ -41,19 +48,20 @@ while True:
         if m.get("from") != BRIDGE_DID:  # not our own write, coming back around
             deliver_to_far_side(m)
     since = messages[-1]["seq"] if messages else view["last_seq"]
-    save_cursor(room, since)
+    save_checkpoint(room, {"generation": generation, "last_delivered_seq": since})
     cold_start = False
 ```
 
 Room reads deliberately return the newest `limit` records. A bridge that was paused can therefore
 receive a `first_seq` greater than its cursor plus one even while the skipped records remain in the
 larger retained ring. The slow path above downloads that ring through `/export`, filters forward
-from the durable cursor, and checks both continuity and room generation before delivering anything.
-On a cold start there is no prior observation to continue from, so begin at the first retained
-record. After a cursor has been saved, if the export also starts beyond that cursor, those records
-have genuinely left the ring: stop and surface the gap rather than advancing the cursor and
-presenting an incomplete mirror as complete. The export costs one ordinary read and is needed only
-after a detected gap.
+from the durable checkpoint, and checks both continuity and room generation before delivering
+anything. On a cold start there is no prior observation to continue from, so adopt the observed
+generation and begin at the first retained record. After a checkpoint has been saved, a generation
+change means the room was deleted and recreated: stop before delivering from the new conversation.
+If the export starts beyond a saved sequence, those records have genuinely left the ring: stop and
+surface the gap rather than advancing the checkpoint and presenting an incomplete mirror as
+complete. The export costs one ordinary read and is needed only after a detected sequence gap.
 
 Inbound is the mirror: a foreign event becomes one signed write. Three things make the difference
 between a bridge that works and one that looks like it does.
@@ -67,15 +75,12 @@ so minting a durable `@alice@bridge.example` for whoever typed `alice` first han
 a stranger. Collapse every unsigned writer into one shared actor and put the claimed name in the
 body, where the service's own `~alice` marker already puts it.
 
-**Qualify object ids with a room epoch.** `seq` is contiguous within one lifetime of a room, and a
-room that is reaped and recreated starts again at 1 — so `…/r/lobby/1284` eventually names two
-different messages, which downstream protocols deduplicate on and silently drop.
-
-Detecting that takes a **cursor-free** read. A poll carrying `since=` echoes your own cursor back as
-`last_seq` when nothing is newer, so the rewind is invisible to the loop above; a bare
-`GET /r/<room>?format=json` reports the room's actual tail. Probe periodically, and when that tail
-is below your cursor the room is a new one: bump the epoch, reset the cursor, and carry the epoch in
-every id you mint.
+**Qualify object ids with the room generation.** A reaped and recreated room is a new conversation.
+Its sequence continues above the old high-water mark so existing cursors do not starve, while the
+read view's `generation` increments to expose the replacement. Persist `{generation, seq}` as one
+checkpoint, compare the saved generation with every poll before delivery, and carry the generation
+in every id you mint. Do not silently resync on a mismatch: stop and let the operator decide whether
+and how to bridge the new conversation.
 
 Foreign identifiers rarely fit the service's name grammar. Fingerprint them the way `/patterns.md`
 fingerprints DIDs — the first 16 hex characters of SHA-256, sharded — and keep the reverse map in

--- a/src/interop.md
+++ b/src/interop.md
@@ -17,15 +17,43 @@ none of it is repeated here.
 Two loops against one room, and a durable cursor between them.
 
 ```python
-since = load_cursor(room)
+import json
+
+cursor = load_cursor(room)
+cold_start = cursor is None
+since = cursor or 0
 while True:
     view = get(f"{BASE}/r/{room}", params={"since": since, "wait": 10, "format": "json"}).json()
-    for m in view["messages"]:
+    messages = view["messages"]
+
+    # A normal read is the newest window, not the oldest records after `since`. If the
+    # bridge fell farther behind than that window, recover everything the ring still has.
+    if view["first_seq"] is not None and view["first_seq"] > since + 1:
+        exported = get(f"{BASE}/r/{room}/export")
+        if int(exported.headers["X-Room-Generation"]) != view["generation"]:
+            continue  # the room changed between the poll and snapshot; read it again
+        retained = [json.loads(line) for line in exported.text.splitlines()]
+        messages = [m for m in retained if m["seq"] > since]
+        if not cold_start and (not messages or messages[0]["seq"] != since + 1):
+            raise RuntimeError(f"retention gap after {room} seq {since}")
+
+    for m in messages:
         if m.get("from") != BRIDGE_DID:  # not our own write, coming back around
             deliver_to_far_side(m)
-    since = view["last_seq"]
+    since = messages[-1]["seq"] if messages else view["last_seq"]
     save_cursor(room, since)
+    cold_start = False
 ```
+
+Room reads deliberately return the newest `limit` records. A bridge that was paused can therefore
+receive a `first_seq` greater than its cursor plus one even while the skipped records remain in the
+larger retained ring. The slow path above downloads that ring through `/export`, filters forward
+from the durable cursor, and checks both continuity and room generation before delivering anything.
+On a cold start there is no prior observation to continue from, so begin at the first retained
+record. After a cursor has been saved, if the export also starts beyond that cursor, those records
+have genuinely left the ring: stop and surface the gap rather than advancing the cursor and
+presenting an incomplete mirror as complete. The export costs one ordinary read and is needed only
+after a detected gap.
 
 Inbound is the mirror: a foreign event becomes one signed write. Three things make the difference
 between a bridge that works and one that looks like it does.

--- a/src/interop.md
+++ b/src/interop.md
@@ -54,14 +54,20 @@ while True:
 
 Room reads deliberately return the newest `limit` records. A bridge that was paused can therefore
 receive a `first_seq` greater than its cursor plus one even while the skipped records remain in the
-larger retained ring. The slow path above downloads that ring through `/export`, filters forward
-from the durable checkpoint, and checks both continuity and room generation before delivering
-anything. On a cold start there is no prior observation to continue from, so adopt the observed
-generation and begin at the first retained record. After a checkpoint has been saved, a generation
-change means the room was deleted and recreated: stop before delivering from the new conversation.
-If the export starts beyond a saved sequence, those records have genuinely left the ring: stop and
-surface the gap rather than advancing the checkpoint and presenting an incomplete mirror as
-complete. The export costs one ordinary read and is needed only after a detected sequence gap.
+larger retained ring. `first_seq` describes only the first message in this bounded response. It is
+not the room's retained floor, and the read response does not publish that floor. The slow path
+above downloads the retained snapshot through `/export`, filters forward from the durable
+checkpoint, and checks both continuity and room generation before delivering anything.
+
+On a cold start there is no prior observation to continue from, so adopt the observed generation
+and begin at the first record in the exported snapshot. After a checkpoint has been saved, a
+generation change means the room was deleted and recreated: stop before delivering from the new
+conversation. If the export starts beyond a saved sequence, those records have genuinely left the
+ring: stop and surface the gap rather than advancing the checkpoint and presenting an incomplete
+mirror as complete. Until the service exposes a distinct retained-floor contract, `/export` plus
+the continuity check is the bridge's only authoritative way to distinguish a recoverable response
+window cut from irreversible retention loss. The export costs one ordinary read and is needed only
+after a detected sequence gap.
 
 Inbound is the mirror: a foreign event becomes one signed write. Three things make the difference
 between a bridge that works and one that looks like it does.

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -453,6 +453,23 @@ def test_interop_is_served_unlimited_and_claims_nothing_for_this_origin(client, 
     assert "x-robots-tag" not in page.headers  # documentation, indexable like the rest
 
 
+def test_the_reference_bridge_recovers_a_retained_cursor_gap_before_advancing(client):
+    """The loop in /interop.md used to advance directly to a tail window's last_seq.
+
+    Falling more than `limit` behind then skipped records silently even while /export
+    could still recover them. Pin the three parts that make the reference loop honest:
+    detect the cut, use the retained snapshot, and refuse an irrecoverable gap.
+    """
+    bridge = client.get("/interop.md").text.split("## ActivityPub", 1)[0]
+    assert "cold_start = cursor is None" in bridge
+    assert 'view["first_seq"] > since + 1' in bridge
+    assert 'get(f"{BASE}/r/{room}/export")' in bridge
+    assert 'exported.headers["X-Room-Generation"]' in bridge
+    assert 'not cold_start and (not messages or messages[0]["seq"] != since + 1)' in bridge
+    assert "raise RuntimeError" in bridge
+    assert "cold_start = False" in bridge
+
+
 def test_the_e2e_pattern_round_trips_within_the_caps(client, tmp_path):
     """Executable version of /patterns.md pattern 4. The server never does crypto here —
     the test proves the documented choreography fits the real lanes and caps: DID notes

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -476,6 +476,21 @@ def test_the_reference_bridge_recovers_a_retained_cursor_gap_before_advancing(cl
     assert "continues above the old high-water mark" in bridge
 
 
+def test_the_reference_bridge_does_not_mistake_a_response_window_for_the_retained_floor(client):
+    """The API's first_seq is a response boundary, not retained-ring metadata.
+
+    Until a distinct retained-floor contract exists, the guide must require an export and
+    continuity check rather than claiming a bounded read can prove how much history remains.
+    """
+    bridge = client.get("/interop.md").text.split("## ActivityPub", 1)[0]
+    prose = " ".join(bridge.split())
+    assert "`first_seq` describes only the first message in this bounded response" in prose
+    assert "It is not the room's retained floor" in prose
+    assert "does not publish that floor" in prose
+    assert "Until the service exposes a distinct retained-floor contract" in prose
+    assert "`/export` plus the continuity check" in prose
+
+
 def test_the_reference_bridge_stops_before_crossing_a_room_generation(client):
     """Execute the published loop against the reviewer's recreated-room example.
 

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -461,13 +461,57 @@ def test_the_reference_bridge_recovers_a_retained_cursor_gap_before_advancing(cl
     detect the cut, use the retained snapshot, and refuse an irrecoverable gap.
     """
     bridge = client.get("/interop.md").text.split("## ActivityPub", 1)[0]
-    assert "cold_start = cursor is None" in bridge
+    assert 'generation = None if cold_start else checkpoint["generation"]' in bridge
+    assert 'checkpoint["last_delivered_seq"]' in bridge
+    assert 'view["generation"] != generation' in bridge
+    assert "was recreated" in bridge
     assert 'view["first_seq"] > since + 1' in bridge
     assert 'get(f"{BASE}/r/{room}/export")' in bridge
     assert 'exported.headers["X-Room-Generation"]' in bridge
     assert 'not cold_start and (not messages or messages[0]["seq"] != since + 1)' in bridge
     assert "raise RuntimeError" in bridge
-    assert "cold_start = False" in bridge
+    assert (
+        'save_checkpoint(room, {"generation": generation, "last_delivered_seq": since})' in bridge
+    )
+    assert "continues above the old high-water mark" in bridge
+
+
+def test_the_reference_bridge_stops_before_crossing_a_room_generation(client):
+    """Execute the published loop against the reviewer's recreated-room example.
+
+    Sequence 4 looks continuous after saved sequence 3, but generation 2 is a different
+    conversation from saved generation 1. The loop must stop before delivery or checkpoint.
+    """
+    bridge = client.get("/interop.md").text
+    script = bridge.split("```python", 1)[1].split("```", 1)[0]
+    delivered = []
+    saved = []
+    checkpoint = {"generation": 1, "last_delivered_seq": 3}
+    view = {
+        "generation": 2,
+        "first_seq": 4,
+        "last_seq": 4,
+        "messages": [{"seq": 4, "from": "did:key:new", "text": "new conversation"}],
+    }
+
+    class Response:
+        def json(self):
+            return view
+
+    namespace = {
+        "BASE": "https://example.invalid",
+        "BRIDGE_DID": "did:key:bridge",
+        "deliver_to_far_side": delivered.append,
+        "get": lambda *_args, **_kwargs: Response(),
+        "load_checkpoint": lambda _room: checkpoint,
+        "room": "recreated",
+        "save_checkpoint": lambda *args: saved.append(args),
+    }
+
+    with pytest.raises(RuntimeError, match="room recreated was recreated: generation 1 -> 2"):
+        exec(script, namespace)
+    assert delivered == []
+    assert saved == []
 
 
 def test_the_e2e_pattern_round_trips_within_the_caps(client, tmp_path):


### PR DESCRIPTION
## What changes for callers

The reference bridge now persists the room generation together with the last delivered sequence.

Before delivering anything, it checks that the current room generation still matches its durable checkpoint. If the room was deleted and recreated, the bridge stops with an explicit error instead of combining two separate conversations whose sequence numbers happen to look continuous.

The loop also detects when an ordinary room read starts after its durable sequence. It recovers retained records from the room export before delivery or checkpoint advancement. If the requested sequence has already left the retained ring, it raises an explicit retention-gap error instead of presenting an incomplete mirror as complete.

## Why

Room reads return the newest `limit` records, so a delayed bridge can skip records that remain recoverable from the larger retained ring. Separately, v0.11 preserves the sequence high-water mark when a room is recreated, so sequence continuity alone cannot prove conversation continuity.

The generation and sequence therefore form one durable checkpoint. `/r/{room}/export` supplies the narrow recovery path for retained sequence gaps, while the read view's `generation` prevents delivery across a room-replacement boundary.

Fixes #481.

## Verification

- 497 tests passed
- 97.25% total coverage
- executable recreated-room regression test passed
- Ruff check passed
- Ruff format check passed
- ty check passed
- size gate passed
- `git diff --check` passed

## Compatibility and abuse surface

This changes documentation and its regression tests only. It adds no endpoint, server-side persistent state, authority, or write lane. The export is fetched only after a sequence gap is detected.
