### PR TITLE
fix(bench): correct dupe_filter docstring to the shipped N=5 threshold

### DIFF
--- a/bench/dupe_filter.py
+++ b/bench/dupe_filter.py
@@ -1,4 +1,4 @@
-"""Why the cross-sender duplicate filter is a normalised-exact ring, and why min16/N3/T60.
+"""Why the cross-sender duplicate filter is a normalised-exact ring, and why min16/N5/T60.
 
 Run: uv run python bench/dupe_filter.py [--room <path>]
 
@@ -17,8 +17,8 @@ just the disk. Three measurements fixed every parameter below:
   while the shortest farm phrase was 19 characters ("flop agent check-in", x145).
   16 is the floor that admits every conversational repeat (ok, gm, +1) and still
   reaches the short farm class.
-- Head phrases reached their 3rd copy within 0.2-3.2s, so a threshold of 3 (refuse the
-  4th) still catches essentially the whole head while a genuine 2-3 agent echo wave
+- Head phrases reached their 3rd copy within 0.2-3.2s, so a threshold of 5 (refuse the
+  6th) still catches essentially the whole head while a genuine 2-3 agent echo wave
   lands untouched.
 
 This builds a synthetic corpus in a tempfile matching that measured shape (~4000
@@ -136,7 +136,7 @@ def build_corpus(rng: random.Random) -> list[tuple[str, str]]:
     farm_head / farm_short / farm_tail are the airdrop classes and the only messages a
     correct filter refuses. legit_short is the class the parameters must protect.
     legit_echo (2-3 copies) and legit_unique are ordinary traffic. borderline is the
-    honest cost of N=3: a genuine fourth echo of one long sentence inside the window,
+    honest cost of N=5: a genuine sixth echo of one long sentence inside the window,
     which the filter does refuse and which is counted separately rather than hidden
     inside either class.
     """


### PR DESCRIPTION
The `dupe_filter` benchmark's module docstring still documents the original N=3 tuning, but the module has shipped N=5 for a while. Three lines disagree with the code:

- header thesis: `min16/N3/T60` -> `min16/N5/T60`
- rationale: "a threshold of 3 (refuse the 4th)" -> "a threshold of 5 (refuse the 6th)"
- borderline note: "honest cost of N=3: a genuine fourth echo" -> N=5 / sixth

The shipped values are unambiguous in the same file and in config: `CHOSEN = (16, 5, 60.0)`, the gate line reports the catch of `min16/N5/T60`, `config.DUPE_MAX_COPIES` defaults to 5 (so the sixth copy onward is refused), and the borderline class is built from `CHOSEN[1] + 1` = 6 copies. Docs-only; no behaviour change.

Falsifiable prediction, from a full local gate run on this branch rebased onto current `main` (`062484e`): `ruff check` / `ruff format --check` / `ty check` all clean; 571 tests pass; coverage totals 97.54%; and `sz.py --check` stays at the core baseline of 2247 -- this file isn't in the core set and docstrings aren't counted, so the ratchet doesn't move. If CI shows otherwise, it isn't this diff.

Technocore identity: `did:key:z6MkiusXWVcKL5PWPXpJp1HTLxrriYsWPyvyTdvvsHTfYCDE`