### PR TITLE
fix(manifest): XML-escape public URLs in the sitemap <loc> elements

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import re
 from datetime import UTC, datetime, timedelta
+from xml.sax.saxutils import escape as xml_escape
 
 import config
 import didkey
@@ -1956,7 +1957,7 @@ def sitemap_xml(base: str) -> str:
     cannot fall back to relative paths. With no trustworthy origin the caller serves a 404
     instead of a sitemap full of unusable `<loc>` values.
     """
-    locs = "".join(f"  <url><loc>{_url(base, p)}</loc></url>\n" for p in SITEMAP_PATHS)
+    locs = "".join(f"  <url><loc>{xml_escape(_url(base, p))}</loc></url>\n" for p in SITEMAP_PATHS)
     return (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1285,6 +1285,22 @@ def test_every_sitemap_url_is_one_the_crawler_is_allowed_to_index(client):
     assert "/rooms" not in client.get("/sitemap.xml").text
 
 
+def test_sitemap_escapes_xml_special_characters_in_the_public_url(client):
+    """The sitemap is served as `application/xml`; a `&` in CHAT_PUBLIC_URL must come out
+    as `&amp;` or a validating crawler rejects the whole document. The base is the one
+    configured origin, so the escape belongs on every `<loc>` regardless of which path."""
+    import config
+
+    with config.override(PUBLIC_URL="https://example.com?a=1&b=2"):
+        body = client.get("/sitemap.xml").text
+    assert "&amp;" in body
+    assert "?a=1&b=2" not in body  # raw ampersand would break XML well-formedness
+    # every loc is well-formed XML that a strict parser accepts
+    import xml.etree.ElementTree as ET
+
+    ET.fromstring(body)
+
+
 def test_markdown_negotiation_reads_q_values_not_header_order(client):
     """Header order is not preference. A client that writes `text/markdown;q=0` has
     refused markdown, and one that ranks markdown above plain text has asked for it


### PR DESCRIPTION
Fixes #582.

## Problem

`sitemap_xml` interpolates `_url(base, p)` straight into `<loc>` elements:

```python
f"  <url><loc>{_url(base, p)}</loc></url>\n"
```

`/sitemap.xml` is served as `Content-Type: application/xml`. When `CHAT_PUBLIC_URL` contains XML-special characters (e.g. `https://example.com?a=1&b=2`), the raw `&` breaks XML well-formedness and a validating crawler rejects the entire document (`xmlParseEntityRef: no name`).

## Fix

Escape every `<loc>` value with `xml.sax.saxutils.escape` before it enters the XML:

```python
from xml.sax.saxutils import escape as xml_escape
locs = "".join(f"  <url><loc>{xml_escape(_url(base, p))}</loc></url>\n" for p in SITEMAP_PATHS)
```

This is applied at the single interpolation site, so every sitemap entry is covered regardless of path.

## Test

Added `test_sitemap_escapes_xml_special_characters_in_the_public_url` — sets `PUBLIC_URL=https://example.com?a=1&b=2`, asserts the body contains `&amp;` and no raw ampersand, and parses the document with `xml.etree.ElementTree` to prove well-formedness. Verified RED on the unfixed code, GREEN with the fix. Gate: ruff + format + ty clean, sitemap test group passes.
