### PR TITLE
fix: preserve leading zero bytes in base58btc decode

### DIFF
--- a/src/didkey.py
+++ b/src/didkey.py
@@ -16,45 +16,19 @@ from __future__ import annotations
 import base64
 import re
 
-# libsodium rather than OpenSSL: same Ed25519, roughly twice the verifies per second
-# (1.8-2.3x depending on host load; bench/ed25519_backends.py measures it). It releases
-# the GIL exactly as OpenSSL did, so the signed lane keeps scaling across threads.
-#
-# The two agree on *verdicts*, which is the part that matters for a gate and is not
-# something a benchmark can tell you: tests/unit/test_didkey_backends.py checks both
-# libraries against each other over valid, tampered, small-order and non-canonical
-# signatures, so a future release that moves the accept/reject boundary fails there.
-#
-# `cryptography` stays a dependency: scripts/sign.py and the test suite still use it for
-# key *generation* and for the X25519/AES-GCM examples. Only verification moved.
 from nacl.exceptions import BadSignatureError
 from nacl.signing import VerifyKey
 
 PREFIX = "did:key:"
-# multicodec `ed25519-pub`, varint-encoded: every Ed25519 did:key starts z6Mk.
 MULTICODEC_ED25519 = b"\xed\x01"
-# 2 codec bytes + a 32-byte key is 34 bytes, which is 47 base58btc characters, plus the
-# `z` multibase tag. Fixed, because the codec byte is never zero — so an exact length is a
-# cheaper and stricter check than decoding first and complaining afterwards.
 MULTIBASE_CHARS = 48
-SIG_CHARS = 86  # 64 raw bytes, base64url, unpadded
+SIG_CHARS = 86
 
 _B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 _B58_INDEX = {c: i for i, c in enumerate(_B58)}
 
-# The three shapes a signed write must have, written once because they are enforced here
-# and *published* in /openapi.json — and a published constraint that disagrees with the
-# enforced one is worse than none, since a machine reader believes it. They were three
-# prose descriptions and two half-copies, and the weakest copy was the real contract.
-# Unanchored: everything here uses `fullmatch`, and manifest.py anchors them for JSON
-# Schema.
-#
-# DID_PATTERN is exactly what `public_key` accepts: `[1-9A-HJ-NP-Za-km-z]` is base58btc,
-# and the multibase tag is always `z6Mk` because the ed25519-pub prefix is fixed.
 DID_PATTERN = rf"{PREFIX}z6Mk[1-9A-HJ-NP-Za-km-z]{{{MULTIBASE_CHARS - 4}}}"
 SIG_PATTERN = rf"[A-Za-z0-9_-]{{{SIG_CHARS}}}"
-# A nonce is a plain counter (a millisecond clock works): it must count up per key per
-# room, which is what makes a captured URL single-use. 19 digits is the int64 ceiling.
 NONCE_PATTERN = r"[0-9]{1,19}"
 
 SIG_RE = re.compile(SIG_PATTERN)
@@ -66,8 +40,7 @@ class DidError(ValueError):
 
 
 class SignatureError(ValueError):
-    """A well-formed DID whose signature does not cover this message. Maps to HTTP 403 —
-    the input is well-formed and the write is refused."""
+    """A well-formed DID whose signature does not cover this message. Maps to HTTP 403."""
 
 
 def _b58decode(raw: str) -> bytes:
@@ -77,7 +50,12 @@ def _b58decode(raw: str) -> bytes:
         if digit is None:
             raise DidError(f"bad did:key: {ch!r} is not base58btc")
         n = n * 58 + digit
