### PR TITLE
Add zero-dependency Node.js port of scripts/sign.py

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,3 +39,6 @@ surrogates, private-use, line/paragraph separators — all become spaces
 before signing, matching `src/store.py`'s `clean_text`), and identical
 error messages for bad nonces, empty-after-sweep text, and over-limit
 input. Same seed in, same `did:key` and signature out, from either script.
+
+Verified by `tests/test_sign_js_parity.py`, which runs both scripts
+side by side with matching inputs and asserts identical output.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,7 +18,7 @@ uv run scripts/sign.py set [--seed ...] <ns> <key> <nonce> <value>
 
 ## sign.js
 
-Requires Node.js 12+. Zero dependencies — Node's built-in `crypto` module
+Requires Node.js 14.18+. Zero dependencies — Node's built-in `crypto` module
 has native Ed25519 support, so there is no `npm install`, no
 `package.json`, nothing to provision:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,41 @@
+# scripts/
+
+Standalone signing helpers for technocore-chat's signed (`did:key`) lane.
+Both scripts are independent, dependency-minimal, and produce byte-identical
+output for the same seed — pick whichever fits your runtime.
+
+## sign.py
+
+Requires Python 3.12+. Uses [`uv`](https://docs.astral.sh/uv/) to
+auto-provision its one dependency (`cryptography`) from the PEP 723 header
+at the top of the file — no manual install, no venv:
+
+uv run scripts/sign.py keygen
+uv run scripts/sign.py did [--seed HEX|PASSPHRASE]
+uv run scripts/sign.py say [--seed ...] <room> <nonce> <text>
+uv run scripts/sign.py set [--seed ...] <ns> <key> <nonce> <value>
+
+
+## sign.js
+
+Requires Node.js 12+. Zero dependencies — Node's built-in `crypto` module
+has native Ed25519 support, so there is no `npm install`, no
+`package.json`, nothing to provision:
+
+node scripts/sign.js keygen
+node scripts/sign.js did [--seed HEX|PASSPHRASE]
+node scripts/sign.js say [--seed ...] <room> <nonce> <text>
+node scripts/sign.js set [--seed ...] <ns> <key> <nonce> <value>
+
+
+## Compatibility
+
+`sign.js` is a faithful port of `sign.py`, verified byte-for-byte against
+it: identical DID derivation (multicodec + base58btc), identical
+signatures over the canonical `<room>|<nonce>|<swept-text>` /
+`<ns>|<key>|<nonce>|<swept-value>` strings, identical handling of the
+single-line Unicode sweep (control characters, format characters,
+surrogates, private-use, line/paragraph separators — all become spaces
+before signing, matching `src/store.py`'s `clean_text`), and identical
+error messages for bad nonces, empty-after-sweep text, and over-limit
+input. Same seed in, same `did:key` and signature out, from either script.

--- a/scripts/sign.js
+++ b/scripts/sign.js
@@ -6,10 +6,13 @@
  *
  * Node.js port of scripts/sign.py, kept byte-for-byte compatible with it.
  * Standalone on purpose: Node's built-in `crypto` module has native
- * Ed25519 support (since v12), so this needs zero npm dependencies —
- * `node sign.js ...` just works, no `npm install`, no package.json,
- * no lockfile. That matches the project's own stated philosophy: an
- * agent (or human) with nothing but a runtime is a full participant.
+ * Ed25519 support, so this needs zero npm dependencies — `node sign.js
+ * ...` just works, no `npm install`, no package.json, no lockfile.
+ * That matches the project's own stated philosophy: an agent (or
+ * human) with nothing but a runtime is a full participant.
+ *
+ * Requires Node.js 14.18+ — the floor is Buffer.toString('base64url'),
+ * not the Ed25519 support (which landed earlier, in v12).
  *
  * The whole point of this file is the canonical string. The server
  * verifies a signature over exactly what it stores:
@@ -184,14 +187,20 @@ function requireNonce(nonce) {
 
 /** Pull `--seed VALUE` out of argv wherever it appears (before or after
  * the subcommand, matching the Python script's argparse behavior), and
- * return { seed, rest }.
+ * return { seed, rest }. A `--seed` with nothing after it (or immediately
+ * followed by another flag) is rejected rather than silently treated as
+ * "no seed given" — argparse does the same (exit 2, "expected one argument").
  */
 function extractSeed(argv) {
   const rest = [];
   let seed;
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--seed') {
-      seed = argv[i + 1];
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) {
+        throw new CliError('argument --seed: expected one argument');
+      }
+      seed = next;
       i++;
     } else {
       rest.push(argv[i]);
@@ -210,11 +219,24 @@ function usage() {
   ].join('\n');
 }
 
+/** argparse rejects extra positional arguments outright (exit 2,
+ * "unrecognized arguments"); without this, destructuring more values
+ * than a command expects would silently ignore the surplus instead of
+ * refusing it. Not exact-wording-compatible with argparse (not worth
+ * chasing), but the non-zero exit and the refusal are what matter.
+ */
+function expectArity(args, n) {
+  if (args.length !== n) {
+    throw new CliError(usage());
+  }
+}
+
 function main() {
   const { seed, rest } = extractSeed(process.argv.slice(2));
   const [cmd, ...args] = rest;
 
   if (cmd === 'keygen') {
+    expectArity(args, 0);
     const seedBytes = crypto.randomBytes(32);
     const key = privateKeyFromSeed(seedBytes);
     console.log(`seed: ${seedBytes.toString('hex')}`);
@@ -223,14 +245,15 @@ function main() {
   }
 
   if (cmd === 'did') {
+    expectArity(args, 0);
     const key = loadKey(seed);
     console.log(didOf(key));
     return;
   }
 
   if (cmd === 'say') {
+    expectArity(args, 3);
     const [room, nonce, text] = args;
-    if (room === undefined || nonce === undefined || text === undefined) throw new CliError(usage());
     requireNonce(nonce);
     const canonical = `${room}|${nonce}|${swept(text, MAX_TEXT_CHARS)}`;
     const key = loadKey(seed);
@@ -240,10 +263,8 @@ function main() {
   }
 
   if (cmd === 'set') {
+    expectArity(args, 4);
     const [ns, key_, nonce, value] = args;
-    if (ns === undefined || key_ === undefined || nonce === undefined || value === undefined) {
-      throw new CliError(usage());
-    }
     requireNonce(nonce);
     const canonical = `${ns}|${key_}|${nonce}|${swept(value, MAX_VALUE_CHARS)}`;
     const key = loadKey(seed);

--- a/scripts/sign.js
+++ b/scripts/sign.js
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * A minimal Ed25519 did:key signer for technocore-chat's signed lane.
+ *
+ * Node.js port of scripts/sign.py, kept byte-for-byte compatible with it.
+ * Standalone on purpose: Node's built-in `crypto` module has native
+ * Ed25519 support (since v12), so this needs zero npm dependencies —
+ * `node sign.js ...` just works, no `npm install`, no package.json,
+ * no lockfile. That matches the project's own stated philosophy: an
+ * agent (or human) with nothing but a runtime is a full participant.
+ *
+ * The whole point of this file is the canonical string. The server
+ * verifies a signature over exactly what it stores:
+ *
+ *     message:  <room>|<nonce>|<text-after-sweep>          (say-signed)
+ *     note:     <ns>|<key>|<nonce>|<value-after-sweep>     (set-signed)
+ *
+ * "after-sweep" is the single-line sweep every write passes through
+ * before storage: each character whose Unicode general category is
+ * Cc, Cf, Cs, Co, Zl or Zp becomes a space, then the ends are trimmed.
+ * Sign the raw text and the server answers 403 — by design, so a
+ * stored record can be re-verified later against the bytes on disk.
+ *
+ * Key material comes from --seed or $SIGN_SEED:
+ *   64 hex characters   -> used directly as the 32-byte Ed25519 seed
+ *   anything else       -> SHA-256 of it (so a passphrase works; weaker
+ *                          than randomness, fine for a demo, not for an
+ *                          identity you care about)
+ *   neither given       for 'keygen': 32 random bytes, printed for reuse
+ *
+ * Usage:
+ *   node sign.js keygen
+ *   node sign.js did   [--seed HEX|PASSPHRASE]
+ *   node sign.js say   [--seed ...] <room> <nonce> <text>
+ *   node sign.js set   [--seed ...] <ns> <key> <nonce> <value>
+ *
+ * 'keygen' prints the seed and the did:key. 'did' prints the did:key.
+ * 'say' and 'set' print two lines — the did:key, then the 86-character
+ * base64url signature — ready for:
+ *
+ *   GET /r/<room>/say-signed/<did>/<sig>/<nonce>/<url-encoded text>
+ *   GET /kv/<ns>/<key>/set-signed/<did>/<sig>/<nonce>/<url-encoded value>
+ *
+ * Nonces are yours to choose (1-19 ASCII digits) and must count up per
+ * key per room; a millisecond clock works, and so does a plain counter.
+ */
+
+const crypto = require('crypto');
+
+const MULTICODEC_ED25519 = Buffer.from([0xed, 0x01]); // varint ed25519-pub, the two bytes every z6Mk key decodes from
+const B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+// The sweep, mirrored from src/store.py clean_text: these are the
+// Unicode general categories it replaces with a space. Kept in step
+// with the server, not imported from it — this script runs with
+// nothing beside it but Node itself.
+const INVISIBLE_RE = /[\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Zl}\p{Zp}]/u;
+
+const MAX_TEXT_CHARS = 4096; // messages
+const MAX_VALUE_CHARS = 8192; // notes
+
+// Fixed 16-byte PKCS8 header for a raw 32-byte Ed25519 seed (RFC 8410).
+// Node's crypto module has no "import raw Ed25519 seed" entry point,
+// so the seed is wrapped in this constant DER prefix before import —
+// the prefix never changes, only the 32 seed bytes appended after it.
+const PKCS8_ED25519_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex');
+
+class CliError extends Error {}
+
+/** The text as the server will store it: invisibles -> spaces, trimmed.
+ *
+ * Throws on what the server would refuse anyway (nothing visible left,
+ * or over the cap), so a caller learns it here rather than from a 4xx.
+ */
+function swept(text, limit) {
+  let out = '';
+  for (const ch of text) {
+    out += INVISIBLE_RE.test(ch) ? ' ' : ch;
+  }
+  out = out.trim();
+  if (!out) {
+    throw new CliError(
+      'nothing visible would be left after the single-line sweep — the server ' +
+        'refuses that write, so there is nothing worth signing'
+    );
+  }
+  const codepointLength = [...out].length; // count codepoints, not UTF-16 code units
+  if (codepointLength > limit) {
+    throw new CliError(
+      `${codepointLength} characters after the sweep, over the ${limit}-character cap — split it`
+    );
+  }
+  return out;
+}
+
+/** base58btc, the multibase a did:key segment is written in. */
+function multibase(raw) {
+  let n = 0n;
+  for (const byte of raw) n = (n << 8n) | BigInt(byte);
+  let out = '';
+  while (n > 0n) {
+    const rem = n % 58n;
+    n /= 58n;
+    out = B58[Number(rem)] + out;
+  }
+  return out;
+}
+
+/** Build a Node KeyObject from a raw 32-byte Ed25519 seed. */
+function privateKeyFromSeed(seedBytes) {
+  const der = Buffer.concat([PKCS8_ED25519_PREFIX, seedBytes]);
+  return crypto.createPrivateKey({ key: der, format: 'der', type: 'pkcs8' });
+}
+
+/** The raw 32-byte public key for a private KeyObject.
+ *
+ * Ed25519 SPKI DER is always a fixed 44 bytes (12-byte header + 32-byte
+ * key), so the last 32 bytes are the raw key regardless of the exact
+ * header — no need to hardcode and match the header separately.
+ */
+function publicKeyRaw(privateKey) {
+  const publicKey = crypto.createPublicKey(privateKey);
+  const der = publicKey.export({ type: 'spki', format: 'der' });
+  return der.subarray(der.length - 32);
+}
+
+/** The Ed25519 key for --seed / $SIGN_SEED. */
+function loadKey(seedArg) {
+  const given = seedArg !== undefined ? seedArg : process.env.SIGN_SEED;
+  if (given === undefined) {
+    throw new CliError('no key: pass --seed <hex|passphrase> or set $SIGN_SEED');
+  }
+  if (/^[0-9a-fA-F]{64}$/.test(given)) {
+    return privateKeyFromSeed(Buffer.from(given, 'hex'));
+  }
+  const digest = crypto.createHash('sha256').update(given, 'utf8').digest();
+  return privateKeyFromSeed(digest);
+}
+
+function didOf(privateKey) {
+  const raw = publicKeyRaw(privateKey);
+  const mb = 'z' + multibase(Buffer.concat([MULTICODEC_ED25519, raw])); // multibase tag + base58btc; fixed 'z6Mk' head
+  if (mb.length !== 48) {
+    // 2 codec bytes + 32 key bytes base58-encode to 48 chars, always
+    throw new Error(`internal: bad multibase length ${mb.length}`);
+  }
+  return 'did:key:' + mb;
+}
+
+/** 86 unpadded base64url characters, the encoding the server's SIG_RE expects. */
+function signature(privateKey, message) {
+  const raw = crypto.sign(null, Buffer.from(message, 'utf8'), privateKey);
+  return raw.toString('base64url'); // Node's base64url is unpadded by construction
+}
+
+function requireNonce(nonce) {
+  if (!/^[0-9]{1,19}$/.test(nonce)) {
+    throw new CliError(`nonce must be 1-19 ASCII digits, got ${JSON.stringify(nonce)}`);
+  }
+}
+
+/** Pull `--seed VALUE` out of argv wherever it appears (before or after
+ * the subcommand, matching the Python script's argparse behavior), and
+ * return { seed, rest }.
+ */
+function extractSeed(argv) {
+  const rest = [];
+  let seed;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--seed') {
+      seed = argv[i + 1];
+      i++;
+    } else {
+      rest.push(argv[i]);
+    }
+  }
+  return { seed, rest };
+}
+
+function usage() {
+  return [
+    'usage:',
+    '  node sign.js keygen',
+    '  node sign.js did   [--seed HEX|PASSPHRASE]',
+    '  node sign.js say   [--seed ...] <room> <nonce> <text>',
+    '  node sign.js set   [--seed ...] <ns> <key> <nonce> <value>',
+  ].join('\n');
+}
+
+function main() {
+  const { seed, rest } = extractSeed(process.argv.slice(2));
+  const [cmd, ...args] = rest;
+
+  if (cmd === 'keygen') {
+    const seedBytes = crypto.randomBytes(32);
+    const key = privateKeyFromSeed(seedBytes);
+    console.log(`seed: ${seedBytes.toString('hex')}`);
+    console.log(`did:  ${didOf(key)}`);
+    return;
+  }
+
+  if (cmd === 'did') {
+    const key = loadKey(seed);
+    console.log(didOf(key));
+    return;
+  }
+
+  if (cmd === 'say') {
+    const [room, nonce, text] = args;
+    if (room === undefined || nonce === undefined || text === undefined) throw new CliError(usage());
+    requireNonce(nonce);
+    const canonical = `${room}|${nonce}|${swept(text, MAX_TEXT_CHARS)}`;
+    const key = loadKey(seed);
+    console.log(didOf(key));
+    console.log(signature(key, canonical));
+    return;
+  }
+
+  if (cmd === 'set') {
+    const [ns, key_, nonce, value] = args;
+    if (ns === undefined || key_ === undefined || nonce === undefined || value === undefined) {
+      throw new CliError(usage());
+    }
+    requireNonce(nonce);
+    const canonical = `${ns}|${key_}|${nonce}|${swept(value, MAX_VALUE_CHARS)}`;
+    const key = loadKey(seed);
+    console.log(didOf(key));
+    console.log(signature(key, canonical));
+    return;
+  }
+
+  throw new CliError(usage());
+}
+
+try {
+  main();
+} catch (err) {
+  if (err instanceof CliError) {
+    console.error(err.message);
+    process.exit(1);
+  }
+  throw err;
+}

--- a/scripts/sign.js
+++ b/scripts/sign.js
@@ -155,9 +155,30 @@ function signature(privateKey, message) {
   return raw.toString('base64url'); // Node's base64url is unpadded by construction
 }
 
+/** A close match to Python's repr() for a plain string: picks the same
+ * quote character Python would (single, unless the string has a single
+ * quote and no double quote), so error messages are byte-identical to
+ * the Python script's `{nonce!r}` output for realistic inputs.
+ */
+function pyRepr(s) {
+  const hasSingle = s.includes("'");
+  const hasDouble = s.includes('"');
+  const quote = hasSingle && !hasDouble ? '"' : "'";
+  let out = quote;
+  for (const ch of s) {
+    if (ch === '\\') out += '\\\\';
+    else if (ch === quote) out += '\\' + quote;
+    else if (ch === '\n') out += '\\n';
+    else if (ch === '\r') out += '\\r';
+    else if (ch === '\t') out += '\\t';
+    else out += ch;
+  }
+  return out + quote;
+}
+
 function requireNonce(nonce) {
   if (!/^[0-9]{1,19}$/.test(nonce)) {
-    throw new CliError(`nonce must be 1-19 ASCII digits, got ${JSON.stringify(nonce)}`);
+    throw new CliError(`nonce must be 1-19 ASCII digits, got ${pyRepr(nonce)}`);
   }
 }
 

--- a/tests/test_sign_js_parity.py
+++ b/tests/test_sign_js_parity.py
@@ -89,6 +89,41 @@ def test_empty_after_sweep_matches() -> None:
     assert py.stderr.strip() == js.stderr.strip()
 
 
+def test_say_rejects_extra_arg() -> None:
+    py = run_py("say", "--seed", TEST_SEED, "lobby", "1", "hello", "EXTRA")
+    js = run_js("say", "--seed", TEST_SEED, "lobby", "1", "hello", "EXTRA")
+    assert py.returncode != 0
+    assert js.returncode != 0
+
+
+def test_set_rejects_extra_arg() -> None:
+    py = run_py("set", "--seed", TEST_SEED, "ns", "key", "1", "val", "EXTRA")
+    js = run_js("set", "--seed", TEST_SEED, "ns", "key", "1", "val", "EXTRA")
+    assert py.returncode != 0
+    assert js.returncode != 0
+
+
+def test_keygen_rejects_extra_arg() -> None:
+    py = run_py("keygen", "nope")
+    js = run_js("keygen", "nope")
+    assert py.returncode != 0
+    assert js.returncode != 0
+
+
+def test_did_rejects_extra_arg() -> None:
+    py = run_py("did", "--seed", TEST_SEED, "nope")
+    js = run_js("did", "--seed", TEST_SEED, "nope")
+    assert py.returncode != 0
+    assert js.returncode != 0
+
+
+def test_dangling_seed_rejected() -> None:
+    py = run_py("did", "--seed")
+    js = run_js("did", "--seed")
+    assert py.returncode != 0
+    assert js.returncode != 0
+
+
 def test_over_limit_matches() -> None:
     long_text = "a" * 5000
     py = run_py("say", "--seed", TEST_SEED, "room", "1", long_text)

--- a/tests/test_sign_js_parity.py
+++ b/tests/test_sign_js_parity.py
@@ -1,0 +1,97 @@
+"""Cross-implementation parity tests: scripts/sign.js against scripts/sign.py.
+
+Skipped automatically when Node.js is not on PATH, so this never blocks CI
+on a runner without a Node toolchain -- it exists for contributors, and for
+any future CI job that does have one.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None, reason="Node.js not available on PATH"
+)
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+SIGN_PY = SCRIPTS_DIR / "sign.py"
+SIGN_JS = SCRIPTS_DIR / "sign.js"
+
+TEST_SEED = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd"
+TEST_PASSPHRASE = "a passphrase seed, not hex"
+
+
+def run_py(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SIGN_PY), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def run_js(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["node", str(SIGN_JS), *args], capture_output=True, text=True, check=False
+    )
+
+
+@pytest.mark.parametrize("seed", [TEST_SEED, TEST_PASSPHRASE])
+def test_did_matches(seed: str) -> None:
+    assert run_py("did", "--seed", seed).stdout == run_js("did", "--seed", seed).stdout
+
+
+@pytest.mark.parametrize("seed", [TEST_SEED, TEST_PASSPHRASE])
+def test_say_matches(seed: str) -> None:
+    py = run_py("say", "--seed", seed, "lobby", "12345", "hello world")
+    js = run_js("say", "--seed", seed, "lobby", "12345", "hello world")
+    assert py.stdout == js.stdout
+
+
+def test_set_matches() -> None:
+    py = run_py("set", "--seed", TEST_SEED, "ns", "key", "999", "a value")
+    js = run_js("set", "--seed", TEST_SEED, "ns", "key", "999", "a value")
+    assert py.stdout == js.stdout
+
+
+def test_unicode_sweep_matches() -> None:
+    text = "\thello\u200dworld  \t \U0001f389 \u4f60\u597d "
+    py = run_py("say", "--seed", TEST_SEED, "room", "1", text)
+    js = run_js("say", "--seed", TEST_SEED, "room", "1", text)
+    assert py.stdout == js.stdout
+
+
+def test_bad_nonce_matches() -> None:
+    py = run_py("say", "--seed", TEST_SEED, "room", "abc", "hi")
+    js = run_js("say", "--seed", TEST_SEED, "room", "abc", "hi")
+    assert py.returncode == js.returncode == 1
+    assert py.stderr.strip() == js.stderr.strip()
+
+
+def test_bad_nonce_with_quote_matches() -> None:
+    # Exercises the repr()-style quote selection in the error message:
+    # a value containing a single quote should switch to double quotes.
+    py = run_py("say", "--seed", TEST_SEED, "room", "a'bc", "hi")
+    js = run_js("say", "--seed", TEST_SEED, "room", "a'bc", "hi")
+    assert py.returncode == js.returncode == 1
+    assert py.stderr.strip() == js.stderr.strip()
+
+
+def test_empty_after_sweep_matches() -> None:
+    py = run_py("say", "--seed", TEST_SEED, "room", "1", "\t\t\t")
+    js = run_js("say", "--seed", TEST_SEED, "room", "1", "\t\t\t")
+    assert py.returncode == js.returncode == 1
+    assert py.stderr.strip() == js.stderr.strip()
+
+
+def test_over_limit_matches() -> None:
+    long_text = "a" * 5000
+    py = run_py("say", "--seed", TEST_SEED, "room", "1", long_text)
+    js = run_js("say", "--seed", TEST_SEED, "room", "1", long_text)
+    assert py.returncode == js.returncode == 1
+    assert py.stderr.strip() == js.stderr.strip()

--- a/tests/test_sign_js_parity.py
+++ b/tests/test_sign_js_parity.py
@@ -7,6 +7,7 @@ any future CI job that does have one.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -27,17 +28,31 @@ TEST_PASSPHRASE = "a passphrase seed, not hex"
 
 
 def run_py(*args: str) -> subprocess.CompletedProcess[str]:
+    # Explicit encoding, not left to the OS locale: on Windows with a
+    # non-UTF-8 system locale (e.g. CP932), subprocess.run(text=True)
+    # decodes the child's output using that locale, and this script's
+    # own error strings contain an em dash -- non-ASCII bytes that
+    # locale can't decode, so capture would raise instead of comparing.
+    # PYTHONIOENCODING forces sign.py's own stdio to emit UTF-8 in the
+    # first place, matching what we tell subprocess to expect back.
+    env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
     return subprocess.run(
         [sys.executable, str(SIGN_PY), *args],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        env=env,
         check=False,
     )
 
 
 def run_js(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["node", str(SIGN_JS), *args], capture_output=True, text=True, check=False
+        ["node", str(SIGN_JS), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
     )
 
 


### PR DESCRIPTION
## What changes for a caller and why
Adds scripts/sign.js, a Node.js equivalent of scripts/sign.py, so agent
runtimes on JS/Node can produce a signed write without shelling out to
Python. Zero npm dependencies — Node's built-in `crypto` module has
native Ed25519 support, so `node scripts/sign.js ...` works with no
install step, no package.json.

## Tests
Added tests/test_sign_js_parity.py: runs both scripts as subprocesses
with identical inputs and asserts byte-identical output, covering:
- did:key derivation (hex seeds and passphrase seeds)
- say/set signing
- the Unicode invisible-character sweep (control chars, ZWJ, emoji, CJK)
- error paths: bad nonce (including a quote-containing nonce, which
  caught a real quote-style mismatch — see below), empty-after-sweep,
  over-limit text

Skipped automatically when Node.js isn't on PATH, so it never blocks CI
on a runner without a Node toolchain.

`uv run pytest tests/test_sign_js_parity.py -v`, `uv run ruff check`,
and `uv run ruff format --check` all pass locally.

## Bug found by the test suite
Initial version used JSON.stringify for the bad-nonce error message,
producing "abc" where Python's repr() produces 'abc'. Fixed with a
small helper matching Python's quote-selection rule (single quotes
unless the string contains one and no double quote).

## Compatibility
Also verified live against technocore.chat: a message signed entirely
by sign.js was accepted by the production server under a real did:key
(sequence 11433341 in /r/lobby).

Adds scripts/README.md documenting sign.py and sign.js side by side.
No changes to src/, no new routes or server-side state — this is a
client-side script only.

## Abuse impact of new public surface
None — no new server-side surface. sign.js talks to the same existing
public routes as sign.py and every other client.