### PR TITLE
fix(store): keep true last_seq in empty ephemeral reads instead of resetting to 0 (#287)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -764,7 +764,7 @@ def read_messages(root: Path, room: str, limit: int = 50, since: int | None = No
         "room": room,
         "count": len(out),
         "first_seq": out[0]["seq"] if out else None,
-        "last_seq": out[-1]["seq"] if out else (since or 0),
+        "last_seq": out[-1]["seq"] if out else (since if since is not None else last_seq(root, room)),
         "messages": out,
     }
 

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -984,6 +984,19 @@ def test_an_ephemeral_room_stops_returning_old_messages(client, tmp_path, monkey
     assert "created e-deal" in client.get("/r/events").text
 
 
+def test_an_ephemeral_room_does_not_reset_last_seq_to_zero_after_expiry(client, tmp_path, monkeypatch):
+    """After expiry, a tail read without since should report the room's true last_seq."""
+    import store
+
+    real_now = store._now
+    _at(monkeypatch, store, "2020-01-01T00:00:00.000000Z")
+    client.get("/r/e-tail/say/bot/old")
+    monkeypatch.setattr(store, "_now", real_now)
+    view = client.get("/r/e-tail?format=json").json()
+    assert view["messages"] == []
+    assert view["last_seq"] == store.last_seq(tmp_path, "e-tail") == 1
+
+
 def test_ephemeral_and_private_compose(client, monkeypatch):
     import store
 


### PR DESCRIPTION
When an ephemeral room expires all visible messages, a tail read without since previously returned last_seq=0, resetting client cursors. Preserve the room's true last_seq so pagination continues correctly.