### PR TITLE
docs(edge): the lane table and the counts beside it match snapshot.py, and a test keeps them there (#665)

### DIFF
--- a/edge/README.md
+++ b/edge/README.md
@@ -1,8 +1,11 @@
-# Origin-first edge fallback for the document surface
+# Edge policy for the document surface
 
-A Cloudflare Worker attached to seventeen exact paths. It proxies each one to the origin and
-returns whatever the origin says. Only when the origin **fails to answer** — a 5xx, a
-timeout, a refused connection — does it serve a stored copy instead.
+A Cloudflare Worker attached to twenty exact paths: the seventeen documents `snapshot.py`
+stores a copy of, and three paths it deliberately never stores. The default lane proxies the
+origin and returns whatever the origin says; only when the origin **fails to answer** — a
+5xx, a timeout, a refused connection — does it serve the stored copy instead. Every
+departure from that default is a policy set in `snapshot.py`, which the Worker, `deploy.sh`
+and `tests/edge/` all read, so they cannot disagree about it.
 
 ## Why
 
@@ -11,14 +14,27 @@ document went down with the service, so an agent hitting 503s could not read `/s
 `/llms.txt` to find out how to back off and retry. Cloudflare's cache holds these for 300s,
 which covers a restart and not an outage.
 
-## Two lanes
+## Five lanes
 
 | lane | paths | behaviour |
 |---|---|---|
-| **static-first** | `/skill.md`, `/patterns.md`, `/robots.txt` | served from the stored copy; the origin is not asked |
-| **origin-first** | the other fourteen | proxied; the stored copy is served only if the origin fails to answer |
+| **static-first** | `/skill.md`, `/patterns.md` | served from the stored copy; the origin is not asked |
+| **origin-first** | the other fifteen documents | proxied; the stored copy is served only if the origin fails to answer |
+| **edge-cached** | `/healthz` | held by the edge for a few seconds; never snapshotted, never falls back (`EDGE_CACHED`) |
+| **revalidating** | `/rooms` | the edge copy is always the answer, refreshed behind the request; never snapshotted (`EDGE_REVALIDATE`) |
+| **edge-only** | `/favicon.ico` | the origin serves nothing here, so the stored bytes are the only answer (`EDGE_ONLY`) |
 
-The split is whether a document's bytes depend on the running configuration.
+`route()` in `src/worker.js` tries them in the order edge-cached, revalidating, static-first,
+edge-only, and origin-first for whatever is left. The last three lanes are not documents at
+all: a stored copy of a liveness answer or a room listing would be the wrong answer rather
+than a late one, and the origin has no favicon to copy. The comment beside each set in
+`snapshot.py` says why, and the numbers live there too.
+
+The split between the first two lanes is whether a document's bytes depend on the running
+configuration. `/robots.txt`
+looks like it belongs in the static lane but stays origin-first: `manifest.robots_txt` embeds
+an absolute `Sitemap:` URL built from `CHAT_PUBLIC_URL`, so moving the public origin changes
+its bytes the same way it changes the manual's.
 
 `/llms.txt` carries `MAX_ROOMS` and `MAX_NOTES_PER_NS`, `/openapi.json` and
 `/.well-known/agent.json` carry the version and the whole `limits` object, `/config` carries
@@ -29,7 +45,7 @@ copy of them in preference to the origin publishes the last upload's limits as c
 2026-09-01 three compose knobs changed on the box in one afternoon, none of them via a
 release.
 
-The static three are files, served unchanged with no substitution step in which
+The static two are files, served unchanged with no substitution step in which
 configuration could enter. `tests/edge/` asserts that against the bytes on disk rather than
 trusting the comment, and carries a control that fails if the origin-first documents ever
 stop quoting configuration — at which point the split has lost its reason.
@@ -38,10 +54,10 @@ stop quoting configuration — at which point the split has lost its reason.
 
 Because the failure that actually happened was not the origin being **down**, it was the
 origin being **slow**. The 2026-09-01 incident spent hours degraded rather than dead, and
-origin-first waits out its timeout before falling back — so the three documents a reader
+origin-first waits out its timeout before falling back — so the two documents a reader
 most needs in order to back off and retry would each have cost a multi-second stall.
 
-**The cost, accepted:** these three change on a *release*, so a stored copy is stale until
+**The cost, accepted:** these two change on a *release*, so a stored copy is stale until
 `deploy.sh` runs again. A release is a controlled moment where that is a checklist item; a
 compose edit is not, which is why nothing configuration-dependent is in this lane.
 
@@ -69,7 +85,7 @@ a snapshot committed to the repo is one that goes stale quietly.
 ### Content types
 
 `snapshot.py` records the origin's `Content-Type` per path in `src/types.json`, and the
-Worker sets it from there. Six of these paths have no file extension (`/humans`, `/config`,
+Worker sets it from there. Four of these documents have no file extension (`/`, `/humans`, `/config`,
 `/.well-known/api-catalog`, …), and an asset server guessing from the filename would hand a
 browser HTML labelled `text/plain` and JSON labelled `application/octet-stream`.
 

--- a/edge/src/worker.js
+++ b/edge/src/worker.js
@@ -1,13 +1,18 @@
 /**
- * Edge policy for the document surface: two lanes, chosen by whether a document's bytes
- * depend on the running configuration.
+ * Edge policy for the document surface. Five lanes, and snapshot.py owns which path is in
+ * which, so this Worker, deploy.sh and tests/edge/ cannot disagree about it. Two of them
+ * split the stored documents by whether a document's bytes depend on the running
+ * configuration:
  *
- *   static-first  /skill.md, /patterns.md, /robots.txt
+ *   static-first  /skill.md, /patterns.md
  *                 Served from the stored copy without asking the origin. Nothing in them
  *                 comes from config — enforced by tests/edge/, which renders each under two
- *                 different configs and requires identical bytes.
+ *                 different configs and requires identical bytes. /robots.txt looks like it
+ *                 belongs here but is origin-first: manifest.robots_txt embeds an absolute
+ *                 Sitemap URL built from CHAT_PUBLIC_URL, so its bytes move with a compose
+ *                 edit the way the static two's never do.
  *
- *   origin-first  everything else
+ *   origin-first  every other document
  *                 Proxied to the origin; the stored copy is served only when the origin
  *                 fails to answer at all. /llms.txt carries MAX_ROOMS and MAX_NOTES_PER_NS,
  *                 /openapi.json and /.well-known/agent.json carry the version and the whole
@@ -17,13 +22,20 @@
  *                 incidents, which is when these get read. Measured 2026-09-01: three
  *                 compose knobs changed on the box that day, none of them via a release.
  *
+ * The other three lanes hold paths that are never snapshotted at all, because a stored copy
+ * of them would be the wrong answer rather than a late one: edge-cached (/healthz, held for
+ * a few seconds and never falling back — a stored "ok" can only answer for a service that
+ * is gone), revalidating (/rooms, the edge copy always, refreshed behind the request) and
+ * edge-only (/favicon.ico, which the origin does not serve). route() tries them in that
+ * order, before the two document lanes; each is explained at its constant below.
+ *
  * Why the split rather than origin-first for everything: origin-first already survives an
  * outage, so the static lane is not about the origin being *down* — it is about the origin
  * being *slow*. That outage spent hours degraded rather than dead, and origin-first waits
- * out its timeout before falling back, so the three documents a reader most needs in order
+ * out its timeout before falling back, so the two documents a reader most needs in order
  * to back off and retry would each have cost a multi-second stall.
  *
- * The cost, accepted: the static three change on a release, so a stored copy is stale until
+ * The cost, accepted: the static two change on a release, so a stored copy is stale until
  * deploy.sh runs again. A release is a controlled moment; a compose edit is not.
  *
  * Not in front of /r/ or /kv/. Those are ~80% of traffic, are writes as often as reads, and
@@ -115,8 +127,8 @@ const isOriginFailure = (status) => status >= 500;
 
 /** The stored copy, with the Content-Type the origin gave it when it was captured.
  *
- * The type comes from the manifest rather than the asset server's guess because six of
- * these paths carry no file extension (/humans, /config, /.well-known/api-catalog among
+ * The type comes from the manifest rather than the asset server's guess because four of
+ * these documents carry no file extension (/humans, /config, /.well-known/api-catalog among
  * them), and a guess hands a browser HTML labelled text/plain or JSON as octet-stream.
  */
 async function stored(request, env, pathname, { fallback }) {

--- a/edge/wrangler.jsonc
+++ b/edge/wrangler.jsonc
@@ -21,7 +21,7 @@
 
   // Plain routes, NOT a custom domain: technocore.chat already has an origin — the chat
   // service, reached through a Cloudflare tunnel — and these attach in front of it for
-  // sixteen exact paths. mcp/worker uses `custom_domain` because the Worker *is* the origin
+  // twenty exact paths. mcp/worker uses `custom_domain` because the Worker *is* the origin
   // for its hostname; the opposite job, and the opposite setting.
   //
   // Enumerated per path rather than a prefix or a suffix. /r/ and /kv/ are ~80% of traffic

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -481,3 +481,47 @@ def test_the_icon_is_built_from_the_tracked_brand_mark():
     script = (EDGE / "make_favicon.py").read_text(encoding="utf-8")
     assert 'SOURCE = HERE / "assets" / "icon-source.png"' in script
     assert ".." not in script.split("SOURCE =")[1].split("\n")[0]
+
+
+_NUMBER_WORDS = {
+    word: n
+    for n, word in enumerate(
+        "zero one two three four five six seven eight nine ten eleven twelve thirteen "
+        "fourteen fifteen sixteen seventeen eighteen nineteen twenty".split()
+    )
+}
+
+
+def _spelled(text: str, pattern: str) -> int:
+    """The number word `pattern` captures in `text` — exactly once, so a sentence that was
+    reworded out of the pattern's reach fails here rather than going unchecked."""
+    flat = re.sub(r"\s*\n\s*(?:\*|//)?\s*", " ", text)  # unwrap prose and comment lines
+    found = re.findall(pattern, flat)
+    assert len(found) == 1, f"{pattern!r} matched {len(found)} times, expected exactly one"
+    return _NUMBER_WORDS[found[0].lower()]
+
+
+def test_the_spelled_out_counts_are_the_counts_in_the_sources():
+    """README.md, worker.js and wrangler.jsonc each spell out how many paths or documents a
+    lane holds, and every one of those numbers has drifted: three static-first documents
+    when the set had two, sixteen routes when there were seventeen, seventeen when #664,
+    #674 and #684 each added one without the sentence beside them moving. Prose is not a
+    source, so each spelled-out count is read back against the list it describes."""
+    snapshot = _snapshot_module()
+    static = len(snapshot.STATIC_FIRST)
+    documents = len(snapshot.PATHS)
+    routes = len(_wrangler_routes())
+    no_extension = sum("." not in path.rsplit("/", 1)[-1] for path in snapshot.PATHS)
+
+    readme = (EDGE / "README.md").read_text(encoding="utf-8")
+    worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
+    wrangler = (EDGE / "wrangler.jsonc").read_text(encoding="utf-8")
+
+    assert _spelled(readme, r"attached to (\w+) exact paths") == routes
+    assert _spelled(wrangler, r"in front of it for (\w+) exact paths") == routes
+    assert _spelled(readme, r"the (\w+) documents `snapshot.py`") == documents
+    assert _spelled(readme, r"the other (\w+) documents") == documents - static
+    assert _spelled(readme, r"The static (\w+) are files") == static
+    assert _spelled(worker, r"the static (\w+) change on a release") == static
+    assert _spelled(readme, r"(\w+) of these documents have no file extension") == no_extension
+    assert _spelled(worker, r"(\w+) of these documents carry no file extension") == no_extension


### PR DESCRIPTION
## What

Closes #665. Rebased onto `main` @ `674c2aa` (#687).

`edge/README.md` and `edge/src/worker.js` described a Worker with two lanes and a static-first set of three, in front of sixteen or seventeen paths depending on which sentence you read. Counted from the sources at `674c2aa`:

```
STATIC_FIRST     2   /skill.md, /patterns.md  (/robots.txt is deliberately origin-first)
PATHS           17   so the other fifteen are origin-first
EDGE_CACHED      1   /healthz       (#664)
EDGE_REVALIDATE  1   /rooms         (#674)
EDGE_ONLY        1   /favicon.ico   (#684)
routes          20
no extension     4   of the documents in types.json: /, /humans, /config, /.well-known/api-catalog
```

- `edge/README.md`: the lane table has five rows in the order `route()` tries them, with a paragraph on why the last three are never snapshotted. `/robots.txt` moves to origin-first with the reason (`manifest.robots_txt` embeds a `Sitemap:` URL built from `CHAT_PUBLIC_URL`). "seventeen exact paths" → twenty, "the other fourteen" → fifteen, "the static three" → two, "Six of these paths have no file extension" → four (that one was already wrong at #662: no list in the tree has six).
- `edge/src/worker.js`: the same in the file docstring, and "six of these paths" in `stored()` → four. No code changes.
- `edge/wrangler.jsonc`: "sixteen exact paths" → twenty.
- `tests/edge/test_edge_worker.py`: one new test, `test_the_spelled_out_counts_are_the_counts_in_the_sources`, reads every spelled-out number back against the list it describes — `STATIC_FIRST`, `PATHS`, the `routes` array, the no-extension count. Red on `main`'s prose (`assert 17 == 20`), green here. Each pattern has to match exactly once, so a sentence reworded out of its reach fails rather than going unchecked.

## Why

Every one of these numbers has drifted at least once, in the same direction each time: a set or the route list changed and the sentence beside it did not. The test file's own docstring already calls three hand-kept lists "drift waiting to happen", and the review on this PR named the gap exactly — nothing asserted a spelled-out number. Now something does, so the next route added without its sentence fails in CI rather than in a review.

The direction of the original error still matters during an incident: an operator reading either file would expect `/robots.txt` to answer from the stored copy with no origin round-trip, the opposite of what happens.

## Checks

- [x] `uv run --frozen --group dev python -m pytest tests -q` — 665 passed, 1 skipped (`tests/edge`: 26 passed, 1 skipped); the new test fails on `main`'s prose and passes here
- [x] `uv run --frozen ruff check .` and `uv run --frozen ruff format --check .` — clean
- [x] Docs that would now be wrong are updated: this PR is the docs fix; `snapshot.py`, the Worker's code and `CHANGELOG.md` are untouched
- [x] New surface on a world-writable service: none — prose, a comment, and a test
