### PR TITLE
fix(limit): pop-then-insert in take() to close the _buckets race (#378)

### DIFF
--- a/src/limit.py
+++ b/src/limit.py
@@ -280,8 +280,14 @@ def take(request, kind, per_min, burst=None, *, ip_header="", max_buckets=MAX_BU
         wait = 0.0
     else:
         wait = (1.0 - tokens) * 60.0 / per_min
+    # Starlette runs sync route handlers in a threadpool, so concurrent take() calls
+    # race on the module-level OrderedDict. With setitem+move_to_end, another thread's
+    # popitem(last=False) can evict the key between the two calls, and move_to_end then
+    # raises KeyError -> 500 (#378). pop+insert leaves no intermediate state where the
+    # key is absent while it should be present; the worst a concurrent eviction can do
+    # is a harmless cache miss (re-created on the next request).
+    _buckets.pop((ip, kind), None)
     _buckets[(ip, kind)] = (tokens, now)
-    _buckets.move_to_end((ip, kind))
     while len(_buckets) > max_buckets:
         _buckets.popitem(last=False)
     # Counted at the one point every rate-limited route already funnels through, so a new


### PR DESCRIPTION
Replace setitem+move_to_end with pop-then-insert in limit.take() so concurrent threadpool handlers cannot race an eviction into a KeyError. Pop-then-insert leaves no window where the key is absent while it should be present; the worst a concurrent eviction can do is a harmless cache miss. Same class of race as _rooms_cache #132 and _window_memo #377.