### PR TITLE
docs(design): fix three stale claims in design.md

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -175,9 +175,9 @@ the next cursor URL, so an agent that follows links naturally paginates and natu
 | Time-based expiry | full scan per pass | scan cost is unbounded; wall-clock retention was never the requirement |
 | Fixed-width records + true ring | O(1) seek | forces padding and a max message size into the on-disk format; unreadable by `grep` |
 | Two-file ping-pong (active + archive) | 2× disk | keeps history, doubles the read path for `since=` |
-| **Size-triggered compaction to last K lines** | one rewrite per MiB | **chosen**: bounded disk, bounded worst-case read, single file, seq stays monotonic |
+| **Size-triggered compaction to last K bytes** | one rewrite per MiB | **chosen**: bounded disk, bounded worst-case read, single file, seq stays monotonic |
 
-Implementation (`store.py:_compact`): under the room lock, read the newest `KEEP_LINES` via the same
+Implementation (`store.py:_compact`): under the room lock, read the newest `COMPACT_KEEP_BYTES` via the same
 backwards reader, write a temp file, `os.replace` (atomic rename). Amortised cost is one rewrite per
 `MAX_ROOM_BYTES` of traffic — at 10 MiB with a half-ring keep budget that is one ~5 MiB rewrite per ~10 MiB written.
 
@@ -532,10 +532,10 @@ curl -s 'localhost:8080/r/lobby?since=0'               # read
 ```
 
 **Unverified here:** the container image was not built — no Docker daemon in this session's
-sandbox. The app, store and tests were run natively; `Dockerfile`/`docker-compose.yml` are reviewed
+sandbox. The app, store and tests were run natively; `Dockerfile` is reviewed
 but not exercised.
 
-Tests (45, all passing) cover the cursor, traversal rejection, record forgery, the POST lane,
+Tests cover the cursor, traversal rejection, record forgery, the POST lane,
 compaction bounds + observable gap, the tail reader, unlisted `p-` names (§5.5), the room/note caps + idle reaper, a torn final line, concurrent
 appends, unicode, input rejection, the room overview, the header contract, and both rate-limiter
 properties from §3.3 (actionable 429 body, budget warning before the wall):


### PR DESCRIPTION
Fixes #616.

Three facts in `docs/design.md` drifted from the code:

1. §2.2 says compaction keeps "last K lines" and names `KEEP_LINES` the implementation switched to `COMPACT_KEEP_BYTES` and the code comment explains why lines were wrong.
2. §4 says "Tests (45, all passing)" there are 557 at this commit. Dropped the count entirely since it drifts every PR.
3. §4 references `docker-compose.yml` which does not exist in the repo. Only `docker/Dockerfile`.

Four `sed` substitutions, no code touched. Verified against `248bcf3`.