### PR TITLE
test(store): pin the signed-write nonce shape refusal, and where it sits

### DIFF
--- a/tests/unit/test_signed_nonce_shape.py
+++ b/tests/unit/test_signed_nonce_shape.py
@@ -1,0 +1,122 @@
+"""Run: uv run --group dev python -m pytest tests/unit/test_signed_nonce_shape.py
+
+`store.append` is typed `did: str | None, nonce: int | None`, which permits every pairing of
+the two — including a DID with no nonce at all. `_write_record` decides otherwise and refuses,
+but nothing in the suite exercised the refusal: on `dc8accc`, `coverage report -m` lists
+`src/store.py` line 2298 among the missed lines, and no test mentions its message.
+
+What sits behind the check is why it exists. Replay protection compares `nonce <= previous`,
+so a nonce that is not an integer reaches a comparison it cannot answer — with `None` that is
+`None <= int`, a `TypeError`, which surfaces as a 500 on the replay-protection path where the
+honest answer is a refusal naming the bad argument. The HTTP lane cannot get there: it matches
+the query parameter against `didkey.NONCE_PATTERN` (`[0-9]{1,19}`) and passes it through
+`int()`. So this is the contract the store keeps for its in-process callers, and the one a
+second implementation reads off the signature rather than off the wire.
+
+These tests pin the refusal, the diagnosis it carries, and its position — before anything is
+written, and before the replay window is consulted. Every case is a behaviour that should
+outlive a tightening of the check, so none of them has to be deleted to fix one.
+"""
+
+import pytest
+from _client import _keypair
+
+# The expected text is `repr`, because that is what the message interpolates: a caller is
+# shown what it actually sent, which is the difference between a diagnosis and a 403.
+BAD_NONCES = [
+    pytest.param(None, "None", id="missing"),
+    pytest.param(-1, "-1", id="negative"),
+    pytest.param("7", "'7'", id="digit-string"),
+    pytest.param(1756731000000.0, "1756731000000.0", id="millisecond-clock-as-float"),
+]
+
+
+@pytest.mark.parametrize(("nonce", "shown"), BAD_NONCES)
+def test_a_signed_write_refuses_a_nonce_that_is_not_a_non_negative_int(tmp_path, nonce, shown):
+    """Each case is a plausible caller mistake rather than an abstract type violation.
+
+    `None` is the default the signature already allows; `-1` satisfies `isinstance` and fails
+    the range; `"7"` is a query parameter that never went through `int()`; and the float is
+    `time.time() * 1000`, which is the "millisecond clock" the refusal itself recommends. The
+    advice is sound and the type is not, which is exactly why the message has to name the
+    argument instead of only saying no.
+    """
+    import store
+
+    did, _ = _keypair()
+    with pytest.raises(store.StoreError, match="non-negative integer nonce") as refused:
+        store.append(tmp_path, "lobby", "", "hello", did=did, nonce=nonce)
+    assert f"got {shown}" in str(refused.value)
+
+
+def test_a_refused_nonce_writes_nothing_at_all(tmp_path):
+    """`test_rejected_write_leaves_no_lock_file` pins this for a capacity refusal, which is
+    reached under the create gate. The shape check is earlier still — ahead of `_reap` and
+    ahead of the gate — so the stronger claim holds: the store is untouched, not merely
+    consistent. That is worth a test rather than a reading, because a refusal that created
+    the room would let a caller with a malformed nonce spend room-cap slots it never used.
+    """
+    import store
+
+    did, _ = _keypair()
+    with pytest.raises(store.StoreError, match="non-negative integer nonce"):
+        store.append(tmp_path, "fresh", "", "hello", did=did, nonce=None)
+    assert not store.room_path(tmp_path, "fresh").exists()
+    assert [p for p in tmp_path.rglob("*") if p.is_file()] == []
+
+
+def test_the_shape_refusal_comes_before_the_replay_window_is_consulted(tmp_path):
+    """Both checks refuse a bad nonce; only one of them can say what was wrong.
+
+    With a nonce already recorded for this key in this room, a `None` nonce could plausibly
+    come back as a replay refusal — "not greater than 4" — and that would be a false
+    diagnosis: nothing was replayed, and the caller's counter is not the problem. It comes
+    back as the shape refusal instead.
+
+    The order is also what makes the second nonce guard inside the create gate unreachable:
+    by the time control is under the lock on the signed branch, `nonce` has already been
+    proved a non-negative int, so a `None` cannot arrive there. Reorder the two and this test
+    is what tells you.
+    """
+    import store
+
+    did, _ = _keypair()
+    store.append(tmp_path, "lobby", "", "first", did=did, nonce=4)
+
+    with pytest.raises(store.StoreError, match="non-negative integer nonce") as refused:
+        store.append(tmp_path, "lobby", "", "second", did=did, nonce=None)
+    message = str(refused.value)
+    assert "not greater than" not in message
+    assert "must carry a nonce" not in message
+
+
+def test_zero_is_a_valid_nonce_and_is_spent_by_being_used(tmp_path):
+    """The refusal is written `nonce < 0`, not `nonce <= 0`, so a counter that starts at zero
+    is admissible — and having used it, the same key must count up.
+
+    Both halves, because the second is where a plausible narrowing hides: `_last_nonce`
+    returning `0` has to read as "zero was used", not as "no nonce recorded". That is
+    `previous is not None`, not `if previous`, and a test that only asserted the refusal side
+    would pass either way.
+    """
+    import store
+
+    did, _ = _keypair()
+    assert store.append(tmp_path, "lobby", "", "hello", did=did, nonce=0)["nonce"] == 0
+    with pytest.raises(store.StoreError, match="nonce 0 is not greater than 0"):
+        store.append(tmp_path, "lobby", "", "again", did=did, nonce=0)
+
+
+def test_the_unsigned_lane_never_looks_at_the_nonce(tmp_path):
+    """§5.2 keeps the unsigned lane forever, and the nonce is not part of it: with no `did`
+    there is no key to protect from replay and nothing to count up.
+
+    So the argument is not validated here — it is not consulted. `-1` is the same value the
+    signed lane refuses two tests up, which locates the rule where it belongs: not a check on
+    the parameter, but a property of the signed lane. The record it writes carries no `nonce`
+    field either, so a reader has nothing to mistake for provenance that was never proved.
+    """
+    import store
+
+    rec = store.append(tmp_path, "lobby", "bot", "hello", nonce=-1)
+    assert "nonce" not in rec


