### PR TITLE
docs(app,store): mention the bounded tail in nonce-rejection messages (#349)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1448,7 +1448,7 @@ def _burn_nonce(room: str, nonce: str) -> Response | None:
     current = store.note_get(config.ROOT, store.NONCE_NS, room)
     if current is not None and not (current.isdigit() and int(nonce) > int(current)):
         return text(
-            f"403 nonce {nonce} was already used for /r/{room} (last {current}). A signed "
+            f"403 nonce {nonce} was already used for /r/{room} (highest {current} in the recent tail). A signed "
             "ownership URL is single-use — count up and sign again.",
             403,
         )

--- a/src/store.py
+++ b/src/store.py
@@ -1821,8 +1821,8 @@ def _write_record(
             previous = _last_nonce(root, room, did)
             if previous is not None and nonce <= previous:
                 raise StoreError(
-                    f"nonce {nonce} is not greater than {previous}, the last one this key "
-                    f"used in /r/{room} — a signed URL is single-use, so count up"
+                    f"nonce {nonce} is not greater than {previous}, the highest nonce in the recent "
+                    f"tail for this key in /r/{room} — a signed URL is single-use, so count up"
                 )
         rec["seq"] = last_seq(root, room) + 1
         line = orjson.dumps(rec) + b"\n"

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -1020,6 +1020,16 @@ def test_ephemeral_mailbox_keeps_authentication_while_expiring_messages(client, 
     assert view["messages"][0]["from"] == did
 
 
+def test_nonce_rejection_mentions_recent_tail(client):
+    did, sign = _keypair()
+    # First signed message burns nonce 1 in the room.
+    assert _say_signed(client, "d-tailwarn", did, sign, "hello", nonce=1).status_code == 200
+    # Replay the same signed URL — nonce 1 is now reused.
+    r = client.get(f"/r/d-tailwarn/say-signed/{did}/{sign('d-tailwarn|1|hello')}/1/hello")
+    assert r.status_code == 400
+    assert "recent tail" in r.text
+
+
 def test_two_signed_writers_cannot_both_spend_one_nonce(client, tmp_path, monkeypatch):
     """The counter is read before it is claimed, so two writers racing one room both pass
     the "greater than the last one" check against the same stale value. Only the


### PR DESCRIPTION
Fixes #349.

- `src/store.py`: nonce-rejection string now says "highest nonce in the recent tail for this key in /r/<room>" instead of "last one this key used in /r/<room>"
- `src/app.py`: ownership nonce-rejection uses the same wording
- `tests/http/test_rooms.py`: regression test asserts "recent tail" appears in the 400/403 rejection text

No behavior change, only wording. Tests pass: 135/135.