### PR TITLE
docs(manifest): align /rooms limit+format schema with runtime behavior (#372)

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -434,7 +434,11 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         {
                             "in": "query",
                             "name": "format",
-                            "schema": {"type": "string", "enum": ["json"]},
+                            "schema": {
+                                "type": "string",
+                                "enum": ["json"],
+                                "description": "json returns structured data; anything else renders text.",
+                            },
                         },
                         {
                             "in": "query",
@@ -627,12 +631,21 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         {
                             "in": "query",
                             "name": "limit",
-                            "schema": {"type": "integer", "minimum": 1, "default": 50},
+                            "schema": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "default": 50,
+                                "description": "Page size; values below 1 fall back to the default.",
+                            },
                         },
                         {
                             "in": "query",
                             "name": "format",
-                            "schema": {"type": "string", "enum": ["json"]},
+                            "schema": {
+                                "type": "string",
+                                "enum": ["json"],
+                                "description": "json returns structured data; anything else renders text.",
+                            },
                         },
                     ],
                     "responses": {


### PR DESCRIPTION
Fixes #372

Document the runtime behavior for /rooms query parameters: limit falls back to 50 below 1, and format renders text for anything except json. This matches the actual handler behavior instead of publishing a stricter schema that silently diverges.

## What

The /rooms manifest now accurately describes the fallback for limit < 1 and the accepted format values.

## Why

Issue #372. The schema published stricter rules than the runtime actually enforces.

## Checks

- [ ] `uv run coverage run -m pytest tests -q && uv run coverage report`
- [ ] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [ ] Docs that would now be wrong are updated: src/patterns.md
- [ ] New surface on a world-writable service: nothing new