### PR TITLE
fix(worker): match the bearer scheme case-insensitively, and trim both sides of the token

### DIFF
--- a/mcp/worker/src/worker.py
+++ b/mcp/worker/src/worker.py
@@ -202,7 +202,17 @@ class Default(WorkerEntrypoint):
 
     async def fetch(self, request):
         key = getattr(self.env, "TECHNOCORE_SIGNING_KEY", None)
-        token = getattr(self.env, "TECHNOCORE_MCP_TOKEN", None)
+        # Normalised ONCE, so the guard below and the comparison further down cannot
+        # disagree about what "no token" means. Trimming at the comparison alone while
+        # the guard tested the raw value made a whitespace-only secret fail *open*: the
+        # guard saw a truthy "   " and let the request through to a comparison whose
+        # expected credential had become b"", which `Authorization: Bearer ` — and an
+        # absent header — also strip to, so `compare_digest` matched and the signing
+        # endpoint admitted a caller carrying no credential material at all. Reported by
+        # @yukkie3276 in review on this PR. A whitespace-only secret now normalises to
+        # empty and takes the 503 below, which is the fail-closed answer this gate
+        # already had for a key with no token.
+        token = str(getattr(self.env, "TECHNOCORE_MCP_TOKEN", None) or "").strip()
         if key and not token:
             return Response(
                 "503 TECHNOCORE_SIGNING_KEY is set but TECHNOCORE_MCP_TOKEN is not. A "
@@ -213,7 +223,23 @@ class Default(WorkerEntrypoint):
                 status=503,
             )
         if token:
-            presented = (request.headers.get("Authorization") or "").removeprefix("Bearer ")
+            # One shape is accepted, in any spelling of the scheme: the documented
+            # `Authorization: Bearer <token>`. The scheme is matched case-insensitively
+            # because it is a case-insensitive token (RFC 9110 §11.1) and clients spell it
+            # as they like — `removeprefix("Bearer ")` matched one spelling, so
+            # `bearer <token>` was answered 401, a refusal naming the header the caller had
+            # got right.
+            #
+            # Anything that is not scheme-plus-credential presents nothing, so it cannot
+            # match: no separator (a bare token with no scheme), a scheme that is not
+            # bearer, or a bearer with an empty credential. The bare token was accepted
+            # before this — `removeprefix` left it whole and it compared equal — an
+            # undocumented spelling on the one gate standing in front of a signing key,
+            # where the documented contract is the only shape worth honouring
+            # (@yukkie3276 on this PR).
+            raw = request.headers.get("Authorization") or ""
+            scheme, sep, rest = raw.partition(" ")
+            presented = rest if sep and scheme.lower() == "bearer" else ""
             # Compared as bytes, not str: `compare_digest` refuses two `str` arguments
             # unless both are ASCII, and raises `TypeError` rather than returning False.
             # The header is attacker-controlled, so `Authorization: Bearer café` would
@@ -221,7 +247,15 @@ class Default(WorkerEntrypoint):
             # 500 instead of a 401. It fails closed either way — the throw happens before
             # anything is served — but a crash is not an answer, and encoding both sides
             # keeps the comparison constant-time over the bytes that actually arrived.
