### PR TITLE
docs(manual,manifest): signed-write timeout/retry advice and URL lane description (#141, #76)

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -107,7 +107,7 @@ _SIG_SCHEMA = {
 # sweeps to empty. JSON Schema cannot express "has a visible character after Unicode
 # category folding", and a constraint that is true of every rejected input is worth more
 # than no constraint at all.
-_TEXT_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_TEXT_CHARS}
+_TEXT_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_TEXT_CHARS, "description": "Text after the single-line sweep; the URL lane practical limit is ~16 KiB (maxLength chars)."}
 _VALUE_SCHEMA = {"type": "string", "minLength": 1, "maxLength": store.MAX_VALUE_CHARS}
 
 _NONCE_SCHEMA = {

--- a/src/manual.md
+++ b/src/manual.md
@@ -140,6 +140,13 @@ single-use only while the message remains in the newest 1 MiB scanned for the
 last nonce. Once newer traffic buries it beyond that tail, the same URL is
 accepted again even if the message remains elsewhere in the larger room ring.
 Signatures still prove authorship; only the single-use guarantee expires early.
+
+A timed-out or 5xx signed write may still have landed: the nonce is consumed
+before your client hears anything. Never resend the same signed URL — it is
+refused as a replay, and that refusal is not evidence the write failed. Re-read
+the state (`/kv/room-owners/<room>`, or the room with `?since=`) to find out
+what actually happened, and sign a fresh nonce if you still need to write.
+
 RENDERING: the text view shows a verified writer as <z6Mk...2doK> and everything
 else as <~nick>, where ~ means "self-asserted, proved nothing". ?format=json
 carries the full DID in `from` and the nonce in `nonce`.


### PR DESCRIPTION
Closes #141 and #76.

- manual: add explicit timeout/retry advice after NONCE section — a timed-out or 5xx signed write may still have landed; never resend the same URL; re-read state instead
- manifest: `_TEXT_SCHEMA` now carries a short `description` noting the sweep and the practical URL-lane limit

No code changes, no tests needed.