### PR TITLE
fix(mcp): send both note conditions so the service can refuse the pair

### DIFF
--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -487,7 +487,8 @@ async def read_note(namespace: Namespace, key: Key) -> str:
     description=(
         "Write a durable note (<= 8192 characters). Optionally conditional: `if_matches` "
         "writes only when the note still holds that exact value, `if_absent` only when it "
-        "does not exist yet. A failed condition reports the value that is actually there."
+        "does not exist yet. Send one condition, not both. A failed condition reports the "
+        "value that is actually there."
     ),
     annotations=OVERWRITES,
     structured_output=False,
@@ -504,7 +505,7 @@ async def write_note(
     payload: dict[str, object] = {"value": value}
     if if_absent:
         payload["if_absent"] = "1"
-    elif if_matches is not None:
+    if if_matches is not None:
         payload["if"] = if_matches
     return await _post(f"/kv/{_segment(namespace)}/{_segment(key)}", payload)
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -368,11 +368,14 @@ def test_generated_schemas_still_say_what_clients_already_integrated_against(mcp
 def test_the_descriptions_the_model_reads_survive_the_generation(mcp):
     """The point of `Field` here: the sentence lives next to the parameter, and one room
     description is shared by the four tools that take a room."""
-    schemas = {tool.name: tool.input_schema for tool in mcp.tools()}
+    tools = mcp.tools()
+    schemas = {tool.name: tool.input_schema for tool in tools}
     for name in ("read_room", "wait_for_message", "say"):
         assert schemas[name]["properties"]["room"]["description"] == "Room name."
     assert "4096" in schemas["say"]["properties"]["text"]["description"]
     assert "TECHNOCORE_NICK" in schemas["say"]["properties"]["nick"]["description"]
+    write_note = next(tool for tool in tools if tool.name == "write_note")
+    assert "Send one condition, not both." in write_note.description
 
 
 def test_every_tool_publishes_its_effect_annotations(mcp):
@@ -450,6 +453,31 @@ def test_if_absent_creates_only_once(mcp):
     second = mcp.call("write_note", {"namespace": "l", "key": "k", "value": "b", "if_absent": True})
     assert second.is_error is True
     assert "a" in text_of(mcp.call("read_note", {"namespace": "l", "key": "k"}))
+
+
+def test_the_two_write_note_conditions_are_sent_together_so_that_service_can_refuse_them(mcp):
+    """#290: dropping `if_matches` when `if_absent` is true makes a contradictory request
+    look like a successful create. Keep both fields on the recorded wire so the service's
+    refusal remains the single source of truth for this semantic input error."""
+    reply = mcp.call(
+        "write_note",
+        {
+            "namespace": "plans",
+            "key": "new",
+            "value": "replacement",
+            "if_matches": "current",
+            "if_absent": True,
+        },
+    )
+    assert reply.is_error is True
+    assert "send one condition, not both" in text_of(reply)
+    method, url, body = mcp.sent[-1]
+    assert (method, url) == ("POST", f"{mcp.module.BASE_URL}/kv/plans/new")
+    assert json.loads(body) == {
+        "value": "replacement",
+        "if_absent": "1",
+        "if": "current",
+    }
 
 
 def test_discovery_and_room_listing_reach_their_lanes(mcp):


### PR DESCRIPTION
## What changes for a caller

An MCP `write_note` call that passes **both** `if_matches` and `if_absent=true` now gets the
service's own refusal back as a tool error:

```
bad if_absent: refused with if= — send one condition, not both
```

instead of a note write. Calls with one condition, or none, are byte-identical to before.
The tool description gains the sentence "Send one condition, not both." (`mcp/src/technocore_mcp/server.py:488-491`).

## Why

The service refuses the contradictory pair on purpose — `_condition` in `src/app.py:1475-1491`
spells out why: with `if_absent` beside `if=` "there is no correct pick between them, only a
refusal", and its docstring records that dropping the `if=` half used to answer `ok` for a
request whose other half could not hold (#290).

The MCP wrapper reintroduced exactly that at its own layer. `write_note` built the body with
`if if_absent: … elif if_matches is not None: …` (`server.py:505-509`), so when both arrived
`if_matches` was silently discarded and the request went out as a plain create-only write.
On a key that does not exist yet, that *succeeds* — the wrapper turned a request the service
would refuse into a note.

The fix is `elif` → `if`: send both fields and let the service answer. That keeps the wrapper's
existing stance (the `value` parameter's comment: the service is the one that measures) rather
than duplicating semantic validation client-side, and `_request` already surfaces a 4xx body as
a `ToolError` (`server.py:232-265`), so no new error path is needed.

## Checks

- `ruff check .`, `ruff format --check .`, `ty check`, `sz.py --check` — all pass (`mcp/` is
  outside the core count; core unchanged at 2241).
- Regression test `test_the_two_write_note_conditions_are_sent_together_so_that_service_can_refuse_them`
  (`tests/test_mcp.py`): without the fix the recorded POST body is
  `{"value": …, "if_absent": "1"}` with no `if` and the call is **not** an error → fails.
  With the fix the body carries both fields and the reply is a tool error containing
  `send one condition, not both` → passes. The description sentence is pinned in the existing
  `test_the_descriptions_the_model_reads_survive_the_generation`.
- `pytest tests -q`: **615 passed** in 3m46s.

Verified against `main` at `248bcf3`.
