### PR TITLE
docs(limit): stop advertising /healthz to throttled callers

### DIFF
--- a/src/limit.py
+++ b/src/limit.py
@@ -42,7 +42,20 @@ PROXY_IP_HEADERS = ("cf-connecting-ip", "x-forwarded-for", "x-real-ip", "true-cl
 # The paths that cost nothing, named once because the 429 body and the manual both list
 # them. A 429 that points at a path which is itself rate limited is advice that fails at
 # exactly the moment it is taken.
-FREE_PATHS = "/, /llms.txt, /skill.md, /patterns.md, /interop.md, /auth.md, /openapi.json, /config, /.well-known/* and /healthz"
+# The paths a throttled agent is told it may still reach. /healthz is NOT here, and its
+# absence is the point: it is genuinely never rate limited — the handler simply never calls
+# take() — but naming it in a 429 is handing a throttled caller a free endpoint at the exact
+# moment it is looking for one. Measured 2026-09-02: /healthz was 10.4% of all traffic
+# (19.6 req/s, 2,478 of 2,480 requests arriving through the tunnel rather than from the
+# container's own probes) while appearing in no other document. This list, rendered into the
+# manual as __FREE_PATHS__ and into every 429 body, was the only place the service mentioned
+# it in prose. The list stays honest either way: it promises the named paths are free, never
+# that they are the only free ones.
+#
+# The api-catalog still advertises /healthz as the service's `status` link, and /openapi.json
+# still describes the operation. Those are deliberate, machine-readable and asked for; a
+# rate-limit refusal is neither.
+FREE_PATHS = "/, /llms.txt, /skill.md, /patterns.md, /interop.md, /auth.md, /openapi.json, /config and /.well-known/*"
 
 # Bounded LRU, because every unseen IP would otherwise add entries forever and the
 # proxy's per-IP rule caps requests per IP, not the number of distinct IPs — a rotating


### PR DESCRIPTION
## What

Removes `/healthz` from `FREE_PATHS`. Nothing else changes — no route, no limit, no header.

## Why

`FREE_PATHS` is rendered into the manual as `__FREE_PATHS__` and into every 429 body, and it
was **the only place in the service's prose that mentioned `/healthz`**. Naming it in a
rate-limit refusal hands a throttled caller a free endpoint at the exact moment it is looking
for one.

Measured 2026-09-02: `/healthz` was **10.4% of all traffic** at 19.6 req/s, and **2,478 of
2,480** requests in a two-minute window arrived through the tunnel rather than from the
container's own probes — so almost none of it is ours. Its per-IP distribution is flat
(busiest client **11.5 requests/minute**, one check per five seconds), which is why a rate
limit does not help: there is no outlier to clip. Not advertising it fits the shape of the
traffic; throttling it does not.

**Behaviour is unchanged.** `FREE_PATHS` is a display string — `/healthz` is exempt because
`healthz()` never calls `take()`, and it still is. The list stays honest too: it promises the
named paths are free, never that they are the only ones, and
`test_every_path_the_429_calls_free_really_is_free` checks exactly that direction.

`/openapi.json` still describes the operation and `/.well-known/api-catalog` still carries it
as the service's `status` link. Those are deliberate and machine-readable; a rate-limit
refusal is neither.

## Checks

- [x] `uv run coverage run -m pytest tests -q` — 646 passed, 1 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] `uv run sz.py --check`
- [x] New surface on a world-writable service: **nothing new** — this removes advertising

## Deployer note

The Cloudflare read rule's custom response carries the same list and should drop `/healthz`
too, or the two surfaces disagree.
