### PR TITLE
test(limit): pin the exact retry-after value and bucket-eviction count

### DIFF
--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -109,6 +109,44 @@ def test_rate_limit_is_actionable_without_headers(client, monkeypatch):
         assert client.get("/r/lobby").status_code == 200  # reads have their own budget
 
 
+def test_retry_after_pins_the_exact_wait_not_just_a_loose_bound(client, monkeypatch):
+    """The check above only bounds retry-after from *above* (`<= 60 // 4 + 1`), and that
+    range is silent on three regressions in the formula that computes it: the refill
+    divisor inverted (`* 60.0` -> `/ 60.0`), the remaining-tokens term sign-flipped
+    (`1.0 - tokens` -> `1.0 + tokens`), and the seconds-per-minute constant off by one
+    (`60.0` -> `61.0`) — none of them move the result far enough for a loose bound to
+    notice. Seed a bucket at a token count where the real formula and all three mutants
+    each round to a different integer, and pin that one.
+    """
+    import app as app_module
+    import config
+
+    with config.override(RATE_WRITE=2):
+        client.get("/r/lobby/say/bot/warm")  # learns this test's bucket key
+        (key,) = [k for k in app_module._buckets if k[1] == "write"]
+        app_module._buckets[key] = (0.02, time.monotonic())
+        refused = client.get("/r/lobby/say/bot/again")
+        assert refused.status_code == 429
+        # (1 - 0.02) * 60 / 2 = 29.4 -> 29. The divisor/sign/constant mutants above give
+        # 0, 31 and 30 respectively for this same seeded state.
+        assert int(refused.headers["retry-after"]) == 29
+
+
+def test_rate_limit_bucket_eviction_stops_exactly_at_the_cap(client, monkeypatch):
+    """`len(_buckets) <= max_buckets` after eviction is equally true of an eviction loop
+    that runs one turn too many (`>` mutated to `>=`), which drops one extra live caller
+    for no reason — pin the count at exactly the cap instead of merely under it.
+    """
+    import app as app_module
+    import config
+
+    monkeypatch.setattr(app_module, "MAX_BUCKETS", 8)
+    with config.override(CLIENT_IP_HEADER="cf-connecting-ip"):
+        for i in range(50):
+            client.get("/r/lobby", headers={"cf-connecting-ip": f"2001:db8:precise::{i:x}"})
+        assert len(app_module._buckets) == 8
+
+
 def test_every_rate_limited_route_returns_the_same_recovery_plan(client, monkeypatch):
     """A new route must not accidentally become a free validation/IO oracle, and an agent
     that only sees the body must get the same useful next step whichever lane it exhausted.


### PR DESCRIPTION
`limit.take()`'s two existing tests only bound their results from *above*:

- `test_rate_limit_is_actionable_without_headers` checks `1 <= retry-after <= 60 // 4 + 1`
- `test_rate_limit_buckets_are_bounded` checks `len(_buckets) <= max_buckets`

Found via a local mutation-testing run (`mutmut`, following the pattern in #248): four mutants in `take()` survive the full suite today because neither range is tight enough to notice them:

```
wait = (1.0 - tokens) * 60.0 / per_min   ->  / 60.0 /     (refill divisor inverted)
wait = (1.0 - tokens) * 60.0 / per_min   ->  (1.0 + tokens) * ...   (sign flipped)
wait = (1.0 - tokens) * 60.0 / per_min   ->  * 61.0 /      (constant off by one)
while len(_buckets) > max_buckets        ->  >=            (evicts one turn too many)
```

The first three are the ones that matter: Retry-After is the number the whole pacing contract rests on (it's in the header, repeated in the 429 body because most agent harnesses show only page text, and `/.well-known/agent.json` points callers at it), and a caller that trusts a value that's off by a sign or a factor either busy-loops back into the bucket it just emptied, or sleeps far longer than it needs to.

Two new tests, no behavior change:

- `test_retry_after_pins_the_exact_wait_not_just_a_loose_bound` seeds a bucket at a token count (`0.02`) chosen so the real formula and all three arithmetic mutants above each round to a *different* integer (29 vs 0, 31, 30), then asserts the exact one.
- `test_rate_limit_bucket_eviction_stops_exactly_at_the_cap` asserts `== max_buckets` instead of `<=`, which the eviction-loop mutant fails (drops to `max_buckets - 1`).

Verified each test against its mutant by hand-applying the change to `src/limit.py`, confirming the new test fails, then restoring the original — not by mutant name, since mutmut renumbers mutants when the pattern set changes.

Checks on this branch: `ruff check`/`ruff format --check`/`ty check` clean, `sz.py --check` unaffected (tests/ isn't in the capped core set), full suite 616 passed.