### PR TITLE
docs: a release PR may fold the changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,12 @@ Growth past a cap needs a new primitive, or belongs in extra.
   the issue form requires it.
 - One issue, one PR: if an open PR already covers it, review or extend that one. CI
   comments on a new PR when open PRs cite the same issue (queue-guard.yml).
-- Never edit CHANGELOG.md or sz-baseline.json in a PR — both are maintainer-regenerated,
-  and CI fails the PR. If a size cap binds, propose the missing primitive or move the
-  change to extra.
+- Never edit CHANGELOG.md or sz-baseline.json in an ordinary PR — both are
+  maintainer-regenerated. Release-note wording goes in the PR body; if a size cap binds,
+  propose the missing primitive or move the change to extra. **A release PR a maintainer
+  asked for is the exception**: folding [Unreleased] into a dated section *is* the
+  packaging, and release.yml refuses to tag a version CHANGELOG.md has no section for.
+  queue-guard only fails fork PRs, so on an in-repo branch this is a rule, not a check.
 - Move tests, don't rewrite them: test bodies stay byte-identical across reorganisations.
 - Size the core with `uv run sz.py` (table) and `uv run sz.py --check`
   (fails if core code-lines grew past `sz-baseline.json`). Its PEP 723 header makes it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,9 @@ The public API is the HTTP surface: paths, response shapes, documented caps, and
 `text/plain` line format. Reordering or reshaping a line can break an agent even when all the same
 fields remain. Describe notable user-visible changes in the pull request body; maintainers fold
 accepted notes into `[Unreleased]` when merging or cutting a release. Do not edit `CHANGELOG.md`
-unless a maintainer asks.
+unless a maintainer asks — packaging a release is when they ask, and that pull request folds
+`[Unreleased]` into a dated section, because `release.yml` refuses to tag a version the changelog
+has no section for.
 
 The service, MCP wrapper, and published skill share the version in `pyproject.toml`. Leave release
 version changes to a dedicated release change unless a maintainer asks otherwise.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,11 @@ Then check the health endpoint at <http://localhost:8080/healthz> or read the lo
 
 Several pull requests racing one issue cost more review than they save. Two checks are
 automated in `.github/workflows/queue-guard.yml`: a new pull request gets one comment listing
-open PRs that cite the same issues, and a PR touching `CHANGELOG.md` or `sz-baseline.json` —
-both maintainer-regenerated — fails. What only you can do:
+open PRs that cite the same issues, and a *fork* PR touching `CHANGELOG.md` or
+`sz-baseline.json` — both maintainer-regenerated — fails. The file rule is the same either
+way; only the enforcement differs, because the check returns early for a branch in this
+repository and for OWNER/MEMBER/COLLABORATOR authors, which is where the release exception
+below lives. Do not read a green check as permission. What only you can do:
 
 - Verify claims against current `main`, not a cached copy of the source, and name the commit.
 - If an open PR already addresses the issue, review or build on it — with credit — rather than


### PR DESCRIPTION
## What

`AGENTS.md` and `CONTRIBUTING.md` now say that a release PR may fold `[Unreleased]` into a
dated `CHANGELOG.md` section. `sz-baseline.json` keeps its absolute prohibition.

## Why

`AGENTS.md` said "Never edit CHANGELOG.md or sz-baseline.json in a PR" with no exception, so
an agent that follows it cannot package a release: `release.yml` gates the tag on
`grep "^## \[<version>\]" CHANGELOG.md`, and a release PR that obeys the rule produces a
release that fails its own gate. `CONTRIBUTING.md` already had "unless a maintainer asks"
but never said packaging a release *is* the ask, so the two documents disagreed about the
only case where it matters. Surfaced while preparing #592.

Also corrects "and CI fails the PR" — it does not, on the branches most agents work from.
queue-guard's `protected-files` job returns early for an in-repo branch (#570: a head branch
here is proof of write access) and for OWNER/MEMBER/COLLABORATOR authors; it is aimed at
fork PRs, where the maintainer exception cannot apply anyway. Documenting a check that will
not fire teaches the reader to trust green CI over the rule, which is backwards.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 571 passed
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Prose only — no served document changes; nothing in `src/` or the manual moves
- [x] Nothing new: no runtime surface, no route, no response field

🤖 Generated with [Claude Code](https://claude.com/claude-code)
