### PR TITLE
docs(openapi): describe /rooms engagement schema

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -138,6 +138,138 @@ _SIG_SCHEMA = {
     "minLength": didkey.SIG_CHARS,
     "maxLength": didkey.SIG_CHARS,
 }
+
+_ROOMS_ENTRY_SCHEMA = {
+    "type": "object",
+    "description": (
+        "One listed public room. `room` and `topic` are caller-controlled input; "
+        "the remaining fields are service measurements."
+    ),
+    "properties": {
+        "room": {
+            "type": "string",
+            "description": "Caller-chosen room name, untrusted like message text.",
+        },
+        "last_seq": {
+            "type": "integer",
+            "description": "Highest retained sequence number seen for this room.",
+        },
+        "bytes": {
+            "type": "integer",
+            "description": "Bytes currently held by the room's retained log file.",
+        },
+        "idle_seconds": {
+            "type": "integer",
+            "description": "Seconds since the room file was last modified.",
+        },
+        "topic": {
+            "type": ["string", "null"],
+            "description": (
+                "Caller-controlled topic note from /kv/topic/{room}, truncated in text "
+                "renderings and untrusted like the room name."
+            ),
+        },
+        "window": {
+            "type": "integer",
+            "description": (
+                "Messages scanned for this room's engagement fields. Bounded by both "
+                "the message cap and the per-room byte budget."
+            ),
+        },
+        "zero_response_share": {
+            "type": ["number", "null"],
+            "description": (
+                "Fraction of the scanned room window after which no different nick spoke. "
+                "Null means the window was empty."
+            ),
+        },
+        "nick_diversity": {
+            "type": ["number", "null"],
+            "description": (
+                "Distinct nicks divided by messages in this room's scanned window. Null "
+                "means the window was empty."
+            ),
+        },
+    },
+    "required": [
+        "room",
+        "last_seq",
+        "bytes",
+        "idle_seconds",
+        "topic",
+        "window",
+        "zero_response_share",
+        "nick_diversity",
+    ],
+}
+
+_ROOMS_NOTES_SCHEMA = {
+    "type": "object",
+    "description": "Service-wide note capacity and byte gauges; namespace names are never listed.",
+    "properties": {
+        "total": {"type": "integer", "description": "Total notes across every namespace."},
+        "bytes": {"type": "integer", "description": "Total retained note bytes."},
+        "capacity": {
+            "type": "integer",
+            "description": "Maximum notes across every namespace, service-wide.",
+        },
+        "capacity_per_namespace": {
+            "type": "integer",
+            "description": "Maximum notes allowed in any one namespace.",
+        },
+    },
+    "required": ["total", "bytes", "capacity", "capacity_per_namespace"],
+}
+
+_ROOMS_ENGAGEMENT_SCHEMA = {
+    "type": "object",
+    "description": (
+        "Rollup over only the rooms returned by this /rooms request. It is shaped by "
+        "the caller's limit and the current recency page, not a whole-service census."
+    ),
+    "properties": {
+        "window_cap": {
+            "type": "integer",
+            "description": (
+                "Maximum messages considered per returned room before the per-room byte "
+                "budget is also applied."
+            ),
+        },
+        "windowed_messages": {
+            "type": "integer",
+            "description": "Total messages actually scanned across the returned rooms.",
+        },
+        "zero_response_share": {
+            "type": ["number", "null"],
+            "description": (
+                "Fraction of scanned messages, pooled across returned rooms, after which "
+                "no different nick spoke. Null means no messages were scanned."
+            ),
+        },
+        "nick_diversity": {
+            "type": ["number", "null"],
+            "description": (
+                "Distinct nicks divided by scanned messages, pooled across returned "
+                "rooms. Null means no messages were scanned."
+            ),
+        },
+        "windowed_note_to_message_ratio": {
+            "type": ["number", "null"],
+            "description": (
+                "Service-wide note count divided by windowed_messages from the returned "
+                "rooms. The numerator is service-wide; the denominator is page-scoped. "
+                "Null means no messages were scanned."
+            ),
+        },
+    },
+    "required": [
+        "window_cap",
+        "windowed_messages",
+        "zero_response_share",
+        "nick_diversity",
+        "windowed_note_to_message_ratio",
+    ],
+}
 # `minLength: 1` on both free-form fields, because `required` does not imply it. `""`
 # satisfies `required: ["text"]` and is nonetheless a 400: `store.clean_text` refuses a
 # value with nothing visible left after the single-line sweep. Two readers were misled by
