### PR TITLE
release: 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-08-31
+
+### Changed
+
+- **Room and note creation no longer serialise behind one service-wide lock.** Creating a
+  room checked the caps by walking every bucket while holding a lock that also spanned the
+  append, its fsync and any compaction, so creation ran one at a time across every worker;
+  both figures now come from `.usage`, which the reaper rewrites from a walk it already
+  makes. **Deployer note:** `MAX_ROOMS` may now be overshot by the creates in flight at one
+  reap pass — bounded, non-accumulating, and corrected on the next pass — and the total
+  room-byte budget is a stale-by-one-reap figure on the create path, the same trade the
+  adaptive ring already made for it. `.usage` gains a second field; one written by an
+  earlier release is rebuilt on first read and rewritten by the first reap, so there is no
+  migration step and downgrading is safe.
+
 ## [0.11.0] - 2026-08-31
 
 ### Changed
@@ -978,7 +993,9 @@ this is the point it became a standalone, versioned, independently released proj
 - Per-IP token-bucket rate limiting with the retry delay in the 429 **body**, since agent harnesses
   show the page text and not the headers.
 
-[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.1
+[0.11.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.0
 [0.10.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.10.0
 [0.9.7]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.7
 [0.9.6]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.9.6

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.flop-labs/technocore-chat",
   "description": "Shared rooms and durable notes for agents over plain HTTP: rendezvous, hand-off, coordination.",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "status": "active",
   "websiteUrl": "https://technocore.chat",
   "repository": {
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "technocore-mcp",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -78,7 +78,7 @@ from .fetch import Fetch, urllib_fetch
 # here at build time, so the wheel, `initialize`'s serverInfo and the User-Agent cannot
 # disagree. `mcp/server.json` states it twice more, which a test and the release workflow
 # check against this constant.
-VERSION = "0.11.0"
+VERSION = "0.11.1"
 DEFAULT_URL = "https://technocore.chat"
 # The public instance's `?wait=` ceiling. Documentation and a default here, *not* a clamp:
 # CHAT_MAX_WAIT is a per-instance knob, and a wrapper enforcing 10 against an instance

--- a/mcp/worker/README.md
+++ b/mcp/worker/README.md
@@ -50,7 +50,7 @@ as `--no-build` but has no binary distribution ``. Re-run it after every change 
 
 **And rebuilding the wheel is not enough on its own.** pywrangler vendors the resolved set
 into `mcp/worker/python_modules/`, and it decides what to install from the wheel's *name*.
-A rebuild during development produces the same name — `technocore_mcp-0.11.0-py3-none-any.whl`
+A rebuild during development produces the same name — `technocore_mcp-0.11.1-py3-none-any.whl`
 — so the vendored copy is considered current and your change is silently left out of the
 bundle. Nothing fails; you deploy, the Worker runs, and it runs the old code. Clear the
 vendor directory whenever you change `mcp/src` without bumping the version:
@@ -91,7 +91,7 @@ That needs a Cloudflare account and `wrangler login`; the endpoint lands at
 first if you would rather it were called something else.
 
 To serve a published release rather than this checkout, drop the `find-links` line from
-`[tool.uv]` in `pyproject.toml`. The dependency is an exact `technocore-mcp==0.11.0`, so with
+`[tool.uv]` in `pyproject.toml`. The dependency is an exact `technocore-mcp==0.11.1`, so with
 nothing pointing at `mcp/dist` the resolve takes that wheel from PyPI instead — and
 `uv build` stops being a prerequisite, because there is no local wheel in the picture.
 

--- a/mcp/worker/pyproject.toml
+++ b/mcp/worker/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # built it. See `[tool.uv]` below for why this is a wheel and not a path source, and
     # mcp/worker/README.md for the one command that produces it. Drop the `find-links`
     # below to resolve this from PyPI instead and deploy a published release.
-    "technocore-mcp==0.11.0",
+    "technocore-mcp==0.11.1",
     # Pulled in by the SDK anyway; named here so a resolve failure says which package
     # could not be built for wasm rather than surfacing three levels down.
     "mcp>=2.1,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "technocore-chat"
-version = "0.11.0"
+version = "0.11.1"
 description = "HTTP-native chat and notes for AI agents — over plain GETs or MCP"
 license = "Apache-2.0"
 # One Python, everywhere: `.python-version` pins what uv provisions locally and in CI, and

--- a/uv.lock
+++ b/uv.lock
@@ -1593,7 +1593,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.11.0"
+version = "0.11.1"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

Packages 0.11.1. Folds `[Unreleased]` into a dated section and moves the version in every place that declares it, so `release.yml` will accept a `v0.11.1` tag — it refuses a tag whose version the changelog has no section for, and separately fails if the tag and `pyproject.toml` disagree.

One change since 0.11.0: #597, which retired the service-wide create gate (#578).

## Why

Requested by a maintainer, which is the exception CONTRIBUTING names for editing `CHANGELOG.md`. Nothing else in this PR: no source change, and `sz-baseline.json` is untouched.

The changelog entry leads with the deployer-facing consequences rather than the speedup, because those are what an operator has to decide about — `MAX_ROOMS` may now be overshot by the creates in flight at one reap pass (bounded, non-accumulating, corrected next pass), the total room-byte budget is a stale-by-one-reap figure on the create path, and `.usage` gains a second field that files from an earlier release heal into on first read, so there is no migration step and downgrading is safe.

Versions moved together, as CONTRIBUTING requires. Two parity tests (`test_the_skill_the_image_and_the_wrapper_all_name_one_version`, `test_every_place_that_declares_a_version_agrees`) caught two sites I had missed, so the set is: `pyproject.toml`, `uv.lock` (regenerated with `uv lock`, never by hand), the wrapper's `VERSION`, `mcp/server.json` in both places, and the Worker's exact `technocore-mcp==` pin plus the wheel name its README documents.

Judgment calls worth a reviewer's eye:

- **Two `0.11.0` strings are deliberately left.** `README.md` ("carried a private `max-age=3600` until 0.11.0") and `mcp/worker/pyproject.toml` ("Publishing 0.11.0 ends that") are statements about the past and would become false if bumped.
- **Adds the `[0.11.0]` link reference the previous release omitted**, and moves `[Unreleased]` off its stale `v0.10.0` compare base. Same file, same packaging job.
- **`mcp/worker/uv.lock` is left alone.** It already recorded `technocore-mcp 0.10.0` / `>=0.10` before this PR, and CI resolves the Worker without `--frozen` against the wheel it builds from the checkout, so it is regenerated at resolve time. Pre-existing and out of scope here — worth its own fix if you want it pinned.
- **#598 is not in this release.** It is unmerged; if you want the seq-state sharding in 0.11.1, merge it first and I will fold its note in and re-run the checks.

Verified against `main` at `487caca`.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 579 passed, 97.53%, including both version-parity tests
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: the Worker README's wheel name and pin move with the version; `uv sync --frozen` verified against the regenerated lockfile
- [x] New surface on a world-writable service: nothing new — no code change at all

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5SWXieTC6NDgNuGszup3j)_