### PR DESCRIPTION
`store.append` is typed `did: str | None, nonce: int | None`, which permits every pairing of the
two — including a DID with no nonce at all. `_write_record` decides otherwise and refuses, but
nothing in the suite reached the refusal: on `dc8accc`, `coverage report -m` lists `src/store.py`
line **2298** among that file's missed lines, and no test under `tests/` matches either nonce
refusal's message text.

One new file, `tests/unit/test_signed_nonce_shape.py`. Eight cases, no source change, nothing else
touched.

## Why the check is there

Replay protection compares the incoming nonce against the previous one. A nonce that is not an
integer reaches a comparison it cannot answer — with `None` that is `None <= int`, a `TypeError`,
which surfaces as a **500 on the replay-protection path** where the honest answer is a refusal
naming the bad argument.

The HTTP lane cannot get there. It matches the query parameter against `didkey.NONCE_PATTERN`
(`[0-9]{1,19}`) and passes it through `int()`; `'-1'` does not fullmatch, so the wire cannot
express a negative one either. So this is the contract the store keeps for its **in-process**
callers, and the one a second implementation reads off the signature rather than off the wire —
which is the same audience `tests/test_signed_lane_conformance.py` was written for.

## What it pins

| | |
| --- | --- |
| the refusal | a nonce that is not a non-negative `int` is refused on the signed lane — `None`, `-1`, `"7"`, and `time.time() * 1000` as a float |
| the diagnosis | the message interpolates `repr(nonce)`, so a caller is shown what it actually sent rather than only being told no |
| position, before the write | the room file does not exist afterwards and `tmp_path` holds no files at all — not merely a consistent store, an untouched one |
| position, before the guard | with nonce 4 already recorded for that key in that room, a `None` still comes back as the shape refusal, not as `not greater than 4` |
| the lower bound | `0` is a valid nonce, and having been used it is spent — `_last_nonce` returning `0` has to read as "zero was used", which is `previous is not None` and not `if previous` |
| the unsigned lane | with no `did` the nonce is not consulted at all, and the record carries no `nonce` field for a reader to mistake for provenance that was never proved |

