### PR TITLE
perf(store): halve the export's expired prefix instead of parsing it

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -855,18 +855,27 @@ def _cutoff(room: str) -> float | None:
     return time.time() - EPHEMERAL_TTL_SECONDS if is_ephemeral(room) else None
 
 
+def _ts(rec: dict) -> float | None:
+    """The record's timestamp as an epoch second, or None where it cannot be read.
+
+    Split out of `_expired` because the two questions it used to answer together are not
+    the same question. "Older than the cutoff" is monotone along an append-ordered file and
+    is what `_export_start` bisects on; "undated" is not, and a record that fails closed on
+    a `ts` nothing can parse can sit anywhere. Folding them made every undated record look
+    like a boundary."""
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ"):
+        try:
+            return datetime.strptime(str(rec.get("ts")), fmt).replace(tzinfo=UTC).timestamp()
+        except ValueError:
+            continue
+    return None
+
+
 def _expired(rec: dict, cutoff: float) -> bool:
     """Fail closed on an unreadable `ts`: an `e-` room promises the record is gone by now,
     and a record whose age cannot be established cannot honour that promise. Elsewhere `ts`
-    stays what it always was — an opaque string nothing parses."""
-    ts = rec.get("ts")
-    if isinstance(ts, str):
-        for fmt in ("%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ"):
-            try:
-                return datetime.strptime(ts, fmt).replace(tzinfo=UTC).timestamp() < cutoff
-            except ValueError:
-                continue
-    return True
+    stays what it always was, an opaque string nothing parses."""
+    return (ts := _ts(rec)) is None or ts < cutoff
 
 
 def _parse(line: bytes) -> dict | None:
@@ -941,21 +950,41 @@ def _export_start(f, cutoff: float | None, end: int) -> int:
     Ephemeral expiry is drop-on-read and a raw dump is a read: streaming records the class
     promises have stopped being readable would make export the one lane that ignores the
     TTL. Records are append-ordered, so the expired records are a prefix, and the export
-    starts at the first line whose record is still readable — judged by the same `_expired`
-    the tail read uses, unparsable `ts` failing closed with it. Costs one forward parse of
-    the bytes being dropped, on the `e-` class only; every other room starts at 0 for free.
-    """
+    starts at the first line whose record is still readable, judged by the same cutoff the
+    tail read uses. On the `e-` class only; every other room starts at 0 for free.
+
+    Halved rather than scanned, and "the expired records are a prefix" above is what pays
+    for it: the same property `read_messages` spends when it stops at the first expired
+    record instead of filtering the file. A forward parse made this the one read lane
+    bounded by nothing but the room. Compaction fires only *over* the ring, so an `e-` room
+    parked just under MAX_ROOM_BYTES keeps its whole expired prefix on disk, and dumping
+    one cost an `orjson.loads` and a `strptime` per record to answer with an empty body:
+    69,059 pairs and 659 ms of CPU at 10 MiB, against one parse for the tail read of that
+    same room, for one read token and repeatable until the room idles out.
+
+    `lo` is a line start with nothing readable before it, `hi` a line start known readable
+    or `end`, and each pass reads one dated record to move one of them. A midpoint lands
+    mid-line, so the probe is the next line start after it. Undated lines are stepped over
+    rather than decided on (see `_ts`): they carry no boundary, so a half holding only
+    those, or none at all, decides nothing and the pass spends its read on `lo`'s own line
+    instead, which always moves `lo`. That case is also the whole of a half too small to
+    hold a line, so it needs no separate floor."""
     if cutoff is None:
         return 0
-    f.seek(0)
-    pos = 0
-    while pos < end:
-        line = f.readline()
-        rec = _parse(line)
-        if rec is not None and not _expired(rec, cutoff):
-            return pos
-        pos += len(line)
-    return end
+    lo, hi = 0, end
+    while lo < hi:
+        f.seek(lo + (half := (hi - lo) // 2))
+        if half:
+            f.readline()  # past the partial line the midpoint landed in
+        probe, ts = f.tell(), None
+        while probe < hi and ts is None:
+            if (ts := _ts(_parse(line := f.readline()) or {})) is None:
+                probe += len(line)
+        if ts is None:
+            f.seek(probe := lo)
+            ts = _ts(_parse(line := f.readline()) or {})
+        lo, hi = (lo, probe) if ts is not None and ts >= cutoff else (probe + len(line), hi)
+    return hi
 
 
 def export_room(root: Path, room: str) -> tuple[int, Iterator[bytes]]:

--- a/src/store.py
+++ b/src/store.py
@@ -962,6 +962,13 @@ def _export_start(f, cutoff: float | None, end: int) -> int:
     69,059 pairs and 659 ms of CPU at 10 MiB, against one parse for the tail read of that
     same room, for one read token and repeatable until the room idles out.
 
+    Precondition, and load-bearing in a way it was not before: `ts` is non-decreasing down
+    the file. It holds because a record is appended under the room lock with a `ts` from
+    `_now()`, never from a caller, and compaction copies a prefix out rather than reordering
+    one. A forward scan tolerated any order; halving cannot, so a path that lets a caller
+    supply `ts`, or a clock that steps backwards mid-file, moves this lane from slow to
+    wrong rather than merely slow.
+
     `lo` is a line start with nothing readable before it, `hi` a line start known readable
     or `end`, and each pass reads one dated record to move one of them. A midpoint lands
     mid-line, so the probe is the next line start after it. Undated lines are stepped over

--- a/tests/unit/test_export_snapshot.py
+++ b/tests/unit/test_export_snapshot.py
@@ -4,6 +4,7 @@ The interleavings the HTTP layer cannot stage — an append or a compaction land
 two chunks of one export — are staged here by driving the iterator by hand.
 """
 