-            if not hmac.compare_digest(presented.strip().encode(), str(token).encode()):
+            #
+            # Both sides are trimmed. Trimming only the presented half meant a token stored
+            # with surrounding whitespace — a newline survives more than one way of putting
+            # a secret into an environment — could not be matched by any caller at all,
+            # including one reproducing it byte for byte, and the 401 told them to send
+            # exactly what they were already sending. Trimming the stored side only widens
+            # the set of deployments that work: a token whose spelling depended on an
+            # invisible character had no working caller before.
+            if not hmac.compare_digest(presented.strip().encode(), token.encode()):
                 return Response(
                     "401 this endpoint requires `Authorization: Bearer <token>`.",
                     status=401,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -23,6 +23,7 @@ import hmac
 import json
 import sys
 import time
+import types
 from contextlib import ExitStack
 from pathlib import Path
 
@@ -1139,6 +1140,165 @@ def test_the_worker_gates_a_signing_key_behind_the_bearer_token():
     assert source.index("hmac.compare_digest") < source.index("signing_key=key")
 
 
+def _worker_module():
+    """`worker.py` with the runtime SDK stubbed, so its gate can be *run* and not just read.
+
+    The checks above are source-level because "the Worker's own gates cannot be executed off
+    the Cloudflare runtime". Only one import stands in the way of executing them —
+    `from workers import ...`, the SDK Cloudflare injects — and the `_cloudflare` import
+    beside it is already guarded by `except ImportError`, which is the branch a non-Worker
+    takes. Stubbing that one module is enough, and a gate in front of a signing key is worth
+    a stub: a string match cannot tell a comparison that is written correctly from one that
+    is correct, and both of the bugs this file now pins passed every source check.
+
+    `asgi.fetch` returns a sentinel, so "the gate let this through" is observable without a
+    real ASGI app.
+    """
+    import importlib.util
+
+    stub = types.ModuleType("workers")
+    for name, value in (
+        ("Response", type("Response", (), {"__init__": _stub_response_init})),
+        ("WorkerEntrypoint", type("WorkerEntrypoint", (), {})),
+        ("asgi", types.SimpleNamespace(fetch=_stub_asgi_fetch)),
+        ("fetch", lambda *a, **k: None),
+    ):
+        setattr(stub, name, value)
+    saved = sys.modules.get("workers")
+    sys.modules["workers"] = stub
+    try:
+        path = ROOT / "mcp" / "worker" / "src" / "worker.py"
+        spec = importlib.util.spec_from_file_location("technocore_worker_probe", path)
+        assert spec is not None and spec.loader is not None, f"cannot load {path}"
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if saved is None:
+            del sys.modules["workers"]
+        else:
+            sys.modules["workers"] = saved
+
+
+def _stub_response_init(self, body, status=200):
+    self.body, self.status = body, status
+
+
+async def _stub_asgi_fetch(*args, **kwargs):
+    return "SERVED"
+
+
+class _Req:
+    def __init__(self, authorization):
+        self.headers = {} if authorization is None else {"Authorization": authorization}
+
+
+async def _worker_answer(authorization, token="s3cret-token-value", key="a" * 64):
+    """What the Worker answers a request carrying `authorization`, with both secrets set.
+
+    `_technocore` is stubbed, so a request that passes the gate stops at the seam instead of
+    configuring the real `technocore_mcp.server`. That is not tidiness: `fetch` calls
+    `configure(signing_key=...)` on the way through, which is process-wide state, and a gate
+    test that left a signer behind would silently change what every later test in this file
+    sees. What is under test is the gate, and the gate is entirely above that call.
+    """
+    module = _worker_module()
+    module._technocore = lambda: types.SimpleNamespace(
+        configure=lambda **kwargs: None,
+        use_fetch=lambda fetch: None,
+        streamable_http_app=lambda: None,
+    )
+    entry = module.Default.__new__(module.Default)
+    entry.env = types.SimpleNamespace(
+        TECHNOCORE_SIGNING_KEY=key,
+        TECHNOCORE_MCP_TOKEN=token,
+        TECHNOCORE_URL=None,
+        TECHNOCORE_NICK=None,
+    )
+    entry.ctx = None
+    module.Default._configured = False
+    return await entry.fetch(_Req(authorization))
+
+
+@pytest.mark.parametrize("scheme", ["Bearer", "bearer", "BEARER", "BeArEr"])
+def test_the_worker_matches_the_bearer_scheme_case_insensitively(scheme):
+    """The auth scheme is a case-insensitive token (RFC 9110 §11.1), and clients spell it as
+    they like. `removeprefix("Bearer ")` matched exactly one spelling, so a conforming client
+    sending `bearer <token>` was answered 401 — a refusal naming the header it had got right,
+    on the endpoint whose whole job is to stand in front of a signing key."""
+    with anyio.from_thread.start_blocking_portal() as portal:
+        assert portal.call(_worker_answer, f"{scheme} s3cret-token-value") == "SERVED"
+
+
+def test_the_worker_accepts_a_token_stored_with_surrounding_whitespace():
+    """Trimming only the presented half meant a stored token carrying a newline could not be
+    matched by any caller — including one reproducing it byte for byte, since their copy was
+    trimmed and the stored one was not. The endpoint refused everyone and its 401 named the
+    header the operator was already sending correctly."""
+    with anyio.from_thread.start_blocking_portal() as portal:
+        for stored in ("s3cret-token-value\n", " s3cret-token-value", "s3cret-token-value "):
+            assert portal.call(_worker_answer, "Bearer s3cret-token-value", stored) == "SERVED"
+            wrong = portal.call(_worker_answer, "Bearer nope", stored)
+            assert wrong.status == 401
+
+
+def test_a_whitespace_only_token_fails_closed_rather_than_admitting_everyone():
+    """The stored-token trimming must not turn a misconfigured secret into an open door.
+
+    The outer guard and the comparison have to agree about what "no token" means. Trimming
+    only at the comparison left a whitespace-only `TECHNOCORE_MCP_TOKEN` truthy at the
+    guard and empty at the compare, so `Authorization: Bearer ` — and an absent header —
+    stripped to the same `b""` and matched: the signing endpoint admitted a caller with no
+    credential material. Reported by @yukkie3276 on this PR. Normalising once sends that
+    configuration to the 503 this gate already had for a key with no token.
+    """
+    with anyio.from_thread.start_blocking_portal() as portal:
+        for stored in ("   ", " ", "\t", "\n"):
+            for header in ("Bearer ", "Bearer    ", "Bearer", "", None):
+                answer = portal.call(_worker_answer, header, stored)
+                # A served request comes back as the ASGI sentinel, not a Response, so
+                # name that case rather than dying on a missing `.status`.
+                assert answer != "SERVED", (
+                    f"ADMITTED with no credential: stored={stored!r} header={header!r}"
+                )
+                assert answer.status == 503, (stored, header, answer.status)
+
+
+def test_the_worker_refuses_a_bare_token_with_no_scheme():
+    """The gate honours one shape: `Authorization: Bearer <token>`, in any spelling of the
+    scheme. A bare token with no scheme was accepted before — `removeprefix` left it whole
+    and it compared equal — which is an undocumented credential form on the one endpoint
+    standing in front of a signing key. Reported by @yukkie3276 on this PR; pre-existing
+    rather than introduced by the case-insensitivity fix, and closed here because this is
+    the change that makes the gate match its documented contract.
+    """
+    with anyio.from_thread.start_blocking_portal() as portal:
+        for header in ("s3cret-token-value", "  s3cret-token-value  "):
+            assert portal.call(_worker_answer, header).status == 401
+        # ...while every documented spelling of the scheme still passes.
+        for scheme in ("Bearer", "bearer", "BEARER"):
+            assert portal.call(_worker_answer, f"{scheme} s3cret-token-value") == "SERVED"
+
+
+def test_the_worker_still_refuses_every_credential_that_is_not_the_token():
+    """The direction that must never regress. A gate that wrongly refuses is an outage; one
+    that wrongly accepts hands out the identity."""
+    with anyio.from_thread.start_blocking_portal() as portal:
+        for header in (
+            None,
+            "",
+            "Bearer wrong",
+            "Bearer s3cret",  # a prefix of the token
+            "Bearer s3cret-token-valueX",  # the token plus a character
+            "Bearer ",
+            "Bearer",
+            "Basic s3cret-token-value",  # right credential, wrong scheme
+            "Bearer café",  # non-ASCII: a refusal, never a TypeError
+            "Bearer \x00",
+        ):
+            assert portal.call(_worker_answer, header).status == 401
+
+
 # ------------------------------------------------------------------ the transport
 
 
@@ -1488,7 +1648,11 @@ def test_the_worker_token_check_answers_a_non_ascii_header_rather_than_crashing(
     source = (
         Path(__file__).resolve().parents[1] / "mcp" / "worker" / "src" / "worker.py"
     ).read_text()
-    assert "compare_digest(presented.strip().encode(), str(token).encode())" in source
+    # Both sides still reach `compare_digest` as bytes; the stored side is normalised
+    # once at the top of `fetch` now (see the whitespace-only-token regression), so it
+    # arrives here already trimmed rather than being trimmed in place.
+    assert "compare_digest(presented.strip().encode(), token.encode())" in source
+    assert 'str(getattr(self.env, "TECHNOCORE_MCP_TOKEN", None) or "").strip()' in source
     # And the property that motivates it, asserted against the stdlib rather than assumed.
     with pytest.raises(TypeError):
         hmac.compare_digest("café", "cafe")


### PR DESCRIPTION
**Verified against `019b57a`** — fresh fetch; the branch is based on it.

## What changes for a caller

Two credentials the Worker used to refuse now authenticate:

- `Authorization: bearer <token>` (any case of the scheme), and
- the correct token when the stored `TECHNOCORE_MCP_TOKEN` has surrounding whitespace.

Nothing that was refused for being wrong is accepted now.

## Why

The gate this touches is the one control in front of a configured signing key — `worker.py`'s
own words: with the key set, "an open endpoint would be a public signing oracle — anyone who
found the URL could post as this identity". Both bugs are refusals of a *correct* credential,
which on this endpoint means the deployment is down and the 401 names the header the caller
already got right.

**1. The scheme was matched case-sensitively.** `removeprefix("Bearer ")` strips exactly one
spelling, but the auth scheme is a case-insensitive token (RFC 9110 §11.1) and clients spell
it as they like. This service already normalises protocol tokens by meaning rather than by
spelling — `if_absent` matches case-insensitively (`manifest.IF_ABSENT`, issue 282) and
`public_base` lowercases the Host — so this gate was the exception.

**2. Only the presented half was trimmed.** `presented.strip()` against a bare `str(token)`.
A token stored with surrounding whitespace — a newline survives more than one way of getting
a secret into an environment — could then be matched by *no caller at all*, including one
reproducing it byte for byte, because their copy was trimmed and the stored one was not. The
endpoint refused everyone, permanently, and the 401 told the operator to send exactly what
they were sending.

Trimming the stored side can only widen the set of deployments that work: a token whose
spelling depended on an invisible character had no working caller before.

## The refusal direction is unchanged

That is the half that matters here — a gate that wrongly refuses is an outage, one that
wrongly accepts hands out the identity. Still 401, and pinned by a test that passes both
before and after this change: a wrong token, a prefix of the token, the token plus a
character, a bare scheme, `Basic <token>`, an empty header, a missing header, and non-ASCII
bytes. The non-ASCII case remains a refusal rather than the `TypeError` `compare_digest`
raises on two non-ASCII `str`s, which is what the existing test exists to protect.

## Tests

The existing worker checks are source-level, and say why: "the Worker's own gates cannot be
executed off the Cloudflare runtime."

They can. Only `from workers import ...` stands in the way — the SDK Cloudflare injects — and
the `_cloudflare.allow_entropy` import beside it is already guarded by `except ImportError`,
which is the branch a non-Worker takes. Stubbing that one module runs `Default.fetch` under
CPython, so the gate is now tested by **driving it** rather than by matching its text. That
matters here beyond tidiness: a string match cannot tell a comparison that is written
correctly from one that is correct, and **both of these bugs passed every source-level check**.

Added, all failing on `019b57a` and passing here:

- `test_the_worker_matches_the_bearer_scheme_case_insensitively` (4 spellings)
- `test_the_worker_accepts_a_token_stored_with_surrounding_whitespace`
- `test_the_worker_still_refuses_every_credential_that_is_not_the_token` — the guard on the
  direction that must not regress; passes before *and* after.

The two existing worker tests keep their shape. One of them pins the comparison line as a
string, and this change alters that line, so the pinned text moves with it —
`str(token).encode()` becomes `str(token).strip().encode()`.

The gate test stubs `_technocore`, deliberately: `fetch` calls `configure(signing_key=...)` on
the way through, which is process-wide state, and a gate test that left a signer behind would
change what later tests in that file see. What is under test is entirely above that call.

## Checks

Run from AGENTS.md / CONTRIBUTING.md, all green on `019b57a`:

```
uv run ruff check .                    All checks passed!
uv run ruff format --check .           71 files already formatted
uv run ty check                        All checks passed!
uv run coverage run -m pytest tests -q 576 passed
uv run coverage report                 97.54%
uv run sz.py --check                   check ok: core code-lines <= baseline
bash examples/beautiful_chat.sh        done — the whole protocol
uv build --project mcp + verify        exact LICENSE/NOTICE, matching metadata
contract job (exact CI args)           845 generated, 845 passed
```

Also checked for order dependence, since the gate test touches module state: the file alone,
the worker tests first, and two consecutive full-suite runs all pass.

No core code-lines added — this is `mcp/worker/`, which `sz.py` does not count as core, and
the baseline is unchanged either way. `CHANGELOG.md` and `sz-baseline.json` untouched.

## Documentation and compatibility

No document changes. `mcp/worker/README.md` documents the header as
`Authorization: Bearer <token>`, which is still exactly right and now also the only spelling
anyone needs to remember. No published schema, route, or response shape moves.

Purely widening: every request that authenticated before still does.

## Abuse impact

None new. No route, parameter, or persistent state is added, and no refusal is removed. The
change only stops the gate refusing credentials that are correct; the set of credentials that
authenticate is otherwise identical, and the comparison stays constant-time over bytes.

## Overlapping work

Checked the open queue by full pagination (458 pull requests, 121 issues, all states):
nothing open or closed touches `mcp/worker/`, the bearer gate, or `TECHNOCORE_MCP_TOKEN`. The
neighbouring case-insensitivity work — issues 282 and 284, and the pull requests citing
them — is all `if_absent` in `src/app.py` and does not reach this file.

(Issue numbers above are written without the `#` on purpose: queue-guard finds overlaps by
text-searching for `#N`, so citing a PR in order to *distinguish* it reads to the bot as
racing it. The comment it left on this PR is that false positive, not a real collision.)
