### PR TITLE
docs(sitemap): list the discovery documents it serves

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1629,11 +1629,11 @@ def config_document(version: str) -> dict:
 # document naming an endpoint the origin does not answer is worse than no document, since
 # the reader believes it and the first real request fails.
 
-# The paths worth naming to a crawler: the prose, the machine-readable pair, and the human
-# page. Content is excluded — robots.txt disallows /r/ and /kv/, and /rooms, though it is a
-# listing rather than a room, answers with `X-Robots-Tag: noindex` because what it lists is
-# anonymous and non-durable. A sitemap entry whose response forbids indexing is a
-# contradiction the crawler resolves by distrusting the sitemap.
+# The paths worth naming to a crawler: the prose, the machine-readable discovery documents,
+# and the human page. Content is excluded — robots.txt disallows /r/ and /kv/, and /rooms,
+# though it is a listing rather than a room, answers with `X-Robots-Tag: noindex` because
+# what it lists is anonymous and non-durable. A sitemap entry whose response forbids
+# indexing is a contradiction the crawler resolves by distrusting the sitemap.
 SITEMAP_PATHS = (
     "/",
     "/llms.txt",
@@ -1646,6 +1646,9 @@ SITEMAP_PATHS = (
     "/config",
     "/.well-known/agent.json",
     "/.well-known/api-catalog",
+    "/.well-known/ai-catalog.json",
+    "/.well-known/agent-skills/index.json",
+    "/.well-known/mcp/server-card.json",
 )
 
 

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1273,6 +1273,11 @@ def test_every_sitemap_url_is_one_the_crawler_is_allowed_to_index(client):
     than a room, but what it lists is anonymous and non-durable, so it stays out."""
     import manifest
 
+    assert {
+        "/.well-known/agent-skills/index.json",
+        "/.well-known/ai-catalog.json",
+        "/.well-known/mcp/server-card.json",
+    } <= set(manifest.SITEMAP_PATHS)
     for path in manifest.SITEMAP_PATHS:
         response = client.get(path)
         assert response.status_code == 200, f"{path} is listed but not served"


### PR DESCRIPTION
## What

Adds the three indexable discovery documents missing from `SITEMAP_PATHS`: the AI catalog, the Agent Skills index, and the MCP server card.

## Why

The service already serves these documents without `X-Robots-Tag: noindex`, and nearby discovery surfaces point at them. A crawler following only `/sitemap.xml` missed documents the origin intentionally publishes.

## Checks

- [x] `.venv\Scripts\ruff.exe check .`
- [x] `.venv\Scripts\ruff.exe format --check src\manifest.py tests\http\test_docs.py`
- [x] `.venv\Scripts\python.exe sz.py --check`
- [x] focused sitemap test passed locally with a Windows-only test-runner shim for `fcntl`
- [x] Docs that would now be wrong are updated: the sitemap source comment now says discovery documents, not only the older machine-readable pair
- [x] New surface on a world-writable service: nothing new; these routes were already public and indexable