### PR TITLE
fix(store): a full did namespace names the caller's own sharded path (#165)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -2213,15 +2213,39 @@ def _count_new_room(root: Path, delta: int) -> None:
     _write_note_count(root, max(0, count + delta), used, name=USAGE_FILE)
 
 
-def _at_capacity(cap: int, what: str) -> StoreError:
+_DID_FINGERPRINT = re.compile(r"[0-9a-f]{16}")
+
+
+def _shard_hint(ns: str, key: str) -> str:
+    """The sharded path for a flat `did` note, as a sentence to append to its refusal.
+
+    Empty for every other namespace and for any key that is not a fingerprint, so this only
+    ever speaks about the one namespace #96 split.
+
+    Named for the caller's own key rather than as a `<first 2>/<remaining 14>` template: the
+    agent is handling this 400 right now, and a path it can use as-is is one fewer thing to
+    derive wrongly. Every agent-facing document already gives the sharded form, but a writer
+    only moves if it re-read them, and #165 measured 0.07% of writes doing so against 21,286
+    that did not. A refusal is the one channel still reaching the rest — they are here, and
+    the advice they get instead ("reuse one you already have") is not actionable for an
+    agent publishing its first identity note.
+    """
+    if ns != "did" or not _DID_FINGERPRINT.fullmatch(key):
+        return ""
+    return f" Publish at /kv/{ns}-{key[:2]}/{key[2:]} instead — the same fingerprint, sharded."
+
+
+def _at_capacity(cap: int, what: str, hint: str = "") -> StoreError:
     """The refusal, in one place because two callers raise it (rooms count both a cap and a
     byte budget). Only *new* names are refused, which is the actionable half: an agent
-    blocked here can always keep working in a room or note it is already using."""
+    blocked here can always keep working in a room or note it is already using.
+
+    `hint` carries a namespace-specific escape hatch when one exists — see `_shard_hint`."""
     return StoreError(
         f"{what} limit reached ({cap} is the cap, and this would be a new one). "
         f"Existing {what}s still accept writes, so reuse one you already have — "
         f"GET /rooms shows what exists. Idle {what}s are reclaimed after 7 days "
-        f"(a room still on its first message goes after {STILLBORN_SECONDS // 3600} hours)."
+        f"(a room still on its first message goes after {STILLBORN_SECONDS // 3600} hours).{hint}"
     )
 
 
@@ -2321,7 +2345,7 @@ def _check_note_capacity(root: Path, ns_dir: Path, path: Path) -> None:
     # key's bucket now, and counting that would both compare the cap against ~1 note and drop
     # the namespace's `.notes-count` two levels below where every other reader looks for it.
     if _note_totals(ns_dir, _ns_totals, persist=True)[0] >= MAX_NOTES_PER_NS:
-        raise _at_capacity(MAX_NOTES_PER_NS, "note")
+        raise _at_capacity(MAX_NOTES_PER_NS, "note", _shard_hint(ns_dir.name, path.stem))
     if _note_count(root) >= MAX_NOTES_TOTAL:
         raise StoreError(
             f"note limit reached ({MAX_NOTES_TOTAL} across all namespaces, and this would "

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -1153,3 +1153,49 @@ def test_a_second_reap_pass_gives_up_rather_than_overlapping_the_first(tmp_path,
     assert walked, "premise: the first pass walked"
     assert "second" not in walked, f"two passes walked the store at once: {walked}"
     assert store._note_totals(tmp_path) == store._count_notes(tmp_path), "and the count holds"
+
+
+def test_a_full_did_namespace_names_the_asking_agent_s_own_sharded_path(tmp_path, monkeypatch):
+    """#165: the refusal is the last channel that reaches a writer still using the flat path.
+
+    The generic advice — "reuse one you already have" — is not actionable for an agent
+    publishing its first identity note: there is nothing to reuse, and #269 reports agents
+    reading it literally and overwriting strangers' notes. The hint must carry the caller's
+    OWN sharded path rather than a `<first 2>/<remaining 14>` template, because a template
+    is the thing the client already failed to apply.
+    """
+    import store
+
+    fp = "00e6998b15a826e9"  # a 16-hex fingerprint, the shape the convention publishes
+    monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 1)
+    store.note_set(tmp_path, "did", "aaaaaaaaaaaaaaaa", "v")  # fills the namespace
+
+    with pytest.raises(store.StoreError) as refusal:
+        store.note_set(tmp_path, "did", fp, "v")
+    assert f"/kv/did-{fp[:2]}/{fp[2:]}" in str(refusal.value), (
+        "the caller's real path, usable as-is"
+    )
+    assert "<first 2>" not in str(refusal.value), "a template is what they already got wrong"
+
+
+def test_the_shard_hint_speaks_only_for_flat_did_fingerprints(tmp_path, monkeypatch):
+    """The hint must not appear where it would be wrong, which is everywhere else.
+
+    A `did-xx` shard is already sharded, another namespace has no such escape hatch, and a
+    `did` key that is not a fingerprint is not the convention's note — steering any of them
+    at `/kv/did-<2>/<14>` would invent a path that means nothing.
+    """
+    import store
+
+    monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 1)
+    for ns, key in (("did-00", "e6998b15a826e9"), ("topic", "lobby"), ("did", "not-a-fingerprint")):
+        store.note_set(tmp_path, ns, "filler", "v")
+        with pytest.raises(store.StoreError) as refusal:
+            store.note_set(tmp_path, ns, key, "v")
+        assert "sharded" not in str(refusal.value), f"{ns}/{key} must get the plain refusal"
+
+    # …and the predicate itself, on the two boundaries a fingerprint has.
+    assert store._shard_hint("did", "0" * 16) != "", "16 lowercase hex is the fingerprint"
+    assert store._shard_hint("did", "0" * 15) == "", "15 is not"
+    assert store._shard_hint("did", "0" * 17) == "", "17 is not"
+    assert store._shard_hint("did", "A" * 16) == "", "uppercase is not the published form"


### PR DESCRIPTION
Closes #165. Verified against `c0455ff` (current `main`).

## What changes for a caller

An agent whose DID note is refused because the flat `did` namespace is full now gets told where to publish instead:

```
note limit reached (40960 is the cap, and this would be a new one). Existing notes
still accept writes, so reuse one you already have — GET /rooms shows what exists.
Idle notes are reclaimed after 7 days (a room still on its first message goes after
24 hours). Publish at /kv/did-00/e6998b15a826e9 instead — the same fingerprint, sharded.
```

The appended sentence is the whole change.

## Why the caller's own path, not the template

#165 asks for `/kv/did-<first 2>/<remaining 14>`. This emits the real path instead, computed from the key being refused. @sv closed #283 partly for the opposite — *"its hint is a literal placeholder string rather than the caller's actual computed path"* — and the reasoning generalises: the template is precisely what these clients already failed to apply. Every agent-facing document gives it correctly, and #165 still measured 15 sharded writes against 21,286 legacy ones in a 15-minute window (0.07%). A path that can be used as-is removes the derivation rather than restating it.

The advice being replaced is also not actionable for the agent hitting it. "Reuse one you already have" assumes there is one; an agent publishing its first identity note has nothing to reuse, and #269 reports agents reading that literally and overwriting strangers' notes to get unstuck.

## Scope

`_shard_hint` returns `""` for everything that is not a flat DID fingerprint:

| namespace / key | hint |
|---|---|
| `did` + 16 lowercase hex | the sharded path |
| `did-00` (already sharded) | none |
| any other namespace | none |
| `did` + non-fingerprint key | none |

Steering any of those at `/kv/did-<2>/<14>` would invent a path that resolves to nothing.

## Tests

Two in `tests/unit/test_note_count.py`, both fail on `main`:

- `test_a_full_did_namespace_names_the_asking_agent_s_own_sharded_path` — the refusal carries the caller's real path, and asserts `<first 2>` is *not* in the body, since the template is the failure mode.
- `test_the_shard_hint_speaks_only_for_flat_did_fingerprints` — the three wrong-place cases above, plus the fingerprint boundaries (15 chars, 17 chars, uppercase).

## Checks

- `uv run pytest tests -q` — **634 passed** (632 on main + 2 new)
- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run ty check` — clean
- `uv run python sz.py --check` — **fails**, see below

## sz-baseline.json is deliberately untouched, and `sz.py --check` therefore fails

This adds 5 core code-lines, so CI's `sz.py --check` step goes red until a maintainer regenerates the baseline:

```
core code-lines grew vs sz-baseline.json: core/store.py 935 -> 940 (cap 1000)
``` No *cap* is breached — `core/store.py` is 940 of 1000, `core_total` 2261 of 3000 — so there is no missing primitive to propose under CONTRIBUTING's "Overlapping work"; only the ratchet moves.

I originally hand-edited the two figures that moved and `protected-files` correctly failed it, so it is dropped. Flagging the consequence rather than leaving it to be discovered: as it stands the two guards are mutually exclusive for any fork PR that adds a core code-line — `protected-files` fails if `sz-baseline.json` is touched, `sz.py --check` fails if it is not, and CONTRIBUTING says all required checks must pass before merge. Filed separately as #655; happy to follow whatever convention you prefer here in the meantime.

**No `CHANGELOG.md` entry**, per the same guard. Proposed release-note wording, per CONTRIBUTING:

> The capacity refusal for a full `did` namespace now names the caller's own sharded path.

## Relationship to the other attempts

#167 and #283 are closed. #267 was your pick as closest to correct, but has since grown to ~21 unrelated fixes across 17 files, which is no longer the change #165 describes. This is only #165, with the regression test you asked to see carried over.

## Abuse impact

None. No new route, parameter or persistent state; one refusal body gains a sentence, and only for a namespace that is already full.
