### PR TITLE
fix(mcp): reject malformed base64url signing keys

### DIFF
--- a/mcp/src/technocore_mcp/signing.py
+++ b/mcp/src/technocore_mcp/signing.py
@@ -126,7 +126,11 @@ def load(spec: str) -> Signer:
             seed = None
     if seed is None and re.fullmatch(r"[A-Za-z0-9_-]{43}=?", spec):
         try:
-            seed = base64.urlsafe_b64decode(spec.rstrip("=") + "==")
+            unpadded = spec.removesuffix("=")
+            candidate = base64.urlsafe_b64decode(unpadded + "==")
+            canonical = base64.urlsafe_b64encode(candidate).decode().rstrip("=")
+            if canonical == unpadded:
+                seed = candidate
         except ValueError:
             seed = None
     if seed is None or len(seed) != 32:

--- a/mcp/src/technocore_mcp/signing.py
+++ b/mcp/src/technocore_mcp/signing.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import re
 import time
 import unicodedata
 
@@ -112,9 +113,9 @@ class Signer:
 
 
 def load(spec: str) -> Signer:
-    """A `Signer` from the TECHNOCORE_SIGNING_KEY spelling: the 32-byte Ed25519 seed as
-    64 hex characters or as unpadded base64url. Generate one with
-    `python -c "import secrets; print(secrets.token_hex(32))"`.
+    """A `Signer` from the TECHNOCORE_SIGNING_KEY spelling: the 32-byte Ed25519 seed
+    as 64 hex characters or as 43 base64url characters, optionally followed by `=`.
+    Generate one with `python -c "import secrets; print(secrets.token_hex(32))"`.
     """
     spec = spec.strip()
     seed: bytes | None = None
@@ -123,7 +124,7 @@ def load(spec: str) -> Signer:
             seed = bytes.fromhex(spec)
         except ValueError:
             seed = None
-    if seed is None and len(spec) in (43, 44):
+    if seed is None and re.fullmatch(r"[A-Za-z0-9_-]{43}=?", spec):
         try:
             seed = base64.urlsafe_b64decode(spec.rstrip("=") + "==")
         except ValueError:
@@ -131,7 +132,7 @@ def load(spec: str) -> Signer:
     if seed is None or len(seed) != 32:
         raise ValueError(
             "TECHNOCORE_SIGNING_KEY must be a 32-byte Ed25519 seed, as 64 hex characters "
-            "or unpadded base64url — generate one with: "
+            "or 43 base64url characters with optional trailing = — generate one with: "
             "python -c 'import secrets; print(secrets.token_hex(32))'"
         )
     return Signer(seed)

--- a/tests/unit/test_mcp_signing.py
+++ b/tests/unit/test_mcp_signing.py
@@ -9,6 +9,7 @@ repo, not a 403 in someone's deployment.
 
 from __future__ import annotations
 
+import base64
 import re
 import sys
 from pathlib import Path
@@ -70,16 +71,35 @@ def test_the_signature_verifies_under_the_services_own_verifier():
 
 
 def test_the_key_loads_from_both_documented_spellings():
-    import base64
-
     seed = bytes.fromhex(SEED_HEX)
     by_hex = signing.load(SEED_HEX)
-    by_b64 = signing.load(base64.urlsafe_b64encode(seed).decode().rstrip("="))
-    assert by_hex.did == by_b64.did
+    encoded = base64.urlsafe_b64encode(seed).decode().rstrip("=")
+    by_b64 = signing.load(encoded)
+    by_padded_b64 = signing.load(encoded + "=")
+    assert by_hex.did == by_b64.did == by_padded_b64.did
 
     for junk in ("", "abc", "zz" * 32, SEED_HEX + "00"):
         with pytest.raises(ValueError):
             signing.load(junk)
+
+
+def test_the_key_loader_rejects_malformed_base64url():
+    encoded = base64.urlsafe_b64encode(bytes.fromhex(SEED_HEX)).decode().rstrip("=")
+    malformed = (
+        encoded + "!",
+        encoded + ".",
+        encoded + "~",
+        encoded[:10] + "." + encoded[10:],
+        "+" + encoded[1:],
+        "/" + encoded[1:],
+        "=" + encoded,
+        encoded[:10] + "=" + encoded[11:],
+        encoded[:-1] + "==",
+        encoded + "==",
+    )
+    for spec in malformed:
+        with pytest.raises(ValueError):
+            signing.load(spec)
 
 
 def test_the_identity_note_path_matches_the_published_convention():

--- a/tests/unit/test_mcp_signing.py
+++ b/tests/unit/test_mcp_signing.py
@@ -83,6 +83,30 @@ def test_the_key_loads_from_both_documented_spellings():
             signing.load(junk)
 
 
+def test_the_key_loader_rejects_noncanonical_base64url_pad_bits():
+    alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    seed = bytes.fromhex(SEED_HEX)
+    canonical = base64.urlsafe_b64encode(seed).decode().rstrip("=")
+    index = alphabet.index(canonical[-1])
+    group_start = index & ~0b11
+    spellings = [canonical[:-1] + alphabet[group_start + offset] for offset in range(4)]
+
+    assert len(canonical) == 43
+    assert canonical in spellings
+    aliases = [value for value in spellings if value != canonical]
+    assert len(aliases) == 3
+
+    expected = signing.load(SEED_HEX).did
+    assert signing.load(canonical).did == expected
+    assert signing.load(canonical + "=").did == expected
+    for alias in aliases:
+        assert base64.urlsafe_b64decode(alias + "==") == seed
+        with pytest.raises(ValueError):
+            signing.load(alias)
+        with pytest.raises(ValueError):
+            signing.load(alias + "=")
+
+
 def test_the_key_loader_rejects_malformed_base64url():
     encoded = base64.urlsafe_b64encode(bytes.fromhex(SEED_HEX)).decode().rstrip("=")
     malformed = (


### PR DESCRIPTION
## What

Validate `TECHNOCORE_SIGNING_KEY` before accepting its base64url spelling. Preserve hexadecimal seeds, canonical 43-character unpadded base64url, and the same spelling with one trailing `=`. Reject invalid characters, malformed padding, and non-canonical pad-bit aliases that decode to the same 32 bytes. Add focused regression coverage.

## Why

Python's permissive decoder discarded non-alphabet characters and accepted multiple final-character spellings for the same seed. Configuration could therefore contain malformed or non-canonical text while silently selecting a valid signing identity.

Valid keys, derived identities, signatures, canonical strings, authentication, and protocol behavior are unchanged.

Verified after rebase onto upstream `main` at `20a4457b89ba11254f4aa48217b066884a148d98`.

## Checks

- [x] GitHub CI: `lint + tests + image` — green
- [x] GitHub CI: `openapi contract` — green
- [x] GitHub CI: `mcp worker bundles` — green
- [x] `pr-guards` — green
- [x] Core-size, MCP build, image build/smoke, lint, types, and full tests are covered by the green CI run
- [x] New public surface: nothing new