+import orjson
 import pytest
 
 import store
@@ -125,3 +126,33 @@ def test_a_bad_name_refuses_before_the_stream_starts(tmp_path):
     which is only possible while no bytes of a 200 have been promised yet."""
     with pytest.raises(StoreError):
         store.export_room(tmp_path, "NOT-A-NAME")
+
+
+def test_export_does_not_parse_the_whole_expired_prefix(tmp_path, monkeypatch):
+    """An `e-` room whose records have all expired answers with an empty body, and must
+    not pay one parse per record to say so: the expired records are a prefix, which is
+    the same property `read_messages` already spends to stop at the first expired one."""
+    path = store.room_path(tmp_path, "e-victim")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    old, records, total = "2020-01-01T00:00:00.000000Z", [], 0
+    while total < (2 << 20):
+        line = (
+            orjson.dumps({"seq": len(records) + 1, "ts": old, "from": "bot", "text": "x" * 80})
+            + b"\n"
+        )
+        records.append(line)
+        total += len(line)
+    path.write_bytes(b"".join(records))
+
+    parses = 0
+    original = store._parse
+
+    def counted(line):
+        nonlocal parses
+        parses += 1
+        return original(line)
+
+    monkeypatch.setattr(store, "_parse", counted)
+    generation, chunks = store.export_room(tmp_path, "e-victim")
+    assert b"".join(chunks) == b""
+    assert parses <= 64, f"{parses} parses over {len(records)} expired records"


### PR DESCRIPTION

## What changes for a caller

Nothing in the response. `GET /r/<room>/export` returns the same bytes for the same room; what changes is what it costs the server to decide where those bytes start.

## The problem

`_export_start` walks an `e-` room forward from offset 0, parsing every record until it finds one that is still readable. When every retained record has passed `EPHEMERAL_TTL_SECONDS`, that walk runs to `end` and the lane answers with an empty body, having spent one `orjson.loads` and one `strptime` per record to say so.

Measured against `main` at `248bcf3`, on a 10 MiB `e-` room whose records are all expired:

read_messages : parses=1 6.3 ms msgs=0
export_room : parses=69059 659.0 ms body=0 bytes

Every other read on this service is bounded: `read_messages` reads backwards under `READ_BUDGET` and stops at the first expired record, so it answers the same room with one parse. This lane is bounded by nothing but the room. Compaction fires only *over* the ring, so a room parked just under `MAX_ROOM_BYTES` keeps its whole expired prefix on disk, and `_reapable` keys on mtime while export opens `"rb"`, so it stays that expensive for `IDLE_SECONDS` after its last write. The cost is one read token, repeatable.

`room_export`'s own justification for reusing the read budget is inverted in this case: bytes out are zero and CPU in is maximal.

## The fix

The expired records are a prefix. That is the same property `read_messages` already spends when it stops at the first expired record instead of filtering the file, and it is what lets the boundary be halved rather than scanned.

10 MiB, all expired : 69059 parses / 659.0 ms -> 15 parses / 0.30 ms
10 MiB, 90% expired : -> 15 parses / 0.26 ms
10 MiB, none expired: -> 18 parses / 0.30 ms

`_ts` is split out of `_expired` because the two questions it answered together are not the same question. "Older than the cutoff" is monotone along an append-ordered file; "undated" is not, and a record that fails closed on a `ts` nothing can parse can sit anywhere. Folding them made every undated record look like a boundary, which a bisect cannot survive. `_expired` keeps its exact behaviour and its callers are untouched.

## Verification

Beyond the regression test in `tests/unit/test_export_snapshot.py`, the new `_export_start` was checked against the forward scan it replaces over 8,000 randomised files carrying interleaved unparsable lines, records with an unreadable `ts`, both accepted timestamp formats, and a torn tail: identical answers, 8000/8000.

- `uv run ruff check .`, `ruff format --check .`, `uv run ty check`: clean.

- `uv run coverage run -m pytest tests -q`: 615 passed.

- Verified against `main` at commit `248bcf3`.

## Core size

`uv run sz.py --check` reports `core/store.py 925 -> 930 (cap 933)`. The change is under its per-file cap (933) and under the core total cap (2246 of 2247); only the ratchet moves. `sz-baseline.json` is maintainer-regenerated, so per CONTRIBUTING I have not touched it.

## Documentation

No route, response shape, status code or cap moves, so `/openapi.json`, the manual and `/.well-known/agent.json` are unaffected. `CHANGELOG.md` is left to the maintainers to fold.

## Abuse impact

Strictly reduced. This removes a read lane whose CPU cost was linear in the room and unpriced by the read budget. It adds no public surface.

## Proposed release note

**`GET /r/<room>/export` stops parsing the expired prefix it is about to drop.** An `e-` room whose retained records have all passed the TTL answered with an empty body and paid one `orjson.loads` and one `strptime` per record to do it, 69,059 pairs and 659 ms at 10 MiB, against one parse for the tail read of the same room. The expired records are a prefix, so the boundary is halved rather than scanned: 15 parses and 0.30 ms in that case. No route, response shape or cap moves.

