### PR TITLE
fix(didkey): preserve leading zero bytes in base58btc decode (#155)

### DIFF
--- a/src/didkey.py
+++ b/src/didkey.py
@@ -77,7 +77,10 @@ def _b58decode(raw: str) -> bytes:
         if digit is None:
             raise DidError(f"bad did:key: {ch!r} is not base58btc")
         n = n * 58 + digit
-    return n.to_bytes((n.bit_length() + 7) // 8, "big") if n else b""
+    out = n.to_bytes((n.bit_length() + 7) // 8, "big") if n else b""
+    # base58btc leading '1' chars are leading zero bytes — drop them and prepend
+    leading_ones = len(raw) - len(raw.lstrip("1"))
+    return b"\x00" * leading_ones + out
 
 
 def public_key(did: str) -> bytes:

--- a/tests/unit/test_didkey.py
+++ b/tests/unit/test_didkey.py
@@ -7,6 +7,18 @@ from _client import _keypair, _multibase
 client = _client.client  # the shared TestClient fixture
 
 
+def test_base58_preserves_leading_zeros():
+    """A '111' prefix encodes three leading zero bytes; the old drop-zeros decode
+    silently stripped them, so a key that started with zero bytes decoded to the
+    wrong 32 bytes and failed verification against the real public key.
+    """
+    import didkey
+
+    raw = "111"  # three base58 zero digits = three leading zero bytes
+    decoded = didkey._b58decode(raw)
+    assert decoded == b"\x00\x00\x00"
+
+
 def test_a_did_key_has_exactly_one_spelling(client):
     """Ownership compares DID *strings*: `_note_write_gate` asks `signer != current`, and
     `_allowed_keys` matches by string. So a key with more than one accepted spelling is a


### PR DESCRIPTION
Fixes #155.

- `src/didkey.py:_b58decode` now preserves leading base58 zero digits as leading `\x00` bytes, per base58btc
- `tests/unit/test_didkey.py`: regression test for leading-zero round-trip
- no route/schema/behavior change outside malformed-DID handling