### PR TITLE
perf(store): retire the global create gate for a counter reservation (#578)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -79,11 +79,34 @@ MAX_TOTAL_ROOM_BYTES = 5 << 30
 # = MAX_TOTAL_ROOM_BYTES // MAX_ROOMS on purpose: the floor times the cap is the budget, so
 # even the worst case — every room at its floor — lands exactly on the number.
 RESERVED_ROOM_BYTES = MAX_TOTAL_ROOM_BYTES // MAX_ROOMS
-# Total room bytes as of the last reap pass. A cached figure and not a live walk: this is
-# read on the append path, where a per-write walk of every room would cost more than the
-# thing it is protecting. The reaper already walks the tree on a timer, so refreshing it
-# there is free, and a stale-by-one-interval number is fine for a bound whose overshoot is
-# bounded by the rate limiter anyway.
+# How many rooms exist and how many bytes they occupy — "count bytes", the same two-integer
+# format and the same machinery as NOTES_FILE below, so one atomic replace keeps both halves
+# describing the same store.
+#
+# The byte half is what this file always held: a cached figure and not a live walk, because
+# it is read on the append path where a per-write walk of every room would cost more than the
+# thing it is protecting. The reaper already walks the tree on a timer, so refreshing it there
+# is free, and a stale-by-one-interval number is fine for a bound whose overshoot is bounded
+# by the rate limiter anyway.
+#
+# The count half is new and is what retires the global create gate (#578). `_check_room_capacity`
+# used to answer MAX_ROOMS with a live sized walk of every bucket — ~16 ms per new room, run
+# under a service-wide flock that also spanned the append, the fsync and any compaction, which
+# is what made room creation globally serial at a measured 229 ms per flock. Reading a count
+# instead makes the check O(1), so the only thing left to serialise is the counter's own
+# read-modify-write: two small file operations, held for microseconds.
+#
+# What that trades away is exactness, deliberately and with the same fail-closed doctrine
+# NOTES_FILE already documents. The reservation moves before the file is created, so a crash in
+# between over-counts and refuses a create that was allowed. `_reconcile_note_count`'s room
+# equivalent — the reaper's own rewrite below — is a snapshot of a walk that cannot see a
+# reservation whose file has not landed yet, so a rewrite racing creates lands low by at most
+# the creates in flight at that instant, once per REAP_EVERY, and the next pass re-establishes
+# it. The resulting overshoot on MAX_ROOMS is bounded by in-flight creates and does not
+# accumulate: every subsequent check reads the higher figure and refuses. Rooms can afford that
+# where notes cannot, because MAX_ROOMS bounds the walks and the *byte* budget bounds the disk
+# — and a room is created empty, so an overshoot of N rooms is N sidecar locks of disk, not N
+# rings.
 USAGE_FILE = ".usage"
 # How many notes exist and how many bytes they occupy, so neither the global note cap nor
 # the /rooms gauge walks every namespace — the same trade USAGE_FILE already makes for room
@@ -116,7 +139,7 @@ USAGE_FILE = ".usage"
 # deletes (there is no delete route — the manual says so), so between reaps the note count
 # only grows, and the single grower is the create path that writes this file. `_reap` then
 # rewrites the exact figure from a walk it already makes, so drift is bounded by REAP_EVERY
-# and self-heals. That rewrite takes `.notes-create` too — being the only deleter makes the
+# and self-heals. That rewrite takes the create span too — being the only deleter makes the
 # walk exact against *deletions* and nothing else; a create counted but not yet written is
 # invisible to it, so the creates have to be held still for the figure to be true.
 #
@@ -130,7 +153,7 @@ USAGE_FILE = ".usage"
 # malformed file falls back to the full walk — exactly the old behaviour, so the worst case
 # is the old cost and never a wrong answer, and that is also how a single-integer file from
 # a build before the byte half was added heals itself: it fails to parse, so it is walked.
-# And it is read under `.notes-create`, which already serialises note creation, so the check
+# And it is read under this file's own lock, which a create holds while it reserves, so the check
 # and the increment cannot interleave.
 #
 # What it does not survive: an unclean shutdown under CHAT_FSYNC=0 can lose the last write,
@@ -576,13 +599,21 @@ def _prune(d: Path | str) -> bool:
 
 
 @contextmanager
-def _locked(target: Path):
+def _locked(target: Path, shared: bool = False):
     """Exclusive lock held on a sidecar file, so compaction can replace the data
-    file inode without writers holding a lock on the orphan."""
+    file inode without writers holding a lock on the orphan.
+
+    `shared` takes LOCK_SH instead, which is what lets a lock mean "a create is in flight"
+    without meaning "one create at a time" (see `_create_gate`): any number of holders
+    coexist, and the one caller that needs them all to stand still — the reaper, rewriting a
+    count from a walk or removing a directory a create is entering — takes the same file
+    exclusively and waits them out. A read/write open is deliberate and safe: flock locks the
+    open file description, not a byte range, so LOCK_SH on a writable fd is ordinary.
+    """
     target.parent.mkdir(parents=True, exist_ok=True)
     lock = target.with_suffix(target.suffix + ".lock")
     with open(lock, "a+b") as lf:
-        fcntl.flock(lf, fcntl.LOCK_EX)
+        fcntl.flock(lf, fcntl.LOCK_SH if shared else fcntl.LOCK_EX)
         config._dbg(2, "flock", path=target.name)
         try:
             yield
@@ -1304,13 +1335,21 @@ def _reconcile_note_count(root: Path) -> None:
     """Rewrite the note count from a walk, under the create gate. Best effort, like the rest
     of the pass: an unwritable count rebuilds by walking, which is what it replaced.
 
-    Runs after the deletions, so the figure reflects the disk as it now is — and the gate is
+    Runs after the deletions, so the figure reflects the disk as it now is — and the lock is
     what makes that "as it now is" true rather than nearly true. A create writes its `+1`
-    reservation and its note at two different moments, both inside `.notes-create`, and a
-    walk landing between them sees neither the note nor any reason to expect one. It then
-    rewrites the count *low*, and a low count admits a note the cap should refuse. Being the
-    only deleter makes the walk exact against deletions and nothing else; the creates have to
-    be standing still too, and this gate is the only thing that holds them.
+    reservation and its note at two different moments, and a walk landing between them sees
+    neither the note nor any reason to expect one. It then rewrites the count *low*, and a low
+    count admits a note the cap should refuse. Being the only deleter makes the walk exact
+    against deletions and nothing else; the creates have to be held still for the figure to be
+    true, and this is what holds them.
+
+    The *span* lock, taken exclusively — not the counter lock a create holds only while it
+    reserves. A create holds `.notes-count.create` shared from before its reservation until
+    after its note is on disk (see `_create_gate`), so taking it exclusively here waits out
+    every create already in flight and keeps the next one out until the walk has been
+    installed. That is the property this always had, when the same guarantee came from a
+    service-wide mutex that also made every create wait for every other one. Shared holders do
+    not block each other, so the cost moved off the create path and onto this pass alone.
 
     `_replace` settles which writer may stage a file. This settles which one wins.
 
@@ -1319,10 +1358,10 @@ def _reconcile_note_count(root: Path) -> None:
     REAP_EVERY per process and every write path calls it — `note_set` before it knows whether
     it has a create or an overwrite, `_write_record` on every room message — so the pass that
     crosses the interval pays this wherever it arrives from, and a note create arriving while
-    it runs waits on the gate. Bought because a cap that can be breached is not a cap.
+    it runs waits on the span. Bought because a cap that can be breached is not a cap.
     """
     try:
-        with _locked(root / ".notes-create"):
+        with _locked((root / NOTES_FILE).with_suffix(".create")):
             _write_note_count(root, *_count_notes(root))
     except OSError:
         pass
@@ -1374,24 +1413,26 @@ def _drop_emptied_namespaces(root: Path) -> None:
     it and none after. Re-establishing each figure from the walk would work too and is
     strictly more code to be wrong in; an unlink cannot be off by one.
 
-    Under the create gate, for a nearer reason than the count's. A create makes its namespace
-    directory inside `_locked`, one `mkdir` before the `open` that creates the sidecar lock in
-    it, and the directory is still empty in between — precisely what this rmdir looks for.
-    Removing it in that gap does not merely lose a race, it fails the create: creating a file
-    in a directory being removed is EINVAL on APFS, measured here and needing O_CREAT to
-    reproduce at all, where a directory merely *gone* gives the ENOENT POSIX specifies — the
-    errno this was expected to be and never was. Either way the note write dies on a path it
-    had just made.
+    Under the create span, taken exclusively, for a nearer reason than the count's. A create
+    makes its namespace directory inside `_locked`, one `mkdir` before the `open` that creates
+    the sidecar lock in it, and the directory is still empty in between — precisely what this
+    rmdir looks for. Removing it in that gap does not merely lose a race, it fails the create:
+    creating a file in a directory being removed is EINVAL on APFS, measured here and needing
+    O_CREAT to reproduce at all, where a directory merely *gone* gives the ENOENT POSIX
+    specifies — the errno this was expected to be and never was. Either way the note write
+    dies on a path it had just made. A create holds that span shared across the whole of its
+    reservation and write (see `_create_gate`), so waiting for it exclusively is waiting for
+    exactly the gap to close.
 
     Per namespace rather than once around the loop: a create only ever needs the directory it
-    is entering to stand still, so holding the gate across all 32 of them at the cap would
+    is entering to stand still, so holding the span across all 32 of them at the cap would
     queue creates behind namespaces they have nothing to do with. Inside the `try` for the
     reason this whole tail is best effort — `_reap` runs on the request path, and a pass that
-    cannot take the gate must skip a cleanup, never fail the create that triggered it.
+    cannot take the span must skip a cleanup, never fail the create that triggered it.
     """
     for d in (root / "notes").glob("*"):
         try:
-            with _locked(root / ".notes-create"):
+            with _locked((root / NOTES_FILE).with_suffix(".create")):
                 (d / NOTES_FILE).unlink(missing_ok=True)
                 # Buckets first: since sharding a namespace's notes sit a level further down,
                 # so a drained namespace holds empty directories, and rmdir refuses those
@@ -1470,26 +1511,27 @@ def _reap(root: Path) -> None:
                 continue  # racing writer or vanished file: next pass picks it up
     if any(reaped.values()):  # one lock for the whole pass, not one per deleted room
         _bump(root, **reaped)
-    # After the deletions, so the figure reflects the disk as it now is. One extra walk of
-    # the rooms directory (~13 ms at the cap) on a pass that already costs half a second,
-    # bought because the alternative is walking it on every append instead.
-    try:
-        used = _scan(root / "rooms", ".jsonl", sized=True)[1]
-        _replace(root / USAGE_FILE, str(used).encode())
-    except OSError:
-        pass  # a missing usage file reads as no pressure, which fails open, not closed
     _reconcile_note_count(root)
     _sweep_orphan_locks(root, now)
     _drop_emptied_namespaces(root)
-    # Room buckets, once their locks have gone with the sweep above. Under the create gate for
-    # the reason `_drop_emptied_namespaces` spells out: `_locked` makes a room's bucket one
-    # mkdir before it opens the lock inside it, and removing the directory in that gap fails
-    # the write rather than merely losing a race. Best effort, like the rest of the tail.
+    # The room figures, and then the buckets — one span, because both want the same thing that
+    # `_reconcile_note_count` wants and there is no reason to wait for it twice. Creates are
+    # held off for the length of this block (they hold the same span shared), which is what
+    # makes the walk's answer true rather than nearly true, and what keeps a bucket from being
+    # removed inside a creator's mkdir-to-open gap. Both after the deletions and after the
+    # orphan-lock sweep, so the walk sees the disk as it now is and `_prune` can reach a bucket
+    # the sweep has just emptied.
+    #
+    # One extra walk of the rooms directory (~13 ms at the cap) on a pass that already costs
+    # half a second, bought because the alternative is walking it on every append — and, since
+    # #578, on every room create as well: this is now the only thing that establishes the room
+    # COUNT that MAX_ROOMS is enforced against, not just the byte budget.
     try:
-        with _locked(root / ".rooms-create"):
+        with _locked((root / USAGE_FILE).with_suffix(".create")):
+            _write_note_count(root, *_count_rooms(root), name=USAGE_FILE)
             _prune(root / "rooms")
     except OSError:
-        pass
+        pass  # a missing usage file reads as no pressure, which fails open, not closed
 
 
 def snapshots(root: Path) -> list[dict]:
@@ -1660,7 +1702,7 @@ def _count_notes(root: Path) -> tuple[int, int]:
     return total, size
 
 
-def _write_note_count(root: Path, total: int, size: int) -> None:
+def _write_note_count(root: Path, total: int, size: int, name: str = NOTES_FILE) -> None:
     """Replace the totals atomically. Raises rather than swallowing: a caller that cannot
     record a create must not go on to make one, or the cap it just checked means nothing.
 
@@ -1668,8 +1710,12 @@ def _write_note_count(root: Path, total: int, size: int) -> None:
     two files could be read either side of a reap and report a count and a byte total that
     never coexisted. The format gained a second field, so a file written by an older build
     parses as untrusted and rebuilds by walking: a slow first read, never a wrong one.
+
+    `name` is which of the two count files is being written — NOTES_FILE for notes (globally
+    and per namespace), USAGE_FILE for rooms. One implementation because the two hold the same
+    shape and want the same guarantees; the caps they feed differ, not the bookkeeping.
     """
-    _replace(root / NOTES_FILE, f"{total} {size}".encode())
+    _replace(root / name, f"{total} {size}".encode())
 
 
 def _ns_totals(d: Path) -> tuple[int, int]:
@@ -1678,22 +1724,24 @@ def _ns_totals(d: Path) -> tuple[int, int]:
     return _scan(d, ".txt", sized=True)
 
 
-def _note_totals(d: Path, rebuild=_count_notes, persist: bool = False) -> tuple[int, int]:
+def _note_totals(d: Path, rebuild=_count_notes, persist=False, name=NOTES_FILE) -> tuple[int, int]:
     """(notes, bytes) without walking — or by walking, when the file cannot be trusted.
 
-    The same file in two places, because the two caps have the same shape: `d` is the store
-    root for the global count and one namespace directory for that namespace's own, and
+    The same file in three places, because all three caps have the same shape: `d` is the
+    store root for the global note count and for the room count (`name=USAGE_FILE`, the count
+    MAX_ROOMS is enforced against), and one namespace directory for that namespace's own, and
     `rebuild` is the walk that re-establishes whichever was asked for.
 
     Read without the lock, like `counters`: replacement is atomic, so a reader sees the old
     bytes or the new ones. Reading is safe unserialised; *persisting* what the read rebuilt
     is not, so `persist` is off by default and only `_check_note_capacity` turns it on —
-    that one runs inside `.notes-create`, and every other write of a count file is under the
-    same gate. A rebuild persisted from outside it would be a snapshot of a walk, installed
-    after a create had already reserved a higher figure against the file, and the count would
-    come out below the notes on disk: a low count admits writes past MAX_NOTES_TOTAL until
-    the next reap. Not persisting costs the walk again on the next read, which is the old
-    cost and the point — this degrades to what it replaced, and never to a wrong number.
+    that one runs inside the create gate, which IS this file's lock, and every other write of
+    a count file is under the same lock. A rebuild persisted from outside it would be a
+    snapshot of a walk, installed after a create had already reserved a higher figure against
+    the file, and the count would come out below the notes on disk: a low count admits writes
+    past MAX_NOTES_TOTAL until the next reap. Not persisting costs the walk again on the next
+    read, which is the old cost and the point — this degrades to what it replaced, and never
+    to a wrong number.
 
     A zero is never persisted, and that is load-bearing rather than an optimization:
     `_write_note_count` creates the directory it writes into, so persisting the zero a
@@ -1702,7 +1750,7 @@ def _note_totals(d: Path, rebuild=_count_notes, persist: bool = False) -> tuple[
     possible walk, so there is nothing to cache.
     """
     try:
-        count, size = (d / NOTES_FILE).read_text(encoding="utf-8").split()
+        count, size = (d / name).read_text(encoding="utf-8").split()
         if int(count) >= 0 and int(size) >= 0:
             return int(count), int(size)
     except (OSError, ValueError):
@@ -1710,7 +1758,7 @@ def _note_totals(d: Path, rebuild=_count_notes, persist: bool = False) -> tuple[
     totals = rebuild(d)
     if persist and totals[0]:
         try:
-            _write_note_count(d, *totals)
+            _write_note_count(d, *totals, name=name)
         except OSError:
             pass
     return totals
@@ -1724,10 +1772,13 @@ def _note_count(root: Path) -> int:
 def _count_new_note(root: Path, ns_dir: Path, size: int, delta: int) -> None:
     """Move both note counts by `delta` — +1 to reserve a create, -1 to give it back.
 
-    Takes the file's own lock as well as the create gate: the gate orders note creates
-    against each other, this orders the read-modify-write against a concurrent rebuild. One
-    lock for both counts, because both are written here and nowhere else on this path, so
-    the second costs a write and no more waiting.
+    The caller holds NOTES_FILE's lock, because that lock IS the create gate now (see
+    `_create_gate`): the same critical section that read the counts to check the cap writes
+    the reservation against them, so no two creates can both pass a check that only one of
+    them had room for. Taking it here as well is what the gate did when it was a separate
+    file, and it would now be a deadlock on the same lock. One lock for both counts, because
+    both are written here and nowhere else on this path, so the second costs a write and no
+    more waiting.
 
     `size` keeps the byte gauge current on the path that actually moves it in bulk — a
     flood is creates. Overwrites deliberately do not update it: they never change the
@@ -1735,11 +1786,30 @@ def _count_new_note(root: Path, ns_dir: Path, size: int, delta: int) -> None:
     display gauge exact is the trade `note_stats` explains not making. Their drift is
     corrected by the next reap, like everything else here.
     """
-    with _locked(root / NOTES_FILE):
-        count, used = _note_totals(root)
-        _write_note_count(root, max(0, count + delta), max(0, used + size * delta))
-        ns_count, ns_used = _note_totals(ns_dir, _ns_totals)
-        _write_note_count(ns_dir, max(0, ns_count + delta), max(0, ns_used + size * delta))
+    count, used = _note_totals(root)
+    _write_note_count(root, max(0, count + delta), max(0, used + size * delta))
+    ns_count, ns_used = _note_totals(ns_dir, _ns_totals)
+    _write_note_count(ns_dir, max(0, ns_count + delta), max(0, ns_used + size * delta))
+
+
+def _count_rooms(root: Path) -> tuple[int, int]:
+    """(rooms, bytes) by walking every bucket — the walk USAGE_FILE caches. `sized`, because
+    the byte budget is the half that bounds the disk and the count comes free with it."""
+    return _scan(root / "rooms", ".jsonl", sized=True)
+
+
+def _count_new_room(root: Path, delta: int) -> None:
+    """Move the room count by `delta` — +1 to reserve a create, -1 to give it back.
+
+    The byte half is carried through untouched: a room is created empty, so a reservation has
+    no bytes to add, and the figure a compaction is gated on (`_ring_limit`) must keep meaning
+    "measured at the last reap" rather than drifting on creates that contributed nothing. The
+    reaper re-establishes both halves from one walk.
+
+    Caller holds USAGE_FILE's lock — the room create gate, exactly as `_count_new_note` above.
+    """
+    count, used = _note_totals(root, _count_rooms, name=USAGE_FILE)
+    _write_note_count(root, max(0, count + delta), used, name=USAGE_FILE)
 
 
 def _at_capacity(cap: int, what: str) -> StoreError:
@@ -1758,11 +1828,20 @@ def room_bytes_used(root: Path) -> int:
     """Total room bytes at the last reap pass, or 0 if none has run yet.
 
     0 means "no pressure", which is the right default: on a fresh store there is none, and
-    the first write runs a reap and establishes the real figure.
+    the first write runs a reap and establishes the real figure. A file written by a build
+    before USAGE_FILE carried a count is a single integer, so it has no second field and
+    reads as that same 0 — the one write this figure gates is a *compaction*, so failing open
+    keeps a full ring for at most one reap interval, where failing closed would compact every
+    room in the store back to its floor on the strength of a parse error. The first reap
+    rewrites it in the two-integer format and it never parses short again.
+
+    Deliberately not `_note_totals`, which rebuilds by walking what it cannot parse: this runs
+    on the append path, and a walk of every room per write is the cost the file exists to
+    avoid.
     """
     try:
-        return int((root / USAGE_FILE).read_text(encoding="utf-8").strip() or 0)
-    except (OSError, ValueError):
+        return int((root / USAGE_FILE).read_text(encoding="utf-8").split()[1])
+    except (OSError, ValueError, IndexError):
         return 0
 
 
@@ -1782,12 +1861,19 @@ def _check_room_capacity(root: Path, path: Path) -> None:
     below, which has enforced a local cap and a global one side by side since notes got a
     global cap, so there is one pattern here rather than two.
 
-    This still walks, where both note caps have stopped. It is worth it here and was not
-    there: room *creation* is the rare, rate-limited, already-gated path — appends to a room
-    that exists never reach here at all (`path.exists()` returns above, and again in
-    `_create_gate`) — and the byte budget has to be exact, so the alternative is a running
-    total on disk that every reap, compaction and append would have to keep honest. A note
-    create is the path a flood actually runs at, and the count it needs is a count.
+    This no longer walks, and that is the whole of #578. It used to `_scan` every bucket —
+    ~16 ms per new room — while holding a service-wide create gate that also spanned the
+    append, its fsync and any compaction, so every room and note create in the deployment ran
+    one at a time at a measured 229 ms per flock. Both figures come off USAGE_FILE now, which
+    the reaper rewrites from a walk it was already making, so the check is two small reads and
+    the only serialised part of a create is the counter's own read-modify-write.
+
+    What that costs is stated where the file is defined: the count can lag a walk that raced
+    an in-flight create, so MAX_ROOMS may be overshot by the creates in flight at one reap,
+    non-accumulating and healed on the next pass. The byte budget was already a
+    stale-by-one-reap figure for `_ring_limit` and is unchanged. Both remain exact against
+    everything but that window, because the reservation and this check happen in one critical
+    section (`_create_gate`) rather than as a check and a later write.
 
     Only new rooms are refused. A room that exists keeps accepting writes past the budget,
     the same way it does past the count: compaction already holds each one under
@@ -1796,11 +1882,11 @@ def _check_room_capacity(root: Path, path: Path) -> None:
     """
     if path.exists():
         return
-    # `root / "rooms"` and NOT `path.parent`, which since sharding is the room's own bucket:
-    # counting one bucket would report ~1 room where the cap wants all of them, and both
-    # MAX_ROOMS and MAX_TOTAL_ROOM_BYTES would stop being enforced on a world-writable
-    # service. `_scan` recurses, so this is the whole tree either way.
-    count, used = _scan(root / "rooms", ".jsonl", sized=True)
+    # The store root and NOT `path.parent`, which since sharding is the room's own bucket:
+    # USAGE_FILE is one figure for the whole tree, and a per-bucket count would report ~1 room
+    # where the cap wants all of them, so neither MAX_ROOMS nor MAX_TOTAL_ROOM_BYTES would be
+    # enforced on a world-writable service. `_count_rooms` recurses for the rebuild either way.
+    count, used = _note_totals(root, _count_rooms, name=USAGE_FILE)
     if count >= MAX_ROOMS:
         raise _at_capacity(MAX_ROOMS, "room")
     if used >= MAX_TOTAL_ROOM_BYTES:
@@ -1814,24 +1900,6 @@ def _check_room_capacity(root: Path, path: Path) -> None:
         )
 
 
-def _check_note_total(root: Path) -> None:
-    """The global half of the note cap: one file read, no directory walk at all.
-
-    Split out so it can run *before* the create gate as well as inside it. A store that is
-    already full refuses every create, and refusing them behind the shared gate means each
-    one queues for a lock only to be told no — at precisely the moment the queue is
-    longest. This sheds them for the price of a read. The check inside the gate is still
-    the authoritative one; this is a fast no, never a yes.
-    """
-    if _note_count(root) >= MAX_NOTES_TOTAL:
-        raise StoreError(
-            f"note limit reached ({MAX_NOTES_TOTAL} across all namespaces, and this would "
-            "be a new one). A fresh namespace buys nothing — the cap is global. Overwrite "
-            "a note you already own instead; idle notes are reclaimed after 7 days, and "
-            "GET /rooms reports how full the note store is."
-        )
-
-
 def _check_note_capacity(root: Path, ns_dir: Path, path: Path) -> None:
     """Both note caps, neither of which walks any more. Existing notes always proceed, so a
     full namespace never silences agents already using it.
@@ -1842,6 +1910,12 @@ def _check_note_capacity(root: Path, ns_dir: Path, path: Path) -> None:
     notes was ~20,000 directory entries read to answer one comparison, on every write, while
     the writes were themselves growing it. `CHAT_MAX_NOTES_PER_NS` made that worse by
     exactly the factor it raises: the cap is what the directory is allowed to grow to.
+
+    The global half used to be a function of its own so `note_set` could also run it *before*
+    the create gate: a full store refuses every create, and refusing them behind a
+    service-wide gate meant each one queued for a lock only to be told no, at precisely the
+    moment the queue was longest. The gate is a counter lock held for two file operations now
+    (#578), so there is no queue left to shed and no second copy of the check to keep honest.
     """
     if path.exists():
         return
@@ -1850,18 +1924,57 @@ def _check_note_capacity(root: Path, ns_dir: Path, path: Path) -> None:
     # the namespace's `.notes-count` two levels below where every other reader looks for it.
     if _note_totals(ns_dir, _ns_totals, persist=True)[0] >= MAX_NOTES_PER_NS:
         raise _at_capacity(MAX_NOTES_PER_NS, "note")
-    _check_note_total(root)
+    if _note_count(root) >= MAX_NOTES_TOTAL:
+        raise StoreError(
+            f"note limit reached ({MAX_NOTES_TOTAL} across all namespaces, and this would "
+            "be a new one). A fresh namespace buys nothing — the cap is global. Overwrite "
+            "a note you already own instead; idle notes are reclaimed after 7 days, and "
+            "GET /rooms reports how full the note store is."
+        )
 
 
 @contextmanager
-def _create_gate(gate: Path, path: Path, check, counted=None):
-    """Serialise *creation* so a cap counted across files is exact, not merely likely.
+def _create_gate(gate: Path, path: Path, check, counted):
+    """Hold the write lock on `path`, and — for a *create* — check a cap and reserve against
+    it under a second lock held only for that.
 
     A per-file lock cannot enforce a cap over other files: two concurrent creates of
-    different names each pass their own lock, each count `cap - 1`, and both write, so
-    the cap is overshot by up to one write per in-flight request. Counting and creating
-    under one shared gate makes it hard. Writes to a file that already exists never take
-    the gate, so steady-state traffic stays as parallel as before.
+    different names each pass their own lock, each count `cap - 1`, and both write, so the
+    cap is overshot by up to one write per in-flight request. What closes that is that the
+    count a create is checked against and the count it consumes move together, with nothing
+    in between — not that the *creation* is serialised too. Separating those two is #578.
+
+    `gate` used to be a service-wide create mutex (`.rooms-create`, `.notes-create`) held
+    across the whole body: the capacity walk, the append, its fsync and any compaction. Room
+    and note creation therefore had a global concurrency of one across every worker, measured
+    in production at 229 ms per flock with every AnyIO thread parked in it — once room
+    creation turned out to be a high-rate ongoing operation rather than the rare event the
+    old docstring assumed (~90k rooms created against ~49k live, because the reaper keeps
+    freeing slots). `gate` is the *counter file* now — USAGE_FILE for rooms, NOTES_FILE for
+    notes — read by `check` and written by `counted`, and it is released before the body
+    runs. What stays serialised across the store is two small file operations. `check` and
+    `counted` are called holding it and must not take it again.
+
+    Three locks, each for one job, taken in this order everywhere:
+
+      - `<gate>.create`, SHARED, spanning the whole create. It is never contended by another
+        create; it exists so the reaper can take it exclusively and know that no create is
+        between its reservation and its write. `_reconcile_note_count` needs that to rewrite
+        a count from a walk without losing a create the walk could not see, and `_prune` and
+        `_drop_emptied_namespaces` need it because `_locked` below makes a directory one
+        `mkdir` before opening the sidecar lock inside it, and removing it in that gap fails
+        the write outright (ENOENT, or EINVAL on APFS) rather than merely losing a race.
+      - `path`'s own sidecar lock, which the body would take anyway, taken *before* the
+        counter so that "does this file exist" is a settled question for the name being
+        created. That is what keeps two racers on ONE name counting one note: the loser
+        blocks here, and by the time it looks the file is there, so it reserves nothing.
+      - `gate` itself, exclusive, for exactly `check` + `counted(1)`.
+
+    `check` therefore runs twice, and the first one is not redundant: taking `path`'s lock
+    *creates* it, and its bucket with it, so a store at its cap would spend an inode per
+    rejection — which is not a cap. The early call refuses before anything is made. It reads
+    counters and never persists a zero, so it creates nothing itself. The one inside the locks
+    stays the authoritative answer.
 
     `counted` is a reservation, so it takes a sign: the count moves before the write and
     moves back if the write does not happen. Both halves are needed and neither is the
@@ -1872,33 +1985,35 @@ def _create_gate(gate: Path, path: Path, check, counted=None):
         repeating one against fresh keys used to add a note to the totals every time while
         creating none — cheap for them, since a refusal writes nothing, and enough to walk
         a namespace to MAX_NOTES_PER_NS and lock it out until the next reap.
-      - The file can be created by somebody else *while we wait for the gate*. The waiter
-        then holds the gate over an overwrite, not a create, so it must not count either —
-        hence the second `path.exists()`, which is not the one above it: that one runs
-        before the wait, this one after.
+      - The file can be created by somebody else *while we wait for the locks*. The waiter
+        then holds them over an overwrite, not a create, so it must not count either — hence
+        the second `path.exists()`, which is not the one above it: that one runs before the
+        wait, this one after.
     """
-    if path.exists():
-        yield
-        return
-    with _locked(gate):
-        if path.exists():  # created while we waited: this is an overwrite now, not a create
+    if path.exists():  # an overwrite takes neither the span nor the counter: see the docstring
+        with _locked(path):
             yield
-            return
-        check()  # authoritative: nothing else can create between this count and the write
-        if counted is not None:
-            # Before the write, not after: a crash in between leaves the count one too
-            # high, which refuses a create that was allowed. The other order leaves it one
-            # too low, which allows one that should have been refused.
-            counted(1)
+        return
+    check()  # before anything is created, so a refusal never costs an inode
+    with _locked(gate.with_suffix(".create"), shared=True), _locked(path):
+        reserved = False
+        if not path.exists():
+            with _locked(gate):
+                check()  # authoritative: the reservation below consumes what it just counted
+                # Before the write, not after: a crash in between leaves the count one too
+                # high, which refuses a create that was allowed. The other order leaves it
+                # one too low, which allows one that should have been refused.
+                counted(1)
+                reserved = True
         try:
             yield
         finally:
-            # Exact rather than merely fail-closed: a reservation nothing was written
-            # against is given back. Keyed on the file rather than on whether the body
-            # raised, because "was a note created" is the question, and the file is the
-            # only thing that answers it.
-            if counted is not None and not path.exists():
-                counted(-1)
+            # Exact rather than merely fail-closed: a reservation nothing was written against
+            # is given back. Keyed on the file rather than on whether the body raised, because
+            # "was a note created" is the question, and the file alone answers it.
+            if reserved and not path.exists():
+                with _locked(gate):
+                    counted(-1)
 
 
 def append(
@@ -2022,17 +2137,18 @@ def _write_record(
         if sig is not None:
             rec["sig"] = sig
     _reap(root)
-    # Checked before the gate as well as under it: taking the gate serialises the caller
-    # behind every other create, and a rotating room name flooding rejections should not
-    # queue up behind them. The check inside the gate stays authoritative.
-    _check_room_capacity(root, path)
-    with (
-        _create_gate(
-            root / ".rooms-create",
-            path,
-            lambda: _check_room_capacity(root, path),
-        ),
-        _locked(path),
+    # No check before the gate any more. That one existed because taking the gate meant
+    # queueing behind every other create in the store, so a rotating room name flooding
+    # rejections had to be shed before it got there — and because the check it repeated was a
+    # 16 ms walk, which the pair of them paid twice. The gate is USAGE_FILE's own lock now and
+    # the check is two small reads, so the duplicate buys nothing it costs. The gate holds the
+    # room's own lock too (it has to take it first, to settle whether this is a create at all),
+    # so everything below is under it exactly as it was.
+    with _create_gate(
+        root / USAGE_FILE,
+        path,
+        lambda: _check_room_capacity(root, path),
+        lambda d: _count_new_room(root, d),
     ):
         # Under the lock, before the write: two concurrent first-writers must not both
         # decide they created the room and announce it twice.
@@ -2156,22 +2272,17 @@ def note_set(
     ns_dir = _note_ns_dir(root, ns)
     value = clean_text(value, MAX_VALUE_CHARS)
     _reap(root)
-    # The global half only, and only for a create. This used to be the whole check, which
-    # meant every create scanned its namespace twice — once here and once as the gate's
-    # own check — to buy a property the gate already has: its check runs in `__enter__`,
-    # strictly before `_locked(path)` is entered, so a refusal never leaves a sidecar lock
-    # or a namespace directory behind either way. What this call is actually worth is
-    # shedding a full store's worth of refusals without queueing for the gate first.
-    if not path.exists():
-        _check_note_total(root)
-    with (
-        _create_gate(
-            root / ".notes-create",
-            path,
-            lambda: _check_note_capacity(root, ns_dir, path),
-            lambda d: _count_new_note(root, ns_dir, len(value.encode("utf-8")), d),
-        ),
-        _locked(path),
+    # No cap check before the gate any more. One ran here to shed a full store's worth of
+    # refusals without queueing for a service-wide create gate first; the gate is NOTES_FILE's
+    # own lock now, held for two small file operations (#578), so a refusal costs the lock it
+    # was worth avoiding and nothing more. The check inside the gate was always the
+    # authoritative one, and it still runs in `__enter__`, strictly before `_locked(path)` is
+    # entered — so a refusal leaves no sidecar lock and no namespace directory behind.
+    with _create_gate(
+        root / NOTES_FILE,
+        path,
+        lambda: _check_note_capacity(root, ns_dir, path),
+        lambda d: _count_new_note(root, ns_dir, len(value.encode("utf-8")), d),
     ):
         if expect_absent or expect is not None:
             current = path.read_text(encoding="utf-8") if path.exists() else None

--- a/tests/_client.py
+++ b/tests/_client.py
@@ -167,11 +167,11 @@ def _race_before_lock(monkeypatch, store, path, action):
     fired = []
 
     @contextmanager
-    def hook(target):
+    def hook(target, shared=False):
         if target == path and not fired:
             fired.append(True)
             action()
-        with real_locked(target):
+        with real_locked(target, shared):
             yield
 
     monkeypatch.setattr(store, "_locked", hook)

--- a/tests/capacity_bench.py
+++ b/tests/capacity_bench.py
@@ -23,11 +23,19 @@ create figure below is an upper bound rather than the shape. MAX_NOTES_TOTAL is 
 and 480 ms at 163840 when re-measured on tmpfs, and is ~0.1 ms now, so the line below is
 the cost that change removed rather than a cost anyone still pays:
 
-  store, per NEW room/note (the create path, serialised behind the create gate):
+  store, per NEW room/note (the create path):
     _check_room_capacity                 ~16 ms   count + byte budget, one scandir pass.
-                                                  Still O(rooms), deliberately: the byte
-                                                  total has to be exact, and the scan that
-                                                  gets it returns the count anyway
+                                                  O(rooms) when this was measured; #578 moved
+                                                  both figures onto .usage, which the reaper
+                                                  rewrites from a walk it already makes, so
+                                                  this is ~0 ms now and reads no directories
+                                                  at all (tests/unit/test_room_count.py pins
+                                                  the zero). The line below is the cost that
+                                                  change removed. #578 also retired the
+                                                  service-wide create gate this whole section
+                                                  used to be serialised behind: what a create
+                                                  now holds against other creates is a
+                                                  counter read-modify-write, not a room write
     _check_note_capacity                  ~0 ms   was ~25 ms. The global cap reads
                                                   .notes-count instead of walking every
                                                   namespace; only the per-namespace cap

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -127,7 +127,7 @@ def test_the_count_survives_a_lost_file_by_walking(tmp_path) -> None:
 
 
 def test_a_read_outside_the_gate_never_persists_what_it_rebuilt(tmp_path) -> None:
-    """Every write of a count file happens under `.notes-create`. Reading is safe
+    """Every write of a count file happens under that file's own lock. Reading is safe
     unserialised — the replace is atomic — but *persisting* what a read rebuilt is not.
 
     The rebuild is a snapshot of a walk. A create writes its `+1` reservation against the
@@ -534,8 +534,8 @@ def test_a_reap_cannot_lose_a_create_that_has_counted_but_not_written(
     """The concurrent half of the test above, and the one that breached the cap.
 
     A create writes its `+1` reservation and its note at two different moments. Both are
-    inside `.notes-create`, but `_reap` used to rewrite the count from a walk while holding
-    nothing — so a pass landing between the two saw the reservation's note not yet on disk,
+    inside the shared create span, but `_reap` used to rewrite the count from a walk while
+    holding nothing — so a pass between the two saw the reservation's note not yet on disk,
     wrote the lower figure, and the count came out one short of the store. A short count
     admits a note the cap should refuse, which is how MAX_NOTES_TOTAL ended up holding
     `cap + 1`.

--- a/tests/unit/test_room_count.py
+++ b/tests/unit/test_room_count.py
@@ -1,0 +1,271 @@
+"""Run: uv run --group dev python -m pytest tests
+
+The room caps used to be enforced by walking every bucket on every new room — ~16 ms a
+create at the live caps — and that walk ran under a service-wide flock that also spanned the
+append, its fsync and any compaction. Room and note creation therefore had a global
+concurrency of one across every worker (#578).
+
+`.usage` carries the room count as well as the byte total now, so the walk moved onto the
+reaper and the create path reads a file. Three things have to hold, and the last two are the
+ones that would actually hurt if they broke: creates of distinct rooms must really run at the
+same time, the count must not drift *low* (a low count admits a room the cap should refuse),
+and the reaper must not delete a directory out from under a create that is entering it.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+SRC = str(Path(__file__).resolve().parents[2] / "src")
+
+
+def _scandir_calls(monkeypatch, work) -> int:
+    """How many directories `work` reads — the unit the old create path grew with."""
+    import store
+
+    calls = 0
+    real = os.scandir
+
+    def counting(path):
+        nonlocal calls
+        calls += 1
+        return real(path)
+
+    monkeypatch.setattr(store.os, "scandir", counting)
+    work()
+    monkeypatch.setattr(store.os, "scandir", real)
+    return calls
+
+
+def _settled(root: Path, rooms: int = 1) -> None:
+    """A store with `rooms` rooms and a reap pass behind it, so `.usage` is established and
+    the throttle keeps another pass from firing inside whatever the test is measuring."""
+    import store
+
+    for i in range(rooms):
+        store._write_record(root, f"seed{i}", "bot", "hi")
+    (root / ".reaped").unlink(missing_ok=True)
+    store._reap(root)
+
+
+# --------------------------------------------------------------------------- the cost
+
+
+@pytest.mark.parametrize("rooms", [2, 40])
+def test_a_new_room_reads_no_directories_at_any_store_size(tmp_path, monkeypatch, rooms):
+    """Parametrised rather than looped so a failure names the size it failed at. The count
+    must be identical for both — and it must be zero, which is the whole of #578 on this
+    path: the check was one `scandir` per bucket plus a `stat` per room, so it grew with the
+    store, and it was the thing the global create gate was held across.
+    """
+    import store
+
+    root = tmp_path / f"store{rooms}"
+    _settled(root, rooms)
+
+    fresh = store.room_path(root, "brand-new")
+    reads = _scandir_calls(monkeypatch, lambda: store._check_room_capacity(root, fresh))
+    assert reads == 0, f"a new room read {reads} directories; both caps must come off .usage"
+
+
+def test_creates_of_distinct_rooms_run_at_the_same_time(tmp_path, monkeypatch):
+    """The regression test for #578 itself, stated as a topology rather than a duration.
+
+    Four creates of four different names are made to meet at a barrier *inside* the write,
+    after the cap check and the reservation. Under the old gate — one flock held from the
+    capacity walk to the last fsync — only one of them could ever be in there, so the barrier
+    could not fill and this fails by timeout rather than by a flaky millisecond count.
+    """
+    import store
+
+    root = tmp_path
+    _settled(root)
+    parties = 4
+    together = threading.Barrier(parties)
+    real_last_seq = store.last_seq
+
+    def wait_inside_the_write(r, room):
+        if room.startswith("para"):
+            together.wait(timeout=10)  # every party must be inside the body at once
+        return real_last_seq(r, room)
+
+    monkeypatch.setattr(store, "last_seq", wait_inside_the_write)
+    failed = []
+
+    def create(i):
+        try:
+            store._write_record(root, f"para{i}", "bot", "hi")
+        except BaseException as exc:  # noqa: BLE001 - reported through `failed`, not swallowed
+            failed.append(exc)
+
+    threads = [threading.Thread(target=create, args=(i,)) for i in range(parties)]
+    [t.start() for t in threads]
+    [t.join(30) for t in threads]
+
+    assert not failed, f"creates of distinct rooms could not overlap: {failed}"
+    assert not [t for t in threads if t.is_alive()], "a create never finished"
+    assert store._count_rooms(root)[0] == parties + 1, "and every one of them was written"
+
+
+# --------------------------------------------------------------------------- the count
+
+
+def test_racers_on_one_room_count_one_room(tmp_path) -> None:
+    """The count is a reservation, and a create that turns out to be an *append* must not
+    take one. Eight racers, one name, one file — and the count has to say one, not eight.
+
+    This is why `_create_gate` takes the room's own lock before the counter: whoever loses
+    blocks there, and by the time it looks the file exists, so it reserves nothing.
+    """
+    import store
+
+    _settled(tmp_path)
+    before = store._note_totals(tmp_path, store._count_rooms, name=store.USAGE_FILE)[0]
+    start = threading.Barrier(8)
+
+    def create(i):
+        start.wait()
+        store._write_record(tmp_path, "same", "bot", f"hi{i}")
+
+    threads = [threading.Thread(target=create, args=(i,)) for i in range(8)]
+    [t.start() for t in threads]
+    [t.join(30) for t in threads]
+
+    counted = store._note_totals(tmp_path, store._count_rooms, name=store.USAGE_FILE)[0]
+    assert counted == before + 1, "eight writes to one room are one room"
+    assert store._count_rooms(tmp_path)[0] == counted, "and the count must match the disk"
+
+
+def test_the_room_cap_binds_under_concurrent_creates_of_distinct_names(tmp_path) -> None:
+    """Racing the cap is the thing a per-file lock cannot survive: without a shared counter
+    each racer counts `cap - 1` and they all write. The check and the reservation happen in
+    one critical section, so the cap holds even though the *writes* no longer serialise."""
+    import store
+
+    _settled(tmp_path)
+    room_cap = store._count_rooms(tmp_path)[0] + 3
+    start = threading.Barrier(12)
+    refused = []
+
+    def create(i):
+        start.wait()
+        try:
+            store._write_record(tmp_path, f"race{i}", "bot", "hi")
+        except store.StoreError:
+            refused.append(i)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(store, "MAX_ROOMS", room_cap)
+        threads = [threading.Thread(target=create, args=(i,)) for i in range(12)]
+        [t.start() for t in threads]
+        [t.join(30) for t in threads]
+
+    on_disk = store._count_rooms(tmp_path)[0]
+    assert refused, "premise: the cap was reached, or this proves nothing"
+    assert on_disk == room_cap, f"{on_disk} rooms exist against a cap of {room_cap}"
+
+
+def test_a_reap_cannot_lose_a_room_create_that_has_counted_but_not_written(
+    tmp_path, monkeypatch
+) -> None:
+    """A create writes its `+1` reservation and its room at two different moments, and the
+    reaper rewrites the count from a walk that cannot see a room not yet on disk. A pass
+    landing between the two would write the lower figure, and a low count admits a room the
+    cap should refuse.
+
+    The shared `.usage.create` span is what closes it: a create holds it from before its
+    reservation until after its write, and the reaper takes it exclusively. Driven from
+    inside the write, so the reap really does land in the window rather than being timed to
+    it, and joined with a bound — once the reap is ordered behind the span it *cannot*
+    finish until the create does, so an unconditional wait would hang instead of failing.
+    """
+    import store
+
+    _settled(tmp_path)
+    before = store._count_rooms(tmp_path)[0]
+    monkeypatch.setattr(store, "REAP_EVERY", 0)  # every pass is due, including this one
+    real_last_seq = store.last_seq
+    reaper = []
+
+    def race_a_reap_from_inside_the_write(r, room):
+        if room == "late" and not reaper:
+            reaper.append(threading.Thread(target=store._reap, args=(tmp_path,), daemon=True))
+            reaper[0].start()
+            reaper[0].join(1.0)  # unfixed it finishes here and clobbers; fixed it is blocked
+        return real_last_seq(r, room)
+
+    monkeypatch.setattr(store, "last_seq", race_a_reap_from_inside_the_write)
+    store._write_record(tmp_path, "late", "bot", "hi")
+
+    assert reaper, "premise: the reap ran inside the create's reservation window"
+    reaper[0].join(30)  # outside the span, so the blocked pass can now finish its walk
+    assert not reaper[0].is_alive(), "the reap never completed"
+    assert store._count_rooms(tmp_path)[0] == before + 1, "premise: the room is on disk"
+    counted = store._note_totals(tmp_path, store._count_rooms, name=store.USAGE_FILE)[0]
+    assert counted == before + 1, "a reap must not drop a reservation in flight"
+
+
+def test_a_reap_cannot_remove_a_bucket_a_room_create_is_entering(tmp_path, monkeypatch) -> None:
+    """`_locked` makes the room's bucket one `mkdir` before it creates the sidecar lock
+    inside it, and in that instant the bucket holds nothing `_prune` would refuse. A pass
+    landing there removed the directory out from under a create that had just made it, and
+    the create died on the `open` — ENOENT, or EINVAL on APFS.
+
+    The gate used to hold `.rooms-create` across that gap and the reaper's prune took the
+    same file. Both now use the shared span, which is the same guarantee without making
+    every create wait for every other one.
+    """
+    import store
+
+    _settled(tmp_path)
+    monkeypatch.setattr(store, "REAP_EVERY", 0)
+    real_mkdir = Path.mkdir
+    reaper = []
+
+    def race_a_reap_between_the_mkdir_and_the_open(self, *args, **kwargs):
+        made = real_mkdir(self, *args, **kwargs)
+        if self.parent.name == "rooms" and not reaper:  # a room bucket, just created
+            reaper.append(threading.Thread(target=store._reap, args=(tmp_path,), daemon=True))
+            reaper[0].start()
+            reaper[0].join(1.0)
+        return made
+
+    monkeypatch.setattr(Path, "mkdir", race_a_reap_between_the_mkdir_and_the_open)
+    store._write_record(tmp_path, "entering", "bot", "hi")  # must not raise
+    monkeypatch.undo()
+
+    assert reaper, "premise: a reap ran inside the mkdir-to-open gap"
+    reaper[0].join(30)
+    assert store.room_path(tmp_path, "entering").exists(), "the create lost its own bucket"
+
+
+# --------------------------------------------------------------------------- the format
+
+
+def test_a_usage_file_from_before_the_count_heals_by_walking(tmp_path) -> None:
+    """`.usage` held a single integer before it carried a count. It has no second field, so
+    it parses as untrusted and the caps rebuild from a walk — the old cost, never a wrong
+    answer — and the next reap rewrites it in the two-integer format.
+
+    `room_bytes_used` is the one reader that must NOT walk: it runs on the append path, which
+    is what the file exists to keep cheap. It reads the legacy file as 0, which is the same
+    fail-open a missing file gets, and the write it gates is a compaction — so the cost of
+    being wrong for one reap interval is a full ring kept, not a ring thrown away.
+    """
+    import store
+
+    _settled(tmp_path, rooms=2)
+    walked = store._count_rooms(tmp_path)
+    (tmp_path / store.USAGE_FILE).write_text(str(walked[1]))  # the pre-#578 format
+
+    assert store._note_totals(tmp_path, store._count_rooms, name=store.USAGE_FILE) == walked
+    assert store.room_bytes_used(tmp_path) == 0, "the hot path fails open, it never walks"
+
+    (tmp_path / ".reaped").unlink(missing_ok=True)
+    store._reap(tmp_path)
+    assert (tmp_path / store.USAGE_FILE).read_text().split() == [str(n) for n in walked]
+    assert store.room_bytes_used(tmp_path) == walked[1], "and it reads back without a walk"

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -369,8 +369,8 @@ def test_a_reaped_room_does_not_leave_its_bucket_behind(tmp_path, monkeypatch):
 def test_a_reap_that_prunes_buckets_never_meets_a_create_gate_it_already_holds(
     tmp_path, monkeypatch
 ):
-    """`_prune(rooms)` takes `.rooms-create`, and `_reap` runs on the write path — so the
-    question is whether any caller can be inside that gate when a pass fires.
+    """`_prune(rooms)` takes the room create span, and `_reap` runs on the write path — so
+    the question is whether any caller can be inside that span when a pass fires.
 
     `flock` is per open file description and `_locked` opens a fresh fd every time, so a
     second acquire from the same thread does not re-enter: it blocks on itself, forever, with

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -86,6 +86,10 @@ def test_room_disk_is_capped_independently_of_the_room_count(tmp_path, monkeypat
     monkeypatch.setattr(store, "MAX_ROOMS", 10_000)  # far from binding: bytes must do it
     monkeypatch.setattr(store, "MAX_TOTAL_ROOM_BYTES", 400)
     store.append(tmp_path, "room0", "bot", "x" * 300)  # room0 + events ≈ 452B, over budget
+    # The reaper is what establishes the byte figure the cap reads (#578): the create path
+    # stopped walking every bucket per new room, so the budget bites off the last pass.
+    (tmp_path / ".reaped").unlink()
+    store._reap(tmp_path)
     with pytest.raises(store.StoreError, match="room storage is full") as refused:
         store.append(tmp_path, "overflow", "bot", "hi")
     message = str(refused.value)
@@ -126,7 +130,7 @@ def test_the_byte_budget_bounds_growth_and_not_only_creation(tmp_path, monkeypat
 
     # Now make the budget look spent, as a reap pass would have recorded it, and keep
     # writing. The room that receives the writes yields back to its guaranteed floor.
-    (tmp_path / store.USAGE_FILE).write_text(str(store.MAX_TOTAL_ROOM_BYTES + 1))
+    (tmp_path / store.USAGE_FILE).write_text(f"2 {store.MAX_TOTAL_ROOM_BYTES + 1}")
     assert fill("second") <= store.RESERVED_ROOM_BYTES
     assert fill("first") <= store.RESERVED_ROOM_BYTES, "an existing large room must yield too"
 
@@ -143,15 +147,18 @@ def test_the_byte_budget_binds_at_the_cap_and_not_one_byte_past_it(tmp_path, mon
 
     monkeypatch.setattr(store, "MAX_ROOMS", 10_000)  # far from binding: bytes must do it
     store.append(tmp_path, "room0", "bot", "hi")
-    used = store._scan(tmp_path / "rooms", ".jsonl", sized=True)[1]
+    count, used = store._count_rooms(tmp_path)
     monkeypatch.setattr(store, "MAX_TOTAL_ROOM_BYTES", used)  # exactly at the budget
+    # The figure the cap compares against is the one the last reap recorded (#578), so put
+    # the store exactly on the number there rather than only on disk.
+    store._write_note_count(tmp_path, count, used, name=store.USAGE_FILE)
 
     with pytest.raises(store.StoreError, match="room storage is full"):
         store.append(tmp_path, "overflow", "bot", "hi")
 
     # The same equality on the growth half: at the budget a room gets its floor, not the
     # full ring, or "the budget bounds growth" is off by one byte.
-    (tmp_path / store.USAGE_FILE).write_text(str(used))
+    (tmp_path / store.USAGE_FILE).write_text(f"{count} {used}")
     assert store._ring_limit(tmp_path) == store.RESERVED_ROOM_BYTES
 
 
@@ -181,7 +188,7 @@ def test_a_capacity_refusal_carries_the_numbers_a_caller_acts_on(tmp_path, monke
     # shifts that produce it are one character from reporting megabytes as terabytes.
     monkeypatch.setattr(store, "MAX_ROOMS", 10_000)
     monkeypatch.setattr(store, "MAX_TOTAL_ROOM_BYTES", 3 << 20)
-    monkeypatch.setattr(store, "_scan", lambda *a, **k: (1, 5 << 20))  # 5 MiB on disk
+    store._write_note_count(tmp_path, 1, 5 << 20, name=store.USAGE_FILE)  # 5 MiB on disk
     with pytest.raises(store.StoreError, match="5 MiB of a 3 MiB budget"):
         store.append(tmp_path, "overflow", "bot", "hi")
 


### PR DESCRIPTION
## What

Room and note creation no longer serialise behind one service-wide flock. `_create_gate` now holds the *counter file* for a check-and-reserve and releases it before the write. `.usage` carries a room count beside the byte total (the two-integer format `.notes-count` already uses), so `_check_room_capacity` reads a file instead of walking every bucket, and the reaper rewrites both from the walk it was already making.

8 threads creating distinct rooms, ms/create — this branch vs. the walk-and-gate it replaces: 1k rooms **2.9 vs 50.3**, 5k **3.0 vs 173.6**, 20k **3.1 vs 643.5**. The old path scales with the store; this one is flat. Callers see no API change.

## Why

Closes #578. Creation had a global concurrency of one across all workers — 229 ms/flock, 72% of syscall time — because room creation is a high-rate ongoing operation, not the rare event the old docstring assumed.

The cap only needs the count you check against and the count you consume to move together; it never needed the *creation* serialised too. Three locks each do one job now, taken in one order everywhere — a **shared** `<counter>.create` span across the create (the reaper takes it exclusively, which is what keeps a walk-rewritten count from losing a create in flight and keeps a bucket from being pruned inside a creator's mkdir-to-open gap), the file's own lock *before* the counter (so two racers on one name still count once), and the counter for exactly check + reserve.

Judgment calls worth a reviewer's eye: the note cap stays exact, but **MAX_ROOMS may be overshot by the creates in flight at one reap** (non-accumulating, healed next pass), and the room byte budget is now stale-by-one-reap on the create path — the same trade `_ring_limit` already makes for that figure. Both are documented at `USAGE_FILE`. A pre-existing single-integer `.usage` rebuilds by walking and `room_bytes_used` reads it as 0, failing open; no migration step.

Leaves alone, but promotes — **issue 489** (`.seqstate`, deliberately unlinked so queue-guard does not read this as racing the PRs that do address it; this PR changes nothing there). It is now the binding constraint on room creation: `.seqstate` is read and rewritten in full under one global lock per room create and never pruned, measured here at **90 ms/create** at the ~90k rooms this service has already reaped, against 3.2 ms on a fresh store. Fixing this PR's gate alone will move production less than the table above suggests until that one lands too. Issue 588 (`_bump`) is untouched and measures ~20–28% of append wall time, flat in store size.

Release note: room and note creation no longer serialise behind a single service-wide lock; the room caps are read from `.usage` rather than a per-create directory walk.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 579 passed, 97.53% (was 97.54%); 8 new tests in `tests/unit/test_room_count.py`, each verified to fail against a mutated version of the new code
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: none — the gate, `.usage` and the counter files are internal; no doc references them. `uv run sz.py --check` passes with core 7 lines *smaller*
- [x] New surface on a world-writable service: nothing new — no route, parameter or response field changes