### PR TITLE
perf(store): shard the lifetime counters by writer (#588)

### DIFF
--- a/bench/counters.py
+++ b/bench/counters.py
@@ -28,7 +28,16 @@ Three measurements.
    app's note gauge — so an uncached /rooms request pays for three sums. This is the half that
    picks the width: writers want it wide, /rooms wants it narrow.
 
-3. Single-op write latency, uncontended, before and after — the cost of the change to a
+3. The write path end to end, at production's concurrency. `_bump` in isolation overstates
+   the payoff, and eight processes understate it: production runs WEB_CONCURRENCY worker
+   PROCESSES each serving sync handlers from a THREADPOOL, so the queue on the old global
+   lock was tens of writers deep, not five. Sharding by pid divides that queue by the number
+   of workers — threads inside one worker still share its shard, by design — so this is the
+   only measurement that predicts what the deployment sees. It also carries a third column,
+   `store.append` with the counter removed entirely, because the honest reading of a fix is
+   how much of the available headroom it took.
+
+4. Single-op write latency, uncontended, before and after — the cost of the change to a
    writer that was never waiting for anyone.
 
 Builds its own store in a tempfile directory — never read a real one.
@@ -44,6 +53,7 @@ import shutil
 import statistics
 import sys
 import tempfile
+import threading
 import time
 import timeit
 from functools import partial
@@ -56,6 +66,8 @@ import orjson  # noqa: E402
 import store  # noqa: E402
 
 WORKERS = (1, 2, 4, 8)
+WORKERS_LIVE = 5  # WEB_CONCURRENCY in production
+APPENDS = 60  # per thread, for the end-to-end section
 PER_WORKER = 400  # bumps each, enough that a 1-worker run still lasts long enough to time
 WIDTHS = (1, 2, 4, 8, 16, 32, 64, 256)  # 1 is today: the single `.counters` file, unsharded
 SHIPPED = store.COUNTER_SHARDS
@@ -192,6 +204,93 @@ def width_choice() -> None:
     print("  (8 writers, and production runs 5), and the read column is still cheap there.")
 
 
+def _append_proc(root: str, mode: str, threads: int, barrier, out: str) -> None:
+    """One worker process: `threads` threads, each appending to its own room, so nothing here
+    contends on a room lock and the counter is the only thing shared. `mode` is patched after
+    the fork, which is why this benchmark can compare implementations at all."""
+    # Through the module dict, like `_widen`: rebinding a module function is exactly what a
+    # type checker should object to, and swapping the implementation is what this measures.
+    if mode == "global":
+        vars(store)["_bump"] = _global_bump
+    elif mode == "none":
+        vars(store)["_bump"] = lambda *a, **k: None
+    path = Path(root)
+    laps: list[float] = []
+    guard = threading.Lock()
+
+    def one(tid: int) -> None:
+        room = f"r{os.getpid() % 9973:04d}x{tid}"
+        store.append(path, room, "bot", "warm")  # the create is outside the timed section
+        mine = []
+        barrier.wait()
+        for i in range(APPENDS):
+            t0 = time.perf_counter()
+            store.append(path, room, "bot", f"message number {i} with a little padding")
+            mine.append(time.perf_counter() - t0)
+        with guard:
+            laps.extend(mine)
+
+    workers = [threading.Thread(target=one, args=(i,)) for i in range(threads)]
+    start = time.perf_counter()
+    [t.start() for t in workers]
+    [t.join(600) for t in workers]
+    Path(out).write_text(json.dumps({"start": start, "end": time.perf_counter(), "laps": laps}))
+
+
+def _append_run(procs: int, threads: int, mode: str) -> tuple[float, float, float]:
+    context = multiprocessing.get_context("fork")
+    root = Path(tempfile.mkdtemp())
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        # Both throttles satisfied up front: neither the reap pass nor the snapshot is under
+        # test here, and one of them landing inside a run is worth more than every lock in it.
+        (root / ".reaped").touch()
+        (root / store.SNAPSHOTS_FILE).touch()
+        barrier = context.Barrier(procs * threads)
+        running = [
+            context.Process(
+                target=_append_proc, args=(str(root), mode, threads, barrier, str(root / f"a{i}"))
+            )
+            for i in range(procs)
+        ]
+        [p.start() for p in running]
+        [p.join(600) for p in running]
+        assert all(p.exitcode == 0 for p in running), [p.exitcode for p in running]
+        results = [json.loads((root / f"a{i}").read_text()) for i in range(procs)]
+        laps = sorted(lap for r in results for lap in r["laps"])
+        elapsed = max(r["end"] for r in results) - min(r["start"] for r in results)
+        return len(laps) / elapsed, laps[len(laps) // 2] * 1e3, laps[int(len(laps) * 0.99)] * 1e3
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def write_path() -> None:
+    """`store.append` end to end at WORKERS_LIVE processes x T threads — the shape production
+    actually has, and the only one where the lock split shows up in a whole write.
+
+    Read the third column before quoting the second: the counter's own read-modify-replace is
+    the larger cost, and splitting its lock does not touch it. What this change buys is the
+    queue in front of it, which is what #588 measured (63-81% of syscall time in `flock`).
+    """
+    print(f"\nstore.append() end to end, {WORKERS_LIVE} processes x T threads, own room each")
+    print(
+        f"  {'threads':>7}  {'global lock':>26}  {'sharded by writer':>26}  {'no counter at all':>26}"
+    )
+    for threads in (4, 8, 16):
+        row = {m: _append_run(WORKERS_LIVE, threads, m) for m in ("global", "sharded", "none")}
+        print(
+            f"  {threads:>7}  "
+            + "  ".join(
+                f"{row[m][0]:>6,.0f}/s p50 {row[m][1]:>6.2f} p99 {row[m][2]:>7.2f}ms"
+                for m in ("global", "sharded", "none")
+            )
+        )
+    print("  Eight processes with no threads show almost none of this: the lock is only the")
+    print("  constraint once the queue on it is tens of writers deep, which threads are how")
+    print("  this service gets. Traffic concentrated in ONE room shows none of it either —")
+    print("  those writers already serialise on that room's own flock.")
+
+
 def single_write() -> None:
     """The uncontended cost, for completeness: one writer, nobody to wait for."""
     print("\nsingle-op write latency, uncontended")
@@ -220,5 +319,6 @@ if __name__ == "__main__":
         f"python {platform.python_version()}, store shard width {store.COUNTER_SHARDS}"
     )
     throughput()
+    write_path()
     width_choice()
     single_write()

--- a/bench/counters.py
+++ b/bench/counters.py
@@ -1,0 +1,224 @@
+"""Why the lifetime counters shard by writer, and why that width is 8.
+
+Run: uv run python bench/counters.py
+
+`_bump` is called by every write in the service — every message append, every note write, and
+the reaper's tally — and it used to take one exclusive flock on `.counters` and do a
+read-parse-modify-replace inside it. So writes to unrelated rooms serialised against each
+other: on technocore.chat (0.11.1, 6 vCPU, WEB_CONCURRENCY=5, ~316 req/s, ~135 writes/s)
+`flock` was 63-81% of a worker's syscall time at ~95 ms mean, sampled eight times across two
+REAP_EVERY cycles with no periodic component — per-write contention, not the reaper (#588).
+
+The claim being tested is about CONTENTION, which one process cannot show. So the headline
+number here is concurrent throughput across real processes, and the baseline is the previous
+implementation itself — `_global_bump` below is byte-for-byte what `_bump` did before this
+change, kept here so the "before" column stays reproducible after the change has landed.
+
+Three measurements.
+
+1. Concurrent write throughput — the headline. N processes bumping one store, N = 1, 2, 4, 8.
+   The global lock should be near-FLAT in N: adding writers adds queueing, not throughput. A
+   run that does not show that flat baseline has not reproduced the bug and its "after" column
+   means nothing. The sharded one should climb with N until something else binds — and what
+   binds is the directory: every shard is replaced by rename into the same parent, so the
+   kernel's lock on that one directory inode is the next constraint down.
+
+2. The read path, which is where a shard's cost lands. `counters` sums every part, and two of
+   its callers are stamps on hot read paths — `room_stats`'s topic stamp (the /rooms walk) and
+   app's note gauge — so an uncached /rooms request pays for three sums. This is the half that
+   picks the width: writers want it wide, /rooms wants it narrow.
+
+3. Single-op write latency, uncontended, before and after — the cost of the change to a
+   writer that was never waiting for anyone.
+
+Builds its own store in a tempfile directory — never read a real one.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+import platform
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+import timeit
+from functools import partial
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import orjson  # noqa: E402
+
+import store  # noqa: E402
+
+WORKERS = (1, 2, 4, 8)
+PER_WORKER = 400  # bumps each, enough that a 1-worker run still lasts long enough to time
+WIDTHS = (1, 2, 4, 8, 16, 32, 64, 256)  # 1 is today: the single `.counters` file, unsharded
+SHIPPED = store.COUNTER_SHARDS
+
+
+def _global_bump(root: Path, **deltas: int) -> None:
+    """`_bump` as it stood before the change: one exclusive lock on one global file, holding a
+    whole read-parse-modify-replace. The baseline every "before" figure below comes from."""
+    path = root / store.COUNTERS_FILE
+    try:
+        with store._locked(path):
+            current = store._read_counters(path)
+            merged = {key: current[key] + deltas.get(key, 0) for key in store.COUNTER_KEYS}
+            store._replace(path, orjson.dumps(merged))
+    except OSError:
+        pass
+
+
+def _bump_loop(root: str, count: int, sharded: bool, barrier, out: str) -> None:
+    """One worker. Latencies are recorded per op and written out as JSON: a child cannot hand
+    a list back through a fork, and a queue would add its own lock to what is being measured.
+
+    The barrier is what makes this a contention benchmark rather than N staggered runs — every
+    worker is inside the loop before any of them is timed.
+    """
+    bump = store._bump if sharded else _global_bump
+    path = Path(root)
+    barrier.wait()
+    start = time.perf_counter()
+    laps = []
+    for _ in range(count):
+        t0 = time.perf_counter()
+        bump(path, messages=1)
+        laps.append(time.perf_counter() - t0)
+    Path(out).write_text(json.dumps({"start": start, "end": time.perf_counter(), "laps": laps}))
+
+
+def _widen(width: int) -> None:
+    """Re-shard the store module in this process. The children are forked after it, so they
+    inherit the width under test — there is no knob for this at runtime, deliberately (the
+    layout is on-disk, exactly like `_shard`), and a benchmark that could not vary it could
+    not show why the shipped number is the shipped number."""
+    # Through the module dict: the shipped width is a literal, and a type checker rightly
+    # objects to rebinding it — this benchmark is the one caller with a reason to.
+    vars(store)["COUNTER_SHARDS"] = width
+    store._COUNTER_SHARD_FILES = tuple(f"{store.COUNTERS_FILE}.{i:02x}" for i in range(width))
+    store._COUNTER_FILES = (store.COUNTERS_FILE, *store._COUNTER_SHARD_FILES)
+
+
+def _run(workers: int, sharded: bool, width: int = 0) -> tuple[float, float, float]:
+    """Returns bumps/s over the whole run, and p50/p99 of one bump, in milliseconds."""
+    if width:
+        _widen(width)
+    context = multiprocessing.get_context("fork")
+    root = Path(tempfile.mkdtemp())
+    try:
+        barrier = context.Barrier(workers)
+        procs = [
+            context.Process(
+                target=_bump_loop,
+                args=(str(root), PER_WORKER, sharded, barrier, str(root / f"o{i}")),
+            )
+            for i in range(workers)
+        ]
+        [p.start() for p in procs]
+        [p.join(300) for p in procs]
+        results = [json.loads((root / f"o{i}").read_text()) for i in range(workers)]
+        laps = sorted(lap for r in results for lap in r["laps"])
+        elapsed = max(r["end"] for r in results) - min(r["start"] for r in results)
+        total = store.counters(root)["messages"]
+        assert total == workers * PER_WORKER, f"lost {workers * PER_WORKER - total} bumps"
+        return len(laps) / elapsed, laps[len(laps) // 2] * 1e3, laps[int(len(laps) * 0.99)] * 1e3
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+        _widen(SHIPPED)
+
+
+def throughput() -> None:
+    print(f"\nconcurrent write throughput ({PER_WORKER} bumps per worker, one store)")
+    print(f"  {'workers':>7}  {'global lock':>26}  {'sharded by writer':>26}  {'gain':>6}")
+    print(f"  {'':>7}  {'bumps/s   p50     p99':>26}  {'bumps/s   p50     p99':>26}")
+    for workers in WORKERS:
+        before = _run(workers, sharded=False)
+        after = _run(workers, sharded=True)
+        print(
+            f"  {workers:>7}  {before[0]:>9,.0f} {before[1]:>6.2f}ms {before[2]:>6.2f}ms  "
+            f"{after[0]:>9,.0f} {after[1]:>6.2f}ms {after[2]:>6.2f}ms  {after[0] / before[0]:>5.2f}x"
+        )
+    print("  A flat 'global lock' column IS the bug: more writers, no more writes.")
+
+
+def _populate(root: Path, width: int) -> None:
+    """A store whose every shard has been written — the steady state after one restart, and
+    the worst case for the reader, since a shard that does not exist is a cheaper `open`."""
+    root.mkdir(parents=True, exist_ok=True)
+    counts = orjson.dumps(dict.fromkeys(store.COUNTER_KEYS, 1_234_567))
+    (root / store.COUNTERS_FILE).write_bytes(counts)
+    for i in range(width):
+        (root / f"{store.COUNTERS_FILE}.{i:02x}").write_bytes(counts)
+
+
+def _read_cost(width: int) -> float:
+    """Seconds for one `counters()` at `width`, against a store where every shard exists —
+    the steady state after one restart, and the reader's worst case."""
+    root = Path(tempfile.mkdtemp())
+    try:
+        _populate(root, 0 if width == 1 else width)
+        _widen(0 if width == 1 else width)
+        n = 2_000
+        return timeit.timeit(lambda r=root: store.counters(r), number=n) / n
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+        _widen(SHIPPED)
+
+
+def width_choice() -> None:
+    """The whole trade-off in one table, and the only place the shipped number is argued.
+
+    A shard buys write concurrency up to the number of concurrent WRITERS — there are
+    WEB_CONCURRENCY of those, five in production — and past that it buys nothing, because
+    there is no sixth process to keep the sixth lock busy. Every shard costs the READER
+    unconditionally: `counters` sums them all, and three sums are on one uncached /rooms
+    request (`_rooms_stamp`, `room_stats`'s topic stamp, app's note gauge). One is paid per
+    write, the other per read, and this service reads far more than it writes.
+    """
+    print("\nwidth — writes want it wide, /rooms wants it narrow")
+    print(f"  {'width':>9}  {'8 writers':>18}  {'counters()':>12}  {'3x (one /rooms)':>17}")
+    for width in WIDTHS:
+        rate = _run(8, sharded=True, width=width)[0] if width > 1 else _run(8, sharded=False)[0]
+        per = _read_cost(width)
+        label = f"{width} (today)" if width == 1 else f"{width}{' <-' if width == SHIPPED else ''}"
+        print(f"  {label:>9}  {rate:>11,.0f} b/s  {per * 1e6:>9.1f} us  {per * 3e6:>14.1f} us")
+    print(f"  Shipped width: {SHIPPED} — the write column has stopped climbing well before it")
+    print("  (8 writers, and production runs 5), and the read column is still cheap there.")
+
+
+def single_write() -> None:
+    """The uncontended cost, for completeness: one writer, nobody to wait for."""
+    print("\nsingle-op write latency, uncontended")
+    for label, bump in (("global lock (before)", _global_bump), ("sharded (after)", store._bump)):
+        root = Path(tempfile.mkdtemp())
+        try:
+            root.mkdir(parents=True, exist_ok=True)
+            bump(root, messages=1)  # warm: the lock file and the shard both exist
+            one = partial(bump, root, messages=1)
+            laps = [timeit.timeit(one, number=1) for _ in range(2_000)]
+            laps.sort()
+            print(
+                f"  {label:<22} p50 {statistics.median(laps) * 1e6:>8.1f} us"
+                f"   p99 {laps[int(len(laps) * 0.99)] * 1e6:>8.1f} us"
+            )
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    assert store._COUNTER_FILES[0] == store.COUNTERS_FILE, (
+        "the benchmark and the store disagree about the layout"
+    )
+    print(
+        f"{platform.platform()}\n{os.cpu_count()} logical CPUs, "
+        f"python {platform.python_version()}, store shard width {store.COUNTER_SHARDS}"
+    )
+    throughput()
+    width_choice()
+    single_write()

--- a/docs/store.md
+++ b/docs/store.md
@@ -5,7 +5,7 @@ via stdlib `inspect` — never edited by hand; a test regenerates and diffs this
 
 - `append(root: pathlib.Path, room: str, nick: str, text: str, did: str | None = None, nonce: int | None = None, sig: str | None = None) -> dict` — Append a message, and announce the room the first time it appears.
 - `clean_text(text: str, limit: int = 4096) -> str` — Replace every character in INVISIBLE_CATEGORIES with a space, then trim.
-- `counters(root: pathlib.Path) -> dict` — The lifetime counters, with every key present. Read without the lock: the file is
+- `counters(root: pathlib.Path) -> dict` — The lifetime counters, with every key present: the pre-shard file plus every writer
 - `export_room(root: pathlib.Path, room: str) -> tuple[int, collections.abc.Iterator[bytes]]` — The room's stored JSONL, bytes as written, snapshotted at open — and the room
 - `is_ephemeral(name: str) -> bool` — (undocumented)
 - `is_mailbox(name: str) -> bool` — `mb-` rooms take signed writes only, so spam is attributable and ignorable by key.

--- a/src/store.py
+++ b/src/store.py
@@ -239,6 +239,43 @@ COUNTER_KEYS = (
     "notes_written",
     "topics_written",
 )
+# One counter file per *writer*, because there is nothing else to shard on. `.seqstate`
+# shards by room name (`_shard`); these six are global scalars with no name in them, so the
+# only axis that separates two concurrent writers is the writer itself. Every worker adds
+# its deltas to its own file and takes only that file's lock; `counters` sums them.
+#
+# `os.getpid() % COUNTER_SHARDS` rather than a hash of the pid, deliberately. Workers are
+# forked in one burst, so their pids are near-consecutive and the modulo spreads them one
+# per shard with no collisions at all — where hashing 5 workers into 8 buckets collides
+# about a third of the time (birthday). Two workers that do collide are not broken, only
+# back to sharing one lock, and a lock shared by 2 of N writers is still a fraction of the
+# queue this replaces. Threads inside one worker share its shard by design: they are the
+# same writer, and at the production rate (~135 writes/s over 5 workers) one worker's own
+# arrivals are a few percent of one lock's capacity.
+#
+# 8, not the 256 `.seqstate` uses, because the two sides of this number are paid by
+# different people. A shard buys write concurrency only up to the number of concurrent
+# WRITERS — WEB_CONCURRENCY, five in production — and there is no sixth process to keep a
+# sixth lock busy. Every shard costs the READER unconditionally: `counters` sums them all,
+# and two of its callers are stamps on hot read paths (`room_stats`'s topic preview stamp,
+# app's note gauge), so one uncached /rooms request pays for three sums. bench/counters.py
+# measures both halves against each other: with 8 writers the write column is flat from 8
+# shards on, within run-to-run noise (5,264 bumps/s at 8, 5,500 at 16, against 2,910
+# unsharded), while the read column doubles for every doubling of the width (202 us at 8,
+# 387 us at 16, against 26 us for the single file).
+COUNTER_SHARDS = 8
+_COUNTER_SHARD_FILES = tuple(f"{COUNTERS_FILE}.{i:02x}" for i in range(COUNTER_SHARDS))
+# The pre-shard file is summed as one more shard, for as long as it exists — which is what
+# makes this change need no migration, no flag day and no operator step. Nothing folds it
+# into a shard and deletes it, and that omission is the design, not a shortcut: a fold is
+# the one operation that can make a summed counter go DOWN (a reader that read the old file
+# before the fold and the shards after it counts a delta twice; one that reads them the
+# other way round misses it), and two of these counters are cache stamps. `_bump` is allowed
+# to lose a delta on a crash — it says so — but a stamp that goes backwards is a different
+# property, and this design never gives one up. A downgrade is likewise better served: the
+# old code reads `.counters` and finds the totals it wrote, where a `.pre-shard` rename
+# would have left it reading zero.
+_COUNTER_FILES = (COUNTERS_FILE, *_COUNTER_SHARD_FILES)
 # Periodic aggregate samples, so growth over a window is answerable at all: the counters
 # above say what the totals are *now*, and nothing but a stored history says what they were
 # a day ago. Kept here rather than in the reader because the service is the only thing that
@@ -678,37 +715,75 @@ def _now() -> str:
     return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
-def counters(root: Path) -> dict:
-    """The lifetime counters, with every key present. Read without the lock: the file is
-    replaced atomically, so a reader either sees the old bytes or the new ones."""
+def _read_counters(path: Path) -> dict:
+    """One counter file, with every key present and non-negative.
+
+    Absent, torn, hand-edited and "not an object at all" have to mean the same thing — no
+    counts — because this answers a request: `counters` is read on the `/rooms` and `/stats`
+    paths, and a diagnostic that raises there would take down the endpoint it decorates. The
+    `AttributeError` in the catch is the "not an object" case: a JSON array or scalar has no
+    `.get`, which is precisely the `[]` a hand-edited file arrives as.
+    """
     try:
-        data = orjson.loads((root / COUNTERS_FILE).read_bytes())
-    except (OSError, ValueError):
-        data = {}
-    if not isinstance(data, dict):
-        data = {}
-    out = {}
-    for key in COUNTER_KEYS:
-        value = data.get(key, 0)
-        out[key] = value if isinstance(value, int) and value >= 0 else 0
-    return out
+        data = orjson.loads(path.read_bytes())
+        raw = {key: data.get(key, 0) for key in COUNTER_KEYS}
+    except (OSError, ValueError, AttributeError):
+        raw = dict.fromkeys(COUNTER_KEYS, 0)
+    return {k: v if isinstance(v, int) and v >= 0 else 0 for k, v in raw.items()}
+
+
+def counters(root: Path) -> dict:
+    """The lifetime counters, with every key present: the pre-shard file plus every writer
+    shard, summed. Read without any lock, exactly as the single file was — each part is
+    replaced atomically, so a reader sees one part's old bytes or its new ones.
+
+    Summing is not atomic across parts, and does not need to be. Two properties are what the
+    callers actually rely on, and both survive:
+
+      - **Never newer than the disk.** Every shard is read before the caller looks at what it
+        stamped, and a shard only ever grows, so the sum is bounded above by the true total at
+        the instant the last part was read. That is the ordering `_rooms_stamp` is built on —
+        a stamp that cannot be newer than the data the walk then sees, so a stale view is
+        never cached as a fresh one.
+      - **Never decreasing.** Each part is monotonic, and one caller's reads do not overlap
+        each other, so a later sum reads every part at a later instant than the earlier sum
+        did. The stamps at `room_stats` and in app are compared by equality; a value that
+        went backwards could serve a cache entry built before the writes in between. Nothing
+        in this store ever moves a count between two parts, which is the only thing that
+        could break this — see `_COUNTER_FILES`.
+
+    Nine small reads where there was one. That is the price of the write path's lock split, it
+    lands on `/rooms` and `/stats`, and bench/counters.py is where it is measured.
+    """
+    parts = [_read_counters(root / name) for name in _COUNTER_FILES]
+    return {key: sum(part[key] for part in parts) for key in COUNTER_KEYS}
 
 
 def _bump(root: Path, **deltas: int) -> None:
-    """Add to the lifetime counters, atomically.
+    """Add to this writer's own lifetime counter shard, atomically.
+
+    One exclusive lock on one of `COUNTER_SHARDS` files, chosen by pid — never the global
+    lock this used to take on `.counters` itself. Every write in the service came through
+    that one lock (a message append, a note write, the reaper's tally), so writes to
+    unrelated rooms queued behind each other for the length of a read-modify-replace; at
+    ~135 writes/s it was 63-81% of one worker's syscall time (#588). Nothing else here
+    changed: the file is still read, added to and replaced whole under the lock, because the
+    contention was never the size of the file.
 
     Best effort, exactly like `_log_event`: the caller's write has already succeeded by
     the time this runs, so an unwritable counter must never turn that success into an
     error. The cost of that choice is a possible undercount, which is the right way round
     — a digest that reports slightly low is recoverable, a write that 500s is not.
+
+    Deltas for keys outside `COUNTER_KEYS` are dropped rather than stored, so a shard file
+    cannot grow a key `counters` will not read back.
     """
-    path = root / COUNTERS_FILE
+    path = root / _COUNTER_SHARD_FILES[os.getpid() % COUNTER_SHARDS]
     try:
         with _locked(path):
-            current = counters(root)
-            for key, delta in deltas.items():
-                current[key] = current.get(key, 0) + delta
-            _replace(path, orjson.dumps(current))
+            current = _read_counters(path)
+            merged = {key: current[key] + deltas.get(key, 0) for key in COUNTER_KEYS}
+            _replace(path, orjson.dumps(merged))
     except OSError:
         pass
 

--- a/src/store.py
+++ b/src/store.py
@@ -770,6 +770,14 @@ def _bump(root: Path, **deltas: int) -> None:
     changed: the file is still read, added to and replaced whole under the lock, because the
     contention was never the size of the file.
 
+    Where that payoff shows, measured end to end on `append` rather than on this function
+    (bench/counters.py): only once the queue is tens of writers deep, which is what a
+    threadpool per worker produces — 5 processes x 8 threads goes 23.2 ms -> 10.6 ms p50 and
+    84 ms -> 35 ms p99. Eight processes with no threads barely move, and traffic concentrated
+    in ONE room does not move at all, because those writers already serialise on that room's
+    own flock. The larger remaining cost is this function's own read-modify-replace, which
+    the same benchmark bounds by running `append` with the counter removed entirely.
+
     Best effort, exactly like `_log_event`: the caller's write has already succeeded by
     the time this runs, so an unwritable counter must never turn that success into an
     error. The cost of that choice is a possible undercount, which is the right way round

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -292,6 +292,35 @@ def test_a_lost_counter_bump_costs_one_window_and_not_the_listing(client, monkey
         assert "second" in client.get("/rooms").text, "the clock must expire it regardless"
 
 
+def test_another_workers_write_still_moves_the_rooms_stamp(client, monkeypatch):
+    """The counters are sharded per writer now (#588), so the stamp `/rooms` caches under is a
+    SUM across shards rather than one file — and the sum is what keeps this endpoint correct
+    on more than one worker. A reader that saw only its own shard would hold a listing that is
+    missing every other worker's rooms for a whole window, which in production is four fifths
+    of them.
+    """
+    import os
+
+    import config
+    import store
+
+    # A holder rather than a second `setattr` and `undo`: `undo` would also pop the client
+    # fixture's own patches — the pinned cache windows among them — and the miss that follows
+    # would look exactly like the stamp having moved.
+    worker = {"pid": os.getpid()}
+    monkeypatch.setattr(os, "getpid", lambda: worker["pid"])
+    with config.override(ROOMS_CACHE_SECONDS=60):
+        client.get("/r/first/say/bot/hi")
+        assert "first" in client.get("/rooms").text  # populates the cache under one stamp
+
+        worker["pid"] += 1  # a second worker, writing its own shard
+        client.get("/r/second/say/bot/hi")
+        worker["pid"] -= 1  # and back to the worker that holds the cached listing
+
+        assert len(list(config.ROOT.glob(f"{store.COUNTERS_FILE}.??"))) == 2, "premise: 2 shards"
+        assert "second" in client.get("/rooms").text, "the other worker's write moved no stamp"
+
+
 def test_a_cached_view_is_never_served_under_a_different_root(client, tmp_path):
     """The entries are keyed by `limit` alone, so ROOT is in the stamp — exactly as it is in
     the note gauge's. Production never moves ROOT, but a reconfigured reload and this very

--- a/tests/unit/test_counter_shards.py
+++ b/tests/unit/test_counter_shards.py
@@ -1,0 +1,298 @@
+"""Run: uv run --group dev python -m pytest tests
+
+Every write in the service — a message append, a note write, the reaper's tally — called
+`_bump`, and `_bump` took ONE exclusive flock on `.counters` and did a read-parse-replace
+inside it. Writes to unrelated rooms therefore queued behind each other: 63-81% of a
+worker's syscall time at ~135 writes/s, ~95 ms mean (#588).
+
+The counters have no name to shard on the way `.seqstate` does, so the axis is the writer:
+one file per pid bucket, and `counters` sums them. Four things have to hold — a writer takes
+only its own lock, no delta is lost or double-counted (including one written by an old worker
+mid-deploy, which still lands in the pre-shard file), the sum never goes backwards under
+concurrent writers because two of these counters are cache stamps, and the shard files stay
+out of everything that walks the store.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import threading
+from pathlib import Path
+
+import orjson
+import pytest
+
+
+def _legacy(root: Path, **counts: int) -> None:
+    """The pre-shard `.counters`, exactly as builds before this change wrote it — and as an
+    old worker still writes it during a rolling restart."""
+    import store
+
+    root.mkdir(parents=True, exist_ok=True)
+    current = orjson.loads((root / store.COUNTERS_FILE).read_bytes()) if _base(root) else {}
+    (root / store.COUNTERS_FILE).write_bytes(
+        orjson.dumps({key: current.get(key, 0) + counts.get(key, 0) for key in store.COUNTER_KEYS})
+    )
+
+
+def _base(root: Path) -> bool:
+    import store
+
+    return (root / store.COUNTERS_FILE).exists()
+
+
+def _shard_files(root: Path) -> list[str]:
+    import store
+
+    return sorted(p.name for p in root.glob(f"{store.COUNTERS_FILE}.??") if p.is_file())
+
+
+def _as_pid(monkeypatch, pid: int) -> None:
+    """Write as a different worker. The shard is `os.getpid() % COUNTER_SHARDS`, so this is
+    the only thing that separates two writers — there is no name to vary."""
+    monkeypatch.setattr(os, "getpid", lambda: pid)
+
+
+def _bump_in_a_child(root: str, count: int) -> None:
+    """Top-level so `multiprocessing` can reach it. Real processes, not threads: the pid is
+    the shard key, and the lock this test is about is an flock that only separate open file
+    descriptions contend for the way production's workers do."""
+    import store
+
+    for _ in range(count):
+        store._bump(Path(root), messages=1)
+
+
+def _children(root: Path, workers: int, each: int) -> None:
+    context = multiprocessing.get_context("fork")
+    procs = [
+        context.Process(target=_bump_in_a_child, args=(str(root), each)) for _ in range(workers)
+    ]
+    [p.start() for p in procs]
+    [p.join(60) for p in procs]
+    assert [p.exitcode for p in procs] == [0] * workers, "a writer died mid-bump"
+
+
+# --------------------------------------------------------------------------- the lock split
+
+
+def test_a_writer_bumps_its_own_shard_and_never_the_global_file(tmp_path) -> None:
+    """The whole change in one assertion. The file `_bump` takes the lock on is what every
+    write in the service serialised behind; if a bump still lands on `.counters` there is one
+    lock again, whatever the read path does."""
+    import store
+
+    store._bump(tmp_path, messages=1)
+
+    mine = f"{store.COUNTERS_FILE}.{os.getpid() % store.COUNTER_SHARDS:02x}"
+    assert _shard_files(tmp_path) == [mine], "the bump did not land in this writer's shard"
+    assert not _base(tmp_path), "the global file is still being written"
+    assert store.counters(tmp_path)["messages"] == 1
+
+
+def test_distinct_writers_land_in_distinct_shards(tmp_path, monkeypatch) -> None:
+    """Consecutive pids — what a fork of N workers actually produces — must spread one per
+    shard. This is why the key is `pid % width` and not a hash of the pid: hashing five
+    workers into eight buckets collides about a third of the time."""
+    import store
+
+    first = 4096  # a multiple of the width, so the run below starts at shard 00
+    for offset in range(store.COUNTER_SHARDS):
+        _as_pid(monkeypatch, first + offset)
+        store._bump(tmp_path, messages=1)
+
+    assert len(_shard_files(tmp_path)) == store.COUNTER_SHARDS, "workers shared a shard"
+    assert store.counters(tmp_path)["messages"] == store.COUNTER_SHARDS
+
+
+def test_writers_in_different_shards_do_not_serialise_on_one_lock(tmp_path, monkeypatch) -> None:
+    """The topology, not a millisecond count: under one global lock only one writer can be
+    inside the read-modify-replace at a time, so four of them holding it at once is a
+    barrier that never releases. Fails by timeout under the old shape, and cannot flake into
+    passing on a loaded runner the way a duration comparison can."""
+    import store
+
+    writers = 4
+    together = threading.Barrier(writers)
+    real_replace = store._replace
+    failed: list[BaseException] = []
+    pids = threading.local()
+
+    def wait_while_holding_the_lock(path, data, fsync=False):
+        together.wait(timeout=10)  # inside `_locked`: `_replace` is the last step under it
+        return real_replace(path, data, fsync)
+
+    monkeypatch.setattr(store, "_replace", wait_while_holding_the_lock)
+    monkeypatch.setattr(os, "getpid", lambda: pids.value)
+
+    def bump(pid):
+        pids.value = pid
+        try:
+            store._bump(tmp_path, messages=1)
+        except BaseException as exc:  # noqa: BLE001 - surfaced through `failed`
+            failed.append(exc)
+
+    threads = [threading.Thread(target=bump, args=(8192 + i,)) for i in range(writers)]
+    [t.start() for t in threads]
+    [t.join(30) for t in threads]
+
+    assert not failed, f"writers in distinct shards could not overlap: {failed}"
+    assert store.counters(tmp_path)["messages"] == writers
+
+
+def test_no_delta_is_lost_when_every_worker_bumps_at_once(tmp_path) -> None:
+    """The lock is still doing its job. Sharding a counter is only safe while every writer
+    that shares a shard still serialises on it — drop the lock and this is a lost-update race
+    that a single-process test would never show."""
+    import store
+
+    _children(tmp_path, workers=4, each=100)
+
+    assert store.counters(tmp_path)["messages"] == 400
+    assert len(_shard_files(tmp_path)) > 1, "premise: the writers did not share one shard"
+
+
+def test_writers_that_share_a_shard_still_serialise_on_it(tmp_path, monkeypatch) -> None:
+    """The lock the split kept. Threads inside one worker ARE one writer — same pid, same
+    shard — and Starlette runs sync handlers in a threadpool, so this is the common case, not
+    a corner of it. The read-modify-replace releases the GIL at every syscall in it, so
+    without the flock these lose each other's counts."""
+    import store
+
+    _as_pid(monkeypatch, 900)  # every thread below is this one worker
+    threads = [
+        threading.Thread(target=lambda: [store._bump(tmp_path, messages=1) for _ in range(50)])
+        for _ in range(8)
+    ]
+    [t.start() for t in threads]
+    [t.join(60) for t in threads]
+
+    assert _shard_files(tmp_path) == [f"{store.COUNTERS_FILE}.{900 % store.COUNTER_SHARDS:02x}"]
+    assert store.counters(tmp_path)["messages"] == 400, "a bump was lost inside one shard"
+
+
+# --------------------------------------------------------------------------- the read path
+
+
+def test_the_sum_spans_the_pre_shard_file_and_every_shard(tmp_path, monkeypatch) -> None:
+    """The upgrade path, and it needs no migration: the old file is summed as one more shard
+    for as long as it exists. A reader that looked only at the shards would report a store's
+    whole history as zero the moment this version booted."""
+    import store
+
+    _legacy(tmp_path, messages=1_000, rooms_created=7)
+    for pid in (512, 513):
+        _as_pid(monkeypatch, pid)
+        store._bump(tmp_path, messages=1, notes_written=2)
+
+    counted = store.counters(tmp_path)
+    assert counted["messages"] == 1_002, "the pre-shard total was dropped"
+    assert (counted["rooms_created"], counted["notes_written"]) == (7, 4)
+
+
+def test_an_old_workers_bump_during_a_rolling_restart_is_counted_exactly_once(
+    tmp_path, monkeypatch
+) -> None:
+    """Old and new workers run together for the length of a deploy. The old ones keep writing
+    `.counters` under the global lock; the new ones write shards. Nothing moves a count
+    between the two, so a delta from either side is counted once and never lost."""
+    import store
+
+    _as_pid(monkeypatch, 4242)
+    store._bump(tmp_path, messages=1)  # a new worker
+    _legacy(tmp_path, messages=5)  # an old worker, still on the pre-shard code
+    store._bump(tmp_path, messages=1)  # the new worker again, after it
+
+    assert store.counters(tmp_path)["messages"] == 7
+    assert orjson.loads((tmp_path / store.COUNTERS_FILE).read_bytes())["messages"] == 5
+
+
+def test_a_summed_counter_never_goes_backwards_under_concurrent_writers(tmp_path) -> None:
+    """`room_stats` and app's note gauge key caches on these values by equality, so a sum that
+    dipped would serve an entry built before the writes in between. `_bump` is allowed to LOSE
+    a delta — it says so — but that is a different property from one that decreases: parts
+    only grow and nothing is ever moved between them, so a later sum is never smaller.
+    """
+    import store
+
+    _legacy(tmp_path, messages=10)
+    context = multiprocessing.get_context("fork")
+    procs = [context.Process(target=_bump_in_a_child, args=(str(tmp_path), 60)) for _ in range(4)]
+    [p.start() for p in procs]
+    samples = []
+    while any(p.is_alive() for p in procs) or len(samples) < 50:
+        samples.append(store.counters(tmp_path)["messages"])
+        if len(samples) > 5_000:  # a hung writer must fail the test, not hang the suite
+            break
+    [p.join(60) for p in procs]
+
+    assert samples == sorted(samples), "a sampled counter went backwards"
+    assert store.counters(tmp_path)["messages"] == 250
+
+
+def test_a_corrupt_shard_costs_only_its_own_counts(tmp_path, monkeypatch) -> None:
+    """Same promise the single file made — counters are diagnostics, never authority — but
+    now one shard's worth of it. Garbage in one file must not take down the read path or be
+    read as a huge or negative total, and must not hide the shards either side of it."""
+    import store
+
+    for pid in (256, 257, 258):
+        _as_pid(monkeypatch, pid)
+        store._bump(tmp_path, messages=1)
+    victim = tmp_path / f"{store.COUNTERS_FILE}.{256 % store.COUNTER_SHARDS:02x}"
+
+    for junk in (b"[]", b"{", b'{"messages": "many"}', b'{"messages": -5}', b'"messages"'):
+        victim.write_bytes(junk)
+        assert store.counters(tmp_path)["messages"] == 2, junk
+        assert store.counters(tmp_path) == {
+            **dict.fromkeys(store.COUNTER_KEYS, 0),
+            "messages": 2,
+        }, junk
+
+
+def test_a_bump_to_an_unwritable_shard_never_fails_the_write_it_follows(
+    tmp_path, monkeypatch
+) -> None:
+    """Best effort, exactly as before: the caller's append has already landed by the time this
+    runs. A shard that cannot be written costs that delta and nothing else — the other shards
+    still answer."""
+    import store
+
+    _as_pid(monkeypatch, 32)
+    store._bump(tmp_path, messages=1)
+    blocked = tmp_path / f"{store.COUNTERS_FILE}.{33 % store.COUNTER_SHARDS:02x}"
+    blocked.mkdir()  # a directory where the shard file goes: every write to it fails
+
+    _as_pid(monkeypatch, 33)
+    store._bump(tmp_path, messages=1)  # must not raise
+
+    assert store.counters(tmp_path)["messages"] == 1
+    assert blocked.is_dir()
+
+
+# --------------------------------------------------------------------------- isolation
+
+
+def test_shards_are_never_walked_counted_reaped_or_nameable(tmp_path, monkeypatch) -> None:
+    """They sit at the root beside `.seqstate.??` and `.usage`, so the room caps, the listings
+    and the bucket pruning must not see them — and no caller can name one: this is a
+    world-writable service, and the change adds no reachable surface."""
+    import store
+
+    store._write_record(tmp_path, "live", "bot", "hi")
+    real = os.getpid()
+    for pid in range(64, 64 + store.COUNTER_SHARDS):
+        _as_pid(monkeypatch, pid)
+        store._bump(tmp_path, messages=1)
+    _as_pid(monkeypatch, real)  # the reaper below runs as this process, like a real worker
+    (tmp_path / ".reaped").unlink(missing_ok=True)
+    store._reap(tmp_path)
+
+    assert len(_shard_files(tmp_path)) > 1, "premise: the store is sharded"
+    assert store._count_rooms(tmp_path)[0] == 1, "shards counted against the room cap"
+    assert store.list_rooms(tmp_path) == ["live"], "shards listed as rooms"
+    assert [e.name for e in store._walk(tmp_path / "rooms", ".jsonl")] == ["live.jsonl"]
+    for name in _shard_files(tmp_path):
+        with pytest.raises(store.StoreError):
+            store.valid_name(name)


### PR DESCRIPTION
## What

`_bump` writes one counter file per **writer** — `.counters.00`..`.counters.07`, chosen by
`os.getpid() % COUNTER_SHARDS` — and takes only that file's lock; `counters()` sums them.
Callers see nothing new: no route, parameter or response field, and the shard files sit at
the root beside `.seqstate.??`, unwalked, uncounted, unreapable and unnameable
(`valid_name` refuses a dot). Net **zero** code lines in core (store.py 924 → 924, core
total 2246 under the 2247 baseline).

## Why

#588. Every write in the service went through one exclusive flock on `.counters` holding a
whole read-parse-modify-replace, so writes to unrelated rooms queued behind each other:
63-81% of a worker's syscall time at ~95 ms mean, ~135 writes/s. This was the binding
constraint left after #597 and #598. Unlike `.seqstate` there is no name to hash, so the
shard axis is the writer; `pid % width` beats hashing because forked workers get
near-consecutive pids and spread one per shard.

New `bench/counters.py` (medians of 3 runs, 4-vCPU Linux VM, Python 3.12.3; it keeps the
old `_bump` as the baseline so "before" stays reproducible).

**The headline is `store.append` end to end, not `_bump` alone.** The payoff only appears
once the queue on the lock is tens of writers deep, and what produces that is production's
real shape — WEB_CONCURRENCY worker processes each serving sync handlers from a threadpool:

| 5 procs × T threads | global lock | sharded | no counter at all |
|---:|---|---|---|
| 4 | 1,629/s, p50 11.4 ms | 2,539/s, p50 5.3 ms | 4,144/s, p50 2.9 ms |
| **8** | **1,458/s, p50 23.2, p99 84 ms** | **2,568/s, p50 10.6, p99 35 ms** | 4,319/s, p50 5.1 ms |
| 16 | 1,385/s, p50 38.8, p99 211 ms | 1,912/s, p50 24.9, p99 99 ms | 3,362/s, p50 9.5 ms |

At 5×16 the old code's p99 is 211 ms, the range of the mean `flock` wait #588 reported; the
split halves it. The negative results matter as much and are in the benchmark's output:
**eight processes with no threads barely move, and traffic concentrated in one room does not
move at all** — those writers already serialise on that room's own flock, so the counter
lock is redundant there. The third column bounds what is left: the lock split takes about
half the available headroom, and `_bump`'s own read-modify-replace holds the rest.

`_bump` in isolation, for reference — a flat before-column across N is the bug reproduced,
since adding writers adds only queueing:

| N processes | before | after |
|---:|---|---|
| 1 | 3,295 bumps/s, p50 0.29 ms | 2,974, 0.31 ms |
| 4 | 2,848, 1.29 ms | 7,100, 0.45 ms |
| 8 | 2,715, 2.73 ms | 5,966, 0.51 ms |

**Width 8, not 256.** A shard buys write concurrency only up to WEB_CONCURRENCY (five in
production); it costs the reader always, and two counters are stamps on hot read paths, so
`counters()` goes 26 → 202 us at width 8, 387 us at 16, 5.9 ms at 256, while the write
column is flat from 8 on within run noise. Widening later is safe (existing shards keep
being summed); narrowing is not, and would need a fold.

**Nothing is migrated, deliberately** — the judgment call worth a line. `.counters` stays a
summand for as long as it exists: no flag day, no operator step, no reaper hook, reads
correct throughout, and a downgrade finds the file it wrote. A fold is the one operation
that can make a summed counter go *down*, and these values are cache stamps compared by
equality — `_bump` may lose a delta, a stamp may not go backwards. During a rolling restart
old workers keep writing `.counters` and new ones write shards, so no delta is lost or
double-counted; worst case is an old worker's own listing stale by one
`ROOMS_CACHE_SECONDS` window, ending when it exits.

12 new tests, each verified to fail against a mutated store.py (11 mutants) — including one
that folds counts between parts, which trips the monotonicity test.

Leaves alone: #576's walk, the reaper's cost, WEB_CONCURRENCY, what `/stats` reports.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 606 passed,
      97.85% (97.78% on this machine before; the suite randomises order, which moves the
      headline ±0.01)
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: `docs/store.md` regenerated
      (`scripts/gen_store_doc.py`); nothing else describes the on-disk layout
- [x] New surface on a world-writable service: **nothing new** — no route, parameter or
      response field, and shard files are neither nameable nor reachable

Closes #588.