### PR TITLE
fix(mcp): accept loopback hostname case variants

### DIFF
--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -771,7 +771,7 @@ def main() -> None:
         # bearer token; there is no token here, so the wall is the bind address. Loopback
         # with a key is fine and is the default. Off loopback with a key is refused rather
         # than warned about, because a warning scrolls past and the exposure does not.
-        if _signer is not None and host not in _LOOPBACK:
+        if _signer is not None and host.lower() not in _LOOPBACK:
             raise SystemExit(
                 f"refusing to serve --http on {host} with TECHNOCORE_SIGNING_KEY set: an "
                 "endpoint that signs as "

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1339,18 +1339,21 @@ def test_http_refuses_to_serve_a_signing_key_off_loopback(monkeypatch):
     monkeypatch.setattr(mcp_server, "_signer", signing.load(SEED))
     monkeypatch.setattr(sys, "argv", ["technocore-mcp", "--http"])
 
-    monkeypatch.setenv("HOST", "0.0.0.0")  # noqa: S104 - the address under test
-    with pytest.raises(SystemExit) as refused:
-        mcp_server.main()
-    assert "public signing" in str(refused.value)
+    for host in ("0.0.0.0", "example.com"):
+        monkeypatch.setenv("HOST", host)  # noqa: S104 - the address under test
+        with pytest.raises(SystemExit) as refused:
+            mcp_server.main()
+        assert "public signing" in str(refused.value)
+        assert host in str(refused.value)
 
     # ...and the same key on loopback is exactly the case this must not break.
     ran = []
     monkeypatch.setattr(mcp_server.server, "run", lambda *a, **k: ran.append(k.get("host")))
-    for host in ("127.0.0.1", "localhost", "::1"):
+    loopback_hosts = ("127.0.0.1", "localhost", "LOCALHOST", "LoCaLhOsT", "::1")
+    for host in loopback_hosts:
         monkeypatch.setenv("HOST", host)
         mcp_server.main()
-    assert ran == ["127.0.0.1", "localhost", "::1"]
+    assert ran == list(loopback_hosts)
 
 
 def test_the_worker_token_check_answers_a_non_ascii_header_rather_than_crashing():


### PR DESCRIPTION
## What

Make the signed HTTP loopback guard treat case variants of its existing hostname entries as equivalent. `HOST=LOCALHOST` and `HOST=LoCaLhOsT` now reach `server.run()` unchanged; non-loopback hosts are still refused. Regression coverage pins both outcomes.

## Why

The guard compared `$HOST` case-sensitively, rejecting safe loopback binds solely because of hostname casing. The change normalizes only the allow-list comparison. It performs no DNS lookup, adds no aliases or alternate IP forms, and does not change authentication or the HTTP protocol surface.

Verified against upstream `main` at `248bcf3facd93048f2a1f3f1ead0f7fd7863193e`.

## Checks

- [x] Full test suite (`614 passed`); coverage 97.84%
- [x] Ruff lint and format
- [x] `ty`
- [x] Core-size check and MCP package build
- [x] Documentation reviewed; no update needed
- [x] New public surface: nothing new
