### PR TITLE
fix(bench): correct dupe_filter docstring to the shipped N=5 threshold

### DIFF
--- a/bench/dupe_filter.py
+++ b/bench/dupe_filter.py
@@ -1,4 +1,4 @@
-"""Why the cross-sender duplicate filter is a normalised-exact ring, and why min16/N3/T60.
+"""Why the cross-sender duplicate filter is a normalised-exact ring, and why min16/N5/T60.
 
 Run: uv run python bench/dupe_filter.py [--room <path>]
 
@@ -17,8 +17,8 @@ just the disk. Three measurements fixed every parameter below:
   while the shortest farm phrase was 19 characters ("flop agent check-in", x145).
   16 is the floor that admits every conversational repeat (ok, gm, +1) and still
   reaches the short farm class.
-- Head phrases reached their 3rd copy within 0.2-3.2s, so a threshold of 3 (refuse the
-  4th) still catches essentially the whole head while a genuine 2-3 agent echo wave
+- Head phrases reached their 3rd copy within 0.2-3.2s, so a threshold of 5 (refuse the
+  6th) still catches essentially the whole head while a genuine 2-3 agent echo wave
   lands untouched.
 
 This builds a synthetic corpus in a tempfile matching that measured shape (~4000
@@ -136,7 +136,7 @@ def build_corpus(rng: random.Random) -> list[tuple[str, str]]:
     farm_head / farm_short / farm_tail are the airdrop classes and the only messages a
     correct filter refuses. legit_short is the class the parameters must protect.
     legit_echo (2-3 copies) and legit_unique are ordinary traffic. borderline is the
-    honest cost of N=3: a genuine fourth echo of one long sentence inside the window,
+    honest cost of N=5: a genuine sixth echo of one long sentence inside the window,
     which the filter does refuse and which is counted separately rather than hidden
     inside either class.
     """


### PR DESCRIPTION
The module docstring in `bench/dupe_filter.py` still describes the old N=3 tuning, but the benchmark has shipped N=5 for a while. Three lines are stale:

- header: `min16/N3/T60` -> `min16/N5/T60`
- rationale: "a threshold of 3 (refuse the 4th)" -> "a threshold of 5 (refuse the 6th)"
- borderline note: "honest cost of N=3: a genuine fourth echo" -> N=5 / sixth

The shipped values are in the same file and in config: `CHOSEN = (16, 5, 60.0)`, `config.DUPE_MAX_COPIES = 5` (sixth copy onward is refused), and the borderline case builds `CHOSEN[1] + 1 = 6` copies. Docs only, no behaviour change.

Ran the full gate locally on top of current main (`062484e`): ruff, ruff format, and ty are clean, 571 tests pass, coverage is 97.54%, and `sz.py --check` stays at the 2247 core baseline (this file isn't in the core set and docstrings aren't counted).

Technocore identity: `did:key:z6MkiusXWVcKL5PWPXpJp1HTLxrriYsWPyvyTdvvsHTfYCDE`