@@ -798,12 +930,12 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             {
                                 "type": "object",
                                 "properties": {
-                                    "rooms": {"type": "array", "items": {"type": "object"}},
+                                    "rooms": {"type": "array", "items": _ROOMS_ENTRY_SCHEMA},
                                     "total": {"type": "integer"},
                                     "capacity": {"type": "integer"},
                                     "bytes": {"type": "integer"},
-                                    "notes": {"type": "object"},
-                                    "engagement": {"type": "object"},
+                                    "notes": _ROOMS_NOTES_SCHEMA,
+                                    "engagement": _ROOMS_ENGAGEMENT_SCHEMA,
                                     "untrusted": {
                                         "type": "object",
                                         "description": (

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1173,6 +1173,56 @@ def test_every_document_scopes_trust_to_caller_bytes_not_to_message_bodies(clien
     assert "untrusted" in schema["properties"], "the JSON field has to be in the contract"
 
 
+def test_rooms_json_schema_names_the_engagement_shapes():
+    """#334: /rooms?format=json serves these fields, so OpenAPI has to name them.
+
+    A bare ``{"type": "object"}`` is not enough for an agent or generated client to know
+    which engagement fields are caller-scoped, service-wide, nullable, or untrusted.
+    """
+    pytest.importorskip("fcntl")
+    import manifest
+
+    spec = manifest.openapi_document("http://testserver", "test", 2048, 1.0)
+    schema = spec["paths"]["/rooms"]["get"]["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+
+    room = schema["properties"]["rooms"]["items"]
+    assert {
+        "room",
+        "last_seq",
+        "bytes",
+        "idle_seconds",
+        "topic",
+        "window",
+        "zero_response_share",
+        "nick_diversity",
+    } <= set(room["required"])
+    assert "caller-controlled" in room["description"]
+    assert "per-room byte budget" in room["properties"]["window"]["description"]
+
+    notes = schema["properties"]["notes"]
+    assert {
+        "total",
+        "bytes",
+        "capacity",
+        "capacity_per_namespace",
+    } <= set(notes["required"])
+    assert "namespace names are never listed" in notes["description"]
+
+    engagement = schema["properties"]["engagement"]
+    assert {
+        "window_cap",
+        "windowed_messages",
+        "zero_response_share",
+        "nick_diversity",
+        "windowed_note_to_message_ratio",
+    } <= set(engagement["required"])
+    assert "rooms returned by this /rooms request" in engagement["description"]
+    ratio = engagement["properties"]["windowed_note_to_message_ratio"]["description"]
+    assert "numerator is service-wide" in ratio and "denominator is page-scoped" in ratio
+
+
 def test_the_manifest_carries_enough_to_sign_without_reading_prose(client):
     """The metadata is what a machine reads *instead* of the manual, so the byte strings a
     signature is computed over have to be in it — a signature over the wrong concatenation


### PR DESCRIPTION
## What

`/openapi.json` now names the JSON shape returned by `/rooms?format=json`: per-room engagement fields, note capacity gauges, and the engagement rollup. The ratio description also calls out the mixed scope: service-wide note count over the returned page's scanned messages.

## Why

Fixes #334. Generated clients and agents previously only saw bare `object` schemas for `rooms[]`, `notes`, and `engagement`, so the nullable fields and request-scoped rollups were invisible unless they read the prose docs or sampled live traffic.

## Checks

- [ ] `uv run coverage run -m pytest tests -q && uv run coverage report` (not run locally; Windows lacks `fcntl` for the app/store tests)
- [x] `.venv\Scripts\ruff.exe check .`
- [x] `.venv\Scripts\ruff.exe format --check src\manifest.py tests\http\test_docs.py`
- [x] `.venv\Scripts\python.exe sz.py --check`
- [x] Manifest smoke check for the new `/rooms` schema fields
- [x] Docs that would now be wrong are updated: OpenAPI is the changed generated doc; prose docs already described the aggregates
- [x] New surface on a world-writable service: nothing new, metadata only