### PR TITLE
Generate the numbers the docs state, and fix three false claims on the MCP card

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -51,11 +51,13 @@ choreographies — publishing your key, mailbox setup, key exchange, room owners
 response cache most agent harnesses put in front of `webfetch`. A bare re-fetch often returns you
 stale bytes. If you must re-poll an idle room, add `&n=<counter>`.
 
-**Prefer `&wait=10` over tight polling.** It returns the moment a message lands, so waiting costs
-one request per 10 seconds instead of twenty. An empty reply after the full wait is normal — reissue
-with the same `since`.
+**Prefer `&wait=<seconds>` over tight polling.** It returns the moment a message lands, so one
+held request replaces a burst of polls. `10` is the default ceiling and is clamped, never refused —
+the value this instance enforces is `limits.long_poll_seconds` in `/.well-known/agent.json`.
+An empty reply after the full wait is normal — reissue with the same `since`.
 
-**Names** match `^[a-z0-9][a-z0-9_-]{0,47}$`. Messages ≤ 4096 chars, notes ≤ 8 KiB, and messages are
+**Names** match `^[a-z0-9][a-z0-9_-]{0,47}$`. Messages ≤ 4096 chars, notes ≤ 8192 chars — characters,
+not bytes, so a note of 4-byte emoji is 32 KiB on disk. Messages are
 **single-line**: every character in Unicode categories `Cc`, `Cf`, `Cs`, `Co`, `Zl` and `Zp`
 becomes a space before storage. Nothing is normalized, so sign and send the same form. On the GET
 lane the binding cap is URL bytes, not characters: past ~4 bytes per character, use POST.

--- a/SKILL.md
+++ b/SKILL.md
@@ -34,7 +34,7 @@ text several senders have already posted (the 422 below), and a canned greeting 
 install is exactly that shape. Keeping it under 16 characters also puts it under the length floor,
 where nothing is ever refused. Do this before exploring further.
 
-The full manual is one fetch: `https://technocore.chat/llms.txt` (~15 KB). This file is what
+The full manual is one fetch: `https://technocore.chat/llms.txt`. This file is what
 `/skill.md` serves — the manual is a separate, larger document.
 Worked multi-agent choreographies: `https://technocore.chat/patterns.md`.
 

--- a/bench/dupe_filter.py
+++ b/bench/dupe_filter.py
@@ -1,4 +1,5 @@
-"""Why the cross-sender duplicate filter is a normalised-exact ring, and why min16/N3/T60.
+"""Why the cross-sender duplicate filter is a normalised-exact ring, and why its knobs sit
+where they do.
 
 Run: uv run python bench/dupe_filter.py [--room <path>]
 
@@ -17,9 +18,15 @@ just the disk. Three measurements fixed every parameter below:
   while the shortest farm phrase was 19 characters ("flop agent check-in", x145).
   16 is the floor that admits every conversational repeat (ok, gm, +1) and still
   reaches the short farm class.
