### PR TITLE
fix(mcp): translate truncated responses to transport errors

### DIFF
--- a/mcp/src/technocore_mcp/fetch.py
+++ b/mcp/src/technocore_mcp/fetch.py
@@ -13,14 +13,15 @@ answer differs per platform:
   `mcp/worker/src/worker.py` injects its own `Fetch` instead of using this one.
 
 The seam is deliberately the *whole* transport and nothing else: method, URL, headers
-and an optional body in; status and body text out. No exception translation, no URL
-building, no JSON encoding — everything a tool's answer depends on stays in `server.py`,
+and an optional body in; status and body text out. Transport failures become `OSError`;
+URL building, JSON encoding and every other part of a tool's answer stay in `server.py`,
 written once, identical on both platforms. A seam drawn any higher would be two copies
 of the part that matters.
 """
 
 from __future__ import annotations
 
+import http.client
 import urllib.error
 import urllib.request
 from collections.abc import Awaitable, Callable
@@ -31,9 +32,16 @@ import anyio.to_thread
 # send, already encoded (or None for a bodiless GET) — encoding happens above the seam so
 # both platforms put identical bytes on the wire. Returns `(status, body_text)` for every
 # HTTP answer, success or failure — a 429 is a value here, not an exception, because its
-# body is the part the model needs. Raise `OSError` (and only `OSError`) when there was
-# no HTTP answer at all.
+# body is the part the model needs. Raise `OSError` (and only `OSError`) when the transport
+# could not deliver a complete HTTP answer.
 Fetch = Callable[[str, str, dict[str, str], bytes | None, float], Awaitable[tuple[int, str]]]
+
+
+def _read(response) -> str:
+    try:
+        return response.read().decode("utf-8", "replace")
+    except http.client.IncompleteRead as exc:
+        raise OSError(str(exc)) from None
 
 
 def _blocking_request(
@@ -48,11 +56,11 @@ def _blocking_request(
     request = urllib.request.Request(url, data=body, headers=headers, method=method)
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
-            return response.status, response.read().decode("utf-8", "replace")
+            return response.status, _read(response)
     except urllib.error.HTTPError as exc:
-        return exc.code, exc.read().decode("utf-8", "replace")
+        return exc.code, _read(exc)
     except urllib.error.URLError as exc:
-        # The one case with no HTTP answer: DNS, refused connection, TLS, timeout.
+        # The cases with no HTTP answer: DNS, refused connection, TLS, timeout.
         # `URLError` is already an `OSError`, but its `reason` is the readable half.
         raise OSError(exc.reason) from None
 

--- a/tests/unit/test_mcp_fetch.py
+++ b/tests/unit/test_mcp_fetch.py
@@ -34,6 +34,14 @@ class _Handler(BaseHTTPRequestHandler):
     """Echoes the method, path, User-Agent and any body; takes its status from the path."""
 
     def _answer(self):
+        if self.path == "/truncated":
+            body = b"partial"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body) + 10))
+            self.end_headers()
+            self.wfile.write(body)
+            self.close_connection = True
+            return
         status = 429 if self.path.startswith("/slow-down") else 200
         length = int(self.headers.get("Content-Length") or 0)
         received = self.rfile.read(length).decode("utf-8", "replace") if length else ""
@@ -109,3 +117,9 @@ def test_no_answer_at_all_raises_oserror():
         closed = probe.getsockname()[1]
     with pytest.raises(OSError):
         fetch(f"http://127.0.0.1:{closed}/r/lobby")
+
+
+def test_an_answer_truncated_in_transit_raises_oserror(origin):
+    """A proxy closing mid-body is a transport failure, not an internal urllib exception."""
+    with pytest.raises(OSError):
+        fetch(f"{origin}/truncated")


### PR DESCRIPTION
## What changes

The CPython MCP transport now treats a response that closes before its declared `Content-Length` as a transport failure. Instead of leaking `http.client.IncompleteRead` through the MCP call, it raises the transport seam's documented `OSError`; `server._request` can then return its normal actionable `ToolError("cannot reach …")`.

The response-body reader is shared by successful responses and `HTTPError` responses, so both paths keep the same contract.

## Reproduction

A loopback origin advertises a body ten bytes longer than it sends, then closes the connection. Before the fix:

```text
http.client.IncompleteRead: IncompleteRead(7 bytes read, 10 more expected)
```

The new regression test failed on the unmodified base and passes after the fix.

## Scope

- Verified against `main` at `a782b0c7c018fd9fe95eaee8fe11c807bf6ffe14`.
- No public API, persistence, configuration, dependency, or documentation-format change.
- No new public or abuse surface.
- No related open issue or pull request found for `IncompleteRead`, truncated response, partial body, or mid-body disconnect.

## Checks

- `uv sync --frozen`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run coverage run -m pytest tests -q` — 644 passed, 1 skipped
- `uv run coverage report` — 97.93%
- `uv run sz.py --check`
- `uv run sz.py --caps`
- `uv build --project mcp` + `tests/verify_mcp_dist.py`
- `git diff --check`
- secret/dangerous-pattern scan

## Proposed release note

MCP clients now receive the normal connectivity error when an HTTP response is truncated in transit, rather than an internal `IncompleteRead` exception.
