### PR TITLE
fix(app): route ?format=json through the shared text() helper

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -453,14 +453,8 @@ def render(view: dict) -> str:
 
 def respond(request: Request, view: dict, body_text: str | None = None, note: str = "") -> Response:
     if request.query_params.get("format") == "json":
-        return Response(
-            json.dumps(view, ensure_ascii=False, indent=1) + "\n",
-            media_type="application/json",
-            headers={
-                "Cache-Control": "no-store",
-                "X-Content-Type-Options": "nosniff",
-                "X-Robots-Tag": "noindex",
-            },
+        return text(
+            json.dumps(view, ensure_ascii=False, indent=1) + "\n", media_type="application/json"
         )
     return text((body_text if body_text is not None else render(view)) + note)
 

--- a/src/app.py
+++ b/src/app.py
@@ -456,7 +456,11 @@ def respond(request: Request, view: dict, body_text: str | None = None, note: st
         return Response(
             json.dumps(view, ensure_ascii=False, indent=1) + "\n",
             media_type="application/json",
-            headers={"Cache-Control": "no-store", "X-Robots-Tag": "noindex"},
+            headers={
+                "Cache-Control": "no-store",
+                "X-Content-Type-Options": "nosniff",
+                "X-Robots-Tag": "noindex",
+            },
         )
     return text((body_text if body_text is not None else render(view)) + note)
 

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -343,6 +343,22 @@ def test_agent_surfaces_are_never_html(client):
         assert r.headers["x-content-type-options"] == "nosniff", path
 
 
+def test_format_json_is_still_nosniff(client):
+    """`?format=json` is a second rendering of the same world-writable views `respond()`
+    otherwise sends through `text()` — room and note content included, so this reply
+    carries exactly the same caller-controlled bytes as the plain-text one. Every other
+    reply on the service sets `X-Content-Type-Options: nosniff` (see
+    test_agent_surfaces_are_never_html and the export/humans routes); a browser served
+    this one with the header missing would be free to sniff it as something other than
+    the declared `application/json`.
+    """
+    client.get("/r/lobby/say/bot/hi")
+    for path in ("/r/lobby?format=json", "/rooms?format=json"):
+        r = client.get(path)
+        assert r.headers["content-type"].startswith("application/json"), path
+        assert r.headers["x-content-type-options"] == "nosniff", path
+
+
 def test_robots_keeps_rooms_out_of_indexes_but_invites_the_manual(client):
     body = client.get("/robots.txt").text
     assert "Disallow: /r/" in body and "Disallow: /kv/" in body


### PR DESCRIPTION
## Problem

`respond()` (src/app.py) has two rendering lanes: the default
plain-text lane always sets `X-Content-Type-Options: nosniff` via
the shared `text()` helper; the `?format=json` lane built its own
`Response` directly and never included that header.

Both lanes serve the same caller-controlled room and note content
through an unauthenticated service — every other response path is
already guarded (`test_agent_surfaces_are_never_html`), so this was
the one gap.

## Fix

Route the JSON branch through the same `text()` helper the
plain-text lane already uses, passing `media_type="application/json"`.
This picks up `X-Content-Type-Options: nosniff`, `Cache-Control:
no-store`, and `X-Robots-Tag: noindex` automatically — no header
duplication, and any future hardening in `text()` applies to both
lanes.

## Testing

- New test `test_format_json_is_still_nosniff` — verified failing
  before the fix, passing after
- Full suite: 633 tests green
- `ruff check` and `ruff format --check` clean