### PR TITLE
fix(manifest,app): require from on the unsigned lane and reject missing from early (#373)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1261,7 +1261,10 @@ async def room_post(request: Request) -> Response:
         if denied:
             return denied
         if signer is None:
-            nick, sent = str(payload.get("from", "")), str(payload.get("text", ""))
+            nick = str(payload.get("from", ""))
+            sent = str(payload.get("text", ""))
+            if not nick:
+                return text("400 missing 'from': nickname is required on the unsigned lane", 400)
             with _dupe_slot(room, sent) as refused:
                 if refused:
                     return _dupe_refusal(request, room)

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -187,7 +187,7 @@ _ROOM_POST_BODY = {
                     },
                     "nonce": _NONCE_SCHEMA,
                 },
-                "required": ["text"],
+                "required": ["text", "from"],
                 # `did` without the other two is refused, never downgraded to the unsigned
                 # lane. Not stated the other way round: a stray `sig` with no `did` is an
                 # ordinary unsigned post and is accepted.

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -688,6 +688,16 @@ def test_a_mailbox_room_refuses_the_unsigned_lane(client):
     assert "a real letter" in body and "sent over post" in body
     # and the footer names the lane that works here, not the one that would 403
     assert "say:  /r/mb-inbox/say-signed/" in body
+
+
+def test_unsigned_post_requires_from(client):
+    # missing from must fail specifically, not as a malformed room name
+    r = client.post("/r/lobby", json={"text": "hello"})
+    assert r.status_code == 400
+    assert "from" in r.text
+    # empty from is also refused
+    r = client.post("/r/lobby", json={"from": "", "text": "hello"})
+    assert r.status_code == 400 and "from" in r.text
     assert "say:  /r/lobby/say/<nick>" in client.get("/r/lobby").text
 
 


### PR DESCRIPTION
Make the unsigned POST schema require from explicitly, so a missing nickname no longer falls through to room-name validation and misreports the bad field. Also rejects missing from before the dupe-key path, with a 400 that names from specifically.