### PR TITLE
ci: let fork PRs pass the core size gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,15 @@ jobs:
       - name: Core size report and check
         run: |
           uv run sz.py
-          uv run sz.py --check
+          # Fork PRs cannot update sz-baseline.json: queue-guard protects that
+          # maintainer-generated file. Enforce the immutable policy caps on PRs;
+          # keep the ratchet check on pushes to main, where maintainers can
+          # regenerate the baseline after reviewing the merged change.
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            uv run sz.py --caps
+          else
+            uv run sz.py --check
+          fi
 
       # The example is the repo's one-command promise made executable: self-booting on
       # a free port, self-cleaning, deterministic. All four PR-#54 review findings lived

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,11 @@ below lives. Do not read a green check as permission. What only you can do:
   filing a competitor. If yours is materially different, say what the earlier one does not do
   and link it. Collisions that are not clear-cut are the maintainers' call, not a reason for
   mutual stand-down.
+- Core size has two gates with different jobs. Pull requests run `sz.py --caps`, which enforces
+  the immutable policy ceilings without requiring a contributor to edit the protected
+  `sz-baseline.json`. Pushes to `main` run `sz.py --check`, so maintainers can regenerate the
+  ratchet after an approved change. A PR that grows core code therefore does not need to make a
+  protected-file edit just to obtain a green CI result.
 
 ## Tests and checks
 


### PR DESCRIPTION
## Summary

Closes #655.

Fork pull requests that legitimately add a core code line cannot get a green CI result: `sz.py --check` rejects growth over the protected `sz-baseline.json` ratchet, while `queue-guard` rejects touching that same file. This PR separates the two size-policy jobs:

- pull requests run `sz.py --caps`, enforcing the immutable per-file and aggregate policy ceilings;
- pushes to `main` keep running `sz.py --check`, preserving the maintainer-controlled ratchet after review and merge.

The contributor guide documents the distinction so fork contributors have a supported path instead of an impossible pair of gates. No baseline or core code is changed.

## Verification

- `uv sync --frozen`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run coverage run -m pytest tests -q` — 646 passed, 1 skipped
- `uv run coverage report` — 97.93%
- `uv run sz.py --caps` — all caps pass
- `uv run sz.py --check` — check ok
- `git diff --check`
- workflow policy assertions — passed

Verified against `main` at `7771bb247e814da284b7e7867a40f8ba530fd10b`.
