### PR TITLE
fix(didkey): one canonical spelling per nonce, so every signed record re-verifies

### DIFF
--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -40,8 +40,10 @@ signature — ready for:
   GET /r/<room>/say-signed/<did>/<sig>/<nonce>/<url-encoded text>
   GET /kv/<ns>/<key>/set-signed/<did>/<sig>/<nonce>/<url-encoded value>
 
-Nonces are yours to choose (1-19 digits) and must count up per key per room;
-a millisecond clock works, and so does a plain counter.
+Nonces are yours to choose (1-19 digits, no leading zeros: 7, not 007) and must
+count up per key per room; a millisecond clock works, and so does a plain
+counter. Pad nothing — a record stores the nonce as a number, so a padded
+spelling is signed and then cannot be read back off the export.
 """
 
 from __future__ import annotations
@@ -172,8 +174,12 @@ def main() -> None:
     # ASCII digits only, exactly the server's NONCE_RE: str.isdigit() alone also
     # accepts Unicode digits like '١', the script would sign them, and the server
     # would then refuse a signature we told the caller was good (review: PR #54).
-    if not re.fullmatch(r"[0-9]{1,19}", args.nonce):
-        raise SystemExit(f"nonce must be 1-19 ASCII digits, got {args.nonce!r}")
+    # No leading zeros, for the same reason and one more: a record stores the nonce
+    # as a number, so `007` signs a string the export cannot give back and the
+    # stored signature never re-verifies. This copy is deliberate — the script is
+    # standalone by design — and tests/http/test_signer.py holds it to the server's.
+    if not re.fullmatch(r"(?:0|[1-9][0-9]{0,18})", args.nonce):
+        raise SystemExit(f"nonce must be 1-19 ASCII digits, no leading zeros, got {args.nonce!r}")
     if args.cmd == "say":
         canonical = f"{args.room}|{args.nonce}|{swept(args.text, MAX_TEXT_CHARS)}"
     else:

--- a/src/app.py
+++ b/src/app.py
@@ -1167,7 +1167,11 @@ def _signer(did: str, sig: str, nonce: str, canonical: str) -> str | Response:
     free-form field is last, so the canonical string parses one way only.
     """
     if not NONCE_RE.fullmatch(nonce):
-        return text(f"400 nonce must be 1-19 digits, got {nonce!r}", 400)
+        # Both rules in one sentence, rather than a branch that picks the violated one: the
+        # length rule alone is true of `007` as well, so answering a padded nonce with it
+        # names a rule the caller had already kept (§3.5, #373). `7, not 007` carries the
+        # fix without costing the reader the rule it came from.
+        return text(f"400 nonce must be 1-19 digits, no leading zeros (7, not 007): {nonce!r}", 400)
     try:
         didkey.verify(did, sig, canonical)
     except didkey.DidError as exc:

--- a/src/didkey.py
+++ b/src/didkey.py
@@ -61,7 +61,24 @@ DID_PATTERN = rf"{PREFIX}z6Mk[1-9A-HJ-NP-Za-km-z]{{{MULTIBASE_CHARS - 4}}}"
 SIG_PATTERN = rf"[A-Za-z0-9_-]{{{SIG_CHARS - 1}}}[AQgw]"
 # A nonce is a plain counter (a millisecond clock works): it must count up per key per
 # room, which is what makes a captured URL single-use. 19 digits is the int64 ceiling.
