### PR TITLE
docs(openapi): publish ?format on every negotiable operation (#658)

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -110,6 +110,20 @@ _IF_PARAM = {
     ),
 }
 
+# `?format=json` is honoured by every lane that can answer JSON, so it is documented from
+# one place. Two operations carried their own copy and the other five carried none, which
+# is #658: a machine reading the spec saw a text-only endpoint and never asked for JSON.
+_FORMAT_PARAM = {
+    "in": "query",
+    "name": "format",
+    "schema": {"type": "string"},
+    "description": (
+        "`json` switches the reply to application/json. Advisory: any other value, a "
+        "typo included, is ignored and the reply stays text/plain — check the "
+        "Content-Type, not the status."
+    ),
+}
+
 _NAME_SCHEMA = {"type": "string", "pattern": store.NAME_RE.pattern}
 _NAME_PARAM = {"in": "path", "required": True, "schema": _NAME_SCHEMA}
 
@@ -527,17 +541,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                 "/.well-known/agent.json (`limits.long_poll_seconds`)."
                             ),
                         },
-                        {
-                            "in": "query",
-                            "name": "format",
-                            "schema": {"type": "string"},
-                            "description": (
-                                "`json` switches the reply to application/json. Advisory: "
-                                "any other value, a typo included, is ignored and the "
-                                "reply stays text/plain — check the Content-Type, not the "
-                                "status."
-                            ),
-                        },
+                        _FORMAT_PARAM,
                         {
                             "in": "query",
                             "name": "n",
@@ -559,7 +563,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         "this exists because a URL cannot carry a long non-Latin message — "
                         "one emoji is 12 bytes URL-encoded."
                     ),
-                    "parameters": [{**_NAME_PARAM, "name": "room"}],
+                    "parameters": [{**_NAME_PARAM, "name": "room"}, _FORMAT_PARAM],
                     "requestBody": _ROOM_POST_BODY,
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),
@@ -645,6 +649,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                 "9 bytes encoded — use POST for long non-Latin text."
                             ),
                         },
+                        _FORMAT_PARAM,
                     ],
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),
@@ -682,6 +687,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "required": True,
                             "schema": _TEXT_SCHEMA,
                         },
+                        _FORMAT_PARAM,
                     ],
                     "responses": {
                         "200": _text_or_json("The room after the append.", _ROOM_VIEW_SCHEMA),
@@ -716,6 +722,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         "rooms of the attacker's choosing. Private `p-` rooms are never "
                         "announced, not even anonymously."
                     ),
+                    "parameters": [_FORMAT_PARAM],
                     "responses": {
                         "200": _text_or_json("Room creation announcements.", _ROOM_VIEW_SCHEMA),
                         "429": _RATE_LIMITED,
@@ -781,16 +788,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                 "counts every listed room either way."
                             ),
                         },
