### PR TITLE
fix(ci): verify a queue-guard overlap hit actually cites the issue (#610)

### DIFF
--- a/.github/workflows/queue-guard.yml
+++ b/.github/workflows/queue-guard.yml
@@ -49,12 +49,27 @@ jobs:
             const pr = context.payload.pull_request;
             const refs = [...new Set((pr.title + ' ' + (pr.body || '')).match(/#\d+/g) || [])];
             const found = new Map();
+            // The search is a prefilter, not the answer. GitHub's tokenizer does not treat
+            // '#' as part of a word, so a query for "#607" is really a query for the token
+            // 607 and matches any text containing those digits — a byte count, a timing, a
+            // throughput figure. That is how #271 came to be reported as citing #607: its
+            // body measures 6,607 appends/s, and '6,607' tokenizes on the comma. PR bodies
+            // here carry measurements routinely, so this is the common case, not a corner.
+            // Every hit is therefore re-checked against the text the search already returns
+            // (free — no extra request), and only a literal reference survives.
+            const cites = (item, ref) => {
+              const n = ref.slice(1);
+              // '#N' or an issues/N | pull/N URL tail, and not the prefix of a longer
+              // number: #607 must not answer for #6071.
+              const rx = new RegExp('(#|(?:issues|pull)\\/)' + n + '(?!\\d)');
+              return rx.test((item.title || '') + ' ' + (item.body || ''));
+            };
             for (const ref of refs.slice(0, 8)) {
               const q = 'repo:' + context.repo.owner + '/' + context.repo.repo +
                 ' is:pr is:open "' + ref + '" in:title,body';
               const res = await github.rest.search.issuesAndPullRequests({ q, per_page: 10 });
               for (const item of res.data.items)
-                if (item.number !== pr.number && !found.has(item.number))
+                if (item.number !== pr.number && !found.has(item.number) && cites(item, ref))
                   found.set(item.number, ref);
             }
             const marker = '<!-- queue-guard-overlap -->';


### PR DESCRIPTION
Closes #610. Verified against `9da8f42`.

queue-guard's `overlap` job reported any open PR whose text merely *contained the digits* of a
cited issue number. It fired for real today, on the PR before this one.

## The bug

#608 cites `#607`. queue-guard commented that **#271** "also cites #607". #271 is
`fix(store): fsync room directory entries`, opened five days before #607 existed. Its only
occurrence of those digits:

> paired benchmark on WSL2 …: **6,607** appends/s file-only versus 6,292 with two directory syncs

## Root cause — it is the query, not the extraction

`/#\d+/g` extracts `#607` correctly. The defect is the line after it:

```js
const q = 'repo:' + … + ' is:pr is:open "' + ref + '" in:title,body';
```

**GitHub's search tokenizer does not treat `#` as part of a word**, so `"#607"` is searched as the
bare token `607`. Confirmed against the live API — the two queries are indistinguishable:

```
$ gh api -X GET search/issues -f q='… is:pr is:open "#607" in:title,body'
  #271  fix(store): fsync room directory entries
$ gh api -X GET search/issues -f q='… is:pr is:open "607"  in:title,body'
  #271  fix(store): fsync room directory entries
```

`6,607` tokenizes on the comma, so `607` matches exactly. And nothing downstream re-checked the
hit — the search was serving as both prefilter *and* verdict.

## The fix

The search stays the prefilter; the API offers nothing more precise. What changes is that every
hit is now confirmed against the `title` and `body` **the search response already returns** — so
no extra request, no added rate-limit cost:

```js
const cites = (item, ref) => {
  const n = ref.slice(1);
  const rx = new RegExp('(#|(?:issues|pull)\\/)' + n + '(?!\\d)');
  return rx.test((item.title || '') + ' ' + (item.body || ''));
};
```

A literal `#N`, or an `issues/N` / `pull/N` URL tail, and not the prefix of a longer number so
`#607` cannot answer for `#6071`. That puts the split in the right place: the API decides what is
cheap to fetch, this workflow decides what is true.

## Why it is worth fixing rather than tolerating

PR bodies in this repo routinely carry measurements — appends/s, byte counts, millisecond
timings, module counts. Every one is a chance to name an unrelated PR as overlapping work, so the
false positive is the common case, not a corner. A guard that fires on arithmetic teaches
reviewers to skip it, and it then fails quietly on the real collision it exists to catch. It also
publicly mislabels the innocent PR: #271 currently carries a comment implying it duplicates work
it has nothing to do with.

## This PR demonstrates the bug on itself

queue-guard ran against **this** PR using the code on `main`, and reported four overlaps:

```
- #611 (also cites #608)
- #393 (also cites #608)
- #108 (also cites #608)
- #271 (also cites #607)
```

Three are spurious. Running the new `cites()` filter over the real bodies:

| claimed | where the digits actually are | new filter |
|---|---|---|
| #611 cites #608 | *"they picked up #608's `mcp.technocore…`"* — a real reference | ✅ **kept** |
| #393 cites #608 | `66,608 lines held, 7.8 M…` | 🚫 suppressed |
| #108 cites #608 | `66,608 lines` | 🚫 suppressed |
| #271 cites #607 | `6,607 appends/s` | 🚫 suppressed |

The #611 row is the important one: it is a genuine citation and the filter **keeps** it. This is a
precision fix, not a blanket mute.

### End-to-end, against the live API

Replaying the whole job — real search calls for `#608` and `#607`, then the new filter — on this
PR's own refs:

```
BEFORE (current main): #611 (#608), #393 (#608), #108 (#608), #271 (#607)
AFTER  (this PR)     : #611 (#608)
```

One genuine overlap survives; the three arithmetic matches are gone.

### On the "no extra request" claim

Worth stating because the fix depends on it: the filter reads `item.body` from the **search
response**, so it would be a false-*negative* machine if that field were truncated — a real
citation late in a long body would be dropped, which is the one failure this guard cannot afford.
Checked rather than assumed. Search-API bodies are byte-identical to the pulls API:

| PR | body length via search | via `pulls` |
|---|---|---|
| #611 | 3,255 | 3,255 |
| #393 | 5,304 | 5,304 |
| #108 | **12,788** | **12,788** |

No truncation, including the 12.7 KB body — so the check is complete and genuinely free.

## A contributor already diagnosed this by hand

The bug is not new, and it is already costing people time. **#108** — `fix(http): validate a name
before consulting its class` — carries an "Overlapping work" section written to defend against
exactly this:

> I checked the queue for #109 … `gh api search/issues` for open PRs citing `#109` returns only
> #393 … It cites this issue nowhere in its text: **the search matches on the bare digits
> appearing inside a larger figure it quotes (`66,608 lines`)**. No overlap with this change.

An independent contributor reached the same root cause unaided, then spent a paragraph proving a
negative to a reviewer. That is the cost this guard is currently imposing — and it lands on the
people doing the most careful queue triage, since they are the ones who check.

## Verification

The workflow is not reachable from `pytest`, so it was checked directly. The `cites` function was
extracted verbatim from the committed YAML and run against **the real bodies of #271 and #608**
plus twelve synthetic cases — all 14 pass:

| case | expected | got |
|---|---|---|
| **real #271 body** (`6,607 appends/s`) | no match | ✅ no match |
| **real #608 body** (`Closes #607`) | match | ✅ match |
| `607` bare / `6,607` / `18,607 KiB` / `v1.607` | no match | ✅ no match |
| `#607` / `see #607` / `Closes #607.` / title-only | match | ✅ match |
| `#6071` (longer number) | no match | ✅ no match |
| `issues/607`, `pull/607` | match | ✅ match |
| null title and body | no match | ✅ no match |

Also confirmed: the file still parses as YAML with both jobs intact, and both embedded scripts
pass `node --check`. The `protected-files` job is untouched.

Repo gates, all clean:

```
uv sync --frozen                          Checked 62 packages
uv run ruff check .                       All checks passed!
uv run ruff format --check .              74 files already formatted
uv run ty check                           All checks passed!
uv run coverage run -m pytest tests -q    609 passed
uv run sz.py --check                      core code-lines <= baseline (2247)
```

## Note

I did not add a regression test. There is no harness in `tests/` for workflow YAML, and building
one for a single embedded function looked like more surface than the fix. If you would rather have
one — say a `tests/unit/test_queue_guard.py` that extracts the script from the YAML and exercises
the regex through `node` — I am happy to add it.

## Not addressed here

Post-filtering can only remove hits, so a genuine overlap that the fuzzy search pushed past
`per_page: 10` is still missed. That is pre-existing and unchanged by this PR; precision improves,
recall does not. Worth a separate look if it ever bites.

## Suggested release note

> queue-guard no longer reports a PR as citing an issue when its text merely contains those
> digits — a benchmark figure like `6,607` is no longer read as a reference to `#607`.
