### PR TITLE
fix: guard RESERVED_ROOM_BYTES floor, XML-escape sitemap URLs

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import re
 from datetime import UTC, datetime, timedelta
+from xml.sax.saxutils import escape as _xml_escape
 
 import config
 import didkey
@@ -1995,7 +1996,7 @@ def sitemap_xml(base: str) -> str:
     cannot fall back to relative paths. With no trustworthy origin the caller serves a 404
     instead of a sitemap full of unusable `<loc>` values.
     """
-    locs = "".join(f"  <url><loc>{_url(base, p)}</loc></url>\n" for p in SITEMAP_PATHS)
+    locs = "".join(f"  <url><loc>{_xml_escape(_url(base, p))}</loc></url>\n" for p in SITEMAP_PATHS)
     return (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'

--- a/src/store.py
+++ b/src/store.py
@@ -83,6 +83,12 @@ MAX_TOTAL_ROOM_BYTES = 5 << 30
 # = MAX_TOTAL_ROOM_BYTES // MAX_ROOMS on purpose: the floor times the cap is the budget, so
 # even the worst case — every room at its floor — lands exactly on the number.
 RESERVED_ROOM_BYTES = MAX_TOTAL_ROOM_BYTES // MAX_ROOMS
+if RESERVED_ROOM_BYTES == 0:
+    raise ValueError(
+        f"CHAT_MAX_ROOMS={MAX_ROOMS} exceeds MAX_TOTAL_ROOM_BYTES="
+        f"{MAX_TOTAL_ROOM_BYTES}; RESERVED_ROOM_BYTES would be 0 "
+        "— refusing to boot"
+    )
 # How many rooms exist and how many bytes they occupy — "count bytes", the same two-integer
 # format and the same machinery as NOTES_FILE below, so one atomic replace keeps both halves
 # describing the same store.

--- a/tests/unit/test_config_guards.py
+++ b/tests/unit/test_config_guards.py
@@ -1,0 +1,28 @@
+"""Regression tests for #581 and #582."""
+
+import os
+import subprocess
+import sys
+
+
+def test_reserved_room_bytes_zero_refuses_to_boot():
+    """CHAT_MAX_ROOMS large enough to make RESERVED_ROOM_BYTES zero must not boot (#581)."""
+    clean = {k: v for k, v in os.environ.items() if not k.startswith("CHAT_")}
+    run = subprocess.run(
+        [sys.executable, "-c", "import store"],
+        capture_output=True,
+        text=True,
+        env={**clean, "CHAT_MAX_ROOMS": "10000000000"},
+        cwd=os.path.join(os.path.dirname(__file__), "..", "..", "src"),
+    )
+    assert run.returncode != 0, "app booted with RESERVED_ROOM_BYTES == 0"
+    assert "ValueError" in run.stderr
+
+
+def test_sitemap_xml_escapes_ampersand():
+    """CHAT_PUBLIC_URL with & must produce well-formed XML (#582)."""
+    from manifest import sitemap_xml
+
+    xml = sitemap_xml("https://example.com?a=1&b=2")
+    assert "&amp;" in xml, "bare & must be escaped as &amp;"
+    assert "?a=1&b=2" not in xml, "bare & must not appear in <loc>"


### PR DESCRIPTION
Fixes #581, Fixes #582.

Two safety guards:

**src/store.py** refuse to boot when `MAX_TOTAL_ROOM_BYTES // MAX_ROOMS` yields 0, preventing silent full-room compaction on every append. Matches the existing refuse-to-boot pattern used by `CHAT_MAX_WAIT` and `CHAT_WAIT_POLL`.

**src/manifest.py** XML-escape `public_url` in `sitemap_xml()` via `xml.sax.saxutils.escape`, so `&` and `<` in `CHAT_PUBLIC_URL` produce well-formed XML.

Verified against `019b57a`.