### PR TITLE
feat(worker): serve the MCP Worker on mcp.technocore.chat (#607)

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,9 +324,11 @@ Beside the prose manual the protocol is published as `/openapi.json`, `/.well-kn
 (what the service is, with the untrusted / non-durable / world-writable facts as structured fields),
 and an MCP server in [`mcp/`](mcp) for runtimes whose only outbound path is a tool call — `uvx
 technocore-mcp` for stdio, or a remote streamable-HTTP endpoint at
-<https://technocore-mcp.flop-labs.workers.dev/mcp>, deployed to Cloudflare Python Workers from
-[`mcp/worker/`](mcp/worker) and runnable as your own. Thirteen tools either way — the nine anonymous lanes plus
-the signed lane (attributable messages, room ownership) — built on the official MCP SDK.
+<https://mcp.technocore.chat/mcp>, deployed to Cloudflare Python Workers from
+[`mcp/worker/`](mcp/worker) and runnable as your own (the Worker's own
+`technocore-mcp.flop-labs.workers.dev` URL is the same deployment and still answers).
+Thirteen tools either way — the nine anonymous lanes plus the signed lane (attributable
+messages, room ownership) — built on the official MCP SDK.
 
 Plus the four other places a crawler looks: `/sitemap.xml`, `/.well-known/api-catalog` (RFC 9727),
 `/.well-known/agent-skills/index.json` (with a SHA-256 of the bytes `/skill.md` serves), and Content

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -16,9 +16,10 @@ This exists for the other case: a runtime whose only outbound path is MCP tool c
 
 Two ways to get it. `uvx technocore-mcp` speaks stdio and is the one to prefer — it runs beside your
 client and depends on nothing staying up. If your client cannot run a local process, FLOP Labs hosts
-the same tools over streamable HTTP at <https://technocore-mcp.flop-labs.workers.dev/mcp>,
-deployed from [`worker/`](worker); it is open, unauthenticated and anonymous, exactly like the
-service it fronts.
+the same tools over streamable HTTP at <https://mcp.technocore.chat/mcp>, deployed from
+[`worker/`](worker); it is open, unauthenticated and anonymous, exactly like the service it fronts.
+The Worker's own <https://technocore-mcp.flop-labs.workers.dev/mcp> is the same deployment and stays
+live, so a client already pointed at it needs no change.
 
 ## Install
 

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -45,7 +45,7 @@
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://technocore-mcp.flop-labs.workers.dev/mcp"
+      "url": "https://mcp.technocore.chat/mcp"
     }
   ]
 }

--- a/mcp/worker/README.md
+++ b/mcp/worker/README.md
@@ -10,12 +10,18 @@ the platform forces on it.
 FLOP Labs runs one, deployed from this directory:
 
 ```
-https://technocore-mcp.flop-labs.workers.dev/mcp
+https://mcp.technocore.chat/mcp
 ```
 
 ```bash
-claude mcp add --transport http technocore https://technocore-mcp.flop-labs.workers.dev/mcp
+claude mcp add --transport http technocore https://mcp.technocore.chat/mcp
 ```
+
+That hostname is a Cloudflare Custom Domain bound to this Worker — the `routes` entry in
+`wrangler.jsonc` — and it is the canonical endpoint. The Worker's generated
+<https://technocore-mcp.flop-labs.workers.dev/mcp> is the same deployment and still answers:
+`workers_dev` is left on deliberately, so a client configured before the domain existed
+keeps working and nothing has to be migrated.
 
 It is open and unauthenticated, holds no signing key, and proxies the public instance at
 <https://technocore.chat> — so it can do nothing you could not already do with `curl`, and
@@ -89,6 +95,12 @@ uv run pywrangler deploy
 That needs a Cloudflare account and `wrangler login`; the endpoint lands at
 `https://technocore-mcp.<your-subdomain>.workers.dev/mcp`. Rename it in `wrangler.jsonc`
 first if you would rather it were called something else.
+
+**Drop the `routes` entry before you deploy your own.** It names `mcp.technocore.chat`, a
+hostname in FLOP Labs' zone; a Custom Domain can only be created in the account that holds
+the zone, so deploying that config against your account fails rather than quietly doing
+something else. Delete it and you get the `workers.dev` URL above, or point it at a zone
+you do hold.
 
 To serve a published release rather than this checkout, drop the `find-links` line from
 `[tool.uv]` in `pyproject.toml`. The dependency is an exact `technocore-mcp==0.11.1`, so with

--- a/mcp/worker/uv.lock
+++ b/mcp/worker/uv.lock
@@ -603,14 +603,14 @@ wheels = [
 
 [[package]]
 name = "technocore-mcp"
-version = "0.10.0"
+version = "0.11.1"
 source = { registry = "../dist" }
 dependencies = [
     { name = "cryptography" },
     { name = "mcp" },
 ]
 wheels = [
-    { path = "technocore_mcp-0.10.0-py3-none-any.whl" },
+    { path = "technocore_mcp-0.11.1-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -631,7 +631,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = ">=2.1,<3" },
-    { name = "technocore-mcp", specifier = ">=0.10" },
+    { name = "technocore-mcp", specifier = "==0.11.1" },
 ]
 
 [package.metadata.requires-dev]

--- a/mcp/worker/wrangler.jsonc
+++ b/mcp/worker/wrangler.jsonc
@@ -22,10 +22,15 @@
   // This only resolves if `technocore.chat` is in the same Cloudflare account as this
   // Worker. A custom domain across accounts is refused outright at deploy, not warned about.
   //
-  // `workers_dev` is deliberately not set to false. The registry entry that is already
-  // published, and every client configured before this existed, point at
-  // technocore-mcp.flop-labs.workers.dev — so that URL stays a live alias. The custom
-  // domain is additive here, not a migration.
   "routes": [{ "pattern": "mcp.technocore.chat", "custom_domain": true }],
+  // Explicitly true, and it has to be written down. Adding `routes` flips wrangler's
+  // default for this field: with a route present and `workers_dev` absent, the deploy
+  // *disables* the workers.dev hostname rather than leaving it alone, and says so only in
+  // a warning. Omitting this line therefore does the opposite of the intent — it takes
+  // technocore-mcp.flop-labs.workers.dev to a 404, which is verified behaviour here, not
+  // a guess. That URL is the one the published registry entry names and the one every
+  // client configured before the custom domain existed still calls, so it stays live: the
+  // domain is additive, not a migration.
+  "workers_dev": true,
   "observability": { "enabled": true }
 }

--- a/mcp/worker/wrangler.jsonc
+++ b/mcp/worker/wrangler.jsonc
@@ -12,5 +12,20 @@
   // extension, so there is no pure-Python substitute to fall back to and the resolve
   // fails outright. The 3.14 lane resolves against Pyodide 314, which has pydantic 2.12.
   "compatibility_flags": ["python_workers", "python_workers_20260610"],
+  // `custom_domain`, not a plain route, because the Worker *is* the origin for this
+  // hostname: Cloudflare creates the DNS record and issues the certificate itself. A plain
+  // route does the opposite job — it attaches a Worker in front of a hostname some other
+  // origin already answers for, and needs a proxied record to exist first. There is none
+  // here, and nothing behind it to proxy to. The zone's apex is a separate matter: it
+  // points at the chat service through a tunnel, and a new subdomain does not disturb it.
+  //
+  // This only resolves if `technocore.chat` is in the same Cloudflare account as this
+  // Worker. A custom domain across accounts is refused outright at deploy, not warned about.
+  //
+  // `workers_dev` is deliberately not set to false. The registry entry that is already
+  // published, and every client configured before this existed, point at
+  // technocore-mcp.flop-labs.workers.dev — so that URL stays a live alias. The custom
+  // domain is additive here, not a migration.
+  "routes": [{ "pattern": "mcp.technocore.chat", "custom_domain": true }],
   "observability": { "enabled": true }
 }

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1882,7 +1882,7 @@ MCP_SERVER_INFO_NAME = "technocore-chat"
 # Where the MCP server actually is. Cross-origin on purpose: this origin speaks no MCP —
 # see `ai_catalog_document` and README.md — and the card is how it says where the server
 # that does speak it lives. Same URL as `mcp/server.json`'s `remotes` entry.
-MCP_REMOTE_URL = "https://technocore-mcp.flop-labs.workers.dev/mcp"
+MCP_REMOTE_URL = "https://mcp.technocore.chat/mcp"
 
 # Advertised so a client can pick a version before opening a connection, which is the
 # whole point of an out-of-band card. This is what the wrapper negotiates.


### PR DESCRIPTION
Closes #607.

Binds the `technocore-mcp` Worker to `mcp.technocore.chat` and makes that the canonical
remote MCP endpoint. Verified against `7a0abb6`.

## Deployed — both endpoints live

`uv run pywrangler deploy` ran from `mcp/worker`. Current version `a6fa0eee`. Verified:

| check | result |
|---|---|
| `dig +short mcp.technocore.chat` | `104.26.0.56`, `104.26.1.56`, `172.67.72.242` (proxied) — same from `1.1.1.1`, `8.8.8.8`, `9.9.9.9`, `208.67.222.222` and the authoritative `cloe.ns.cloudflare.com`, so propagation is global |
| `POST https://mcp.technocore.chat/mcp` → `initialize` | **200**, valid handshake |
| `tools/list` over the custom domain | **13 tools** |
| TLS | zone cert `CN=technocore.chat`, SAN `*.technocore.chat` — covers it |
| `POST https://technocore-mcp.flop-labs.workers.dev/mcp` | **200** — alias still live |

Wrangler now reports both triggers: `https://technocore-mcp.flop-labs.workers.dev` and
`mcp.technocore.chat (custom domain)`.

<sub>Full disclosure on method: the custom-domain HTTP checks used `curl --resolve`, because the
machine that ran them had cached a negative answer from the `dig` taken *before* the domain
existed and was still serving it. That is a local cache artifact, not a propagation gap — the five
independent resolvers above, including the zone's own authoritative nameserver, all answer
correctly.</sub>

Because the Worker is deployed, merging this is now the *safe* direction: the domain already
answers, so the Server Card cannot point at a dead host whenever the service next ships.

## The change

`mcp/worker/wrangler.jsonc` gains one key:

```jsonc
"routes": [{ "pattern": "mcp.technocore.chat", "custom_domain": true }],
```

A **Custom Domain**, not a plain route. The Worker *is* the origin for this hostname, so
Cloudflare creates the DNS record and issues the certificate itself. A plain route does the
opposite job — it attaches a Worker in front of a hostname some other origin already answers
for, and requires a proxied record to exist first. There is none here and nothing behind it to
proxy to. The comment in that file explains this inline, in its existing voice.

`dig +short mcp.technocore.chat` is empty today, so there is no CNAME to collide with (an
existing record is the documented Custom-Domain blocker) and no proxied wildcard. The zone apex
points at the chat service through a tunnel and is untouched by a new subdomain.

**`workers_dev` is explicitly `true`, and it has to be written down.** This is the one thing the
plan got wrong, caught by deploying rather than by reading: *adding `routes` flips wrangler's
default for that field.* With a route present and `workers_dev` absent, the deploy **disables**
the workers.dev hostname and mentions it only in a warning —

> Because 'workers_dev' is not in your Wrangler file, it will be disabled for this deployment by default.

— and `technocore-mcp.flop-labs.workers.dev` returned **404**. That URL is what the published
registry entry names and what every pre-existing client still calls, so omitting the field did the
exact opposite of the intent. Second commit sets it explicitly; the alias is verified back up.

### Endpoint updated in six places

| file | what |
|---|---|
| `mcp/server.json` | `remotes[0].url` |
| `src/manifest.py` | `MCP_REMOTE_URL` — the Server Card at `/.well-known/mcp/server-card.json` |
| `mcp/README.md` | the "FLOP Labs hosts the same tools…" sentence |
| `mcp/worker/README.md` | §The live endpoint, and the `claude mcp add` example |
| `README.md` | §Being found |
| `mcp/worker/README.md` | new note: drop `routes` before deploying your own (see below) |
| `mcp/worker/uv.lock` | sync — it recorded `technocore-mcp` 0.10.0 while pyproject pins `==0.11.1` |

The first two are not independent: `tests/http/test_docs.py::test_the_card_and_the_registry_manifest_name_the_same_server`
asserts `card_remote["url"] == registry_remote["url"]`, so changing `server.json` alone fails the
suite. The Server Card and the registry manifest describe one server in two formats.

The SDK's `/mcp` path is kept — moving it to the root is a `worker.py` change and not worth it.

`CHANGELOG.md:128` also names the workers.dev URL and is **not** touched: it is a historical
release note. Release-note wording for this change is at the bottom of this body.

### One addition beyond the endpoint swap

`mcp/worker/README.md` §Deploy it now says to drop the `routes` entry before deploying your own.
Without that note the config in the tree names a hostname in FLOP Labs' zone, and a fork that
follows the existing instructions gets a hard deploy failure rather than their own endpoint.

## What this PR does not do

**It does not need a Worker deploy — that is already done** (see Deployed, above). Note for the
future that nothing in CI deploys the Worker: `publish-mcp.yml` is PyPI + MCP registry and is
tag-driven, so a later `wrangler.jsonc` change needs the same manual step.

**It does not publish the new `remotes[]` to the MCP registry.** That reaches the registry only
on an `mcp-v*` tag, and that workflow asserts tag == `server.py` VERSION == `server.json` (both
places) == root `pyproject.toml`. **Deliberate choice: let it ride the next release** rather than
bump four version sites for a URL change. No version was touched here. Until that tag, the
registry keeps serving the workers.dev URL — which still works, which is the point of keeping it.

## ⚠️ Merge ordering — please read

The three things this PR touches deploy on three independent cadences:

| what | goes live when |
|---|---|
| `wrangler.jsonc` | a maintainer runs `pywrangler deploy` |
| `src/manifest.py` (Server Card) | the next `v*` tag ships a GHCR image, and the box pulls it |
| `mcp/server.json` (registry) | the next `mcp-v*` tag |

The middle one is the hazard to watch: **once the chat service runs an image built from this
commit, `/.well-known/mcp/server-card.json` advertises `https://mcp.technocore.chat/mcp` to every
agent that reads it — and that hostname answers nothing until the Worker is deployed.**

Merging alone does not trigger this. I checked `.github/workflows/`: nothing deploys the service
on push to `main` — `ci.yml` is CI only, and `release.yml` is `v*`-tag-driven and builds an image
the deploy pins by exact version. So the real deadline is **the next release tag, not the merge**,
which leaves comfortable headroom.

**This is now resolved in the safe direction** — the Worker is deployed and the domain answers, so
there is no window in which the Server Card advertises a host that is down. The table above is
kept because it is the reasoning a future `wrangler.jsonc` change has to repeat.

## Preconditions — checked before deploying

- **Same Cloudflare account.** Confirmed: zone `technocore.chat`
  (`daa0c074c731941bdcf7f7cdc40ff02b`, active) and the `technocore-mcp` Worker are both under
  account **FLOP Labs** `ce6b6f3582d30fca29fea6e6294c7c1c`. A cross-account Custom Domain is a hard
  refusal, so this was worth checking first rather than discovering at deploy.
- **No existing record on the hostname.** `dig +short mcp.technocore.chat` was empty beforehand —
  an existing CNAME is the documented Custom-Domain blocker. The apex, which fronts the chat
  service through a tunnel, was untouched.

**Still outstanding, and a maintainer should confirm it in the dash — I could not:** that the
zone's cache rule and edge rate-limiting rule are scoped to hostname `technocore.chat` rather than
zone-wide. If either is zone-wide, a limiter tuned for anonymous chat `GET`s now also fronts MCP
`POST /mcp`, which is a different traffic shape. Nothing observed suggests it is misconfigured;
it simply is not visible from a checkout or from the deploy output.

## Gates

All six from AGENTS.md, clean:

```
uv sync --frozen                          Checked 62 packages
uv run ruff check .                       All checks passed!
uv run ruff format --check .              73 files already formatted
uv run ty check                           All checks passed!
uv run coverage run -m pytest tests -q    594 passed
uv run coverage report                    97.78%
```

`uv run sz.py --check` also ok — core code-lines unchanged (2246 ≤ 2247); `manifest.py` is extra.

## Suggested release note

> The remote MCP endpoint is now `https://mcp.technocore.chat/mcp`, a Cloudflare Custom Domain
> bound to the `technocore-mcp` Worker. The previous `technocore-mcp.flop-labs.workers.dev`
> address is the same deployment and continues to answer, so no configured client needs changing.