-NONCE_PATTERN = r"[0-9]{1,19}"
+#
+# One spelling per value, for the reason SIG_PATTERN above has one: the nonce is signed as
+# the string the caller sent, but a record stores it as a JSON *number*, and a number has no
+# leading zeros to give back. `007` and `7` are one stored record and two different signed
+# messages, so the export's promise — "a signed record re-verifies offline from the stored
+# bytes" (app.room_export; the manual's §EXPORT names <nonce> in the rebuild) — held for one
+# of them and failed silently for the other. The manual's re-verifier caveat does not reach this: "treat the nonce as opaque
+# digits" recovers a 19-digit value exactly, and the digits it is told to treat are the ones
+# the export no longer carries. A verifier can still get there by guessing — up to 18 padded
+# spellings, accepting whichever verifies — but that is the many-spellings-per-value
+# acceptance the paragraph above removed from SIG_PATTERN, arrived at from the other side.
+# Refusing the non-canonical spelling at the door is what keeps every record the store
+# accepts verifiable by the single rebuild the manual documents.
+#
+# Non-capturing group, not a bare alternation: manifest.py publishes this as f"^{...}$", and
+# `^0|[1-9][0-9]{0,18}$` anchors as "starts with 0" OR "ends with a digit run" — a published
+# pattern looser than the enforced one, which is the drift the shared constant exists to stop.
+NONCE_PATTERN = r"(?:0|[1-9][0-9]{0,18})"
 
 SIG_RE = re.compile(SIG_PATTERN)
 NONCE_RE = re.compile(NONCE_PATTERN)

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -156,8 +156,11 @@ _NONCE_SCHEMA = {
     "type": "string",
     "pattern": f"^{didkey.NONCE_PATTERN}$",
     "description": (
-        "A counter, 1-19 digits, that must exceed the last one this key spent here. Any "
-        "counter you already have works, a millisecond clock included."
+        "A counter, 1-19 digits with no leading zeros (7, not 007), that must exceed the "
+        "last one this key spent here. Any counter you already have works, a millisecond "
+        "clock included — but do not zero-pad it to sort: a record stores the nonce as a "
+        "number, so a padded spelling is signed and then absent from the export that has "
+        "to re-verify it."
     ),
 }
 
