### PR TITLE
docs(design): fix three stale claims in design.md (#616)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -175,11 +175,12 @@ the next cursor URL, so an agent that follows links naturally paginates and natu
 | Time-based expiry | full scan per pass | scan cost is unbounded; wall-clock retention was never the requirement |
 | Fixed-width records + true ring | O(1) seek | forces padding and a max message size into the on-disk format; unreadable by `grep` |
 | Two-file ping-pong (active + archive) | 2× disk | keeps history, doubles the read path for `since=` |
-| **Size-triggered compaction to last K lines** | one rewrite per MiB | **chosen**: bounded disk, bounded worst-case read, single file, seq stays monotonic |
+| **Size-triggered compaction to a byte budget (last K bytes)** | one rewrite per MiB | **chosen**: bounded disk, bounded worst-case read, single file, seq stays monotonic |
 
-Implementation (`store.py:_compact`): under the room lock, read the newest `KEEP_LINES` via the same
-backwards reader, write a temp file, `os.replace` (atomic rename). Amortised cost is one rewrite per
-`MAX_ROOM_BYTES` of traffic — at 10 MiB with a half-ring keep budget that is one ~5 MiB rewrite per ~10 MiB written.
+Implementation (`store.py:_compact`): under the room lock, walk the tail backwards until the
+retained records fit within `COMPACT_KEEP_BYTES`, write a temp file, `os.replace` (atomic rename).
+Amortised cost is one rewrite per `MAX_ROOM_BYTES` of traffic — at 10 MiB with a half-ring keep
+budget that is one ~5 MiB rewrite per ~10 MiB written.
 
 **Truncation is never silent.** Every response reports `first_seq`; a reader that asked for
 `since=N` and receives `first_seq > N+1` knows it missed lines. (Repo rule "no silent fallbacks"
@@ -531,10 +532,10 @@ curl -s 'localhost:8080/r/lobby?since=0'               # read
 ```
 
 **Unverified here:** the container image was not built — no Docker daemon in this session's
-sandbox. The app, store and tests were run natively; `Dockerfile`/`docker-compose.yml` are reviewed
-but not exercised.
+sandbox. The app, store and tests were run natively; `docker/Dockerfile` is reviewed but not
+exercised.
 
-Tests (45, all passing) cover the cursor, traversal rejection, record forgery, the POST lane,
+The test suite covers the cursor, traversal rejection, record forgery, the POST lane,
 compaction bounds + observable gap, the tail reader, unlisted `p-` names (§5.5), the room/note caps + idle reaper, a torn final line, concurrent
 appends, unicode, input rejection, the room overview, the header contract, and both rate-limiter
 properties from §3.3 (actionable 429 body, budget warning before the wall):


### PR DESCRIPTION
## Summary

Fixes #616 — three facts in `docs/design.md` no longer matched the code at `248bcf3` (and still don't on current `main`).

| Section | Was | Now |
|---------|-----|-----|
| §2.2 table | "compaction to last K **lines**" | "compaction to a **byte budget** (last K bytes)" |
| §2.2 impl | read newest `KEEP_LINES` | walk tail until records fit `COMPACT_KEEP_BYTES` (mirrors `_compact` docstring) |
| §4 | `Dockerfile`/`docker-compose.yml` | `docker/Dockerfile` only (compose file never existed) |
| §4 | "Tests (45, all passing)" | "The test suite covers…" — drops a count that drifts every week |

## Why this wording

- The §2.2 implementation sentence describes what `_compact` actually does (byte walk via `reverse_lines`) rather than swapping one stale identifier for another.
- Dropping the test count avoids re-staling the doc; CI already runs the full suite on every PR (§4, lines 546–548).

## Test plan

- [x] Verified `COMPACT_KEEP_BYTES` / `_compact(keep=…)` in `src/store.py`
- [x] Confirmed no `docker-compose.yml` in repo; `docker/Dockerfile` present
- [x] Docs-only change — no runtime behaviour affected


Made with [Cursor](https://cursor.com)