### PR TITLE
fix(store): clamp since past head to the real head in read_messages

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -889,12 +889,14 @@ def read_messages(
     # advancing past records nobody can read any more, or an expired room would reuse seqs.
     cutoff = _cutoff(room)
     out: list[dict] = []
+    head_seq = 0
     if path.exists():
         with path.open("rb") as f:
             for raw in reverse_lines(f):
                 rec = _parse(raw)
                 if rec is None:
                     continue
+                head_seq = head_seq or rec["seq"]
                 if since is not None and rec["seq"] <= since:
                     break
                 if cutoff is not None and _expired(rec, cutoff):
@@ -907,7 +909,7 @@ def read_messages(
         "room": room,
         "count": len(out),
         "first_seq": out[0]["seq"] if out else None,
-        "last_seq": out[-1]["seq"] if out else (since or 0),
+        "last_seq": out[-1]["seq"] if out else min(since or 0, head_seq),
         "generation": room_generation(root, room),
         "messages": out,
     }

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -596,7 +596,7 @@ def test_limit_is_clamped_to_the_response_budget(client):
 def test_cursor_past_the_end_returns_an_empty_but_usable_view(client):
     client.get("/r/lobby/say/bot/hi")
     view = client.get("/r/lobby?since=999&format=json").json()
-    assert view["count"] == 0 and view["last_seq"] == 999  # cursor preserved, not reset to 0
+    assert view["count"] == 0 and view["last_seq"] == 1  # clamped to real head
     assert "(no new messages)" in client.get("/r/lobby?since=999").text
 
 

--- a/tests/test_store_stateful.py
+++ b/tests/test_store_stateful.py
@@ -265,7 +265,10 @@ class StoreLifecycle(RuleBasedStateMachine):
         if since is not None:
             assert all(s > since for s in seqs), "`since` returned something already seen"
         assert view["first_seq"] == (seqs[0] if seqs else None)
-        assert view["last_seq"] == (seqs[-1] if seqs else (since or 0))
+        if seqs:
+            assert view["last_seq"] == seqs[-1]
+        else:
+            assert view["last_seq"] <= (since or 0), "last_seq must clamp to head, not echo since"
         for message in view["messages"]:
             assert (message["from"], message["text"]) == self.said[room][message["seq"]]
 

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1258,6 +1258,7 @@ def test_a_room_holding_undecodable_bytes_is_counted_not_crashed_on(tmp_path):
     assert store._reapable(p, os.stat(p).st_mtime, stillborn_rule=True) is None
 
 
+
 def test_compaction_retains_the_whole_byte_budget_at_every_record_size(tmp_path):
     """Retention is the byte budget, at every record size.
 
@@ -1303,6 +1304,7 @@ def test_compaction_retains_the_whole_byte_budget_at_every_record_size(tmp_path)
     assert seqs[-1] == written, "the newest record must survive compaction"
 
 
+
 def test_the_append_path_can_size_the_file_it_just_wrote(tmp_path):
     """The compaction check adds `size + len(line)` rather than stat()ing a file it has just
     written while holding the room lock. That is exact only because `size` is read *before*
@@ -1337,3 +1339,16 @@ def test_the_append_path_can_size_the_file_it_just_wrote(tmp_path):
 
     texts = [m["text"] for m in store.read_messages(tmp_path, "torncalc")["messages"]]
     assert texts == ["first", "second"], "the healed record and the new one both survive"
+
+
+def test_a_cursor_past_the_room_head_clamps_so_text_polling_can_progress(tmp_path):
+    """A future cursor must settle on the room's actual head, or the text lane keeps
+    printing a dead next: URL forever (#565)."""
+    import store
+
+    store.append(tmp_path, "cursor", "bot", "one")
+
+    view = store.read_messages(tmp_path, "cursor", since=999)
+
+    assert view["count"] == 0
+    assert view["last_seq"] == 1

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1258,7 +1258,6 @@ def test_a_room_holding_undecodable_bytes_is_counted_not_crashed_on(tmp_path):
     assert store._reapable(p, os.stat(p).st_mtime, stillborn_rule=True) is None
 
 
-
 def test_compaction_retains_the_whole_byte_budget_at_every_record_size(tmp_path):
     """Retention is the byte budget, at every record size.
 
@@ -1302,7 +1301,6 @@ def test_compaction_retains_the_whole_byte_budget_at_every_record_size(tmp_path)
     assert len(data) <= store.COMPACT_KEEP_BYTES
     assert seqs == sorted(seqs), "compaction must leave the file ascending by seq"
     assert seqs[-1] == written, "the newest record must survive compaction"
-
 
 
 def test_the_append_path_can_size_the_file_it_just_wrote(tmp_path):


### PR DESCRIPTION
Fixes #565.

A `?since=` cursor past the room's head was echoed back as `last_seq`, causing the text lane's `next:` line to print a dead cursor. Agents following that line poll forever.

**Fix:** track the room's real head during the reverse scan and clamp `last_seq` to `min(since, head_seq)` when no messages match. Normal polling is unchanged when `out` is non-empty, `out[-1]["seq"]` is still used.

Verified against `019b57a`.