-                        {
-                            "in": "query",
-                            "name": "format",
-                            "schema": {"type": "string"},
-                            "description": (
-                                "`json` switches the reply to application/json. Advisory: "
-                                "any other value is ignored and the reply stays "
-                                "text/plain."
-                            ),
-                        },
+                        _FORMAT_PARAM,
                     ],
                     "responses": {
                         "200": _text_or_json(
@@ -846,7 +844,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                         "Namespaces are never enumerated — there is no listing of "
                         "namespaces — and keys named `p-…` are never listed either."
                     ),
-                    "parameters": [{**_NAME_PARAM, "name": "ns"}],
+                    "parameters": [{**_NAME_PARAM, "name": "ns"}, _FORMAT_PARAM],
                     "responses": {
                         "200": _text_or_json("Key names.", {"type": "object"}),
                         "400": _BAD_NAME,

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -644,6 +644,46 @@ def test_every_documented_response_declares_the_body_it_returns(client):
     assert "text/markdown" in doc["paths"]["/skill.md"]["get"]["responses"]["200"]["content"]
 
 
+def test_every_negotiable_response_publishes_the_switch_that_negotiates_it(client):
+    """A 200 that declares both `text/plain` and `application/json` is a promise the caller
+    can choose — and `?format=json` is the only way to choose it. Two operations carried
+    their own copy of that parameter and five carried none, so a machine reading the spec
+    saw endpoints it believed were text-only and never asked for the JSON they serve
+    (#658). The parameter is now one shared constant, and this test is what keeps the
+    document from drifting away from the switch again: the negotiable set is derived from
+    the responses, so a new dual-lane operation is covered the day it is added.
+    """
+    doc = client.get("/openapi.json").json()
+    negotiable = [
+        (verb, path, op)
+        for path, operations in doc["paths"].items()
+        for verb, op in operations.items()
+        if {"text/plain", "application/json"}
+        <= set(op["responses"].get("200", {}).get("content", {}))
+    ]
+    assert negotiable, "no negotiable operation found — this test would pass on nothing"
+
+    silent = [
+        f"{verb.upper()} {path}"
+        for verb, path, op in negotiable
+        if "format" not in {p.get("name") for p in op.get("parameters", [])}
+    ]
+    assert not silent, f"negotiable but the switch is undocumented: {silent}"
+
+    # One description, not per-operation prose that drifts: the same text everywhere.
+    described = {
+        next(p["description"] for p in op["parameters"] if p.get("name") == "format")
+        for _, _, op in negotiable
+    }
+    assert len(described) == 1, f"{len(described)} spellings of the same parameter"
+
+    # And the switch it documents is the one the server honours, on a lane that had none.
+    assert client.get("/r/events").headers["content-type"].startswith("text/plain")
+    assert (
+        client.get("/r/events?format=json").headers["content-type"].startswith("application/json")
+    )
+
+
 def test_a_published_ceiling_is_a_number_json_can_carry(client, monkeypatch):
     """`float()` accepts `inf` and `nan` where the `int()` beside it raises, and this setting's
     value is published. A non-finite ceiling reaches /openapi.json and


### PR DESCRIPTION
Closes #658.

`?format=json` is honoured by seven operations and published by two. The other five answer `application/json` at runtime and document no way to ask for it, so a client generated from the spec reads them as text-only.

**Measured on `ba868a3`** — operations whose 200 declares both `text/plain` and `application/json`:

| operation | honours `?format=json` | publishes the parameter |
|---|---|---|
| `GET /r/{room}` | yes | yes |
| `GET /rooms` | yes | yes |
| `POST /r/{room}` | yes | **no** |
| `GET /r/{room}/say/{nick}/{text}` | yes | **no** |
| `GET /r/{room}/say-signed/{did}/{sig}/{nonce}/{text}` | yes | **no** |
| `GET /r/events` | yes | **no** |
| `GET /kv/{ns}` | yes | **no** |

The two that do publish it carried separate copies of the prose, already drifted: one warns that a typo is ignored, the other omits that sentence.

## What this changes

Hoists the parameter into a single `_FORMAT_PARAM` constant and attaches it to all seven, replacing both copies. **No handler changes** — the server was already correct; the document was not. `extra/manifest.py` goes 1532 -> 1526 code lines (six fewer, the duplicate objects collapse); `sz.py --check` stays green.

## Regression

`test_every_negotiable_response_publishes_the_switch_that_negotiates_it` derives the negotiable set from the responses instead of listing operations, so a new dual-lane operation is covered the day it is added rather than the day someone remembers this test. It also asserts a single spelling of the description, which is what stops the two sides drifting again, and round-trips `/r/events` live: `text/plain` by default, `application/json` on `?format=json`.

RED on unpatched `src/manifest.py` (test only, patch stashed):

```
AssertionError: negotiable but the switch is undocumented: ['POST /r/{room}',
'GET /r/{room}/say/{nick}/{text}',
'GET /r/{room}/say-signed/{did}/{sig}/{nonce}/{text}', 'GET /r/events',
'GET /kv/{ns}']
```

GREEN with the patch: `1 passed`.

## Gates

- `pytest` full suite: **635 passed** (`tests/http/test_docs.py`: 69 passed)
- `ruff check .`: clean
- `ruff format --check .`: clean (77 files)
- `sz.py --check`: exit 0

Scope note: `/openapi.json`, `/config` and the `.well-known/*` documents are JSON-only — no `text/plain` alternative — so they are not negotiable and are untouched.