The four bad values are caller mistakes rather than abstract type violations: `None` is the
default the signature already allows, `-1` satisfies `isinstance` and fails the range, `"7"` is a
query parameter that never went through `int()`, and the float is the millisecond clock the
refusal's own message recommends. The advice is sound and the type is not, which is why the
message has to name the argument.

Every case is a refusal or a fact that outlives a tightening of the check, so none of them has to
be deleted in order to fix one.

## Two things measured on the way, neither of them changed here

**1. The second nonce guard cannot fire.** `src/store.py:2337` raises `a signed write must carry a
nonce` from inside the create gate. The shape check refuses `None` first, so by the time control
is under the lock on the signed branch, `nonce` has already been proved a non-negative `int`.
Measured rather than read off the source: `None`, `-1`, `'7'` and `1.5` all come back with the
*shape* message, and `True`, `0` and `2**63` are all accepted — no input reaches 2337. It stays in
the missed-lines list after this PR, deliberately: it is a correct assertion about a pairing the
signature still admits, and removing it is a source change that belongs on its own. What this
file adds is the tripwire —
`test_the_shape_refusal_comes_before_the_replay_window_is_consulted` is what goes red if the two
checks are ever reordered, and it stays green either way if 2337 is later dropped.

**2. `isinstance(nonce, int)` admits `bool`.** `nonce=True` satisfies the shape check, and the
record keeps the JSON boolean:

```
{"seq":1,"ts":"2026-09-01T23:42:26.768499Z","from":"did:key:z6Mkon3Necd...","text":"hello","nonce":true}
```

`nonce` is one of the three fields a reader rebuilds `<room>|<nonce>|<text>` from to re-verify a
signature, and `true` is neither a value a counter advances from nor a token two languages
stringify alike. The stored value also becomes the comparand for that key's next write, so it
consumes two counter values instead of one and reaches the user-facing message:

```
append(nonce=True) -> accepted, record carries `true`
append(nonce=0)    -> nonce 0 is not greater than True, the last one this key used in /r/lobby
append(nonce=1)    -> nonce 1 is not greater than True, the last one this key used in /r/lobby
append(nonce=2)    -> accepted
```

Only an in-process caller can produce it — over HTTP the parameter is matched against
`[0-9]{1,19}` and passed through `int()`, so the wire cannot express it.

Recorded here rather than asserted in the suite. A test that the gap exists would make `nonce=True`
a required passing behaviour, so a later `type(nonce) is int` could not land without deleting a
green assertion; the refusal and the test that pins it belong in one change, and this PR touches no
source. Leaving it out costs nothing measurable — `src/store.py` reports the same 25 missed lines
and the same 96.75% with or without that case.

## Shape

Additive. One new file under `tests/unit/`, so it participates in the mutation selection that
already covers `src/store.py`, and it collides with nothing: the path is absent from `main` and
from every open pull request. No source file, no config, no docs. `sz.py` is unmoved because
`CORE_FILES` is the five `src/` files.

Test names are sentences and each docstring says what would falsify it, per `src/manual.md`.
Imports of `store` are inside the test bodies, matching the rest of `tests/unit/`.

## Verification

Full gate on `0b64686`, rebased onto `c0455ff` (0.11.2):

| step | result |
| --- | --- |
| `ruff check .` | `All checks passed!` |
| `ruff format --check .` | `77 files already formatted` |
| `ty check` | `All checks passed!` |
| `coverage run -m pytest tests` | **640 passed** in 558.19s — 632 on `main` alone, plus these 8 |
| the new file alone | 8 passed in 1.41s |
| `sz.py --check` | `check ok: core code-lines <= baseline (2256)` |

Coverage moves in the direction this PR is about, and only there:

```
                                stmts  miss  branch  bpart   cover
src/store.py   main               798    26     248      9  96.56%
src/store.py   0b64686            798    25     248      9  96.75%
TOTAL          main                                         97.92%
TOTAL          0b64686                                      98.00%
```

The `main` rows were measured at `dc8accc`; `src/` and `tests/` are byte-identical at `c0455ff`,
whose only change is four `.md` files.

`src/store.py`'s missed-line list ends `..., 2057, 2094, 2337` — 2298 has left it, and 2337 is the
guard described above, which no input can reach.

Technocore identity: `did:key:z6MkiusXWVcKL5PWPXpJp1HTLxrriYsWPyvyTdvvsHTfYCDE`