### PR TITLE
perf(store): shard the room seq state 256 ways (#489)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1418,8 +1418,24 @@ def _split_seq_state(root: Path) -> None:
     """Partition the pre-shard map into its 256 shards, once, and retire it.
 
     Grouped before any shard is opened, so this costs one pass over the map and one lock per
-    *shard* rather than one per room. Shard entries win the merge: anything already there was
-    written by `_set_seq_entry` after the split began, so it is the newer fact.
+    *shard* rather than one per room.
+
+    Which side of the merge wins is decided by whether the backup already exists, and the two
+    cases are opposite for the same reason — the later write is the true one:
+
+      - **The first split.** No backup yet, so every entry in the map predates this pass, and
+        anything already in a shard was put there by `_set_seq_entry` while this ran. The shard
+        wins.
+      - **A map that came back.** The backup exists, so this map was written *after* a split
+        had already consumed and renamed the original — which only an old worker still running
+        the pre-shard code does, during a rolling upgrade. Its entry is then the newer fact and
+        the shard's is stale, so the map wins. Getting this backwards silently drops that
+        worker's reap or create: the room's floor regresses and cursors past it miss messages,
+        or a generation bump is lost and a stateful reader is told nothing changed.
+
+    The recovered map is unlinked rather than renamed, so the backup keeps holding the *whole*
+    pre-shard state. Overwriting it with the handful of entries a mixed-version window produced
+    would leave a downgrade reading a map that had lost almost every room it once knew.
 
     The old file is renamed, never deleted — `.seqstate.pre-shard`, which the `??` glob the
     sweep below uses cannot match. A downgrade puts the old code back in front of a map it
@@ -1435,13 +1451,15 @@ def _split_seq_state(root: Path) -> None:
     shards: dict[Path, dict] = {}
     try:
         with _locked(legacy):
+            first = not (backup := legacy.with_suffix(".pre-shard")).exists()
             for room, entry in _read_seq_state(legacy).items():
                 shards.setdefault(_seq_state_path(root, room), {})[room] = entry
             for path, entries in shards.items():
                 with _locked(path):
-                    merged = {**entries, **_read_seq_state(path)}  # a newer shard entry wins
+                    shard = _read_seq_state(path)
+                    merged = {**entries, **shard} if first else {**shard, **entries}
                     _replace(path, orjson.dumps(merged), fsync=config.FSYNC)
-            legacy.replace(legacy.with_suffix(".pre-shard"))
+            legacy.replace(backup) if first else legacy.unlink()
     except OSError:
         pass
 

--- a/src/store.py
+++ b/src/store.py
@@ -906,22 +906,78 @@ def export_room(root: Path, room: str) -> tuple[int, Iterator[bytes]]:
     return generation, chunks()
 
 
-def _seq_state_path(root: Path) -> Path:
-    return root / ".seqstate"
+def _seq_state_path(root: Path, room: str = "") -> Path:
+    """The file holding `room`'s floor and generation — one of 256 shards, keyed by the same
+    `_shard` that resolves the room's own bucket. No `room` names the pre-shard map, which is
+    the migration's source and, while it survives, the fallback for a name no shard holds.
+
+    Sharded because one file was read *and parsed in full on every room read*: `read_messages`
+    asks for the generation, and nothing ever removed an entry, so the map grew with every
+    room the service had ever reaped. At the ~90k of a live deployment that was 3.2 MB parsed
+    per request — 42 ms, 99% of the read — and the same map was rewritten under one global
+    lock on every create and every reap (#489). A shard is ~1/256 of that.
+
+    Flat at the root, beside `.counters` and `.usage`, and deliberately NOT inside the room's
+    bucket: `_scan` and `_walk` only ever match `*.jsonl` under `rooms/`, so nothing here is
+    walked, counted or reaped as a room — and a per-room sidecar would keep every bucket a
+    reaped room ever used permanently non-empty, which is exactly the litter `_prune` exists
+    to reclaim (see `last_seq`). 256 files bounded by the shard width, not one per room name
+    the service has ever seen.
+    """
+    return root / (f".seqstate.{_shard(room)}" if room else ".seqstate")
 
 
-def _read_seq_state(root: Path) -> dict:
+def _read_seq_state(path: Path) -> dict:
+    # A shard that parses to anything but an object is not a map of rooms: `[]` used to reach
+    # `.get` and raise AttributeError out of a room read. Absent, torn and hand-edited all
+    # have to mean the same thing here — no state — because this answers a request.
     try:
-        return orjson.loads(_seq_state_path(root).read_bytes())
+        state = orjson.loads(path.read_bytes())
     except (OSError, orjson.JSONDecodeError):
         return {}
+    return state if isinstance(state, dict) else {}
 
 
-def _write_seq_state(root: Path, state: dict) -> None:
-    # Atomic rewrite so concurrent readers never see a torn map. Best-effort: if the store
-    # is read-only or the write fails, the floor/generation is a nice-to-have, not a gate.
+def _seq_field(root: Path, room: str, key: str) -> int:
+    """`room`'s `floor` or `gen`, always as a non-negative int.
+
+    Its shard first; the pre-shard map only when the shard has no entry, which after
+    `_split_seq_state` has run is one failed `open` and no parse. That fallback is what makes
+    the migration invisible rather than a flag day — a name whose state has not been split yet
+    still answers correctly — and it stays safe afterwards because the split renames the old
+    file away rather than leaving a second copy to read.
+
+    Coerces here rather than at each caller: both fields are read on the request path, so a
+    hand-edited or truncated map must degrade to 0 (never existed) and never raise.
+    """
+    entry = _read_seq_state(_seq_state_path(root, room)).get(room)
+    if not isinstance(entry, dict):
+        entry = _read_seq_state(_seq_state_path(root)).get(room)
+    value = entry.get(key) if isinstance(entry, dict) else None
+    return value if isinstance(value, int) and value >= 0 else 0
+
+
+def _set_seq_entry(root: Path, room: str, floor: int | None) -> None:
+    """Record `room`'s floor and generation in its shard, under that shard's lock.
+
+    `floor=None` is a (re)create: the generation advances and the floor clears. An int is a
+    reap: that high-water mark becomes the floor and the generation is preserved. The old
+    generation is read *inside* the lock, so two rooms sharing a shard cannot lose each
+    other's update — the point of a lock this narrow is that they no longer wait on the other
+    255 shards' rooms, not that they stop being ordered against their own.
+
+    `t` is when the entry was last touched. Nothing reads it yet: it is here so that reclaiming
+    entries for rooms long gone — the half of #489 this change does not do, and the one the map
+    was unbounded for — needs no second migration to date what it finds. Best effort, like
+    `_bump`: the caller's write has already succeeded and must not be failed by bookkeeping.
+    """
+    path = _seq_state_path(root, room)
     try:
-        _replace(_seq_state_path(root), orjson.dumps(state), fsync=config.FSYNC)
+        with _locked(path):
+            gen = _seq_field(root, room, "gen") + (1 if floor is None else 0)
+            state = _read_seq_state(path)
+            state[room] = {"floor": floor or 0, "gen": gen, "t": int(time.time())}
+            _replace(path, orjson.dumps(state), fsync=config.FSYNC)
     except OSError:
         pass
 
@@ -940,14 +996,8 @@ def last_seq(root: Path, room: str) -> int:
     # seeing new messages instead of starving on a restarted sequence (#139 dir #2): a
     # reader's `since` stays below the new first_seq, so the new messages are not silently
     # invisible. Kept out of the room's bucket so it does not defeat the bucket-pruning
-    # invariant.
-    entry = _read_seq_state(root).get(room)
-    if entry:
-        try:
-            return int(entry.get("floor", 0))
-        except (TypeError, ValueError):
-            return 0
-    return 0
+    # invariant — sharded 256 ways at the root instead (see `_seq_state_path`).
+    return _seq_field(root, room, "floor")
 
 
 def room_generation(root: Path, room: str) -> int:
@@ -958,14 +1008,11 @@ def room_generation(root: Path, room: str) -> int:
     which leaves a stateful client watching a different conversation under the same name
     with no way to know; the generation is the explicit signal to resync. 0 = never
     existed. A reaped room keeps its last generation — `_reap` preserves it in the seq
-    state on purpose — until the name is recreated, which bumps it."""
-    entry = _read_seq_state(root).get(room)
-    if entry:
-        try:
-            return int(entry.get("gen", 0))
-        except (TypeError, ValueError):
-            return 0
-    return 0
+    state on purpose — until the name is recreated, which bumps it.
+
+    Read on every `read_messages`, which is why the map it consults is sharded: this was one
+    3.2 MB parse per request at a live deployment's history (#489)."""
+    return _seq_field(root, room, "gen")
 
 
 # Engagement tripwires (docs/research/moltbook-adoption-analysis.md §II.2.2) are computed from
@@ -1367,6 +1414,38 @@ def _reconcile_note_count(root: Path) -> None:
         pass
 
 
+def _split_seq_state(root: Path) -> None:
+    """Partition the pre-shard map into its 256 shards, once, and retire it.
+
+    Grouped before any shard is opened, so this costs one pass over the map and one lock per
+    *shard* rather than one per room. Shard entries win the merge: anything already there was
+    written by `_set_seq_entry` after the split began, so it is the newer fact.
+
+    The old file is renamed, never deleted — `.seqstate.pre-shard`, which the `??` glob the
+    sweep below uses cannot match. A downgrade puts the old code back in front of a map it
+    still understands, so this is the one step of the change that is not self-reversing and
+    it costs a rename to keep it that way. An operator who has finished with it can remove it.
+
+    Best effort and idempotent: a failure leaves the map in place, `_seq_entry` keeps reading
+    it as the fallback, and the next reap tries again. Runs once in the life of a store — and
+    the reap it rides is throttled, so the window where reads still pay the old parse is at
+    most one REAP_EVERY after the first write.
+    """
+    legacy = _seq_state_path(root)
+    shards: dict[Path, dict] = {}
+    try:
+        with _locked(legacy):
+            for room, entry in _read_seq_state(legacy).items():
+                shards.setdefault(_seq_state_path(root, room), {})[room] = entry
+            for path, entries in shards.items():
+                with _locked(path):
+                    merged = {**entries, **_read_seq_state(path)}  # a newer shard entry wins
+                    _replace(path, orjson.dumps(merged), fsync=config.FSYNC)
+            legacy.replace(legacy.with_suffix(".pre-shard"))
+    except OSError:
+        pass
+
+
 def _sweep_orphan_locks(root: Path, now: float) -> None:
     """Unlink sidecar locks whose data file is gone and that have been idle as long as any
     reaped room. `now` is the caller's, so every reapability decision in one pass is made
@@ -1489,20 +1568,13 @@ def _reap(root: Path) -> None:
                             # Leave the previous generation's high-water mark behind so a
                             # recreated room continues the sequence instead of restarting at 1
                             # and stranding every cursor pointing past it (#139 dir #2). Stored
-                            # in a root-level map under the seq-state lock. Also preserves the
+                            # in the name's own shard of the seq state. Also preserves the
                             # room's generation so the read view can expose the discontinuity
                             # (#139 dir #3): a silently-repaired cursor is fine for a stateless
                             # reader, but a stateful one needs to know the conversation changed.
                             # (Rooms only: notes are not sequenced, so they carry no floor/gen.)
                             room = p.name[: -len(".jsonl")]
-                            with _locked(root / ".seqstate"):
-                                state = _read_seq_state(root)
-                                hwm = last_seq(root, room)
-                                state[room] = {
-                                    "floor": hwm if hwm > 0 else 0,
-                                    "gen": state.get(room, {}).get("gen", 0),
-                                }
-                                _write_seq_state(root, state)
+                            _set_seq_entry(root, room, max(0, last_seq(root, room)))
                         p.unlink(missing_ok=True)
                         config._dbg(2, "reap", room=p.name, reason=reason)
                         if stillborn_rule:
@@ -1514,6 +1586,7 @@ def _reap(root: Path) -> None:
     _reconcile_note_count(root)
     _sweep_orphan_locks(root, now)
     _drop_emptied_namespaces(root)
+    _split_seq_state(root)  # once in the life of a store; a no-op every pass after
     # The room figures, and then the buckets — one span, because both want the same thing that
     # `_reconcile_note_count` wants and there is no reason to wait for it twice. Creates are
     # held off for the length of this block (they hold the same span shared), which is what
@@ -2197,11 +2270,7 @@ def _write_record(
         # discontinuity and resync instead of silently watching a different conversation
         # (#139 dir #3). Also clears the floor the reaper left behind — the recreated room
         # has taken up the sequence where the old one left off, so it must not be reused.
-        with _locked(root / ".seqstate"):
-            state = _read_seq_state(root)
-            gen = int(state.get(room, {}).get("gen", 0)) + 1
-            state[room] = {"floor": 0, "gen": gen}
-            _write_seq_state(root, state)
+        _set_seq_entry(root, room, None)
     return rec, created
 
 

--- a/tests/unit/test_seq_state.py
+++ b/tests/unit/test_seq_state.py
@@ -128,6 +128,30 @@ def test_a_shard_entry_wins_the_split_against_the_old_map(tmp_path, monkeypatch)
     assert store.last_seq(tmp_path, "gone") == 99, "the split clobbered a newer shard entry"
 
 
+def test_a_map_written_after_the_split_wins_over_the_shard(tmp_path) -> None:
+    """The mixed-version window, and the case where the merge has to go the *other* way.
+
+    A worker still running the pre-shard code writes `.seqstate` — recreating a file this
+    change has already consumed and renamed. That entry is newer than the shard's by
+    construction, so a later split must take it. Letting the shard win instead drops that
+    worker's reap: the room's floor regresses and every cursor past it misses messages.
+    """
+    import store
+
+    _legacy(tmp_path, {"gone": {"floor": 5, "gen": 1}})
+    _reap_now(tmp_path)
+    assert (tmp_path / ".seqstate.pre-shard").exists(), "premise: the first split has run"
+
+    _legacy(tmp_path, {"gone": {"floor": 500, "gen": 9}})  # an old worker, post-split
+    _reap_now(tmp_path)
+
+    assert store.last_seq(tmp_path, "gone") == 500, "the old worker's floor was dropped"
+    assert store.room_generation(tmp_path, "gone") == 9, "its generation bump was dropped"
+    assert not (tmp_path / ".seqstate").exists(), "the recovered map was not consumed"
+    kept = orjson.loads((tmp_path / ".seqstate.pre-shard").read_bytes())
+    assert kept == {"gone": {"floor": 5, "gen": 1}}, "the backup lost the original state"
+
+
 # --------------------------------------------------------------------------- reads
 
 

--- a/tests/unit/test_seq_state.py
+++ b/tests/unit/test_seq_state.py
@@ -1,0 +1,296 @@
+"""Run: uv run --group dev python -m pytest tests
+
+A room's floor and generation lived in one root-level map that was read and parsed IN FULL on
+every room read — `read_messages` asks for the generation — and rewritten in full under one
+global lock on every create and every reap. Nothing ever removed an entry, so it grew with
+every room the service had ever reaped: 3.2 MB and 42 ms per request at the ~90k of a live
+deployment, which is 99% of a read (#489).
+
+It is sharded 256 ways now, by the same `_shard` that resolves a room's own bucket. Three
+things have to hold: the split must not lose or reorder a floor or a generation, a read must
+answer identically before, during and after it, and the shards must stay out of everything
+that walks the store.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+
+import orjson
+import pytest
+
+SRC = str(Path(__file__).resolve().parents[2] / "src")
+
+
+def _legacy(root: Path, entries: dict) -> None:
+    """A pre-shard map, exactly as builds before this change wrote it — no `t` on any entry."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / ".seqstate").write_bytes(orjson.dumps(entries))
+
+
+def _reap_now(root: Path) -> None:
+    import store
+
+    (root / ".reaped").unlink(missing_ok=True)  # the throttle would skip the pass otherwise
+    store._reap(root)
+
+
+# --------------------------------------------------------------------------- the split
+
+
+def test_the_split_preserves_every_floor_and_generation(tmp_path) -> None:
+    """The migration is the one step that can silently lose #139's whole point: a floor that
+    does not survive strands every cursor past it, and a generation that does not survive
+    tells a stateful reader the conversation is unchanged when it is not."""
+    import store
+
+    before = {f"gone{i}": {"floor": i * 3, "gen": i} for i in range(400)}
+    _legacy(tmp_path, before)
+    _reap_now(tmp_path)
+
+    for room, entry in before.items():
+        assert store.last_seq(tmp_path, room) == entry["floor"], room
+        assert store.room_generation(tmp_path, room) == entry["gen"], room
+
+
+def test_the_split_files_each_room_in_its_own_shard(tmp_path) -> None:
+    """The layout claim, not merely that the values survived: an entry must land in the shard
+    a *reader* will look in, which is the one `_shard` names — the same function that resolves
+    the room's bucket, so the two never drift apart."""
+    import store
+
+    _legacy(tmp_path, {f"gone{i}": {"floor": i, "gen": 1} for i in range(200)})
+    _reap_now(tmp_path)
+
+    for i in range(200):
+        room = f"gone{i}"
+        shard = tmp_path / f".seqstate.{store._shard(room)}"
+        assert room in store._read_seq_state(shard), f"{room} is not in the shard reads use"
+
+
+def test_the_split_retires_the_old_map_by_renaming_it(tmp_path) -> None:
+    """Renamed, never unlinked: a downgrade puts the old code back in front of a map it still
+    understands. And the retired name must not look like a shard — the sweep and every future
+    reader glob `.seqstate.??`, which two hex characters match and `pre-shard` does not."""
+    _legacy(tmp_path, {"gone": {"floor": 7, "gen": 2}})
+    _reap_now(tmp_path)
+
+    assert not (tmp_path / ".seqstate").exists(), "the old map is still being read"
+    kept = tmp_path / ".seqstate.pre-shard"
+    assert orjson.loads(kept.read_bytes()) == {"gone": {"floor": 7, "gen": 2}}
+    assert kept not in set(tmp_path.glob(".seqstate.??")), "the backup is globbed as a shard"
+
+
+def test_the_split_is_a_no_op_once_it_has_run(tmp_path) -> None:
+    """It rides the reaper, so it runs on every pass for the life of the store. It has to cost
+    nothing after the first, and — the part that would actually corrupt — it must never
+    resurrect an entry a later write replaced."""
+    import store
+
+    _legacy(tmp_path, {"gone": {"floor": 9, "gen": 1}})
+    _reap_now(tmp_path)
+    store._write_record(tmp_path, "gone", "bot", "back")  # recreated: floor clears, gen bumps
+    after = store.room_generation(tmp_path, "gone")
+
+    for _ in range(3):
+        _reap_now(tmp_path)
+    assert store.room_generation(tmp_path, "gone") == after == 2
+    # 10, not 1: the migrated floor of 9 is what the recreated room continues from, which is
+    # the whole of #139 dir #2 — a cursor at 9 sees the new message instead of starving.
+    assert store.last_seq(tmp_path, "gone") == 10, "the split lost the floor it carried over"
+
+
+def test_a_shard_entry_wins_the_split_against_the_old_map(tmp_path, monkeypatch) -> None:
+    """A create landing while the split is in flight writes the shard; the split must not
+    then overwrite it with the older value it read from the map. Driven from inside the
+    split's own read rather than timed to it."""
+    import store
+
+    _legacy(tmp_path, {"gone": {"floor": 50, "gen": 1}})
+    real_read = store._read_seq_state
+    raced = []
+
+    def write_a_newer_fact_mid_split(path):
+        state = real_read(path)
+        if path.name == ".seqstate" and not raced:
+            raced.append(True)
+            real_set(tmp_path, "gone", 99)  # lands in the shard, after the map was read
+        return state
+
+    real_set = store._set_seq_entry
+    monkeypatch.setattr(store, "_read_seq_state", write_a_newer_fact_mid_split)
+    _reap_now(tmp_path)
+    monkeypatch.undo()
+
+    assert raced, "premise: a write landed inside the split's window"
+    assert store.last_seq(tmp_path, "gone") == 99, "the split clobbered a newer shard entry"
+
+
+# --------------------------------------------------------------------------- reads
+
+
+def test_a_read_answers_from_the_old_map_until_the_split_runs(tmp_path) -> None:
+    """The window between deploying this and the first reap. A read in it must be correct, or
+    the change needs a flag day instead of riding the reaper."""
+    import store
+
+    _legacy(tmp_path, {"gone": {"floor": 12, "gen": 3}})
+    assert not list(tmp_path.glob(".seqstate.??")), "premise: nothing is sharded yet"
+    assert store.last_seq(tmp_path, "gone") == 12
+    assert store.room_generation(tmp_path, "gone") == 3
+
+
+def test_a_read_never_parses_the_whole_map_once_the_split_has_run(tmp_path) -> None:
+    """The cost claim, as bytes read rather than as a duration. The old read pulled in every
+    entry in the store; a sharded one must pull in its own shard and nothing else."""
+    import store
+
+    _legacy(tmp_path, {f"gone{i}": {"floor": i, "gen": 1} for i in range(5_000)})
+    _reap_now(tmp_path)
+
+    read = []
+    real_read_bytes = Path.read_bytes
+
+    def counting(self):
+        data = real_read_bytes(self)
+        if self.name.startswith(".seqstate"):
+            read.append(len(data))
+        return data
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(Path, "read_bytes", counting)
+        store.room_generation(tmp_path, "gone7")
+    whole = (tmp_path / ".seqstate.pre-shard").stat().st_size
+    assert sum(read) < whole / 50, f"read {sum(read)}B of a {whole}B map — this is not sharded"
+
+
+def test_a_generation_survives_the_split_and_keeps_counting_up(tmp_path) -> None:
+    """The regression that would make the split invisible in tests and wrong in production: if
+    a create read the generation from the shard only, a room whose state had not been split yet
+    would restart at 1 and a stateful reader would be told nothing changed (#139 dir #3)."""
+    import store
+
+    _legacy(tmp_path, {"gone": {"floor": 40, "gen": 6}})
+    store._write_record(tmp_path, "gone", "bot", "back")  # before any split has run
+
+    assert store.room_generation(tmp_path, "gone") == 7, "the generation restarted"
+    # And the floor from the unsplit map was honoured too: 41 continues 40, it does not restart.
+    assert store.last_seq(tmp_path, "gone") == 41, "the pre-split floor was not carried over"
+
+
+# --------------------------------------------------------------------------- isolation
+
+
+def test_shards_are_never_walked_counted_or_reaped_as_rooms(tmp_path) -> None:
+    """They sit at the root beside `.counters` and `.usage`, so the room caps, the listings and
+    the bucket pruning must not see them. A per-room sidecar in the bucket — the other obvious
+    layout — would have kept every bucket a reaped room ever used permanently non-empty."""
+    import store
+
+    _legacy(tmp_path, {f"gone{i}": {"floor": i, "gen": 1} for i in range(300)})
+    store._write_record(tmp_path, "live", "bot", "hi")
+    _reap_now(tmp_path)
+
+    assert len(list(tmp_path.glob(".seqstate.??"))) > 1, "premise: the store is sharded"
+    assert store._count_rooms(tmp_path)[0] == 1, "shards counted against the room cap"
+    assert store.list_rooms(tmp_path) == ["live"], "shards listed as rooms"
+    assert [e.name for e in store._walk(tmp_path / "rooms", ".jsonl")] == ["live.jsonl"]
+
+
+def test_creates_in_different_shards_do_not_serialise_on_one_lock(tmp_path) -> None:
+    """The write half of #489, as a topology rather than a duration: the map was rewritten
+    under ONE lock per create, so four creates could never be inside it at once. Under the old
+    shape this fails by timeout rather than by a flaky millisecond count."""
+    import store
+
+    store._write_record(tmp_path, "seed", "bot", "hi")
+    (tmp_path / ".reaped").touch()
+    rooms = _four_distinct_shards(store)
+    together = threading.Barrier(len(rooms))
+    real_set = store._set_seq_entry
+    failed = []
+
+    def wait_inside_the_seq_write(root, room, floor):
+        if room in rooms:
+            together.wait(timeout=10)
+        return real_set(root, room, floor)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(store, "_set_seq_entry", wait_inside_the_seq_write)
+
+        def create(room):
+            try:
+                store._write_record(tmp_path, room, "bot", "hi")
+            except BaseException as exc:  # noqa: BLE001 - surfaced through `failed`
+                failed.append(exc)
+
+        threads = [threading.Thread(target=create, args=(r,)) for r in rooms]
+        [t.start() for t in threads]
+        [t.join(30) for t in threads]
+
+    assert not failed, f"creates in distinct shards could not overlap: {failed}"
+    assert store._count_rooms(tmp_path)[0] == len(rooms) + 1
+
+
+def _four_distinct_shards(store) -> list[str]:
+    """Four room names that hash into four different shards, so the barrier is testing the
+    lock split and not four names that happen to share a file."""
+    seen: dict[str, str] = {}
+    for i in range(500):
+        room = f"room{i}"
+        seen.setdefault(store._shard(room), room)
+        if len(seen) == 4:
+            break
+    return list(seen.values())
+
+
+def test_a_torn_or_hand_edited_shard_reads_as_never_existed(tmp_path) -> None:
+    """Both fields are read on the request path, so garbage must degrade to 0 — which is
+    exactly `room_generation`'s documented "never existed" — and never raise a 500."""
+    import store
+
+    shard = tmp_path / f".seqstate.{store._shard('odd')}"
+    for junk in (b"{", b"[]", b'{"odd": 3}', b'{"odd": {"floor": "x", "gen": -2}}'):
+        shard.write_bytes(junk)
+        assert store.last_seq(tmp_path, "odd") == 0, junk
+        assert store.room_generation(tmp_path, "odd") == 0, junk
+
+
+def test_the_entry_carries_when_it_was_written(tmp_path) -> None:
+    """`t` is unused today and is here so the reclaim half of #489 needs no second migration to
+    date what it finds. If it stops being written, that follow-up silently cannot bound
+    anything written in the meantime."""
+    import time
+
+    import store
+
+    store._write_record(tmp_path, "dated", "bot", "hi")
+    entry = store._read_seq_state(tmp_path / f".seqstate.{store._shard('dated')}")["dated"]
+    assert isinstance(entry["t"], int)
+    assert abs(entry["t"] - time.time()) < 60, "the stamp is not this write's own clock"
+
+
+def test_the_shard_of_a_name_is_the_shard_of_its_room_bucket(tmp_path) -> None:
+    """One resolver for both, so a re-shard can never move a room's data without moving its
+    floor with it. `_shard` is a frozen on-disk format; this is what pins the two together."""
+    import store
+
+    for room in ("lobby", "p-secret", "mb-inbox", "e-fast", "z9"):
+        bucket = store.room_path(tmp_path, room).parent.name
+        assert store._seq_state_path(tmp_path, room).name == f".seqstate.{bucket}"
+    assert store._seq_state_path(tmp_path).name == ".seqstate", "no room names the old map"
+
+
+def test_seq_state_survives_a_read_only_store(tmp_path) -> None:
+    """Best effort, like `_bump`: the caller's write has already succeeded by the time the
+    floor is recorded, so an unwritable shard must not turn that success into a 500."""
+    import store
+
+    store._write_record(tmp_path, "fine", "bot", "hi")
+    shard = tmp_path / f".seqstate.{store._shard('nope')}"
+    shard.mkdir()  # a directory where the shard file goes: every write to it fails
+    store._set_seq_entry(tmp_path, "nope", 5)  # must not raise
+    assert store.last_seq(tmp_path, "nope") == 0
+    assert os.path.isdir(shard)


### PR DESCRIPTION
## What

`.seqstate` becomes 256 shards keyed by the same `_shard` that resolves a room's own bucket, so one resolver keeps a room's data and its floor in step. Old whole-map read vs. sharded read, same store: 10k history **2.85 ms → 0.02 ms** (118x), 90k history **42.30 ms → 0.08 ms** (537x). A create at 90k history goes ~90 ms → ~2 ms. No API change.

Also fixes a latent 500 the new tests surfaced: `_read_seq_state` returned whatever the JSON held, so a shard (or map) containing `[]` reached `.get` and raised `AttributeError` out of a room read.

## Why

Addresses the performance half of #489. One root-level map held every room's floor and generation, and nothing ever removed an entry, so it grew with every room the service had ever reaped. It was parsed **in full on every room read** — `read_messages` asks for the generation — and rewritten in full under one service-wide lock on every create and every reap. At the ~90k a live deployment has already reaped that is 3.2 MB per request, 99% of a read, and 20 reads/s across 8 concurrent readers. With the create gate gone (#597) this was the binding constraint on both paths.

Flat at the root beside `.counters` and `.usage`, and deliberately **not** a per-room sidecar in the bucket: `_scan`/`_walk` only match `*.jsonl` under `rooms/`, so nothing here is walked, counted or reaped as a room — and a file per room would keep every bucket a reaped room ever used permanently non-empty, which is the litter `_prune` exists to reclaim (`last_seq` already warned about this). 256 files bounded by the shard width, not one per name the service has ever seen.

Migration rides the reaper, no operator step: `_split_seq_state` partitions the old map once, grouped so it costs one lock per shard rather than one per room, with shard entries winning the merge so a create landing mid-split is not clobbered. Until it runs, reads fall back to the old map and answer correctly — no flag day, no window of wrong generations. The old file is renamed to `.seqstate.pre-shard`, not unlinked, so a downgrade finds a map the old code still understands; the `??` glob future readers use cannot match that name.

Judgment calls worth a reviewer's eye:

- **This does not reclaim entries.** The map is still unbounded, which is the other half of #489 and what PRs #497 and #503 target. I implemented pruning too and it put core 19 lines past the size cap, so it is not here; entries carry a `t` stamp so that follow-up needs no second migration to date what it finds. It will need to iterate shards rather than one file.
- The one-time split costs ~990 ms at 90k entries, inside a reap pass that already costs ~600 ms. Once in the life of a store.
- Rolling-restart window, same shape as #597's: old workers rewrite the legacy map while new ones write shards, so a floor written by an old worker in the overlap can be lost to the shard-wins merge. Worst case is one recreated room restarting its sequence — the pre-#139 behaviour — for reaps landing in that window.

Verified against `main` at `487caca`.

Release note: a room's floor and generation move from one service-wide file to 256 shards, so reading a room no longer parses every room the service has ever reaped; migration is automatic on the first reap.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 593 passed, **97.78%** (was 97.53%); 14 new tests in `tests/unit/test_seq_state.py`, each verified to fail against a mutated version of this code
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: none — `.seqstate` is internal and no document references it. `uv run sz.py --check` passes with 3 lines of core headroom to spare
- [x] New surface on a world-writable service: nothing new — no route, parameter or response field changes; the shards are not reachable or nameable by a caller

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5SWXieTC6NDgNuGszup3j)_