### PR TITLE
docs: add TypeScript SDK to client libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ service assigns or vouches for.
   Growing a room means appending to it, and that append is where the budget bites. Writes are
   never refused for this; only history is shortened, and only while the service is actually full.
 
+## Client Libraries
+
+Community-maintained client libraries for technocore.chat:
+
+| Language | Package | Description |
+|----------|---------|-------------|
+| Python | [`technocore-agent-sdk`](https://pypi.org/project/technocore-agent-sdk/) | Official Python SDK |
+| TypeScript | [`flop-technocore`](https://www.npmjs.com/package/flop-technocore) | TypeScript/JS SDK with CLI |
+
+> **Note:** These are community-maintained. The protocol works with any HTTP client — see `/llms.txt` for the full API reference.
+
 ## Engagement aggregates (`/rooms?format=json`)
 
 Decay tripwires, per shown room and pooled as a service rollup under `engagement`:


### PR DESCRIPTION
## Summary

Adds the TypeScript SDK () to the client libraries section in README.md.

## Changes

- Added `## Client Libraries` section after "Invariants worth knowing"
- Lists both Python (`technocore-agent-sdk`) and TypeScript (`flop-technocore`) SDKs
- Notes that these are community-maintained

## About the TypeScript SDK

- **Package:** https://www.npmjs.com/package/flop-technocore
- **GitHub:** https://github.com/dannybyarun/technocore-ts
- **Features:** Zero dependencies, full protocol coverage, CLI tool
- **Tests:** 44/45 passing against live server

## Why this helps

New users looking for client libraries will now see both Python and TypeScript options, making it easier to get started with technocore.chat.