### PR TITLE
release: 0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+## [0.11.4] - 2026-09-02
+
+### Changed
+
+- **`/healthz` answers on the event loop instead of the thread pool.** It was a plain `def`,
+  so Starlette ran every liveness check in the anyio thread pool — one of the 40 threads a
+  worker has, and the moment that matters is the one where there are none. Measured the same
+  day: 2,478 of 2,480 `/healthz` requests in two minutes arrived through the tunnel rather
+  than from the container's own probes, 10.4% of all traffic, while the write path had 40 of
+  42 threads parked in `flock`. Nothing else changes: the response, the headers and the
+  `no-store` a direct caller receives are identical.
+
 ## [0.11.3] - 2026-09-02
 
 ### Fixed
@@ -1060,7 +1072,8 @@ this is the point it became a standalone, versioned, independently released proj
 - Per-IP token-bucket rate limiting with the retry delay in the 429 **body**, since agent harnesses
   show the page text and not the headers.
 
-[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.11.3...HEAD
+[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.11.4...HEAD
+[0.11.4]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.4
 [0.11.3]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.3
 [0.11.2]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.2
 [0.11.1]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.1

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.flop-labs/technocore-chat",
   "description": "Shared rooms and durable notes for agents over plain HTTP: rendezvous, hand-off, coordination.",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "status": "active",
   "websiteUrl": "https://technocore.chat",
   "repository": {
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "technocore-mcp",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -78,7 +78,7 @@ from .fetch import Fetch, urllib_fetch
 # here at build time, so the wheel, `initialize`'s serverInfo and the User-Agent cannot
 # disagree. `mcp/server.json` states it twice more, which a test and the release workflow
 # check against this constant.
-VERSION = "0.11.3"
+VERSION = "0.11.4"
 DEFAULT_URL = "https://technocore.chat"
 # The public instance's `?wait=` ceiling. Documentation and a default here, *not* a clamp:
 # CHAT_MAX_WAIT is a per-instance knob, and a wrapper enforcing 10 against an instance

--- a/mcp/worker/README.md
+++ b/mcp/worker/README.md
@@ -56,7 +56,7 @@ as `--no-build` but has no binary distribution ``. Re-run it after every change 
 
 **And rebuilding the wheel is not enough on its own.** pywrangler vendors the resolved set
 into `mcp/worker/python_modules/`, and it decides what to install from the wheel's *name*.
-A rebuild during development produces the same name — `technocore_mcp-0.11.3-py3-none-any.whl`
+A rebuild during development produces the same name — `technocore_mcp-0.11.4-py3-none-any.whl`
 — so the vendored copy is considered current and your change is silently left out of the
 bundle. Nothing fails; you deploy, the Worker runs, and it runs the old code. Clear the
 vendor directory whenever you change `mcp/src` without bumping the version:
@@ -103,7 +103,7 @@ something else. Delete it and you get the `workers.dev` URL above, or point it a
 you do hold.
 
 To serve a published release rather than this checkout, drop the `find-links` line from
-`[tool.uv]` in `pyproject.toml`. The dependency is an exact `technocore-mcp==0.11.3`, so with
+`[tool.uv]` in `pyproject.toml`. The dependency is an exact `technocore-mcp==0.11.4`, so with
 nothing pointing at `mcp/dist` the resolve takes that wheel from PyPI instead — and
 `uv build` stops being a prerequisite, because there is no local wheel in the picture.
 

--- a/mcp/worker/pyproject.toml
+++ b/mcp/worker/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # built it. See `[tool.uv]` below for why this is a wheel and not a path source, and
     # mcp/worker/README.md for the one command that produces it. Drop the `find-links`
     # below to resolve this from PyPI instead and deploy a published release.
-    "technocore-mcp==0.11.3",
+    "technocore-mcp==0.11.4",
     # Pulled in by the SDK anyway; named here so a resolve failure says which package
     # could not be built for wasm rather than surfacing three levels down.
     "mcp>=2.1,<3",

--- a/mcp/worker/uv.lock
+++ b/mcp/worker/uv.lock
@@ -603,14 +603,14 @@ wheels = [
 
 [[package]]
 name = "technocore-mcp"
-version = "0.11.3"
+version = "0.11.4"
 source = { registry = "../dist" }
 dependencies = [
     { name = "cryptography" },
     { name = "mcp" },
 ]
 wheels = [
-    { path = "technocore_mcp-0.11.3-py3-none-any.whl" },
+    { path = "technocore_mcp-0.11.4-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -631,7 +631,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = ">=2.1,<3" },
-    { name = "technocore-mcp", specifier = "==0.11.3" },
+    { name = "technocore-mcp", specifier = "==0.11.4" },
 ]
 
 [package.metadata.requires-dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "technocore-chat"
-version = "0.11.3"
+version = "0.11.4"
 description = "HTTP-native chat and notes for AI agents — over plain GETs or MCP"
 license = "Apache-2.0"
 # One Python, everywhere: `.python-version` pins what uv provisions locally and in CI, and

--- a/uv.lock
+++ b/uv.lock
@@ -1593,7 +1593,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.11.3"
+version = "0.11.4"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

Release 0.11.4. One commit since `v0.11.3`: `/healthz` answers on the event loop instead of
the anyio thread pool (#664).

## Why

`/healthz` was a plain `def`, so Starlette ran every liveness check in the thread pool — one
of the 40 threads a worker has, and the moment that matters is the one where there are none.
Measured 2026-09-02: **2,478 of 2,480 `/healthz` requests in two minutes arrived through the
tunnel** rather than from the container's own probes — 10.4% of all traffic — while the write
path had 40 of 42 threads parked in `flock` and the container healthcheck was failing on
exactly that, reporting the queue rather than the service.

PATCH: no route, parameter, response shape or documented cap moves. A direct caller receives
the same body, the same headers and the same `no-store`.

## Checks

- [x] `uv run coverage run -m pytest tests -q` — 646 passed, 1 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] `uv run sz.py --check`
- [x] `release.yml` gates verified locally: tag `0.11.4` matches `pyproject.toml`, CHANGELOG
      has a `## [0.11.4]` section
- [x] Version lockstep across `pyproject.toml`, `mcp/src/technocore_mcp/server.py`,
      `mcp/server.json`, `mcp/worker/pyproject.toml`, `mcp/worker/README.md`, and
      `mcp/worker/uv.lock` regenerated from a rebuilt wheel
- [x] New surface on a world-writable service: **nothing new** — packaging only

## Note

The edge half of #664 — the Worker lane holding `/healthz` for 10s — is **not** in this
release. It ships separately via `edge/deploy.sh` and is independent of the image.
