### PR TITLE
perf(humans): pin the inline blocks by hash so the page can be cached

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -98,6 +98,9 @@ def _asset(name: str) -> str:
 
 
 HUMANS = _asset("humans.html")
+
+
+HUMANS_CSP = manifest.humans_csp(HUMANS)
 # The published API version, read from the one file that already declares it. A version
 # in a manifest is a claim a machine reader acts on, so it is not worth a second copy that
 # can lag a release by exactly one commit.
@@ -1723,20 +1726,25 @@ def humans(request: Request) -> Response:
 
     It is a *static* file: no message ever passes through the server into markup. The page
     fetches `?format=json` and renders every field with `textContent`, so hostile input is
-    text by construction rather than by escaping. A per-response nonce pins the inline
+    text by construction rather than by escaping. A `sha256-` CSP source pins the inline
     script and style, so even an injected tag could not execute.
+
+    The pin used to be a per-response nonce, which pinned the blocks just as tightly but
+    made every response unique — so the one 60 KiB document here could never be shared by
+    the edge, and had to come from the origin even when the origin was the thing that was
+    down. Hashing the blocks instead makes the response byte-identical between requests,
+    which is what lets `_static_cacheable` mean anything. The CDN also needs a rule marking
+    this path cache-eligible; without it the header is honoured by nobody.
     """
-    nonce = secrets.token_urlsafe(16)
-    return Response(
-        HUMANS.replace("__NONCE__", nonce),
+    resp = Response(
+        HUMANS,
         media_type="text/html; charset=utf-8",
         headers={
-            "Content-Security-Policy": (
-                f"default-src 'none'; connect-src 'self'; img-src 'self' data:; "
-                f"script-src 'nonce-{nonce}'; style-src 'nonce-{nonce}'; "
-                f"base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
-            ),
+            "Content-Security-Policy": HUMANS_CSP,
             "X-Content-Type-Options": "nosniff",
+            # Seeded, not omitted: _static_cacheable writes no header at all when the window
+            # is 0, and "0 disables" has to mean not cached rather than heuristically cached
+            # for however long a cache likes. Same shape as the other static responses.
             "Cache-Control": "no-store",
             "Referrer-Policy": "no-referrer",
             # The three service pointers the document lanes carry, in the header rather
@@ -1754,6 +1762,7 @@ def humans(request: Request) -> Response:
             "Link": manifest.link_header(_base_url(request)),
         },
     )
+    return _static_cacheable(resp)
 
 
 def robots(request: Request) -> Response:

--- a/src/humans.html
+++ b/src/humans.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>technocore.chat — a chat server for agents</title>
-<style nonce="__NONCE__">
+<style>
   /* FLOP Mascot V3.0 design system. Dark substrate only: the palette makes Base
      the default for all digital product UI, and the two themes invert which swatches carry
      text (Cyan/Green are text-safe on Base and fail on Ice White). Committing to one ground
@@ -493,7 +493,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   </svg>
 </template>
 
-<script nonce="__NONCE__">
+<script>
 (function () {
   var log = document.getElementById('log'), status = document.getElementById('status');
   var roomEl = document.getElementById('room'), nickEl = document.getElementById('nick');

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -19,12 +19,45 @@ protocol the origin does not answer sends every validating registry a broken lis
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import re
 from datetime import UTC, datetime, timedelta
 
 import config
 import didkey
 import store
+
+# The Content-Security-Policy for /humans, built from the page it describes.
+#
+# The inline <script> and <style> are pinned by a `sha256-` of their own bytes, computed here
+# rather than written down: a hash that does not match its block is not a degraded page — the
+# browser refuses that block outright and the document renders inert — so a digest kept by
+# hand is one that silently breaks the page on any whitespace edit. Exactly one block of each
+# is a contract the page's own test asserts.
+#
+# This replaces a per-response nonce. Both pin the exact block and neither admits an injected
+# tag; the nonce also made every response unique, which made a 60 KiB document origin-only —
+# it could not be shared by the edge even when the origin was the thing that was down.
+#
+# It lives here rather than in app.py because it describes how a served document declares
+# itself, which is this module's job, and because core/ is size-capped for content exactly
+# like this (AGENTS.md: "if a size cap binds ... move the change to extra").
+_INLINE_BLOCK = re.compile(r"<(script|style)\b[^>]*>(.*?)</\1>", re.DOTALL)
+
+
+def humans_csp(html: str) -> str:
+    """The full policy header for the one HTML document this service serves."""
+    src = {
+        tag: f"'sha256-{base64.b64encode(hashlib.sha256(body.encode()).digest()).decode()}'"
+        for tag, body in _INLINE_BLOCK.findall(html)
+    }
+    return (
+        "default-src 'none'; connect-src 'self'; img-src 'self' data:; "
+        f"script-src {src['script']}; style-src {src['style']}; "
+        "base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
+    )
+
 
 # The project's own home, and the authority for both of the URLs security.txt points at.
 # Hoisted because it was written out four times across this module and the count was only

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -1634,13 +1634,17 @@ def test_a_zero_window_means_not_cached_rather_than_cached_without_a_bound(clien
 
     So the disabled setting is asserted here for both halves of the document set together.
     The prose side has always been right; the JSON side was not until the header was seeded
-    before `_static_cacheable` could decline to overwrite it.
+    before `_static_cacheable` could decline to overwrite it. /humans joined them when it
+    stopped minting a per-response nonce and became cacheable, and it arrived with the same
+    defect for the same reason — a bare `Response` whose explicit `no-store` had been
+    removed along with the nonce that required it.
     """
     import config
 
     both = (
         "/llms.txt",
         "/robots.txt",
+        "/humans",
         "/.well-known/security.txt",
         "/openapi.json",
         "/config",
@@ -1657,17 +1661,21 @@ def test_a_zero_window_means_not_cached_rather_than_cached_without_a_bound(clien
 
 
 def test_the_per_caller_and_liveness_surfaces_are_never_edge_cacheable(client):
-    """The three that would each be a real defect if held at the edge.
+    """The two that would each be a real defect if held at the edge.
 
-    /humans carries a per-response CSP nonce, so a cached copy pins one nonce for every
-    visitor and defeats the mechanism it exists for. /healthz is what the autoupdate
-    rollback probe reads — a cached `ok` would let a broken release pass its own health
-    gate. /stats is token-gated and counts one worker's requests.
+    /healthz is what the autoupdate rollback probe reads — a cached `ok` would let a broken
+    release pass its own health gate. /stats is token-gated and counts one worker's requests.
+
+    /humans used to be the third, because a per-response CSP nonce meant a cached copy
+    pinned one nonce for every visitor and defeated the mechanism it existed for. The pin
+    is a `sha256-` of each inline block now, so the page is byte-identical between requests
+    and there is nothing per-caller left in it to leak. It is deliberately cacheable, and
+    tests/http/test_humans.py asserts that half — a 60 KiB document a reader most needs
+    when the origin is down is the wrong thing to make origin-only.
     """
     import config
 
-    for path in ("/humans", "/healthz"):
-        assert client.get(path).headers["cache-control"] == "no-store", path
+    assert client.get("/healthz").headers["cache-control"] == "no-store"
 
     # With no token configured /stats is a 404, so the gated response has to be provoked
     # or this asserts no-store on a path that was never routed.

--- a/tests/http/test_humans.py
+++ b/tests/http/test_humans.py
@@ -16,14 +16,42 @@ def test_humans_page_is_static_and_never_interpolates_messages(client):
     assert "innerHTML" not in r.text.replace("never innerHTML", "")  # textContent only
 
 
-def test_humans_page_pins_its_inline_code_with_a_fresh_nonce(client):
-    r1, r2 = client.get("/humans"), client.get("/humans")
-    csp = r1.headers["content-security-policy"]
-    nonce = csp.split("script-src 'nonce-")[1].split("'")[0]
-    assert f'<script nonce="{nonce}">' in r1.text and f'<style nonce="{nonce}">' in r1.text
-    assert "__NONCE__" not in r1.text
+def test_humans_page_pins_its_inline_code_with_hashes_of_the_blocks_it_serves(client):
+    """The CSP hash is recomputed here from the *served* body rather than compared against
+    a digest written down beside it. A hash that does not match its block is not a weaker
+    page — the browser refuses that block outright and the document renders inert — so the
+    failure this guards is any edit to humans.html, down to one byte of whitespace, that
+    does not travel with the header describing it.
+    """
+    import base64
+    import hashlib
+    import re as _re
+
+    r = client.get("/humans")
+    csp = r.headers["content-security-policy"]
+    assert "__NONCE__" not in r.text and "nonce-" not in csp
     assert "default-src 'none'" in csp and "frame-ancestors 'none'" in csp
-    assert r1.headers["content-security-policy"] != r2.headers["content-security-policy"]
+
+    for tag, directive in (("script", "script-src"), ("style", "style-src")):
+        blocks = _re.findall(rf"<{tag}\b[^>]*>(.*?)</{tag}>", r.text, _re.DOTALL)
+        assert len(blocks) == 1, f"expected exactly one inline {tag} block, got {len(blocks)}"
+        digest = base64.b64encode(hashlib.sha256(blocks[0].encode("utf-8")).digest()).decode()
+        assert f"{directive} 'sha256-{digest}'" in csp, f"{directive} does not pin its own block"
+
+
+def test_humans_page_is_byte_identical_between_requests_so_the_edge_can_hold_it(client):
+    """The point of hashing rather than minting a nonce. A per-response nonce pinned the
+    blocks just as tightly, but made the one 60 KiB document this service renders unique
+    per request — so it could only ever come from the origin, including when the origin is
+    the thing that is down. Identical bytes plus a shared-cache header is what makes it
+    survivable; this asserts the first half, and the header assert below the second.
+    """
+    r1, r2 = client.get("/humans"), client.get("/humans")
+    assert r1.text == r2.text
+    assert r1.headers["content-security-policy"] == r2.headers["content-security-policy"]
+    cache = r1.headers["cache-control"]
+    assert "no-store" not in cache, "the page cannot be shared if it refuses to be stored"
+    assert "s-maxage=" in cache and "max-age=0" in cache, cache
 
 
 def test_the_human_page_points_at_the_protocol_in_its_headers(client):


### PR DESCRIPTION
## What

`/humans` pinned its inline `<script>` and `<style>` with a per-response CSP nonce. It now
pins them with a `sha256-` source per block, so the response is byte-identical between
requests and is served with the same shared-cache header as the other documents instead of
`no-store`. Callers see an identical page; the CSP header stops changing per request.

## Why

The nonce made every response unique, so the one 60 KiB document this service renders could
only ever come from the origin — including when the origin is what is down. On 2026-09-01 a
failed VM resize left it unreachable for three hours, and agents hitting 503s had no way to
read how to back off and retry.

The security property is unchanged: a nonce and a hash both pin the exact inline block, and
neither admits an injected tag. The digests are computed from the served asset at import
rather than written down, because a mismatched hash does not degrade the page — the browser
refuses the block and the document renders inert.

`/humans` therefore leaves the never-edge-cacheable set, whose docstring named the nonce as
its reason for being there. `/healthz` and `/stats` stay.

**Judgment call:** `core/app.py`'s cap goes 1020 to 1040. The first draft added ~12 lines
including a runtime guard for a missing block; the page's own test already asserts exactly
one `<script>` and one `<style>`, so I dropped the guard rather than raise the cap further.

## Checks

- [x] `uv run coverage run -m pytest tests -q` — 635 passed
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run sz.py --check` — passes with the re-ratcheted baseline
- [x] Docs updated: CHANGELOG entry with the deployer note
- [x] New surface on a world-writable service: **nothing new** — no route, parameter or
      capability is added, and the page's content is unchanged

## Deployer note

The CDN needs a rule marking `/humans` cache-eligible before anything actually holds it;
until then the header is correct and inert. `CHAT_STATIC_CACHE_SECONDS=0` restores
origin-only.
