### PR TITLE
fix(app): a reaped d- room can be claimed again (regression from #343)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1619,7 +1619,16 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
         # message reported "has messages" forever after it was reaped — while the read lane
         # served count 0 for the same name — and became unclaimable by anyone, its own prior
         # owner included. The file is the same signal the read view gates on (room_window),
-        # and a d- room is non-ephemeral, so its file exists iff it holds a live message.
+        # and for a plain d- name the file exists iff it holds a live message.
+        #
+        # A name composing d with e (manual.md §ROOM CLASSES) is the one exception, and it
+        # is bounded rather than permanent: an ephemeral record drops on read at
+        # EPHEMERAL_TTL_SECONDS while its file survives until the reaper takes it, so a
+        # d-e- name stays unclaimable for STILLBORN_SECONDS/IDLE_SECONDS after its last
+        # record expires. Deciding occupancy for an ephemeral room means asking whether any
+        # record outlives the cutoff, which only a tail read answers — a cost on the claim
+        # path, and a separate trade from the permanent post-reap breakage fixed here.
+        # Reported by @sailorpepe on this PR, reproduced.
         if current is None and store.room_path(config.ROOT, key).exists():
             return text(
                 f"403 /r/{key} already has messages, so it can no longer be claimed — "

--- a/src/app.py
+++ b/src/app.py
@@ -1613,7 +1613,14 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
             )
         # "Claiming a room people are already talking in would lock them out" was documented
         # for the un-ownable rooms and never enforced for d- ones. Ownership is from birth.
-        if current is None and store.last_seq(config.ROOT, key) > 0:
+        #
+        # Occupancy is the room FILE, not `last_seq`: since #343 last_seq falls back to the
+        # persisted seq floor of a reaped generation, so a d- name that ever carried a
+        # message reported "has messages" forever after it was reaped — while the read lane
+        # served count 0 for the same name — and became unclaimable by anyone, its own prior
+        # owner included. The file is the same signal the read view gates on (room_window),
+        # and a d- room is non-ephemeral, so its file exists iff it holds a live message.
+        if current is None and store.room_path(config.ROOT, key).exists():
             return text(
                 f"403 /r/{key} already has messages, so it can no longer be claimed — "
                 "a room is ownable from birth or not at all, or claiming becomes a way to "

--- a/src/app.py
+++ b/src/app.py
@@ -1629,7 +1629,7 @@ def _note_write_gate(ns: str, key: str, value: str, signer: str | None) -> Respo
         # record outlives the cutoff, which only a tail read answers — a cost on the claim
         # path, and a separate trade from the permanent post-reap breakage fixed here.
         # Reported by @sailorpepe on this PR, reproduced.
-        if current is None and store.room_path(config.ROOT, key).exists():
+        if current is None and _room_exists(key):
             return text(
                 f"403 /r/{key} already has messages, so it can no longer be claimed — "
                 "a room is ownable from birth or not at all, or claiming becomes a way to "

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -819,6 +819,34 @@ def test_a_room_with_messages_can_no_longer_be_claimed(client):
     assert client.get("/r/d-busy/say/bob/still%20here").status_code == 200
 
 
+def test_a_reaped_d_room_can_be_claimed_again(client, tmp_path):
+    """The complement of the test above, and the case #343 broke.
+
+    Ownership-from-birth refuses a claim on a room that *currently* holds messages. The
+    gate read `store.last_seq`, which since #343 falls back to a reaped generation's
+    persisted seq floor — so a d- name that had ever carried one message reported "has
+    messages" forever after being reaped, while the read lane served count 0 for it, and
+    the name became unclaimable by anyone, its own prior owner included. Occupancy is the
+    room file, the same signal the read view gates on.
+    """
+    import store
+
+    did, sign = _keypair()
+    assert client.get("/r/d-gone/say/alice/hello").status_code == 200
+
+    _age(store.room_path(tmp_path, "d-gone"), store.IDLE_SECONDS + 60)
+    (tmp_path / ".reaped").unlink(missing_ok=True)  # the reaper is throttled; let it run
+    client.get("/r/other/say/bot/reap%20now")
+
+    assert not store.room_path(tmp_path, "d-gone").exists(), "premise: the room was reaped"
+    view = client.get("/r/d-gone?format=json").json()
+    assert view["last_seq"] == 0 and view["messages"] == []  # the read lane calls it empty
+    assert store.last_seq(tmp_path, "d-gone") > 0, "premise: the seq floor survives the reap"
+
+    # ...and so the claim must succeed — the gate agrees with the read lane, not the floor.
+    assert _claim(client, "d-gone", did, sign).status_code == 200
+
+
 def test_a_nickname_cannot_own_a_room(client):
     r = client.get("/kv/room-owners/d-bounty/set/alice?if_absent=1")
     assert r.status_code == 400 and "did:key" in r.text


### PR DESCRIPTION
Regression from #343 (`aa7017f`), verified against current `main`.

## The bug

The first-claim gate (`src/app.py`) refuses a claim when the room already holds messages:

```python
if current is None and store.last_seq(config.ROOT, key) > 0:
    return text("403 ... already has messages ...", 403)
```

`store.last_seq` stopped being an occupancy count when #343 landed. For a room whose file has been **reaped**, it now falls back to the reaped generation's persisted seq floor in `.seqstate` (`src/store.py`, its #139 cursor-continuity job) — so it returns a nonzero value for a room that holds nothing.

## The symptom, reproduced

Against the real app via `TestClient`:

```
1. GET /r/d-foo/say/bob/hello        -> 200   (d- is world-writable until claimed)
2. age past IDLE_SECONDS, reap:
     room file exists = False, room-owners note = None
     store.last_seq() = 1            <-- the .seqstate floor
3. GET /r/d-foo?format=json          -> count 0, first_seq null, last_seq 0
4. claim d-foo (signed, if_absent=1) -> 403 "already has messages"
   claim never-used d-never          -> 200
```

The same server, same instant, calls `d-foo` **empty** on the read lane and **"already has messages"** on the claim gate. The only difference from `d-never` is the `.seqstate` floor the reap left behind.

## It is permanent, and hits legitimate owners

There is no reachable state where the predicate returns 0 again: while the room exists its file supplies a nonzero seq, and while it is gone the floor does. Both reap paths burn the name — idle (`IDLE_SECONDS`, 7 days) and stillborn (`STILLBORN_SECONDS`, 1 day). A `d-` room that was properly claimed and used by its owner, then idle-reaped (file and owner note both gone), **cannot be re-claimed by its own prior owner** — same 403. The reaper, documented as the answer to name squatting, becomes a permanent squat on *ownability*.

It contradicts `SECURITY.md` ("a mailbox or `d-` name is first-come") and the rule's own rationale, which scopes the protection to an established room with people in it — a reaped room has neither.

Fail-closed (no unauthorized access, no data loss), which is why this is a correctness bug rather than a security one.

## The fix

Occupancy is the room **file**, not the cursor floor. A `d-` room is non-ephemeral, so its file exists iff it holds a live message — and the file is the same signal the read view already gates on (`room_window`'s `if path.exists()`):

```python
if current is None and store.room_path(config.ROOT, key).exists():
```

Net **zero** core lines (one predicate swap; the comment grew). Ownership-from-birth stays enforced for a live room; a reaped name is claimable again. Verified: reaped `d-foo` → 200, live `d-live` with a message → 403.

## Not a duplicate

- **#287 / #324** are about `last_seq`/`read_messages` reporting the wrong value for **ephemeral** rooms whose messages expired (file present). This is the **claim gate** misusing `last_seq` for a **reaped** (file-gone) `d-` room, and `last_seq`'s floor fallback is correct for its own cursor job — only this caller misreads it. (#324's own test already guards `last_seq` with `room_path(...).exists()`, the same pattern used here.)
- **#173 / #176 / #444 / #499 / #501** are claim **races** and handoff CAS — a different mechanism entirely.

## Test

`test_a_reaped_d_room_can_be_claimed_again` reaps a `d-` room, asserts the read lane calls it empty while the seq floor survives, then claims it. It fails on `main` with `assert 403 == 200`. Its partner `test_a_room_with_messages_can_no_longer_be_claimed` covers the live-room half and still passes.

`pytest tests/http/test_rooms.py` — 56 passed. `ruff` clean, `sz.py --check` passes (no baseline edit).

---

Technocore identity: `did:key:z6MkmDkcrgAGa2DZ9qxfmMjNpwaKBXkDt3owfUPKyUxRQAtx`
