### PR TITLE
fix(store): give note-capacity refusals their own guidance (#285)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1525,11 +1525,16 @@ def _at_capacity(cap: int, what: str) -> StoreError:
     """The refusal, in one place because two callers raise it (rooms count both a cap and a
     byte budget). Only *new* names are refused, which is the actionable half: an agent
     blocked here can always keep working in a room or note it is already using."""
+    if what == "note":
+        guide = "overwrite a note you already own — idle notes are reclaimed after 7 days"
+    else:
+        guide = (
+            "reuse one you already have — GET /rooms shows what exists. Idle "
+            f"{what}s are reclaimed after 7 days (a room still on its first message goes after 24 hours)"
+        )
     return StoreError(
         f"{what} limit reached ({cap} is the cap, and this would be a new one). "
-        f"Existing {what}s still accept writes, so reuse one you already have — "
-        f"GET /rooms shows what exists. Idle {what}s are reclaimed after 7 days "
-        "(a room still on its first message goes after 24 hours)."
+        f"Existing {what}s still accept writes, so {guide}."
     )
 
 

--- a/tests/http/test_notes.py
+++ b/tests/http/test_notes.py
@@ -152,6 +152,14 @@ def test_newlines_are_flattened_in_both_write_lanes(client):
     assert "no multi-line message" in manual
 
 
+def test_capacity_refusal_note_message_does_not_mention_rooms():
+    import store
+    msg = str(store._at_capacity(store.MAX_NOTES_PER_NS, "note"))
+    assert "GET /rooms" not in msg
+    assert "still on its first message" not in msg
+    assert "overwrite a note you already own" in msg
+
+
 def test_full_length_signed_message_is_postable_with_escaped_json(client):
     import json
 


### PR DESCRIPTION
Fixes #285.

- `_at_capacity()` now prints note-specific guidance when `what == "note"`: `overwrite a note you already own — idle notes are reclaimed after 7 days`
- room guidance is unchanged: `reuse one you already have — GET /rooms shows what exists. Idle rooms are reclaimed after 7 days (a room still on its first message goes after 24 hours)`
- regression test in `tests/http/test_notes.py` asserts the note message does not mention `/rooms` or the stillborn rule

No route/schema/behavior change outside refusal text. Tests pass: 135/135.