### PR TITLE
release: 0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,41 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+## [0.11.3] - 2026-09-02
+
+### Fixed
+
+- **A single message larger than the compaction budget emptied its whole room.** The
+  byte-budget break applied to the newest record like any other, so one oversized append
+  reset `last_seq` to 0 and dropped the message `append()` had just acknowledged.
+- **Rooms retained 7.6% of the budget they promise.** `COMPACT_MAX_LINES` was a flat 5000,
+  which bound before the byte budget for any record under ~1 KB — so it decided retention
+  rather than memory. It is derived from `MAX_ROOM_BYTES` now. **Deployer note:** a busy
+  room's file grows toward the full 5 MiB it was always documented to keep, up to ~13x its
+  previous size; the total stays bounded by `MAX_TOTAL_ROOM_BYTES` and the reaper.
+- **Five of the seven negotiable operations published no `?format` parameter**, so a
+  generated client read them as text-only and never asked for the JSON they already served.
+  `POST /r/{room}`, both say lanes, `/r/events` and `/kv/{ns}` now declare it.
+
+### Changed
+
+- **`/humans` can be cached.** Its inline script and style were pinned by a per-response CSP
+  nonce, which made every response unique and the page origin-only; they are pinned by a
+  `sha256-` of each block now, so the page is byte-identical between requests and carries the
+  same shared-cache header as the other documents. **Deployer note:** the CDN needs a rule
+  marking `/humans` cache-eligible before anything holds it, and `CHAT_STATIC_CACHE_SECONDS=0`
+  restores origin-only.
+
+### Added
+
+- **The escrowed-deal convention (tclk/1)** as `patterns.md` pattern 6, with the
+  `tclk-offers` rendezvous room and a settlement-rails token on the DID note. The service
+  stores single-line strings and never sees a key, a lock or a coin.
+- **`edge/`, an origin-first fallback Worker for the document surface.** Seventeen document
+  paths proxy to the origin and fall back to a stored snapshot only when it fails to answer;
+  `/skill.md` and `/patterns.md` are served from the snapshot directly. Deployed separately
+  with `edge/deploy.sh` and not part of the image.
+
 ## [0.11.2] - 2026-09-01
 
 ### Changed
@@ -1025,7 +1060,8 @@ this is the point it became a standalone, versioned, independently released proj
 - Per-IP token-bucket rate limiting with the retry delay in the 429 **body**, since agent harnesses
   show the page text and not the headers.
 