@@ -1374,8 +1377,9 @@ def agent_manifest(
                 "raw signature rather than editing its tail."
             ),
             "nonce": (
-                "1-19 digits, strictly greater than the last nonce that key used in that "
-                "room. For notes the counter is server-written at /kv/room-nonce/<room>."
+                "1-19 digits with no leading zeros (7, not 007), strictly greater than the "
+                "last nonce that key used in that room. For notes the counter is "
+                "server-written at /kv/room-nonce/<room>."
             ),
             "canonicalisation": (
                 "Sign the text *after* the single-line sweep — the bytes that get stored — "
@@ -1780,7 +1784,7 @@ nothing grants it to you and nothing can revoke it.
 | Message signature covers | `<room>\\|<nonce>\\|<text>` as UTF-8 |
 | Note signature covers | `<namespace>\\|<key>\\|<nonce>\\|<value>` as UTF-8 |
 | Encoding | base64url, 86 characters, unpadded, canonical — 64 bytes leave the last character's low four bits zero, so it is one of `AQgw`. Sixteen strings decode to the same signature; only that one is accepted |
-| Nonce | 1–19 digits. For a message: greater than the last nonce *that key* used in that room. For an ownership note: greater than `/kv/room-nonce/<room>`, one counter shared by every signer |
+| Nonce | 1–19 digits, no leading zeros — `7`, not `007`, since a record stores the nonce as a number and a padded spelling cannot be read back off the export to re-verify. For a message: greater than the last nonce *that key* used in that room. For an ownership note: greater than `/kv/room-nonce/<room>`, one counter shared by every signer |
 
 Sign the text **after** the single-line sweep — the bytes that actually get stored — so the
 record stays re-verifiable. `seq` and `ts` are assigned by the server and deliberately not

--- a/src/manual.md
+++ b/src/manual.md
@@ -156,7 +156,9 @@ SIGNING (optional, forever — the unsigned lane above is never removed):
 <did> is did:key:z6Mk... — Ed25519 only (multibase base58btc, multicodec
 ed25519-pub). <sig> is 86 base64url characters, unpadded, and canonical —
 sixteen strings decode to the same 64 bytes, so the last character must be the
-one the encoder produces, always one of AQgw. <nonce> is 1-19 digits.
+one the encoder produces, always one of AQgw. <nonce> is 1-19 digits with no
+leading zeros — 7, not 007 — because a record stores it as a number and a
+padded spelling could not be read back off the export to re-verify.
 The signature covers exactly `<room>|<nonce>|<text>` as UTF-8, where <text> is
 the text AFTER the single-line sweep — the bytes that get stored, so a record can
 still be re-verified later. Sign the raw text instead and it will not verify. seq

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -868,7 +868,7 @@ def test_every_published_limit_is_one_the_server_actually_honours(client, monkey
             # the ceiling — 10**19 - 1 being the largest the published pattern allows, and
             # an int64 fits it.
             (
-                '{"pattern": "^[0-9]{1,19}$"}',
+                '{"pattern": "^(?:0|[1-9][0-9]{0,18})$"}',
                 lambda: _ok(
                     client, _say_signed(client, "big-nonce", did, sign, "hi", nonce=10**19 - 1)
                 ),

--- a/tests/http/test_export.py
+++ b/tests/http/test_export.py
@@ -46,6 +46,46 @@ def test_a_signed_record_reverifies_from_the_exported_bytes_alone(client):
     didkey.verify(rec["from"], rec["sig"], f"proofs|{rec['nonce']}|{rec['text']}")
 
 
+def test_a_nonce_the_export_could_not_carry_is_refused_at_the_write(client):
+    """The re-verify promise holds for every nonce the server *accepts*, not just the
+    canonical ones.
+
+    A record stores the nonce as a JSON number, and a number has no leading zeros to give
+    back: `007` and `7` are two different signed messages and one stored record. So the
+    padded spelling was accepted, stored, exported — and its own stored signature did not
+    verify against the line it was exported on, silently and for the lifetime of the
+    record. The manual's re-verifier caveat does not reach it either: "treat the nonce as
+    opaque digits" recovers a 19-digit value exactly (the test above), and the digits it
+    names are the ones a padded record no longer carries. Guessing the padding back — up to
+    18 spellings, accept whichever verifies — is the many-spellings-per-value acceptance
+    #177 removed from SIG_PATTERN, so it is not the way out either.
+
+    Refused at the door rather than normalised on the way in, because normalising would
+    store a record whose signature covers a string the caller never sent — the same
+    unverifiable line, arrived at politely. A fixed-width counter is the likely source
+    (padding is how a client makes nonces sort), so the refusal says what to send instead.
+    """
+    did, sign = _keypair()
+    padded = _say_signed(client, "d-padded", did, sign, "padded nonce", nonce="0000000042")
+    assert padded.status_code == 400
+    # Names the rule it broke, not the length rule it kept: `0000000042` is 1-19 digits.
+    assert "leading zeros" in padded.text
+
+    # Nothing was stored, so there is no unverifiable line to export.
+    assert client.get("/r/d-padded/export").content == b""
+
+    # The canonical spelling of the same value still writes and still re-verifies, and
+    # `0` itself stays legal — a counter may start there.
+    assert _say_signed(client, "d-padded", did, sign, "padded nonce", nonce=42).status_code == 200
+    assert _say_signed(client, "d-zero", did, sign, "zero nonce", nonce=0).status_code == 200
+    for room in ("d-padded", "d-zero"):
+        lines = client.get(f"/r/{room}/export").content.splitlines()
+        signed = [rec for rec in map(json.loads, lines) if "sig" in rec]
+        assert len(signed) == 1
+        rec = signed[0]
+        didkey.verify(rec["from"], rec["sig"], f"{room}|{rec['nonce']}|{rec['text']}")
+
+
 def test_a_torn_final_line_is_excluded(client, tmp_path):
     client.get("/r/torn/say/bot/whole%20line")
     path = store.room_path(tmp_path, "torn")

--- a/tests/http/test_signer.py
+++ b/tests/http/test_signer.py
@@ -55,13 +55,24 @@ def test_a_keygen_seed_reproduces_the_did() -> None:
 
 
 def test_nonces_are_rejected_exactly_where_the_server_would_reject() -> None:
-    # '١' is a Unicode digit isdigit() accepts and NONCE_RE ([0-9]{1,19}) refuses;
-    # 20 digits and the empty string are over- and under-length. The script must
-    # refuse to sign all three — a signature we emit must be submittable.
-    for bad_nonce in ("١", "0" * 20, ""):
+    # '١' is a Unicode digit isdigit() accepts and NONCE_RE refuses; 20 digits and the
+    # empty string are over- and under-length; `007` and `0000000042` are padded
+    # spellings the server refuses because a record stores the nonce as a number and
+    # cannot give the zeros back. The script must refuse to sign all of them — a
+    # signature we emit must be submittable.
+    for bad_nonce in ("١", "0" * 20, "", "007", "0000000042"):
         out = run("say", "--seed", SEED, "lobby", bad_nonce, "hi")
         assert out.returncode != 0, f"nonce {bad_nonce!r} was accepted"
         assert "nonce" in (out.stdout + out.stderr).lower()
+
+    # The script's copy of the rule against the server's own, rather than two lists that
+    # can drift: the script is standalone by design (PEP 723) and so cannot import
+    # didkey, which is exactly why the agreement needs a gate rather than a convention.
+    for probe in ("0", "7", "42", "9223372036854775807", "007", "00", "0042", "1" * 20, "1a"):
+        accepted = run("say", "--seed", SEED, "lobby", probe, "hi").returncode == 0
+        assert accepted == bool(didkey.NONCE_RE.fullmatch(probe)), (
+            f"script and server disagree about nonce {probe!r}"
+        )
 
     good = run("say", "--seed", SEED, "lobby", "7", "hi")
     assert good.returncode == 0


### PR DESCRIPTION
Closes #574.

**Verified against `5b6b8f8`** — fresh fetch, and the branch is rebased onto it.

## What changes for a caller

A nonce with a leading zero is now refused with a 400 instead of accepted. `7` is valid,
`007` is not; `0` itself stays valid, and the 19-digit int64 ceiling is unchanged.

Everything else is unchanged: same canonical string, same replay rule, same lanes.

## Why

The signature covers the nonce as the **string** the caller sent (`_signer` builds
`f"{room}|{nonce}|{body}"`), but a record stores it as a **number**
(`store.append(..., nonce=int(nonce))`). A JSON number cannot carry a leading zero, so the
signed spelling is not merely lost — it is unrepresentable in the stored bytes.

`NONCE_PATTERN` published `[0-9]{1,19}`, so the server accepted `0000000042`, stored it,
exported it, and the record's own stored signature then failed against the line it was
exported on. That is the export's headline promise —

> a signed record re-verifies offline from the stored bytes

— failing silently, on input the server itself published as valid. A zero-padded counter is
an ordinary choice (padding is how a client makes nonces sort), and every message such a
client signs is affected.

The manual's existing re-verifier caveat does not reach this case. "Treat the nonce as opaque
digits" recovers a 19-digit value exactly (verified), and the digits it names are the ones a
padded record no longer carries (verified).

Stated precisely, because it is the obvious objection: the signed spelling is not
unrecoverable, it is un-derivable. A verifier that goes looking can find it by trying the
padded spellings — up to 18 for a two-digit value — and accepting whichever verifies. That is
not a way out. It is the many-spellings-per-value acceptance #177 removed from `SIG_PATTERN`,
arrived at from the verifier's side: it turns one verify into up to nineteen and accepts a
signature over a string that differs from the canonical rebuild. What fails here is the single
deterministic rebuild the manual documents.

A pleasant side effect: with padded spellings refused, that existing caveat becomes true
universally — "treat the nonce as opaque digits" now always works, because the stored digits
are always the signed ones.

## Why refuse, rather than normalise or store the string

- **Normalising on input** would store a record whose signature covers a string the caller
  never sent — the same unverifiable line, arrived at politely.
- **Storing the nonce as a string** would change a published record field from
  `{"type": "integer"}` (`_MESSAGE_SCHEMA`) to a string, breaking every reader of the JSON
  view.

So the input gets one spelling per value, which is the same answer `SIG_PATTERN` got in #177
and the same one a `did:key` already has, for the reason `didkey.py` already states: these
strings are published, compared, and re-encoded by other stacks.

The pattern is a non-capturing group deliberately — `manifest.py` publishes it as
`f"^{...}$"`, where a bare alternation would anchor as "starts with `0`" OR "ends with a digit
run", i.e. a published pattern looser than the enforced one.

## Scope

All four signed write lanes share `_signer`, so one pattern covers them: `GET say-signed`,
`POST /r/<room>`, `GET set-signed`, `POST /kv/<ns>/<key>`.

The re-verification failure itself is specific to the two **message** lanes, which are the
ones that persist a signature. A note stores no `sig`, so nothing there became unverifiable;
the note lanes accepted the same input and wrote the padded spelling into
`/kv/room-nonce/<room>` as the counter. They are fixed with the rest because they share the
validator, not because a note was unverifiable.

Both read paths that expose a stored message nonce were affected and are covered: `/export`
and `?format=json`.

## Compatibility

This narrows accepted input, so a client sending zero-padded nonces starts getting a 400 where
it got a 200.

The narrowing is exactly one thing, checked exhaustively rather than argued: over every digit
string of length 1..6 (1,111,110 of them), **nothing is widened** — no string the old pattern
refused is accepted now — and every verdict that changes is a leading-zero string of length
greater than one. The int64 ceiling is still reachable, 20 digits are still refused, `0` is
still valid, and every value has exactly one accepted spelling.

Those clients were already broken — their records do not re-verify — and this converts a
silent, permanent failure into a loud one at the moment it can still be fixed, with a refusal
that names the rule and the spelling to send. No stored record changes, and there is no
migration: records written before this stay exactly as they are (a padded one remains
non-re-verifiable, which no server-side change can undo).

`scripts/sign.py` keeps its own copy of the rule — it is standalone by design (PEP 723) — and
`tests/http/test_signer.py` now holds that copy to the server's over a probe set rather than a
hand-listed pair, so the two cannot drift again.

**Upgrade path, checked against legacy on-disk state.** An instance that ran the old code can
hold a padded spelling in `/kv/room-nonce/<room>` (the counter stores the raw nonce string).
Exercised directly: with `room-nonce` holding `"0000000042"`, the owner's next allow-list
write at nonce `43` is accepted — nobody is locked out — the counter self-heals to the
canonical `"43"`, a replay at `41` is still refused 403, and a legacy stored message record
whose nonce was written from a padded spelling stays readable and can still be counted past.
Nothing on disk is rewritten and no migration is needed.

## Documentation

Updated everywhere the rule is stated, so the published and enforced constraints stay one
object: `src/manual.md` (§SIGNING), `_NONCE_SCHEMA` and the two signing-reference statements in
`src/manifest.py` (which feed `/openapi.json` and `/.well-known/agent.json`), and
`scripts/sign.py`'s docstring.

`CHANGELOG.md` intentionally untouched. Proposed release-note wording:

> A nonce with a leading zero is now refused. It was accepted and stored as a number, which
> could not carry the spelling that was signed, so the record's stored signature did not
> re-verify from the exported bytes.

## Tests

- `tests/http/test_export.py::test_a_nonce_the_export_could_not_carry_is_refused_at_the_write`
  — the regression. Fails on `5b6b8f8` (the padded write returns 200), passes here. Asserts the
  write is refused, that nothing was stored to export, and that the canonical spelling of the
  same value — and `0` — still write and still re-verify.
- `tests/http/test_signer.py` — the script/server agreement, now derived from
  `didkey.NONCE_RE` over a probe set.
- `tests/http/test_docs.py` — the published-bound entry updated to the new pattern (that test
  is what requires every published bound to be exercised).

## Checks

Run from AGENTS.md / CONTRIBUTING.md, all green on `5b6b8f8`:

```
uv run ruff check .                    All checks passed!
uv run ruff format --check .           66 files already formatted
uv run ty check                        All checks passed!
uv run coverage run -m pytest tests -q 535 passed
uv run sz.py --check                   check ok: core code-lines <= baseline
bash examples/beautiful_chat.sh        done — the whole protocol
uv build --project mcp + verify        exact LICENSE/NOTICE, matching metadata
contract job (exact CI args)           845 generated, 845 passed
```

**No core code-lines added** — `sz.py --check` reports the baseline unchanged; the change is a
character class plus comments, docs and tests. `CHANGELOG.md` and `sz-baseline.json` are
untouched (queue-guard).

Docker image not rebuilt locally: this change does not touch packaging or the container.

## Abuse impact

None new. The change only narrows what the signed lanes accept; it adds no route, parameter or
persistent state, and removes no refusal. It slightly reduces attacker-reachable surface, in
that a record which cannot be re-verified can no longer be created at all.

## Overlapping work

Checked open PRs on `5b6b8f8`. Nothing else touches `NONCE_PATTERN` or the export re-verify
path:

- **#444** touches `didkey.py`, but `_b58decode` (base58btc leading zero *bytes*, #155) — a
  different rule in a different function.
- **#418** and **#459** touch the nonce *replay* message in `store.py` (#349), not the format
  validation in `_signer`. I dropped two cosmetic `store.py` message edits from this branch
  specifically so it does not collide with either.
- **#66** is the issue behind the stored `sig`; this is the residual case where that feature's
  promise still fails.
- **#511** is adjacent but explicitly disclaims overlap with the offline-verifier work.
