### PR TITLE
fix(http): check the body cap before buffering a chunk, not after

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1406,9 +1406,9 @@ async def read_json(request: Request) -> dict | Response:
     try:
         async with asyncio.timeout(BODY_TIMEOUT):
             async for chunk in request.stream():
-                raw.extend(chunk)
-                if len(raw) > MAX_BODY:
+                if len(raw) + len(chunk) > MAX_BODY:
                     return text(f"{too_large}\nthe stream passed it before it ended.", 413)
+                raw.extend(chunk)
     except TimeoutError:
         expired = f"408 body upload exceeded {BODY_TIMEOUT:g}s. Send complete JSON promptly; retry on a new connection."
         return text(expired, 408, extra_headers={"Connection": "close"})

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -665,6 +665,47 @@ def test_chunked_body_is_stopped_at_the_same_cap_and_says_how_to_split_it(client
     assert "multiple room lines" in body and "multiple keys" in body
 
 
+def test_the_single_oversize_stream_chunk_is_refused_before_buffer_growth_so_that_the_cap_holds(
+    monkeypatch,
+):
+    """A server can provide one chunk larger than the cap, so reject it before extending raw.
+    The streaming promise is about the bytes held, not only the response status.
+    """
+    import asyncio
+    from typing import cast
+
+    from starlette.requests import Request as StarletteRequest
+    from starlette.responses import Response
+
+    import app as app_module
+
+    class RequestStub:
+        headers = {}
+
+        async def stream(self):
+            yield b"x" * (app_module.MAX_BODY + 1)
+
+    class TrackingBytearray:
+        def __init__(self):
+            self.data = bytearray()
+            self.max_length = 0
+
+        def extend(self, chunk):
+            self.data.extend(chunk)
+            self.max_length = max(self.max_length, len(self.data))
+
+        def __len__(self):
+            return len(self.data)
+
+    raw = TrackingBytearray()
+    monkeypatch.setattr(app_module, "bytearray", lambda: raw, raising=False)
+    response = asyncio.run(app_module.read_json(cast(StarletteRequest, RequestStub())))
+
+    assert isinstance(response, Response)
+    assert response.status_code == 413
+    assert raw.max_length <= app_module.MAX_BODY
+
+
 def test_malformed_payload_shapes_are_400_not_500(client):
     for body in ("[1,2,3]", '"a string"', "42", "null", "true"):
         r = client.post(


### PR DESCRIPTION
## What changes for a caller

Nothing observable. An oversized streamed body still gets the same `413` with the same text;
a body within the cap is read exactly as before. Two lines swap places in `read_json`
(`src/app.py:1359-1361`): the cap is checked against `len(raw) + len(chunk)` *before*
`raw.extend(chunk)` instead of after it. Core line count is unchanged (`sz.py --check` passes,
`app.py` stays at 1014).

## Why

The docstring makes a memory promise — reading incrementally is "what lets MAX_BODY be generous
… without ever holding more than the cap in memory" (`src/app.py:1344-1345`) — and the loop did
not keep it: a chunk was appended first and measured second, so a single chunk larger than the
cap was held in full before the `413` went out.

To be precise about the size of this: uvicorn/h11 hand the app bodies in bounded pieces, so on
the deployed stack a single chunk past 256 KiB is not something I have observed or can claim.
The ASGI interface allows it, the function's contract says it cannot happen, and the fix costs
nothing — that is the whole case. No production incident is being reported.

## Checks

- `ruff check .`, `ruff format --check .`, `ty check`, `sz.py --check` — all pass.
- Regression test `test_the_single_oversize_stream_chunk_is_refused_before_buffer_growth_so_that_the_cap_holds`
  (`tests/http/test_limits.py`): a request stub yields one `MAX_BODY + 1` chunk and a tracking
  accumulator records the most bytes ever held. Without the fix: `262145` held against the
  `262144` cap → fails. With it: `413`, high-water mark `≤ MAX_BODY` → passes.
- `pytest tests -q`: **615 passed** in 4m16s.

Verified against `main` at `248bcf3`.
