### PR TITLE
perf(healthz): answer on the event loop, and let the edge hold it

### DIFF
--- a/edge/snapshot.py
+++ b/edge/snapshot.py
@@ -71,6 +71,19 @@ PATHS = (
 # controlled moment where re-running deploy.sh is a checklist item, unlike a compose edit.
 STATIC_FIRST = {"/skill.md": "SKILL.md", "/patterns.md": "src/patterns.md"}
 
+# Held by the edge for a few seconds and NEVER snapshotted — the third lane, and the
+# distinction is the point. A liveness endpoint must not have a stored copy to fall back on,
+# because the only thing a stored "ok" can do is answer for a service that is gone. So this
+# lane caches and never falls back, and these paths are deliberately absent from PATHS.
+#
+# 10s, not 1s: Cloudflare caches per PoP, so 20.7 req/s across the PoP network arrives at any
+# single one far more slowly than the global rate suggests and a 1s window mostly misses. The
+# same fragmentation made a 3s window buy almost nothing for /rooms. 10s cannot reach an
+# alerting decision — monitors alert on two or three consecutive failures — and it removes
+# ~1.78M origin requests a day (measured 2026-09-02: 2,478 of 2,480 /healthz requests in two
+# minutes arrived through the tunnel, 10.4% of all traffic).
+EDGE_CACHED = {"/healthz": 10}
+
 
 def asset_name(path: str) -> str:
     """Where a URL path is stored under public/.
@@ -132,7 +145,11 @@ def main() -> int:
         return 1
 
     pathlib.Path(args.manifest).write_text(
-        json.dumps({"types": types, "static_first": sorted(STATIC_FIRST)}, indent=2, sort_keys=True)
+        json.dumps(
+            {"types": types, "static_first": sorted(STATIC_FIRST), "edge_cached": EDGE_CACHED},
+            indent=2,
+            sort_keys=True,
+        )
         + "\n",
         encoding="utf-8",
     )

--- a/edge/src/worker.js
+++ b/edge/src/worker.js
@@ -39,6 +39,16 @@ const ORIGIN_TIMEOUT_MS = 8000;
 
 const STATIC_FIRST = new Set(ROUTING.static_first);
 
+// Paths the edge holds for a few seconds and never stores a snapshot of; see snapshot.py,
+// which owns the policy so the Worker and the tests cannot disagree about it. A liveness
+// endpoint must never have a stored copy to fall back on — the only thing a stored "ok" can
+// do is answer for a service that is gone — so this lane caches and never falls back.
+//
+// The origin keeps sending `no-store`, and that stays correct: anything asking it directly,
+// including the container healthcheck and the auto-updater's rollback probe (both on
+// 127.0.0.1, neither through this Worker), gets an uncached answer. Only the edge shares it.
+const EDGE_CACHED_SECONDS = ROUTING.edge_cached ?? {};
+
 /** A 5xx is the origin failing to answer. A 4xx is the origin answering "no", which is a
  * real reply and must pass through untouched — serving a snapshot over a 404 or a 429 would
  * invent content for a path the service deliberately refused. */
@@ -68,13 +78,66 @@ async function stored(request, env, pathname, { fallback }) {
   return new Response(asset.body, { status: 200, headers });
 }
 
+async function edgeCached(request, pathname, seconds) {
+  const cache = caches.default;
+  const hit = await cache.match(request);
+  if (hit) return hit;
+
+  let fresh;
+  try {
+    fresh = await fetch(request, { signal: AbortSignal.timeout(ORIGIN_TIMEOUT_MS) });
+  } catch (err) {
+    // An origin that will not answer inside the budget IS the health answer, so report it
+    // here rather than letting the timeout escape to the fail-open handler. That handler
+    // retries with no deadline of its own, which on a stalled origin would double the work
+    // during the outage this endpoint exists to report, and would delay the report until
+    // the client gave up instead of ending it at our own deadline.
+    return new Response("origin unavailable\n", {
+      status: 503,
+      headers: { "Cache-Control": "no-store" },
+    });
+  }
+
+  // Only a healthy answer is worth holding. A 503 from the concurrency limiter is the
+  // service saying it is saturated *right now*, and caching that would keep reporting a
+  // recovered service as down.
+  if (fresh.status === 200) {
+    const body = await fresh.arrayBuffer();
+    const headers = new Headers(fresh.headers);
+    // `max-age=0` is the load-bearing half, exactly as it is in the app's own
+    // _edge_cacheable: `s-maxage` is a shared-cache directive, so only Cloudflare holds
+    // this copy. A bare `max-age` would let a browser, a monitoring client or a downstream
+    // proxy reuse `ok` without contacting the edge at all — liveness staleness outside
+    // Cloudflare's control, and beyond the reach of a purge.
+    headers.set("Cache-Control", `public, max-age=0, s-maxage=${seconds}`);
+    await cache.put(request, new Response(body, { status: 200, headers }));
+    return new Response(body, { status: 200, headers });
+  }
+  return fresh;
+}
+
 export default {
   async fetch(request, env, ctx) {
+    try {
+      return await route(request, env);
+    } catch (err) {
+      // Fail open. This Worker sits in front of the liveness endpoint now, so an exception
+      // in it must not become the service looking dead: hand the request to the origin and
+      // let the origin answer for itself.
+      return fetch(request);
+    }
+  },
+};
+
+async function route(request, env) {
     // Only GET/HEAD are ever routed here, but a stray method must not be answered from a
     // stored copy: fall through to the origin and let it refuse.
     if (request.method !== "GET" && request.method !== "HEAD") return fetch(request);
 
     const pathname = new URL(request.url).pathname;
+
+    const cacheFor = EDGE_CACHED_SECONDS[pathname];
+    if (cacheFor) return edgeCached(request, pathname, cacheFor);
 
     if (STATIC_FIRST.has(pathname)) {
       const copy = await stored(request, env, pathname, { fallback: false });
@@ -98,5 +161,4 @@ export default {
     const copy = await stored(request, env, pathname, { fallback: true });
     // The origin's own failure is a better answer than a 404 we invented.
     return copy ?? originResponse ?? new Response("origin unavailable\n", { status: 503 });
-  },
-};
+}

--- a/edge/wrangler.jsonc
+++ b/edge/wrangler.jsonc
@@ -37,6 +37,8 @@
     { "pattern": "technocore.chat/interop.md", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/auth.md", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/humans", "zone_name": "technocore.chat" },
+    // Edge-cached, never snapshotted — see EDGE_CACHED in snapshot.py.
+    { "pattern": "technocore.chat/healthz", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/robots.txt", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/sitemap.xml", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/openapi.json", "zone_name": "technocore.chat" },

--- a/src/app.py
+++ b/src/app.py
@@ -1793,7 +1793,18 @@ def security_txt(request: Request) -> Response:
     return _static_cacheable(text(body, index=True))
 
 
-def healthz(request: Request) -> Response:
+async def healthz(request: Request) -> Response:
+    """`async` deliberately, though the body is a constant.
+
+    Starlette runs a plain `def` endpoint in the anyio threadpool, so every liveness check
+    took one of the 40 threads a worker has — and the moment that matters is the one where
+    there are none. Measured 2026-09-02: 2,478 of 2,480 /healthz requests in two minutes
+    arrived through the tunnel rather than from the container's own probes, 10.4% of all
+    traffic, while the write path had 40 of 42 threads parked in flock. A check that has to
+    queue for a thread to answer "ok" reports the queue, not the service, and the container
+    healthcheck was failing on exactly that. On the event loop it answers in microseconds
+    and needs no thread at all.
+    """
     return text("ok")
 
 

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -47,11 +47,40 @@ def test_every_snapshotted_path_is_routed_to_the_worker():
     assert set(_snapshot_module().PATHS) - _wrangler_routes() == set()
 
 
-def test_every_routed_path_is_snapshotted():
+def test_every_routed_path_is_either_snapshotted_or_deliberately_not():
     """The direction that actually breaks: routed but not stored means the fallback has
     nothing to serve, so the Worker hands back the origin's 503 — on the one path someone
-    added to the route list specifically so it would survive an outage."""
-    assert _wrangler_routes() - set(_snapshot_module().PATHS) == set()
+    added to the route list specifically so it would survive an outage.
+
+    The edge-cached lane is the deliberate exception, and has to be named rather than
+    subtracted silently: those paths are routed, are never snapshotted, and that is the
+    whole point of them.
+    """
+    snapshot = _snapshot_module()
+    accounted = set(snapshot.PATHS) | set(snapshot.EDGE_CACHED)
+    assert _wrangler_routes() - accounted == set()
+
+
+def test_a_liveness_path_is_never_snapshotted():
+    """The invariant the third lane exists to hold.
+
+    A stored copy of /healthz is a file that says "ok". The only occasion it would ever be
+    served is the one where the origin cannot answer — so the single thing it can do is
+    report a service that is gone as healthy, to every monitor watching it.
+    """
+    snapshot = _snapshot_module()
+    assert set(snapshot.EDGE_CACHED) & set(snapshot.PATHS) == set()
+    assert set(snapshot.EDGE_CACHED) & set(snapshot.STATIC_FIRST) == set()
+    assert "/healthz" not in snapshot.PATHS
+
+
+def test_the_edge_cache_window_is_long_enough_to_be_worth_having():
+    """1s would mostly miss: Cloudflare caches per PoP, so the per-PoP arrival rate is far
+    below the global one, and a window shorter than the gap between two requests at the same
+    PoP caches nothing. Pinned so a later "make it fresher" edit has to argue with the
+    reason rather than silently neutering the lane."""
+    for path, seconds in _snapshot_module().EDGE_CACHED.items():
+        assert seconds >= 5, f"{path} at {seconds}s is below the per-PoP arrival gap"
 
 
 def test_the_worker_covers_every_document_route_the_app_serves():
@@ -170,3 +199,20 @@ def test_the_origin_first_documents_really_do_carry_configuration(client):
 def test_the_static_first_set_is_a_subset_of_what_is_snapshotted():
     snapshot = _snapshot_module()
     assert set(snapshot.STATIC_FIRST) <= set(snapshot.PATHS)
+
+
+def test_the_edge_cached_lane_shares_its_copy_only_with_the_edge():
+    """A source assertion, deliberately, and narrow.
+
+    There is no JS harness in this repo, and the difference this guards is behavioural
+    rather than cosmetic: `s-maxage` is a shared-cache directive, so only Cloudflare holds
+    the copy, while a bare `max-age` would let a browser, a monitoring client or a
+    downstream proxy reuse `ok` without contacting the edge at all. That puts liveness
+    staleness outside Cloudflare's control and beyond the reach of a purge — on the one
+    endpoint whose entire job is to be current.
+    """
+    worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
+    assert "s-maxage=${seconds}" in worker
+    assert "max-age=0, s-maxage=${seconds}" in worker, (
+        "the edge-cached copy must not carry a private max-age"
+    )


### PR DESCRIPTION
## What

`/healthz` becomes `async def`, and the edge Worker gains a third lane that holds it for 10s
and never snapshots it. The Worker also fails open. No change to what any caller receives
from the origin — it still sends `no-store`.

## Why

`/healthz` was a plain `def`, so Starlette ran every liveness check in the anyio threadpool —
one of the 40 threads a worker has. The moment that matters is the one where there are none:
during the 2026-09-02 collapse the write path had 40 of 42 threads parked in `flock`, and the
container healthcheck was failing on exactly that, reporting the queue rather than the
service.

Measured the same day: **2,478 of 2,480 `/healthz` requests in two minutes arrived through
the tunnel**, 3 came from `127.0.0.1`. So it is 10.4% of all traffic and almost none of it is
ours — both internal probes use `HTTPConnection('127.0.0.1', 8080)` via `docker compose exec`
and never touch the tunnel, the CDN or this Worker.

That is also what makes edge caching safe. The `no-store` rationale in the code is that a
cached `ok` would let a broken release pass its own health gate — true of the rollback probe,
which is precisely the caller that never sees a cache. The origin keeps sending `no-store`;
only the edge shares it, for 10s, removing ~1.78M origin requests a day.

**10s, not 1s:** Cloudflare caches per PoP, so 20.7 req/s across the PoP network arrives at
any one of them far more slowly than the global rate suggests, and a 1s window mostly misses —
the same fragmentation that made a 3s window buy almost nothing for `/rooms`. 10s cannot
reach an alerting decision, since monitors alert on two or three consecutive failures.

**Why the lane caches but never falls back:** a stored copy of `/healthz` is a file that says
`ok`, and the only occasion it would be served is the one where the origin cannot answer — so
the single thing it could do is report a dead service as healthy. `tests/edge/` pins that.

**Nothing else is worth making async.** By volume: `/r/` ~105 rps (already async), `/kv/`
~65 rps (`note_read` calls `store.note_get`, so it needs its thread), `/rooms` 1.6 rps (the
O(rooms) walk, same), and twelve document handlers below 0.2 rps combined — where moving
75 KB of JSON serialisation onto the event loop would be a downgrade. `/healthz` was the
outlier.

## Checks

- [x] `uv run coverage run -m pytest tests -q` — 645 passed, 1 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] `uv run sz.py --check`
- [x] New surface on a world-writable service: **nothing new** — no route, parameter or
      capability is added; an existing public endpoint gets cheaper to serve

## Deploy note

Two halves, and they are independent: the `async` change ships in the next release, the
Worker lane needs `edge/deploy.sh`. **No Cloudflare cache rule is required** — the lane uses
the Workers Cache API, which is programmatic and does not depend on zone cache rules.