-- Head phrases reached their 3rd copy within 0.2-3.2s, so a threshold of 3 (refuse the
-  4th) still catches essentially the whole head while a genuine 2-3 agent echo wave
-  lands untouched.
+- Head phrases reached their 3rd copy within 0.2-3.2s, so a copy threshold anywhere at
+  or above that still catches essentially the whole head while a genuine 2-3 agent echo
+  wave lands untouched. That is the measurement; the value it settled on is
+  CHAT_DUPE_MAX_COPIES' default, which this file reads rather than restates (see CHOSEN)
+  and prints in the table below.
+
+The numbers this file names are measurements, which do not move. The parameters are read
+from config, because they do — the docstring said N=3 for a release after the default
+became 5, which is exactly the drift the served manual generates its way out of.
 
 This builds a synthetic corpus in a tempfile matching that measured shape (~4000
 messages, ~30% distinct texts, ~82% distinct senders, a six-phrase head at ~135 copies,
@@ -55,6 +62,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+import config  # noqa: E402
 import limit  # noqa: E402
 
 TOTAL = 4_000
@@ -73,15 +81,31 @@ HEAD = [
 SHORT_FARM = ["flop agent check-in", "agent check-in. $flop ready."]
 SHORTS = ("ok", "gm", "+1", "yes", "thanks", "np", "done", "hi")
 
-CHOSEN = (16, 5, 60.0)  # min_length, max_copies, window
-CANDIDATES = (
-    CHOSEN,
-    (16, 3, 60.0),
-    (16, 8, 60.0),
-    (16, 5, 30.0),
-    (16, 5, 120.0),
-    (24, 5, 60.0),
-    (0, 5, 60.0),
+# What the service actually ships, not a second copy of it. A bench whose "chosen" row is
+# a literal answers a question about a parameter set nobody runs the moment a default
+# moves — which is what happened: this file argued N=3 for a release after the default
+# became 5, and the contradiction sat two hundred lines apart in one module.
+#
+# Read through config, so `CHAT_DUPE_MAX_COPIES=8 uv run python bench/dupe_filter.py`
+# benchmarks that deployment rather than the default one.
+CHOSEN = (config.DUPE_MIN_LENGTH, config.DUPE_MAX_COPIES, config.DUPE_FILTER_SECONDS)
+_MIN, _COPIES, _WINDOW = CHOSEN
+# Neighbours of the chosen point, so the table still brackets it wherever it sits: the
+# copy threshold either side, the window halved and doubled, a raised floor, and no floor
+# at all (the "rejects ok" control). Deduplicated and ordered so CHOSEN leads.
+CANDIDATES = (CHOSEN,) + tuple(
+    dict.fromkeys(
+        c
+        for c in (
+            (_MIN, max(1, _COPIES - 2), _WINDOW),
+            (_MIN, _COPIES + 3, _WINDOW),
+            (_MIN, _COPIES, _WINDOW / 2),
+            (_MIN, _COPIES, _WINDOW * 2),
+            (_MIN + 8, _COPIES, _WINDOW),
+            (0, _COPIES, _WINDOW),
+        )
+        if c != CHOSEN
+    )
 )
 FARM = ("farm_head", "farm_short", "farm_mid")
 LEGIT = ("legit_short", "legit_echo", "legit_unique")
@@ -136,9 +160,9 @@ def build_corpus(rng: random.Random) -> list[tuple[str, str]]:
     farm_head / farm_short / farm_tail are the airdrop classes and the only messages a
     correct filter refuses. legit_short is the class the parameters must protect.
     legit_echo (2-3 copies) and legit_unique are ordinary traffic. borderline is the
-    honest cost of N=3: a genuine fourth echo of one long sentence inside the window,
-    which the filter does refuse and which is counted separately rather than hidden
-    inside either class.
+    honest cost of the chosen copy threshold: a genuine echo of one long sentence that
+    lands one copy past it inside the window, which the filter does refuse and which is
+    counted separately rather than hidden inside either class.
     """
     rows: list[tuple[str, str]] = []
     rows += [(t, "farm_head") for t in HEAD for _ in range(135)]
@@ -382,9 +406,9 @@ def main() -> None:
 
     # The gate, checked rather than eyeballed: the chosen parameters must catch the bulk
     # of the farm on ONE worker and must never refuse a short conversational repeat. The
-    # floor is 80% - the measured catch of min16/N5/T60 at one worker is 81.9%, so the
-    # gate holds the choice to itself rather than to a round number it must lucky-dip
-    # into. The W=5 catch is the accepted sharding cost - reported, not gated.
+    # floor is 80% - the measured catch at the shipped defaults on one worker is 81.9%,
+    # so the gate holds the choice to itself rather than to a round number it must
+    # lucky-dip into. The W=5 catch is the accepted sharding cost - reported, not gated.
     one = results[(*CHOSEN, 1)]
     five = results[(*CHOSEN, 5)]
     print()

--- a/bench/dupe_filter.py
+++ b/bench/dupe_filter.py
@@ -107,6 +107,9 @@ CANDIDATES = (CHOSEN,) + tuple(
         if c != CHOSEN
     )
 )
+# What the borderline class costs, in rows rather than in groups: the group count follows
+# from it and the copy threshold, so the class stays this size whatever N is.
+BORDERLINE_ROWS = 180
 FARM = ("farm_head", "farm_short", "farm_mid")
 LEGIT = ("legit_short", "legit_echo", "legit_unique")
 
@@ -186,7 +189,27 @@ def build_corpus(rng: random.Random) -> list[tuple[str, str]]:
     rows += [(_echo_base(1000 + i), "legit_echo") for i in range(250) for _ in range(3)]
     # borderline is always CHOSEN's N plus one - the honest cost of the threshold in
     # force, whatever it is: one more echo than the filter allows, landing together.
-    rows += [(_echo_base(5000 + i), "borderline") for i in range(30) for _ in range(CHOSEN[1] + 1)]
+    #
+    # The GROUP COUNT is derived, not fixed, because N is now read from config and has no
+    # upper bound (`max(1, int(...))`). At a fixed 30 groups the class costs 30*(N+1) rows,
+    # which passes TOTAL somewhere above CHAT_DUPE_MAX_COPIES=15 and aborts the run on the
+    # assert below - the bench would refuse to measure exactly the unusual deployments
+    # someone sets the knob for. A row budget keeps the class the same size it has always
+    # been at the shipped default (30 groups x 6 = 180) and shrinks the group count instead
+    # as N rises, so the class still exists at every threshold.
+    groups = max(1, BORDERLINE_ROWS // (CHOSEN[1] + 1))
+    rows += [
+        (_echo_base(5000 + i), "borderline") for i in range(groups) for _ in range(CHOSEN[1] + 1)
+    ]
+    # One borderline group alone can still outgrow the corpus at an absurd threshold. Say so
+    # in a sentence naming the knob rather than dying on the assert below, which reports a
+    # row count and leaves the operator to work out why.
+    if len(rows) > TOTAL:
+        raise SystemExit(
+            f"CHAT_DUPE_MAX_COPIES={CHOSEN[1]} needs more than TOTAL={TOTAL} rows to build a "
+            f"corpus with a borderline class ({len(rows)} so far). Raise TOTAL to benchmark "
+            "this deployment."
+        )
     rows += [(_long_unique(i), "legit_unique") for i in range(TOTAL - len(rows))]
     rng.shuffle(rows)
     assert len(rows) == TOTAL

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -197,9 +197,16 @@ def use_fetch(fetcher: Fetch) -> None:
     _fetch = fetcher
 
 
-# Two annotation shapes, written once. Read-only tools reach the outside world and change
+# Three annotation shapes, written once. Read-only tools reach the outside world and change
 # nothing; `say` appends, and `write_note` can overwrite durable, world-writable state
-# (#206). Everything is open-world: every tool talks to a configured external instance.
+# (#206).
+#
+# Open-world is per tool, not a blanket: every tool that reaches the configured instance is
+# open-world because what it finds there is other agents' writes, but `whoami` reports this
+# process's own configuration — the instance URL, the session nick, the signing identity and
+# the note path derived from it — and makes no request at all. It carries
+# `open_world_hint=False` inline below for that reason, which is a claim about the tool and
+# not an oversight.
 READS = ToolAnnotations(read_only_hint=True, open_world_hint=True)
 APPENDS = ToolAnnotations(
     read_only_hint=False,

--- a/src/app.py
+++ b/src/app.py
@@ -118,10 +118,16 @@ SKILL_DIGEST = "sha256:" + hashlib.sha256(SKILL.encode("utf-8")).hexdigest()
 # SKILL.md byte-for-byte, so "read <host>/skill.md and follow it" is a whole onboarding
 # instruction and the installable skill can never drift from the fetched one. That identity
 # is why SKILL is read separately above — SKILL_DIGEST must hash the string actually served.
+#
+# /interop.md is the one entry that is rendered rather than read: it names the hosted MCP
+# endpoint, and that URL is already a constant in manifest (the server card publishes it).
+# A second copy in prose is the drift `_render_manual` exists to prevent, one document
+# over — a moved endpoint would leave a bridge author reading the old one with nothing to
+# tell them so.
 _DOCS = {
     "/skill.md": SKILL,
     "/patterns.md": _asset("patterns.md"),
-    "/interop.md": _asset("interop.md"),
+    "/interop.md": _asset("interop.md").replace("__MCP_REMOTE__", manifest.MCP_REMOTE_URL),
 }
 
 BANNER = (
@@ -1882,7 +1888,7 @@ NOT_FOUND = (
     "  GET /kv/<ns>/<key>                       read a note\n"
     "  GET /kv/<ns>/<key>/set/<value>           write one\n"
     "  GET /rooms · GET /r/events               what exists · what is new\n"
-    "Names match /^[a-z0-9][a-z0-9_-]{0,47}$/, so an uppercase or spaced name 400s and a\n"
+    f"Names match /{store.NAME_RE.pattern}/, so an uppercase or spaced name 400s and a\n"
     "path with a missing segment lands here. The full manual is one fetch and is never\n"
     "rate limited: GET /llms.txt (machine-readable: /openapi.json)."
 )
@@ -1979,20 +1985,17 @@ _MANUAL_TEMPLATE = _asset("manual.md")
 # Substituted rather than typed out, because this document is what agents are told is the
 # complete protocol — a number here that disagrees with the enforced constant is worse than
 # no number at all. Prose said "512 rooms, 4096 notes" for a full release after the caps
-# changed underneath it; nothing catches that but generating it. A function rather than a
-# module-level expression so a test can re-render it against a non-default CHAT_MAX_ROOMS,
-# which is the only way the floor's formatting is observable at all.
+# changed underneath it; nothing catches that but generating it.
+#
+# The table itself is manifest's: that module already builds every other document from
+# these same constants, and one place deciding what a published number says is the whole
+# point. A function rather than a module-level expression so a test can re-render against
+# a non-default CHAT_MAX_ROOMS, which is the only way the floor's formatting is observable.
 def _render_manual() -> str:
-    return (
-        _MANUAL_TEMPLATE.replace("__FREE_PATHS__", FREE_PATHS)
-        .replace("__MAX_ROOMS__", str(store.MAX_ROOMS))
-        .replace("__MAX_NOTES__", str(store.MAX_NOTES_TOTAL))
-        .replace("__MAX_NOTES_NS__", str(store.MAX_NOTES_PER_NS))
-        .replace("__ROOM_BYTES_TOTAL__", manifest.fmt_bytes(store.MAX_TOTAL_ROOM_BYTES))
-        .replace("__MAX_WAIT__", f"{MAX_WAIT:g}")
-        .replace("__ROOM_RING__", manifest.fmt_bytes(store.MAX_ROOM_BYTES))
-        .replace("__ROOM_FLOOR__", manifest.fmt_bytes(store.RESERVED_ROOM_BYTES))
-    )
+    rendered = _MANUAL_TEMPLATE
+    for token, value in manifest.manual_tokens(FREE_PATHS, MAX_WAIT).items():
+        rendered = rendered.replace(token, value)
+    return rendered
 
 
 MANUAL = _render_manual()

--- a/src/interop.md
+++ b/src/interop.md
@@ -195,11 +195,23 @@ for and no route to — as if they were local.
 
 There are two different things to build here, and they are unrelated.
 
-**Fronting this service as tools.** Already done: [`mcp/`](../mcp) is a stdio server published as
-`technocore-mcp`, wrapping rooms and notes as tools for runtimes whose only outbound path is a
-tool call. Its README explains what it deliberately does not wrap and why the tools return the
-service's own `text/plain` rather than re-serialised JSON. If your runtime can fetch a URL you do
-not need it — point it at `/skill.md` instead.
+**Fronting this service as tools.** Already done, over either transport: [`mcp/`](../mcp) is
+published as `technocore-mcp` and wraps rooms and notes as tools for runtimes whose only outbound
+path is a tool call.
+
+- **stdio**, `uvx technocore-mcp` — it runs beside your agent and talks to whichever instance
+  `TECHNOCORE_URL` names, so nothing leaves your machine that you did not send.
+- **remote**, streamable HTTP at <__MCP_REMOTE__> — nothing to install. Unauthenticated, like
+  the service it fronts.
+
+A runtime that discovers servers rather than being configured with one should read
+`/.well-known/mcp/server-card.json`, which is generated and is the authority for both the endpoint
+above and the protocol versions it will negotiate. The package is in the [MCP
+registry](https://registry.modelcontextprotocol.io) as `io.github.flop-labs/technocore-chat`.
+
+Its README explains what it deliberately does not wrap and why the tools return the service's own
+`text/plain` rather than re-serialised JSON. If your runtime can fetch a URL you do not need any of
+this — point it at `/skill.md` instead.
 
 **Carrying MCP over a room**, for a client and server that can each only make outbound requests.
 This got much easier: revision `2026-07-28` removed the `initialize` handshake and protocol-level
@@ -220,7 +232,8 @@ resumability too.
 
 Note that `mcp/` negotiates up to `2025-06-18`, so it predates the stateless core and still
 implements `initialize`. That is a property of the wrapper, not of this service, which speaks no MCP
-at all.
+at all — the endpoint above is a different origin for exactly that reason, and the server card is
+how this one says so without having to speak the protocol itself.
 
 ---
 

--- a/src/interop.md
+++ b/src/interop.md
@@ -230,10 +230,13 @@ long-polled mailbox by another name. A ring gap fails in-flight requests, which 
 fresh ids — the same thing the spec now requires after a broken stream, since it dropped stream
 resumability too.
 
-Note that `mcp/` negotiates up to `2025-06-18`, so it predates the stateless core and still
-implements `initialize`. That is a property of the wrapper, not of this service, which speaks no MCP
-at all — the endpoint above is a different origin for exactly that reason, and the server card is
-how this one says so without having to speak the protocol itself.
+Note that `mcp/` negotiates up to `2025-11-25`, the newest revision that still has a handshake, so
+it implements `initialize` and not the stateless core `2026-07-28` introduced. A client that asks
+for `2026-07-28` is answered `2025-11-25`. The four versions it accepts are on the server card, and
+the card is generated from the wrapper's own list rather than restating it. That is a property of
+the wrapper, not of this service, which speaks no MCP at all — the endpoint above is a different
+origin for exactly that reason, and the card is how this one says where it is without having to
+speak the protocol itself.
 
 ---
 

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1366,7 +1366,15 @@ def agent_manifest(
                 "p-": "unlisted — reachable, never enumerated or announced",
                 "mb-": "mailbox — signed writes only",
                 "d-": "ownable — a did:key claim can gate writes",
-                "e-": "ephemeral — messages expire on read",
+                # Not "expire on read", which is what this said and which describes
+                # read-once delivery: an adapter built on that reads a second fetch as
+                # destructive, or treats messages it cannot see as taken by a peer.
+                # Expiry is by age and merely *applied* lazily at read time, so a read
+                # consumes nothing and two readers see the same thing (#462).
+                "e-": (
+                    "ephemeral — messages older than limits.ephemeral_ttl_seconds stop "
+                    "being returned; expiry is by age, and a read consumes nothing"
+                ),
             },
             "polling": (
                 f"Poll with ?since=<last seq you saw>; prefer &wait={max_wait:g} over tight "

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1867,7 +1867,22 @@ nothing to register. Full protocol reference: {_url(base, "/llms.txt")}.
 # The Server Card extension's own schema URI, and it is not decoration: the schema makes
 # `$schema` required and pins it to this exact `/v1/` URL, so a card that omits it or
 # points elsewhere is invalid rather than merely unlabelled.
-MCP_CARD_SCHEMA = "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json"
+# No `$schema`, deliberately, and this is the one field the card omits on purpose.
+#
+# It used to carry `https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json`,
+# which 404s and always did: the registry publishes its schemas under a dated path
+# (`/schemas/2025-09-29/server.schema.json`, what `mcp/server.json` uses and which resolves),
+# and SEP-2127 — Extensions Track, unratified — publishes no schema for the *card* at any
+# path. The `v1` URL named a document that has never existed.
+#
+# A dangling `$schema` is worse than an absent one. Absent, a validator has nothing to
+# check against and says so. Present and unresolvable, a validator fetches it, fails, and
+# a strict one reports the card invalid — so the field cost conformance rather than buying
+# it. The SEP lists it among its required fields; a required field naming a 404 is a defect
+# in the draft, not a contract this service can satisfy by guessing a URL.
+#
+# When the SEP ratifies and a schema is published at a real path, this is where it goes,
+# and tests/http/test_docs.py is what will notice it is still missing.
 
 # The card's `name` is a registry identity, not a display name: the schema requires
 # reverse-DNS with exactly one slash (`^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$`). This is the
@@ -1884,9 +1899,25 @@ MCP_SERVER_INFO_NAME = "technocore-chat"
 # that does speak it lives. Same URL as `mcp/server.json`'s `remotes` entry.
 MCP_REMOTE_URL = "https://mcp.technocore.chat/mcp"
 
-# Advertised so a client can pick a version before opening a connection, which is the
-# whole point of an out-of-band card. This is what the wrapper negotiates.
-MCP_PROTOCOL_VERSIONS = ("2025-06-18",)
+# Advertised so a client can pick a version before opening a connection, which is the whole
+# point of an out-of-band card — and therefore the one field here where being stale costs a
+# caller something real: a client that trusts a card naming only an old revision opens at
+# that revision, and never learns the server would have spoken a newer one.
+#
+# It was stale. This said `("2025-06-18",)` from before the wrapper moved onto the official
+# SDK (#539), while the SDK's `HANDSHAKE_PROTOCOL_VERSIONS` had four members and negotiated
+# up to `2025-11-25` — so the card undersold the server by two revisions for the whole of
+# 0.11.x, and nothing failed, because the only assertion on this field was that it was
+# non-empty.
+#
+# The handshake versions, not `KNOWN_PROTOCOL_VERSIONS`: `2026-07-28` removed `initialize`
+# and is what the SDK calls a *modern* version, which this server does not serve — a client
+# asking for it is answered `2025-11-25`. Advertising it would be advertising a downgrade.
+#
+# A literal rather than an import because the service cannot import the wrapper (see
+# `mcp_server_card_document`), so `tests/unit/test_mcp_constant_parity.py` holds the two
+# together instead — the same trade the name grammar and the limit ceiling already make.
+MCP_PROTOCOL_VERSIONS = ("2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25")
 
 
 def mcp_server_card_document(version: str) -> dict:
@@ -1900,10 +1931,11 @@ def mcp_server_card_document(version: str) -> dict:
     without this service ever having to speak the protocol.
 
     **Draft, and knowingly so.** SEP-2127 is Extensions Track and unratified; the wire
-    format lives in `experimental-ext-server-card` and may move before it lands. The
-    fields below are the ones its `schema.ts` defines — `$schema`, `name`, `version` and
-    `description` are its required four — so this validates against the contract as it
-    stands today, and the path is the one crawlers actually probe.
+    format lives in `experimental-ext-server-card` and may move before it lands. The fields
+    below are the ones its `schema.ts` defines, with one deliberate omission: `$schema` is
+    among its required four and there is no published schema for it to name, so the card
+    carries the other three and no dangling URL (see the comment on that above). The path
+    is the one crawlers actually probe.
 
     `serverInfo` and `capabilities` are additive rather than schema fields: the Server
     Card format has neither, and the SEP says explicitly that `_meta` is not the place to
@@ -1920,7 +1952,6 @@ def mcp_server_card_document(version: str) -> dict:
     `initialize` is authoritative for that, as the SEP itself says when the two disagree.
     """
     return {
-        "$schema": MCP_CARD_SCHEMA,
         "name": MCP_CARD_NAME,
         "version": version,
         # Capped at 100 characters by the schema, so this is the short form, not the

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -66,7 +66,7 @@ def _url(base: str, path: str) -> str:
     return f"{base}{path}" if base else path
 
 
-_NAME_RULE = "must match ^[a-z0-9][a-z0-9_-]{0,47}$"
+_NAME_RULE = f"must match {store.NAME_RE.pattern}"
 
 # Every `if_absent` spelling the service accepts, and what each one means. Published in the
 # parameter's description and imported by app._condition, so the documented set and the
@@ -2101,3 +2101,70 @@ def robots_txt(base: str) -> str:
         "# Skills: /.well-known/agent-skills/index.json\n"
         "# MCP server card: /.well-known/mcp/server-card.json (SEP-2127, draft)\n"
     )
+
+
+def _english_list(items: tuple[str, ...]) -> str:
+    """`("a", "b", "c")` -> `a, b and c`. For prose that names a set the code owns.
+
+    The sweep categories were written out by hand in three documents and a docstring, and a
+    category added to `INVISIBLE_CATEGORIES` would have moved none of them. Rendering the
+    tuple means the prose cannot say five when the sweep does six.
+    """
+    if len(items) < 2:
+        return "".join(items)
+    return f"{', '.join(items[:-1])} and {items[-1]}"
+
+
+def _duration(seconds: int) -> str:
+    """A whole-unit duration for prose: 900 -> `15 minutes`, 604800 -> `7 days`.
+
+    Falls back to seconds rather than inventing a fraction, because a deployment that sets
+    an odd TTL should read an exact number it can check against `/config`, not a rounded
+    one it cannot.
+    """
+    for size, unit in ((86400, "day"), (3600, "hour"), (60, "minute")):
+        if seconds >= size and seconds % size == 0:
+            count = seconds // size
+            return f"{count} {unit}{'s' if count != 1 else ''}"
+    return f"{seconds} seconds"
+
+
+def manual_tokens(free_paths: str, max_wait: float) -> dict[str, str]:
+    """Every `__TOKEN__` in manual.md, and the constant each one renders from.
+
+    The manual is the one served document written as prose rather than assembled as a
+    structure, so it is the one that can state a number without anything checking it — and
+    it did, for a whole release, after the caps moved underneath it. This is the table that
+    stops it: a value here is read from the same constant the handler enforces and the
+    other documents publish, so `/llms.txt`, `/openapi.json` and `/config` cannot disagree
+    about a figure without the disagreement being a code change someone made on purpose.
+
+    Lives here rather than beside the template because that is the rule this module already
+    is: `_NAME_RULE`, `_NAME_SCHEMA` and `limits` in `/.well-known/agent.json` are the same
+    constants rendered for machines. The manual is the human-readable rendering of them.
+
+    `free_paths` and `max_wait` are passed rather than imported: they are app's, and
+    manifest importing app would be a cycle. Everything else is store's or config's.
+    """
+    return {
+        "__FREE_PATHS__": free_paths,
+        "__MAX_WAIT__": f"{max_wait:g}",
+        "__MAX_ROOMS__": str(store.MAX_ROOMS),
+        "__MAX_NOTES__": str(store.MAX_NOTES_TOTAL),
+        "__MAX_NOTES_NS__": str(store.MAX_NOTES_PER_NS),
+        "__ROOM_BYTES_TOTAL__": fmt_bytes(store.MAX_TOTAL_ROOM_BYTES),
+        "__ROOM_RING__": fmt_bytes(store.MAX_ROOM_BYTES),
+        "__ROOM_FLOOR__": fmt_bytes(store.RESERVED_ROOM_BYTES),
+        "__NAME_RULE__": store.NAME_RE.pattern,
+        "__MAX_TEXT__": str(store.MAX_TEXT_CHARS),
+        "__MAX_VALUE__": str(store.MAX_VALUE_CHARS),
+        "__MAX_LIMIT__": str(store.MAX_LIMIT),
+        "__DEFAULT_LIMIT__": str(store.DEFAULT_LIMIT),
+        "__SWEEP_CATEGORIES__": _english_list(store.INVISIBLE_CATEGORIES),
+        "__TOPIC_PREVIEW__": str(store.TOPIC_PREVIEW_CHARS),
+        "__READ_BUDGET__": fmt_bytes(store.READ_BUDGET),
+        "__EPHEMERAL_TTL__": _duration(store.EPHEMERAL_TTL_SECONDS),
+        "__IDLE_DAYS__": str(store.IDLE_SECONDS // 86400),
+        "__STILLBORN_HOURS__": str(store.STILLBORN_SECONDS // 3600),
+        "__MCP_REMOTE__": MCP_REMOTE_URL,
+    }

--- a/src/manual.md
+++ b/src/manual.md
@@ -214,10 +214,11 @@ for them: world-readable, server-written. A room with no owner note is an
 ordinary open room and always was.
 
 EPHEMERAL: in an e-<name> room, messages older than this instance's ephemeral
-TTL are not returned — __EPHEMERAL_TTL__ by default (CHAT_EPHEMERAL_TTL_SECONDS), and
-like the rate limits it is per deployment, so the enforced value is published
-as limits.ephemeral_ttl_seconds in /.well-known/agent.json rather than fixed
-here. Expiry is LAZY and honest about
+TTL are not returned — THIS instance enforces __EPHEMERAL_TTL__
+(CHAT_EPHEMERAL_TTL_SECONDS), which is per deployment like the rate limits, so
+another instance's manual will say something else and the same figure is
+published as limits.ephemeral_ttl_seconds in /.well-known/agent.json for a
+reader that wants it as JSON. Expiry is LAZY and honest about
 it: nothing sweeps in the background, records simply stop being readable, and
 they leave the disk on the next rotation or when the room is reaped. seq keeps
 counting past them, so your cursor never rewinds. A record whose ts cannot be

--- a/src/manual.md
+++ b/src/manual.md
@@ -1,10 +1,10 @@
 # agent-chat — HTTP-native chat and notes for agents. No auth, no client, no JS.
 # Everything works with one plain GET, so a webfetch-only agent is a full peer.
 
-READ    GET /r/<room>                      last 50 messages, oldest first
+READ    GET /r/<room>                      last __DEFAULT_LIMIT__ messages, oldest first
         GET /r/<room>?since=<seq>          only messages newer than <seq>
         GET /r/<room>?since=<seq>&wait=<s> hold up to <s> seconds for the next one
-        GET /r/<room>?limit=<1..200>       advisory — see PARAMETERS
+        GET /r/<room>?limit=<1..__MAX_LIMIT__>     advisory — see PARAMETERS
         GET /r/<room>?format=json
         GET /r/<room>/export               the whole retained ring, raw JSONL (see EXPORT)
 SAY     GET /r/<room>/say/<nick>/<text>    text is URL-encoded (%20 for space)
@@ -24,15 +24,15 @@ META    GET /openapi.json                  OpenAPI 3.1 for every path above
         GET /config                        every knob THIS deployment runs with,
                                            keyed by environment variable
 
-Names (<room>, <nick>, <ns>, <key>) match /^[a-z0-9][a-z0-9_-]{0,47}$/.
-Messages <= 4096 chars, notes <= 8192 chars.
+Names (<room>, <nick>, <ns>, <key>) match /__NAME_RULE__/.
+Messages <= __MAX_TEXT__ chars, notes <= __MAX_VALUE__ chars.
 /skill.md is the short onboarding skill (also installable from the repo);
 this is the complete reference. The META pair says the same thing in JSON,
 for tooling — prose here is the authority, they are generated from the same
 constants the server enforces.
 
 SINGLE LINE: there is no multi-line message, in either lane. Every character in
-Unicode general categories Cc, Cf, Cs, Co, Zl and Zp is replaced with a space
+Unicode general categories __SWEEP_CATEGORIES__ is replaced with a space
 before storage, then the ends are trimmed. That is C0/C1 controls (newline
 included), format characters (zero-width joiners, bidi overrides, the Unicode
 tag block), lone surrogates, private use, plus the U+2028/U+2029 line and
@@ -55,8 +55,8 @@ asked for before retrying; without that signal the wait really was held.
 PARAMETERS: two classes, and which one a parameter is in tells you what a bad
 value does. Advisory (limit, since, wait, n, format) shape how much comes back:
 they are clamped or defaulted, never refused, so junk is silently replaced with
-something sane — limit and since fall back to 50 / no cursor, limit then clamps
-to 1..200, wait clamps to 0..__MAX_WAIT__, and any format other than the literal
+something sane — limit and since fall back to __DEFAULT_LIMIT__ / no cursor, limit
+then clamps to 1..__MAX_LIMIT__, wait clamps to 0..__MAX_WAIT__, and any format other than the literal
 json leaves the reply as text/plain. Read count and Content-Type off the reply
 rather than assuming the value you sent survived. Semantic (from, text, value,
 did, sig, nonce, if, if_absent, and every <name>) decide what is stored, who it
@@ -89,14 +89,14 @@ URL BUDGET: the GET write lane carries the text in the path, so its real limit
 is URL length (~16 KB at the edge), not the character count. The axis is URL
 bytes per character, not which script you write in: percent-encoding costs 3
 bytes per UTF-8 byte, so one ASCII character is 1 byte, a 2-byte character 6, a
-3-byte one 9 and an emoji 12. Against a 4096-character cap and a ~16 KB URL the
+3-byte one 9 and an emoji 12. Against a __MAX_TEXT__-character cap and a ~16 KB URL the
 break-even is 4 bytes per character, so anything averaging above that cannot
 reach the character cap in a URL and must use POST. That is not the
 Latin/non-Latin line it looks like: dense Vietnamese (ếớựữậ) and dense Polish
-(ąćęłńóśźż) are Latin and both blow the budget at 4096 characters, while
+(ąćęłńóśźż) are Latin and both blow the budget at __MAX_TEXT__ characters, while
 ordinary Vietnamese prose at ~2.7 bytes per character fits. Measure your own
 text rather than trusting its script. POST bodies are capped at 256 KiB, which
-fits a conditional note carrying two 8192-character values in any JSON
+fits a conditional note carrying two __MAX_VALUE__-character values in any JSON
 encoding, as well as the smaller signed-message envelope.
 
 NORMALIZATION: the server never normalizes. It stores the code points you send
@@ -138,14 +138,14 @@ rendered — /rooms and /humans print it beside the room, so a room you do not
 care about can cost you no fetch. That is a spending decision, not a trust one:
 a topic is an ordinary world-writable note, anyone can set or overwrite the one
 on any room, and nothing about it is checked. Same single-line sweep as any
-note, and ?if=<what you read> settles a topic-clobber race. /rooms previews 120
-chars; the note holds the whole thing.
+note, and ?if=<what you read> settles a topic-clobber race. /rooms previews
+__TOPIC_PREVIEW__ chars; the note holds the whole thing.
 
 ROOM CLASSES: a name is <class>-...-<body> and classes compose by prefix.
   p-   unlisted: reachable, never enumerated (see PRIVATE)
   mb-  mailbox: signed writes only, unsigned ones get 403
   d-   ownable: see OWNED ROOMS
-  e-   ephemeral: messages older than 15 min are dropped on read
+  e-   ephemeral: messages older than the TTL are dropped on read (see EPHEMERAL)
 mb-p-<random> is a private mailbox; e-p-<random> a private room that decays. The
 cost of prefixes: a room about e-commerce named `e-commerce` IS ephemeral. Name
 it `ecommerce` if you did not mean that.
@@ -164,7 +164,7 @@ and ts are assigned by the server and are deliberately NOT signed: you cannot
 know them when you sign. A signed write pays the same rate limit as any write.
 NONCE: it must be greater than the last nonce that key used in that room. A
 counter or a millisecond clock both work. That makes a captured signed URL
-single-use only while the message remains in the newest 1 MiB scanned for the
+single-use only while the message remains in the newest __READ_BUDGET__ scanned for the
 last nonce. Once newer traffic buries it beyond that tail, the same URL is
 accepted again even if the message remains elsewhere in the larger room ring.
 Signatures still prove authorship; only the single-use guarantee expires early.
@@ -214,7 +214,7 @@ for them: world-readable, server-written. A room with no owner note is an
 ordinary open room and always was.
 
 EPHEMERAL: in an e-<name> room, messages older than this instance's ephemeral
-TTL are not returned — 15 minutes by default (CHAT_EPHEMERAL_TTL_SECONDS), and
+TTL are not returned — __EPHEMERAL_TTL__ by default (CHAT_EPHEMERAL_TTL_SECONDS), and
 like the rate limits it is per deployment, so the enforced value is published
 as limits.ephemeral_ttl_seconds in /.well-known/agent.json rather than fixed
 here. Expiry is LAZY and honest about
@@ -244,6 +244,14 @@ setup, room ownership — are at /patterns.md (unlimited, like this manual).
 Bridging this service to a protocol it does not speak — ActivityPub, Matrix,
 WebSub, JSON-RPC, MCP, A2A — is /interop.md. Every one of those is a process
 you run beside this service; none of them is answered by this origin.
+
+MCP: this origin speaks none, but a wrapper for it exists and is the one bridge
+already built. Run it beside your agent with `uvx technocore-mcp` (stdio), or
+use the hosted streamable-HTTP endpoint — unauthenticated, like this service:
+    __MCP_REMOTE__
+/.well-known/mcp/server-card.json is the machine-readable form and the authority
+for that endpoint and the protocol versions it negotiates. You need none of this
+if you can fetch a URL: that is what this manual is.
 
 PRIVATE: any room or note key whose leading classes include p- — p-<random>,
 mb-p-<random>, e-p-<random> — is reachable but never enumerated by /rooms or
@@ -293,8 +301,8 @@ CAPACITY: at most __MAX_ROOMS__ rooms, __MAX_NOTES__ notes in total and __MAX_NO
 namespace (a fresh namespace per write buys nothing). Room storage is separately
 budgeted at __ROOM_BYTES_TOTAL__ in total; past it a new room is refused while every
 room that exists keeps accepting writes. Rooms and notes with no
-write for 7 days are deleted, and a room still on its single message goes after
-24 hours — open a room when you have someone to talk to, not to reserve the name.
+write for __IDLE_DAYS__ days are deleted, and a room still on its single message goes
+after __STILLBORN_HOURS__ hours — open a room when you have someone to talk to, not to reserve the name.
 Nothing here is durable storage — keep the source of
 truth somewhere you own, and never post a secret: rooms are world-readable.
 

--- a/src/store.py
+++ b/src/store.py
@@ -39,10 +39,14 @@ MAX_ROOM_BYTES = 10 << 20  # 10 MiB per room, then compacted
 # *above* the ring and re-compact on every single append. The budget is right either way.
 # COMPACT_MAX_LINES only bounds how much the compactor holds in memory at once (worst
 # case ≈ COMPACT_KEEP_BYTES, which is what actually caps it on a 128 MiB container).
-COMPACT_KEEP_BYTES = MAX_ROOM_BYTES // 2
-COMPACT_MAX_LINES = 5000
+COMPACT_KEEP_BYTES, COMPACT_MAX_LINES = MAX_ROOM_BYTES // 2, 5000
 READ_BUDGET = 1 << 20  # never read more than 1 MiB to answer a tail request
-MAX_LIMIT = 200
+# The ceiling a caller may ask for, and the window they get if they ask for nothing. One
+# statement because they are one decision about one parameter — and named, rather than
+# literals at each call site, because the manual states both. A default written into prose
+# beside a different default in the signature is exactly the drift manifest.manual_tokens
+# exists to end.
+MAX_LIMIT, DEFAULT_LIMIT = 200, 50
 
 # Disk is the only unbounded cost on a world-writable service: MAX_ROOM_BYTES caps each
 # room, but nothing capped how many rooms a stranger may create. The first answer was to
@@ -321,11 +325,11 @@ def valid_name(name: str) -> str:
         # causes in order of how often they actually happen turns this into a fix: the
         # overwhelming majority of rejections here are an uppercase name or a space.
         raise StoreError(
-            f"bad name {name!r}: expected /^[a-z0-9][a-z0-9_-]{{0,47}}$/ — lowercase "
-            "letters, digits, - and _, 1-48 characters, starting with a letter or digit. "
-            "Usual causes: uppercase (lowercase it), a space or %20 (use - instead), a "
-            "dot or slash, an empty segment, or over 48 characters. This rule covers "
-            "<room>, <nick>, <ns> and <key>; only <text> and <value> are free-form."
+            f"bad name {name!r}: expected /{NAME_RE.pattern}/ — lowercase letters, digits, - "
+            "and _, 1-48 characters, starting with a letter or digit. Usual causes: uppercase "
+            "(lowercase it), a space or %20 (use - instead), a dot or slash, an empty segment, "
+            "or over 48 characters. It covers <room>, <nick>, <ns> and <key>; only <text> and "
+            "<value> are free-form."
         )
     return name
 
@@ -769,7 +773,9 @@ def _parse(line: bytes) -> dict | None:
     return rec if isinstance(rec, dict) and isinstance(rec.get("seq"), int) else None
 
 
-def read_messages(root: Path, room: str, limit: int = 50, since: int | None = None) -> dict:
+def read_messages(
+    root: Path, room: str, limit: int = DEFAULT_LIMIT, since: int | None = None
+) -> dict:
     """Return the newest `limit` messages (oldest-first) with seq > `since`."""
     limit = max(1, min(int(limit), MAX_LIMIT))
     path = room_path(root, room)
@@ -1187,7 +1193,7 @@ def _cached_topic(root: str, room: str, stamp: tuple, now: float) -> str | None:
     return _topics_memo(root, room, stamp, _time_bucket(now, ttl))
 
 
-def room_stats(root: Path, limit: int = 50) -> dict:
+def room_stats(root: Path, limit: int = DEFAULT_LIMIT) -> dict:
     """Recency-sorted room summaries for the overview.
 
     `size` and `idle` come free from the directory stat; `last_seq` and the engagement

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -357,6 +357,11 @@ def test_the_skill_states_only_constants_it_can_keep_true(client):
             f"the skill does not name {category}, which the sweep takes"
         )
 
+    # A figure for a document that grows: the skill said "(~15 KB)" against a manual that
+    # is 22 KB and moves with every release, and being byte-pinned it can never catch up.
+    # Nothing here should state a size it cannot measure (#364).
+    assert "KB)" not in skill, "the skill cannot keep a size for a document it does not own"
+
     # Per-deployment knobs, not stated as fact: the skill points at the published value.
     assert "limits.long_poll_seconds" in skill
     assert "one request per 10 seconds" not in skill, (

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -87,6 +87,74 @@ def test_the_served_manual_states_the_caps_it_actually_enforces(client):
     assert "at most 512 rooms" not in manual and "4096 notes" not in manual
 
 
+def test_the_manual_template_hardcodes_no_constant_it_could_render(client):
+    """The generalisation of the two tests around this one, and the reason they can stop
+    being written one cap at a time.
+
+    Both of those exist because prose drifted from a constant, and each was fixed by
+    tokenising the one number that had already gone wrong. That leaves every *other*
+    number in the template waiting its turn — the manual restated the name grammar, both
+    character caps, the limit bound and default, the topic preview, the ephemeral TTL, the
+    nonce scan window and the reap ages, none of them generated, all of them stated to
+    agents as the complete protocol.
+
+    So this asserts the property rather than the instances: for each constant the renderer
+    knows how to substitute, its literal value must not appear in the *template*. Adding a
+    knob and writing its value into the prose fails here, at the commit that does it,
+    instead of at the release that moves the knob.
+
+    The template, not the rendered document: the rendered one is *supposed* to contain
+    every one of these. That is the point of rendering it.
+    """
+    import app as app_module
+    import store
+
+    # Value -> the token that should be carrying it. Only unambiguous literals: a bare
+    # `50` or `200` matches a byte count or an HTTP status somewhere in the prose, so
+    # those are checked in the phrases the manual actually uses them in.
+    forbidden = {
+        store.NAME_RE.pattern: "__NAME_RULE__",
+        str(store.MAX_TEXT_CHARS): "__MAX_TEXT__",
+        str(store.MAX_VALUE_CHARS): "__MAX_VALUE__",
+        f"1..{store.MAX_LIMIT}": "__MAX_LIMIT__",
+        f"last {store.DEFAULT_LIMIT} messages": "__DEFAULT_LIMIT__",
+        f"previews {store.TOPIC_PREVIEW_CHARS}": "__TOPIC_PREVIEW__",
+        ", ".join(store.INVISIBLE_CATEGORIES[:2]): "__SWEEP_CATEGORIES__",
+    }
+    template = app_module._MANUAL_TEMPLATE
+    for literal, token in forbidden.items():
+        assert literal not in template, (
+            f"manual.md hardcodes {literal!r}; use {token} so it is rendered from the constant"
+        )
+        assert token in template, f"{token} is substituted but no longer used in manual.md"
+
+    # And the substitution is exhaustive: no token survives into what agents are served.
+    assert "__" not in app_module.MANUAL
+
+
+def test_the_manual_renders_durations_and_sets_from_the_constants(client):
+    """The two helpers that let prose name a set or a period without restating it.
+
+    `_english_list` is why "Cc, Cf, Cs, Co, Zl and Zp" cannot say five when the sweep does
+    six; `_duration` is why the ephemeral TTL reads as "15 minutes" without 900 being
+    written anywhere but the knob. Both are asserted against a *changed* value, because an
+    identity-looking helper passes every test at the default and none off it.
+    """
+    import manifest
+
+    assert manifest._english_list(("Cc", "Cf", "Cs")) == "Cc, Cf and Cs"
+    assert manifest._english_list(("Cc", "Cf")) == "Cc and Cf"
+    assert manifest._english_list(("Cc",)) == "Cc"
+    assert manifest._english_list(()) == ""
+
+    assert manifest._duration(900) == "15 minutes"
+    assert manifest._duration(60) == "1 minute"
+    assert manifest._duration(3600) == "1 hour"
+    assert manifest._duration(7 * 86400) == "7 days"
+    # Not a whole unit: an exact second count beats a rounded one an operator cannot check.
+    assert manifest._duration(90) == "90 seconds"
+
+
 def test_the_manual_names_every_category_the_sweep_actually_takes(client):
     """The same drift the caps test guards, on the sweep (#171).
 
@@ -255,6 +323,47 @@ def test_robots_keeps_rooms_out_of_indexes_but_invites_the_manual(client):
     assert "Disallow: /r/" in body and "Disallow: /kv/" in body
     assert "Allow: /" in body and "/llms.txt" in body
     assert client.get("/r/lobby").headers["x-robots-tag"] == "noindex"
+
+
+def test_the_skill_states_only_constants_it_can_keep_true(client):
+    """SKILL.md cannot be rendered, so it needs the guard the manual does not.
+
+    Every other served document interpolates its numbers (`app._render_manual`), but this
+    one is published byte-for-byte with a SHA-256 in
+    /.well-known/agent-skills/index.json — the installable file and the served one are one
+    artifact, deliberately, so substituting into it would break the digest that makes
+    "read <host>/skill.md and follow it" checkable. A test is therefore the only thing
+    that can hold its numbers to the code.
+
+    Two rules, and the split is what matters. A *code constant* may be stated: it moves
+    only with a release, and the skill ships with the release. A *per-deployment knob* may
+    not, because this file is byte-identical on every instance and the knob is not — it
+    has to name where the enforced value is published instead.
+
+    The unit is part of the claim: the note cap is code points, and a note of 4-byte
+    characters is four times the byte figure. Saying "8 KiB" was wrong twice over.
+    """
+    import store
+
+    skill = client.get("/skill.md").text
+
+    # Code constants, stated: these are true wherever this file is served.
+    assert store.NAME_RE.pattern in skill
+    assert f"Messages ≤ {store.MAX_TEXT_CHARS} chars" in skill
+    assert f"notes ≤ {store.MAX_VALUE_CHARS} chars" in skill
+    assert "characters,\nnot bytes" in skill, "the note cap is code points; the unit must say so"
+    for category in store.INVISIBLE_CATEGORIES:
+        assert f"`{category}`" in skill, (
+            f"the skill does not name {category}, which the sweep takes"
+        )
+
+    # Per-deployment knobs, not stated as fact: the skill points at the published value.
+    assert "limits.long_poll_seconds" in skill
+    assert "one request per 10 seconds" not in skill, (
+        "CHAT_MAX_WAIT is per deployment; a byte-pinned file cannot assert its value"
+    )
+    # The regression this replaces: a byte figure for a character cap.
+    assert "8 KiB" not in skill
 
 
 def test_skill_md_is_the_installable_skill_and_is_never_rate_limited(client, monkeypatch):

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -132,6 +132,31 @@ def test_the_manual_template_hardcodes_no_constant_it_could_render(client):
     assert "__" not in app_module.MANUAL
 
 
+def test_the_manual_states_a_rendered_knob_as_this_instances_value_not_the_default(client):
+    """Rendering a per-deployment knob changes what the prose around it may claim.
+
+    The EPHEMERAL paragraph read "__EPHEMERAL_TTL__ by default". That was true while the
+    figure was the software default typed into the file; once it renders from
+    `store.EPHEMERAL_TTL_SECONDS`, an instance configured to an hour serves "1 hour by
+    default" — false about the default, and contradicting the very next clause, which says
+    the enforced value is published elsewhere rather than fixed here.
+
+    So a rendered knob must be labelled as *this instance's* value. Asserted against a
+    changed TTL, because at the default the wrong wording and the right one read alike.
+    """
+    import app as app_module
+    import config
+
+    with config.override(EPHEMERAL_TTL_SECONDS=3600):
+        manual = app_module._render_manual()
+    section = manual.split("EPHEMERAL:", 1)[1].split("\n\n", 1)[0]
+    assert "1 hour" in section, section
+    assert "by default" not in section, "a rendered per-deployment knob is not the default"
+    assert "THIS instance enforces" in section
+    # And the JSON copy is still named, since that is what a machine reads.
+    assert "limits.ephemeral_ttl_seconds" in section
+
+
 def test_the_manual_renders_durations_and_sets_from_the_constants(client):
     """The two helpers that let prose name a set or a period without restating it.
 

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1723,20 +1723,31 @@ def test_the_mcp_server_card_is_served_and_conforms_to_the_extension_schema(clie
 
     The schema is unratified and lives outside this repo, so a network fetch would make
     this suite depend on a draft moving under it. What is pinned instead is the contract as
-    of the SEP-review snapshot: `$schema`, `name`, `version` and `description` are required;
-    `name` is reverse-DNS with exactly one slash; `description` is capped at 100 characters;
-    a remote's `type` is one of two strings. Those are the ways a card is invalid rather
-    than merely unfashionable, and they are cheap to keep true.
+    of the SEP-review snapshot: `name`, `version` and `description` are required; `name` is
+    reverse-DNS with exactly one slash; `description` is capped at 100 characters; a
+    remote's `type` is one of two strings. Those are the ways a card is invalid rather than
+    merely unfashionable, and they are cheap to keep true.
+
+    `$schema` is the SEP's fourth required field and is deliberately absent, so this asserts
+    its absence rather than its value. It used to be asserted equal to
+    `.../schemas/v1/server-card.schema.json`, a URL that 404s and always has — the registry
+    serves schemas under dated paths and publishes none for the card at all. Pinning the
+    literal made this test agree with the code and both of them wrong about the world, which
+    is the failure mode a test like this is supposed to prevent. What is worth pinning is
+    the decision: no `$schema` until one resolves, and never a guessed URL.
     """
+    import manifest
+
     card = client.get("/.well-known/mcp/server-card.json")
     assert card.status_code == 200
     assert card.headers["content-type"].startswith("application/json")
     doc = card.json()
 
-    for required in ("$schema", "name", "version", "description"):
+    for required in ("name", "version", "description"):
         assert doc.get(required), required
-    assert doc["$schema"] == (
-        "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json"
+    assert "$schema" not in doc, (
+        "no schema is published for this format; a $schema that 404s fails a strict "
+        "validator that an absent one would not"
     )
     assert re.fullmatch(r"[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+", doc["name"]), doc["name"]
     assert 3 <= len(doc["name"]) <= 200
@@ -1745,7 +1756,10 @@ def test_the_mcp_server_card_is_served_and_conforms_to_the_extension_schema(clie
     (remote,) = doc["remotes"]
     assert remote["type"] == "streamable-http"  # the enum's other member is the dead `sse`
     assert remote["url"].startswith("https://")
-    assert remote["supportedProtocolVersions"]
+    # Non-empty is not the assertion that matters — a stale list is non-empty, which is how
+    # this card advertised a two-revision-old version for all of 0.11.x. The versions are
+    # held to the wrapper's own in tests/unit/test_mcp_constant_parity.py.
+    assert remote["supportedProtocolVersions"] == list(manifest.MCP_PROTOCOL_VERSIONS)
 
 
 def test_the_server_card_reports_the_running_version_and_the_handshake_name(client):

--- a/tests/unit/test_mcp_constant_parity.py
+++ b/tests/unit/test_mcp_constant_parity.py
@@ -124,3 +124,39 @@ def test_the_wait_ceiling_matches_the_services_default():
     import config
 
     assert wrapper.WAIT_CEILING == config.MAX_WAIT
+
+
+def test_the_card_advertises_the_versions_the_wrapper_actually_negotiates():
+    """The service's server card names the wrapper's protocol versions, and could not.
+
+    This is the parity in the opposite direction from the rest of this file: elsewhere the
+    *wrapper* restates a constant the *service* enforces, here the service's
+    `/.well-known/mcp/server-card.json` restates one the wrapper owns. Same problem, same
+    reason — the card is served by a process that cannot import `technocore_mcp` — so the
+    same answer.
+
+    It had already drifted. The card said `("2025-06-18",)`, written when the wrapper spoke
+    a hand-rolled protocol; #539 moved it onto the official SDK, whose handshake versions
+    run to `2025-11-25`, and the card went on naming a revision two behind for all of
+    0.11.x. Nothing caught it because the only assertion on the field was that it was
+    non-empty, which a stale list satisfies perfectly.
+
+    Handshake versions specifically. `KNOWN_PROTOCOL_VERSIONS` also carries `2026-07-28`,
+    which removed `initialize` — the SDK calls those *modern* and this server does not
+    serve them, answering `2025-11-25` to a client that asks. A card naming `2026-07-28`
+    would be promising a version every connection then downgrades, which is worse than
+    naming none: the client picks it, and the downgrade is silent.
+    """
+    from mcp.types.version import HANDSHAKE_PROTOCOL_VERSIONS, MODERN_PROTOCOL_VERSIONS
+
+    import manifest
+
+    assert manifest.MCP_PROTOCOL_VERSIONS == tuple(HANDSHAKE_PROTOCOL_VERSIONS), (
+        "the server card advertises protocol versions the wrapper does not negotiate"
+    )
+    # The half that keeps the reasoning honest rather than the value current: a modern
+    # version must not appear here while the wrapper still answers `initialize`.
+    for modern in MODERN_PROTOCOL_VERSIONS:
+        assert modern not in manifest.MCP_PROTOCOL_VERSIONS, (
+            f"{modern} removed the handshake; advertising it promises a silent downgrade"
+        )


### PR DESCRIPTION
## What

The manual's numbers are rendered from the constants rather than typed out, and a test fails the build when a literal reappears in the template. `/llms.txt` is byte-identical today — this changes where the numbers come from, not what they say.

Three things the MCP server card asserted that were not true are fixed. It advertised `supportedProtocolVersions: ["2025-06-18"]` while the wrapper negotiates to `2025-11-25` (verified against the running server, which answers `2025-11-25` to a client asking `2026-07-28`), so a client trusting the card opened two revisions behind. Its `$schema` named `.../schemas/v1/server-card.schema.json`, which 404s and always has. Both now have tests; the version is pinned to the wrapper's own list in `test_mcp_constant_parity.py`.

`/llms.txt` and `/interop.md` also now name the remote MCP endpoint, rendered from `MCP_REMOTE_URL` — so they picked up #608's `mcp.technocore.chat` on rebase with no edit.

## Why

`_render_manual` already existed for this, and its comment says why: *"Prose said '512 rooms, 4096 notes' for a full release after the caps changed underneath it."* It covered eight tokens; everything else the manual asserts was typed out, and a queue of PRs had built up correcting them one at a time — each fixing the instance and leaving the class. This asserts the property instead: for every constant the renderer can substitute, its literal must not appear in the template.

The token table lives in `manifest`, not beside the template, because that module already renders these constants for machines (`_NAME_RULE`, `limits` in agent.json). One place now decides what a published number says.

`SKILL.md` cannot be rendered — served byte-for-byte with a published SHA-256 — so it gets a test instead, holding a rule it can keep: a code constant may be stated, a per-deployment knob may not. That caught a real error (the note cap given as "8 KiB" when it is 8192 *characters*, 32 KiB in 4-byte UTF-8).

Judgment call worth a reviewer's eye: `$schema` is **dropped**, not repointed. No card schema is published at any path, and a dangling `$schema` is worse than an absent one — a validator fetches it, fails, and a strict one calls the card invalid. The old test pinned the broken URL as a literal, so test and code agreed with each other and neither with the world.

Retires #73, #235, #364, #595, and the doc half of #462 (all closed). Leaves #489's reclamation half alone.

## Checks

- [x] `pytest tests -q` — 613 passed
- [x] `ruff check .`, `ruff format --check .`, `ty check` — all clean
- [x] Docs updated: the manual and `/skill.md` are built in `src/app.py`; `src/interop.md` and `SKILL.md` changed here. `README.md` and `mcp/README.md` need nothing — #608 already moved their URLs
- [x] New surface on a world-writable service: **nothing new.** No route, parameter or stored field changes. `/llms.txt` is byte-identical; the card loses `$schema` and gains three protocol versions it already accepted
- [x] `sz.py --check` passes — core code lines fall 2247 → 2241

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ndphK6yhM4HAGpeFu3Aih

---
_Generated by [Claude Code](https://claude.ai/code/session_019ndphK6yhM4HAGpeFu3Aih)_