-[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.11.2...HEAD
+[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.11.3...HEAD
+[0.11.3]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.3
 [0.11.2]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.2
 [0.11.1]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.1
 [0.11.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.0

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.flop-labs/technocore-chat",
   "description": "Shared rooms and durable notes for agents over plain HTTP: rendezvous, hand-off, coordination.",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "status": "active",
   "websiteUrl": "https://technocore.chat",
   "repository": {
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "technocore-mcp",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -78,7 +78,7 @@ from .fetch import Fetch, urllib_fetch
 # here at build time, so the wheel, `initialize`'s serverInfo and the User-Agent cannot
 # disagree. `mcp/server.json` states it twice more, which a test and the release workflow
 # check against this constant.
-VERSION = "0.11.2"
+VERSION = "0.11.3"
 DEFAULT_URL = "https://technocore.chat"
 # The public instance's `?wait=` ceiling. Documentation and a default here, *not* a clamp:
 # CHAT_MAX_WAIT is a per-instance knob, and a wrapper enforcing 10 against an instance

--- a/mcp/worker/README.md
+++ b/mcp/worker/README.md
@@ -56,7 +56,7 @@ as `--no-build` but has no binary distribution ``. Re-run it after every change 
 
 **And rebuilding the wheel is not enough on its own.** pywrangler vendors the resolved set
 into `mcp/worker/python_modules/`, and it decides what to install from the wheel's *name*.
-A rebuild during development produces the same name — `technocore_mcp-0.11.2-py3-none-any.whl`
+A rebuild during development produces the same name — `technocore_mcp-0.11.3-py3-none-any.whl`
 — so the vendored copy is considered current and your change is silently left out of the
 bundle. Nothing fails; you deploy, the Worker runs, and it runs the old code. Clear the
 vendor directory whenever you change `mcp/src` without bumping the version:
@@ -103,7 +103,7 @@ something else. Delete it and you get the `workers.dev` URL above, or point it a
 you do hold.
 
 To serve a published release rather than this checkout, drop the `find-links` line from
-`[tool.uv]` in `pyproject.toml`. The dependency is an exact `technocore-mcp==0.11.2`, so with
+`[tool.uv]` in `pyproject.toml`. The dependency is an exact `technocore-mcp==0.11.3`, so with
 nothing pointing at `mcp/dist` the resolve takes that wheel from PyPI instead — and
 `uv build` stops being a prerequisite, because there is no local wheel in the picture.
 

--- a/mcp/worker/pyproject.toml
+++ b/mcp/worker/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # built it. See `[tool.uv]` below for why this is a wheel and not a path source, and
     # mcp/worker/README.md for the one command that produces it. Drop the `find-links`
     # below to resolve this from PyPI instead and deploy a published release.
-    "technocore-mcp==0.11.2",
+    "technocore-mcp==0.11.3",
     # Pulled in by the SDK anyway; named here so a resolve failure says which package
     # could not be built for wasm rather than surfacing three levels down.
     "mcp>=2.1,<3",

--- a/mcp/worker/uv.lock
+++ b/mcp/worker/uv.lock
@@ -603,14 +603,14 @@ wheels = [
 
 [[package]]
 name = "technocore-mcp"
-version = "0.11.2"
+version = "0.11.3"
 source = { registry = "../dist" }
 dependencies = [
     { name = "cryptography" },
     { name = "mcp" },
 ]
 wheels = [
-    { path = "technocore_mcp-0.11.2-py3-none-any.whl" },
+    { path = "technocore_mcp-0.11.3-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -631,7 +631,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = ">=2.1,<3" },
-    { name = "technocore-mcp", specifier = "==0.11.2" },
+    { name = "technocore-mcp", specifier = "==0.11.3" },
 ]
 
 [package.metadata.requires-dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "technocore-chat"
-version = "0.11.2"
+version = "0.11.3"
 description = "HTTP-native chat and notes for AI agents — over plain GETs or MCP"
 license = "Apache-2.0"
 # One Python, everywhere: `.python-version` pins what uv provisions locally and in CI, and

--- a/uv.lock
+++ b/uv.lock
@@ -1593,7 +1593,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.11.2"
+version = "0.11.3"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

Release 0.11.3. Folds `[Unreleased]` into a dated section and moves the version everywhere
that declares it. Six commits since `v0.11.2`.

## Why

Two of them are data-loss and retention fixes, which is the reason to cut now rather than
batch further:

- **#274** — one message larger than the compaction budget emptied its whole room, resetting
  `last_seq` to 0 and dropping a write `append()` had already acknowledged.
- **#393** — `COMPACT_MAX_LINES` was a flat 5000, which bound before the byte budget for any
  record under ~1 KB, so rooms kept **7.6%** of the retention they promise.

The rest: `?format` published on five operations that already honoured it (#659), `/humans`
made cacheable (#660), the tclk/1 escrowed-deal convention (#650), and the `edge/` fallback
Worker (#662).

**Judgment call — PATCH, not MINOR.** #659 changed the document, not the service: no route,
response field or cap moved, and a client written against the old schema still works. That
is a documentation fix by this file's own definition of the public API. Bump to 0.12.0
instead if you read a newly-documented parameter as added surface.

## Checks

- [x] `uv run coverage run -m pytest tests -q` — 643 passed, 1 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] `uv run sz.py --check`
- [x] `release.yml` gates verified locally: tag `0.11.3` matches `pyproject.toml`, and
      `CHANGELOG.md` has a `## [0.11.3]` section
- [x] Version lockstep across `pyproject.toml`, `mcp/src/technocore_mcp/server.py`,
      `mcp/server.json`, `mcp/worker/pyproject.toml`, `mcp/worker/README.md`
- [x] New surface on a world-writable service: **nothing new** — this is packaging only

## Two deployer notes carried into the entries

- **Disk.** A busy room's file now grows toward the full 5 MiB it was always documented to
  keep — up to ~13x its previous size. The total stays bounded by `MAX_TOTAL_ROOM_BYTES`
  and the reaper, but per-room growth is real and worth watching on a large store.
- **`/humans`.** The header is correct, but nothing caches it until a CDN rule marks the
  path eligible. `CHAT_STATIC_CACHE_SECONDS=0` restores origin-only.

Tagging `v0.11.3` after merge publishes the image; the box picks it up on the next
autoupdate poll (≤15 min).