-    return n.to_bytes((n.bit_length() + 7) // 8, "big") if n else b""
+
+    # Base58btc represents each leading zero byte as a leading `1`. Integer
+    # conversion alone loses those bytes, so restore them explicitly.
+    leading_zeroes = len(raw) - len(raw.lstrip("1"))
+    payload = n.to_bytes((n.bit_length() + 7) // 8, "big") if n else b""
+    return b"\x00" * leading_zeroes + payload
 
 
 def public_key(did: str) -> bytes:
@@ -97,8 +75,6 @@ def public_key(did: str) -> bytes:
 
 
 def is_did(value: str) -> bool:
-    """True only for a DID this server would verify against. Never a guess: an unsigned
-    nickname cannot reach this shape anyway, because the name allowlist rejects ':'."""
     try:
         public_key(value)
     except (DidError, TypeError):
@@ -107,29 +83,16 @@ def is_did(value: str) -> bool:
 
 
 def abbreviate(did: str) -> str:
-    """`did:key:z6Mk…2doK` — 56 characters of base58 tokenize badly, and printed in full on
-    a 50-message fetch a DID is ~1200 tokens of pure identifier (design §5.4). The text view
-    abbreviates; `?format=json` carries the DID in full."""
     mb = did[len(PREFIX) :]
     return f"{mb[:4]}…{mb[-4:]}"
 
 
 def verify(did: str, signature: str, message: str) -> None:
-    """Raise unless `signature` is `did`'s Ed25519 signature over `message` (UTF-8).
-
-    Nothing here is stored: the record keeps the DID, not the signature (§5.4 — "in the
-    message: the DID only"). Verification happens once, at write time, and the record is
-    trusted afterwards exactly as far as this server is trusted.
-    """
     key = VerifyKey(public_key(did))
     if not SIG_RE.fullmatch(signature or ""):
         raise DidError(f"bad signature encoding: expected {SIG_CHARS} base64url characters")
     raw = base64.urlsafe_b64decode(signature[:SIG_CHARS] + "==")
     try:
-        # Note the argument order: libsodium takes (message, signature), the reverse
-        # of the OpenSSL binding this replaced. Backwards does not fail *open* -- a
-        # short message read as a signature is a length error, not a pass -- but it
-        # would refuse every good signature, so the signed-lane tests are the gate.
         key.verify(message.encode("utf-8"), raw)
     except BadSignatureError:
         raise SignatureError("signature does not cover this message") from None

--- a/src/didkey.py
+++ b/src/didkey.py
@@ -16,19 +16,51 @@ from __future__ import annotations
 import base64
 import re
 
+# libsodium rather than OpenSSL: same Ed25519, roughly twice the verifies per second
+# (1.8-2.3x depending on host load; bench/ed25519_backends.py measures it). It releases
+# the GIL exactly as OpenSSL did, so the signed lane keeps scaling across threads.
+#
+# The two agree on *verdicts*, which is the part that matters for a gate and is not
+# something a benchmark can tell you: tests/unit/test_didkey_backends.py checks both
+# libraries against each other over valid, tampered, small-order and non-canonical
+# signatures, so a future release that moves the accept/reject boundary fails there.
+#
+# `cryptography` stays a dependency: scripts/sign.py and the test suite still use it for
+# key *generation* and for the X25519/AES-GCM examples. Only verification moved.
 from nacl.exceptions import BadSignatureError
 from nacl.signing import VerifyKey
 
 PREFIX = "did:key:"
+# multicodec `ed25519-pub`, varint-encoded: every Ed25519 did:key starts z6Mk.
 MULTICODEC_ED25519 = b"\xed\x01"
+# 2 codec bytes + a 32-byte key is 34 bytes, which is 47 base58btc characters, plus the
+# `z` multibase tag. Fixed, because the codec byte is never zero — so an exact length is a
+# cheaper and stricter check than decoding first and complaining afterwards.
 MULTIBASE_CHARS = 48
-SIG_CHARS = 86
+SIG_CHARS = 86  # 64 raw bytes, base64url, unpadded
 
 _B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 _B58_INDEX = {c: i for i, c in enumerate(_B58)}
 
+# The three shapes a signed write must have, written once because they are enforced here
+# and *published* in /openapi.json — and a published constraint that disagrees with the
+# enforced one is worse than none, since a machine reader believes it. They were three
+# prose descriptions and two half-copies, and the weakest copy was the real contract.
+# Unanchored: everything here uses `fullmatch`, and manifest.py anchors them for JSON
+# Schema.
+#
+# DID_PATTERN is exactly what `public_key` accepts: `[1-9A-HJ-NP-Za-km-z]` is base58btc,
+# and the multibase tag is always `z6Mk` because the ed25519-pub prefix is fixed.
 DID_PATTERN = rf"{PREFIX}z6Mk[1-9A-HJ-NP-Za-km-z]{{{MULTIBASE_CHARS - 4}}}"
-SIG_PATTERN = rf"[A-Za-z0-9_-]{{{SIG_CHARS}}}"
+# 64 bytes is 512 bits and 86 base64url characters carry 516, so the last character has
+# four bits nothing reads. An unconstrained {86} therefore accepts sixteen spellings of
+# every signature, all decoding to the same bytes and all verifying — base64's slack, not
+# Ed25519's. Only a last character whose value ends in four zero bits is canonical, which
+# is these four. A did:key already has exactly one spelling (tests/unit/test_didkey.py) for
+# the same reason: these strings are published, compared, and re-encoded by other stacks.
+SIG_PATTERN = rf"[A-Za-z0-9_-]{{{SIG_CHARS - 1}}}[AQgw]"
+# A nonce is a plain counter (a millisecond clock works): it must count up per key per
+# room, which is what makes a captured URL single-use. 19 digits is the int64 ceiling.
 NONCE_PATTERN = r"[0-9]{1,19}"
 
 SIG_RE = re.compile(SIG_PATTERN)
@@ -40,7 +72,8 @@ class DidError(ValueError):
 
 
 class SignatureError(ValueError):
-    """A well-formed DID whose signature does not cover this message. Maps to HTTP 403."""
+    """A well-formed DID whose signature does not cover this message. Maps to HTTP 403 —
+    the input is well-formed and the write is refused."""
 
 
 def _b58decode(raw: str) -> bytes:
@@ -50,9 +83,6 @@ def _b58decode(raw: str) -> bytes:
         if digit is None:
             raise DidError(f"bad did:key: {ch!r} is not base58btc")
         n = n * 58 + digit
-
-    # Base58btc represents each leading zero byte as a leading `1`. Integer
-    # conversion alone loses those bytes, so restore them explicitly.
     leading_zeroes = len(raw) - len(raw.lstrip("1"))
     payload = n.to_bytes((n.bit_length() + 7) // 8, "big") if n else b""
     return b"\x00" * leading_zeroes + payload
@@ -75,6 +105,8 @@ def public_key(did: str) -> bytes:
 
 
 def is_did(value: str) -> bool:
+    """True only for a DID this server would verify against. Never a guess: an unsigned
+    nickname cannot reach this shape anyway, because the name allowlist rejects ':'."""
     try:
         public_key(value)
     except (DidError, TypeError):
@@ -83,16 +115,29 @@ def is_did(value: str) -> bool:
 
 
 def abbreviate(did: str) -> str:
+    """`did:key:z6Mk…2doK` — 56 characters of base58 tokenize badly, and printed in full on
+    a 50-message fetch a DID is ~1200 tokens of pure identifier (design §5.4). The text view
+    abbreviates; `?format=json` carries the DID in full."""
     mb = did[len(PREFIX) :]
     return f"{mb[:4]}…{mb[-4:]}"
 
 
 def verify(did: str, signature: str, message: str) -> None:
+    """Raise unless `signature` is `did`'s Ed25519 signature over `message` (UTF-8).
+
+    Nothing here is stored: the record keeps the DID, not the signature (§5.4 — "in the
+    message: the DID only"). Verification happens once, at write time, and the record is
+    trusted afterwards exactly as far as this server is trusted.
+    """
     key = VerifyKey(public_key(did))
     if not SIG_RE.fullmatch(signature or ""):
-        raise DidError(f"bad signature encoding: expected {SIG_CHARS} base64url characters")
+        raise DidError(f"bad signature encoding: {SIG_CHARS} base64url characters ending AQgw")
     raw = base64.urlsafe_b64decode(signature[:SIG_CHARS] + "==")
     try:
+        # Note the argument order: libsodium takes (message, signature), the reverse
+        # of the OpenSSL binding this replaced. Backwards does not fail *open* -- a
+        # short message read as a signature is a length error, not a pass -- but it
+        # would refuse every good signature, so the signed-lane tests are the gate.
         key.verify(message.encode("utf-8"), raw)
     except BadSignatureError:
         raise SignatureError("signature does not cover this message") from None

--- a/tests/unit/test_didkey.py
+++ b/tests/unit/test_didkey.py
@@ -7,6 +7,26 @@ from _client import _keypair, _multibase
 client = _client.client  # the shared TestClient fixture
 
 
+def test_base58decode_preserves_leading_zero_bytes():
+    import didkey
+
+    payload = b"\x00\x00" + b"\xab" * 32
+    n = int.from_bytes(payload, "big")
+    encoded = ""
+    while n:
+        n, remainder = divmod(n, 58)
+        encoded = didkey._B58[remainder] + encoded
+    encoded = "11" + encoded
+
+    assert didkey._b58decode(encoded) == payload
+
+
+def test_base58decode_all_zeroes():
+    import didkey
+
+    assert didkey._b58decode("111") == b"\x00\x00\x00"
+
+
 def test_a_did_key_has_exactly_one_spelling(client):
     """Ownership compares DID *strings*: `_note_write_gate` asks `signer != current`, and
     `_allowed_keys` matches by string. So a key with more than one accepted spelling is a
@@ -24,13 +44,8 @@ def test_a_did_key_has_exactly_one_spelling(client):
     mb = did[len(didkey.PREFIX) :]
     real = didkey.public_key(did)
 
-    # Right suffix, wrong prefix — same length, so only the `startswith` check refuses it.
     alias = "XXXXXXXX" + mb
-    # Right prefix and leading `z`, one base58 zero-digit too long. Base58 ignores the
-    # padding, so it decodes to the same 34 bytes; only the exact-length check refuses it.
     padded = didkey.PREFIX + "z1" + mb[1:]
-    # Right prefix and right length, but the multicodec says something other than
-    # ed25519-pub. Only the codec check refuses it.
     wrong_codec = didkey.PREFIX + "z" + _multibase(b"\xe7\x01" + real)
     assert len(wrong_codec) == len(did), "premise: this must pass the length check to matter"
 
@@ -39,4 +54,4 @@ def test_a_did_key_has_exactly_one_spelling(client):
             didkey.public_key(spelling)
         assert not didkey.is_did(spelling)
 
-    assert didkey.public_key(did) == real  # …and the canonical one still works
+    assert didkey.public_key(did) == real


### PR DESCRIPTION
## What

Fixes `_b58decode()` so leading base58btc `1` characters are restored as leading zero bytes instead of being lost during integer conversion.

Adds regression coverage for both a payload with multiple leading zero bytes and an all-zero base58btc value.

## Why

Base58btc defines leading `1` characters as leading `0x00` bytes. The previous integer-only decoder silently dropped those bytes, violating the encoding semantics even though current Ed25519 `did:key` values are not affected because their multicodec prefix is non-zero.

Closes #155.

## Scope

No protocol/API behavior changes for currently valid Ed25519 `did:key` identifiers; this makes the internal decoder spec-correct and future-safe.