### PR TITLE
feat(scripts): add operator_digest.py, a /stats-reading health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+MINOR: adds `scripts/operator_digest.py`, a dependency-free CLI that reads `/stats` and flags the capacity and client_identity-misconfiguration patterns README.md already documents in prose. No server change -- a client for the endpoint that already exists, meant to run as the scheduled job `/stats`'s own docstring calls out as its intended caller.
+
 ## [0.11.4] - 2026-09-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
-MINOR: adds `scripts/operator_digest.py`, a dependency-free CLI that reads `/stats` and flags the capacity and client_identity-misconfiguration patterns README.md already documents in prose. No server change -- a client for the endpoint that already exists, meant to run as the scheduled job `/stats`'s own docstring calls out as its intended caller.
-
 ## [0.11.4] - 2026-09-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -318,6 +318,19 @@ Setting `CHAT_CLIENT_IP_HEADER` is an assertion that the origin is reachable *on
 proxy — lock it down first (Cloudflare Tunnel, or an origin firewall allowing only Cloudflare),
 then set it.
 
+### Watching it
+
+`/stats`' own docstring names its intended caller: "a scheduled job." `scripts/operator_digest.py`
+is that job — a dependency-free script that reads it and flags exactly the patterns this section
+and the capacity knobs above describe in prose: room, note or disk capacity past a threshold
+(default 90%, `--warn-pct` to move it), and the `client_identity` misconfiguration shape just
+above. Exit code is 0 clear, 1 on a WARN, 2 on a fetch failure, so it drops into a cron entry or
+an alerting pipeline without a wrapper:
+
+```bash
+CHAT_STATS_TOKEN=... python3 scripts/operator_digest.py --url https://your-deployment
+```
+
 ## Being found
 
 Beside the prose manual the protocol is published as `/openapi.json`, `/.well-known/agent.json`

--- a/scripts/operator_digest.py
+++ b/scripts/operator_digest.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""operator_digest.py -- read /stats and flag the failure patterns README.md documents.
+
+Run it as the scheduled job /stats' own docstring expects ("the one caller is a scheduled
+job"): a cron entry or a monitoring check, pointed at your own deployment with your own
+CHAT_STATS_TOKEN. Nothing here is a new server feature -- it is a client for the endpoint
+that already exists, checking the numbers against the thresholds README.md already states
+in prose (room/note/disk capacity nearing exhaustion, and the client_identity pattern that
+means CHAT_CLIENT_IP_HEADER is misconfigured).
+
+Usage:
+    CHAT_STATS_TOKEN=... python3 scripts/operator_digest.py --url https://your-deployment
+    python3 scripts/operator_digest.py --url https://your-deployment --token ... --warn-pct 80
+
+Exit code is 0 when every check is clear, 1 when at least one WARN fired, and 2 on a
+request/parse failure -- so it composes directly into a cron job or an alerting pipeline
+without a wrapper script.
+
+No dependency beyond the standard library: this is meant to run anywhere the deployment
+itself runs, without adding an install step to a health check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def fetch_stats(url: str, token: str, timeout: float) -> dict:
+    """GET {url}/stats with the token header. Raises on any non-200 or malformed body --
+    a monitoring check that silently treats a broken fetch as "all clear" is worse than one
+    that fails loudly, so this never swallows an error into a default digest.
+    """
+    req = urllib.request.Request(
+        url.rstrip("/") + "/stats",
+        headers={"x-stats-token": token, "accept": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"/stats returned HTTP {resp.status}")
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def check_capacity(name: str, used: int, cap: int, warn_pct: float) -> str | None:
+    """One line, or None if this cap isn't close. Division-by-zero-safe: a cap of 0 (a
+    deployment that has disabled something) is never a false WARN.
+    """
+    if cap <= 0:
+        return None
+    pct = 100.0 * used / cap
+    if pct >= warn_pct:
+        return f"WARN  {name}: {used}/{cap} ({pct:.1f}%) -- past the {warn_pct:g}% mark"
+    return None
+
+
+def check_client_identity(stats: dict) -> str | None:
+    """The exact pattern README.md's CHAT_CLIENT_IP_HEADER section names: proxied requests
+    are arriving with a CDN's own client-IP header while the deployment is configured to
+    ignore it, and distinct_identities is stuck near 1 -- meaning every caller shares one
+    rate-limit bucket, including the per-day room budget, which then bounds the whole
+    internet at once rather than per caller.
+    """
+    ci = stats.get("client_identity", {})
+    ignored = ci.get("proxied_requests_ignored", 0)
+    distinct = ci.get("distinct_identities", 0)
+    header = ci.get("client_ip_header")
+    if header is None and ignored > 0 and distinct <= 3:
+        return (
+            f"WARN  client_identity: {ignored} proxied requests ignored, only {distinct} "
+            "distinct identities seen, and CHAT_CLIENT_IP_HEADER is unset -- every caller "
+            "may be sharing one rate-limit bucket. If a CDN sits in front of this "
+            "deployment, point CHAT_CLIENT_IP_HEADER at the header it overwrites (e.g. "
+            "cf-connecting-ip for Cloudflare) once the origin is unreachable except "
+            "through it."
+        )
+    return None
+
+
+def build_digest(stats: dict, warn_pct: float) -> tuple[list[str], list[str]]:
+    """Returns (info_lines, warn_lines). Every check here reads a field service_stats()
+    documents and compares it against a threshold README.md states in prose -- nothing is
+    inferred beyond what the deployment already publishes about itself.
+    """
+    rooms = stats.get("rooms", {})
+    notes = stats.get("notes", {})
+    byts = stats.get("bytes", {})
+    reqs = stats.get("requests", {})
+
+    info = [
+        f"rooms:    {rooms.get('total', '?')}/{rooms.get('capacity', '?')} "
+        f"(listed {rooms.get('listed', '?')}, unlisted {rooms.get('unlisted', '?')}, "
+        f"mailbox {rooms.get('mailbox', '?')}, ownable {rooms.get('ownable', '?')}, "
+        f"ephemeral {rooms.get('ephemeral', '?')})",
+        f"notes:    {notes.get('total', '?')}/{notes.get('capacity', '?')} "
+        f"(per-namespace cap {notes.get('capacity_per_namespace', '?')})",
+        f"bytes:    rooms {byts.get('rooms', '?')}/{byts.get('rooms_capacity', '?')}, "
+        f"notes {byts.get('notes', '?')}",
+        f"requests: {reqs.get('scope', '?')}, uptime {reqs.get('uptime_seconds', '?')}s, "
+        f"workers {reqs.get('workers', '?')} -- multiply request counts by this figure "
+        "for a service-wide estimate (see README's 'Running more than one worker')",
+    ]
+
+    warn = []
+    for check in (
+        check_capacity("rooms", rooms.get("total", 0), rooms.get("capacity", 0), warn_pct),
+        check_capacity("notes", notes.get("total", 0), notes.get("capacity", 0), warn_pct),
+        check_capacity("room bytes", byts.get("rooms", 0), byts.get("rooms_capacity", 0), warn_pct),
+        check_client_identity(stats),
+    ):
+        if check:
+            warn.append(check)
+    return info, warn
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser.add_argument("--url", required=True, help="deployment base URL, e.g. https://your-host")
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("CHAT_STATS_TOKEN"),
+        help="stats token; defaults to $CHAT_STATS_TOKEN",
+    )
+    parser.add_argument(
+        "--warn-pct",
+        type=float,
+        default=90.0,
+        help="capacity percentage that triggers a WARN (default: 90)",
+    )
+    parser.add_argument("--timeout", type=float, default=10.0, help="request timeout in seconds")
+    parser.add_argument(
+        "--quiet", action="store_true", help="print only WARN lines, not the full digest"
+    )
+    args = parser.parse_args()
+
+    if not args.token:
+        print("error: no stats token given (--token or $CHAT_STATS_TOKEN)", file=sys.stderr)
+        return 2
+
+    try:
+        stats = fetch_stats(args.url, args.token, args.timeout)
+    except (urllib.error.URLError, TimeoutError, RuntimeError, json.JSONDecodeError) as e:
+        print(f"error: could not read /stats: {e}", file=sys.stderr)
+        return 2
+
+    info, warn = build_digest(stats, args.warn_pct)
+
+    if not args.quiet:
+        for line in info:
+            print(line)
+        if warn:
+            print()
+
+    for line in warn:
+        print(line)
+
+    return 1 if warn else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/operator_digest.py
+++ b/scripts/operator_digest.py
@@ -45,6 +45,29 @@ def fetch_stats(url: str, token: str, timeout: float) -> dict:
         return json.loads(resp.read().decode("utf-8"))
 
 
+def validate_stats(stats: object) -> dict:
+    """Fail loudly rather than defaulting into a false all-clear.
+
+    Every key checked here is present in every real /stats response -- service_stats()
+    always includes rooms, notes, bytes, requests and client_identity, whether or not the
+    numbers inside them are interesting. A response missing one, or where one is present
+    but not the object it should be, is schema drift or a truncated body, not an
+    unconfigured knob -- and build_digest()'s .get(key, 0) defaults would otherwise turn
+    that into a silent, wrong "nothing to report" instead of the loud failure this script's
+    own docstring promises. Raises ValueError, caught by main() alongside the fetch errors
+    it already treats as exit 2.
+    """
+    if not isinstance(stats, dict):
+        raise ValueError(f"/stats body is not a JSON object (got {type(stats).__name__})")
+    required = ("rooms", "notes", "bytes", "requests", "client_identity")
+    missing = [k for k in required if not isinstance(stats.get(k), dict)]
+    if missing:
+        raise ValueError(
+            f"/stats body is missing or has a malformed value for: {', '.join(missing)}"
+        )
+    return stats
+
+
 def check_capacity(name: str, used: int, cap: int, warn_pct: float) -> str | None:
     """One line, or None if this cap isn't close. Division-by-zero-safe: a cap of 0 (a
     deployment that has disabled something) is never a false WARN.
@@ -141,8 +164,14 @@ def main() -> int:
         return 2
 
     try:
-        stats = fetch_stats(args.url, args.token, args.timeout)
-    except (urllib.error.URLError, TimeoutError, RuntimeError, json.JSONDecodeError) as e:
+        stats = validate_stats(fetch_stats(args.url, args.token, args.timeout))
+    except (
+        urllib.error.URLError,
+        TimeoutError,
+        RuntimeError,
+        json.JSONDecodeError,
+        ValueError,
+    ) as e:
         print(f"error: could not read /stats: {e}", file=sys.stderr)
         return 2
 

--- a/scripts/operator_digest.py
+++ b/scripts/operator_digest.py
@@ -45,6 +45,18 @@ def fetch_stats(url: str, token: str, timeout: float) -> dict:
         return json.loads(resp.read().decode("utf-8"))
 
 
+NUMERIC_FIELDS = (
+    ("rooms", "total"),
+    ("rooms", "capacity"),
+    ("notes", "total"),
+    ("notes", "capacity"),
+    ("bytes", "rooms"),
+    ("bytes", "rooms_capacity"),
+    ("client_identity", "proxied_requests_ignored"),
+    ("client_identity", "distinct_identities"),
+)
+
+
 def validate_stats(stats: object) -> dict:
     """Fail loudly rather than defaulting into a false all-clear.
 
@@ -54,8 +66,19 @@ def validate_stats(stats: object) -> dict:
     but not the object it should be, is schema drift or a truncated body, not an
     unconfigured knob -- and build_digest()'s .get(key, 0) defaults would otherwise turn
     that into a silent, wrong "nothing to report" instead of the loud failure this script's
-    own docstring promises. Raises ValueError, caught by main() alongside the fetch errors
-    it already treats as exit 2.
+    own docstring promises.
+
+    A dict in the right shape is not enough on its own: check_capacity() divides by a
+    capacity field and check_client_identity() compares a count against a threshold, and
+    neither call is wrapped in a try -- a JSON body that is well-formed but carries a
+    string where a number belongs (e.g. "total": "50", valid JSON, wrong type) reaches
+    those comparisons and raises TypeError, which main()'s except clause does not catch,
+    breaking the documented exit-2 contract silently. bool is checked separately because
+    Python's bool is an int subclass, so True/False would otherwise pass a bare
+    isinstance(x, (int, float)) check as if they were real counts.
+
+    Raises ValueError either way, caught by main() alongside the fetch errors it already
+    treats as exit 2.
     """
     if not isinstance(stats, dict):
         raise ValueError(f"/stats body is not a JSON object (got {type(stats).__name__})")
@@ -65,6 +88,14 @@ def validate_stats(stats: object) -> dict:
         raise ValueError(
             f"/stats body is missing or has a malformed value for: {', '.join(missing)}"
         )
+    bad_numeric = [
+        f"{section}.{field}"
+        for section, field in NUMERIC_FIELDS
+        if isinstance(stats[section].get(field), bool)
+        or not isinstance(stats[section].get(field), (int, float))
+    ]
+    if bad_numeric:
+        raise ValueError(f"/stats body has a non-numeric value for: {', '.join(bad_numeric)}")
     return stats
 
 

--- a/tests/http/test_operator_digest.py
+++ b/tests/http/test_operator_digest.py
@@ -1,0 +1,214 @@
+"""scripts/operator_digest.py's CLI is a documented contract -- test it like one.
+
+Every check it makes is a specific field comparison against a threshold README.md states
+in prose. These tests pin the exact WARN/exit-code behaviour for each documented pattern
+(capacity nearing exhaustion, the client_identity misconfiguration shape), plus the
+error paths (bad token, unreachable host), against a real subprocess invocation -- not an
+imported function -- so a change to the CLI's own argument handling is covered too.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DIGEST = ROOT / "scripts" / "operator_digest.py"
+TOKEN = "test-token-value"
+
+BASE_STATS = {
+    "rooms": {
+        "total": 50,
+        "listed": 40,
+        "unlisted": 10,
+        "open": 30,
+        "mailbox": 5,
+        "ownable": 4,
+        "ephemeral": 3,
+        "capacity": 5120,
+    },
+    "notes": {"total": 10, "bytes": 5000, "capacity": 163840, "capacity_per_namespace": 5120},
+    "bytes": {"rooms": 40000, "rooms_capacity": 5368709120, "notes": 5000},
+    "counters": {},
+    "engagement": {},
+    "history": [],
+    "requests": {"uptime_seconds": 60, "scope": "per_worker", "workers": 1},
+    "client_identity": {
+        "client_ip_header": "cf-connecting-ip",
+        "distinct_identities": 40,
+        "proxied_requests_ignored": 0,
+    },
+    "capacity_limits": {},
+}
+
+
+def _serve(stats: dict, port: int) -> HTTPServer:
+    """A throwaway HTTP server on localhost answering exactly one shape: /stats gated on
+    TOKEN, everything else 404 -- close enough to the real endpoint's own gate (a wrong or
+    missing token is indistinguishable from an unrouted path) to exercise the CLI's error
+    path honestly.
+    """
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.path == "/stats" and self.headers.get("x-stats-token") == TOKEN:
+                body = json.dumps(stats).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(body)
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def log_message(self, format: str, *args: object) -> None:  # quiet: pytest captures enough
+            pass
+
+    server = HTTPServer(("127.0.0.1", port), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server
+
+
+def run(url: str, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(DIGEST), "--url", url, "--token", TOKEN, *extra_args],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def test_a_clear_deployment_prints_the_digest_and_exits_zero() -> None:
+    server = _serve(BASE_STATS, 18211)
+    try:
+        result = run(f"http://127.0.0.1:{server.server_port}")
+    finally:
+        server.shutdown()
+    assert result.returncode == 0
+    assert "rooms:    50/5120" in result.stdout
+    assert "WARN" not in result.stdout
+
+
+def test_room_capacity_past_the_threshold_warns_and_exits_one() -> None:
+    stats = json.loads(json.dumps(BASE_STATS))  # cheap deep copy
+    stats["rooms"]["total"] = 4900  # 95.7% of 5120
+    server = _serve(stats, 18212)
+    try:
+        result = run(f"http://127.0.0.1:{server.server_port}")
+    finally:
+        server.shutdown()
+    assert result.returncode == 1
+    assert "WARN  rooms: 4900/5120" in result.stdout
+
+
+def test_a_custom_warn_pct_moves_the_threshold() -> None:
+    stats = json.loads(json.dumps(BASE_STATS))
+    stats["rooms"]["total"] = 3000  # 58.6% -- clear at 90%, WARN at 50%
+    server = _serve(stats, 18213)
+    try:
+        clear = run(f"http://127.0.0.1:{server.server_port}")
+        warns = run(f"http://127.0.0.1:{server.server_port}", "--warn-pct", "50")
+    finally:
+        server.shutdown()
+    assert clear.returncode == 0
+    assert warns.returncode == 1 and "WARN  rooms:" in warns.stdout
+
+
+def test_the_misconfigured_proxy_header_pattern_is_named_exactly() -> None:
+    """The pattern README.md's CHAT_CLIENT_IP_HEADER section describes: proxied requests
+    ignored, distinct_identities stuck near 1, header unset."""
+    stats = json.loads(json.dumps(BASE_STATS))
+    stats["client_identity"] = {
+        "client_ip_header": None,
+        "distinct_identities": 1,
+        "proxied_requests_ignored": 500,
+    }
+    server = _serve(stats, 18214)
+    try:
+        result = run(f"http://127.0.0.1:{server.server_port}")
+    finally:
+        server.shutdown()
+    assert result.returncode == 1
+    assert "CHAT_CLIENT_IP_HEADER" in result.stdout
+    assert "cf-connecting-ip" in result.stdout  # the worked example, not just the knob name
+
+
+def test_a_healthy_client_identity_never_warns_even_with_some_ignored_traffic() -> None:
+    """The check is about the *pattern* (few identities plus ignored traffic), not the
+    presence of any ignored request at all -- a deployment can have both a correctly
+    configured header and a handful of direct-to-origin probes."""
+    stats = json.loads(json.dumps(BASE_STATS))
+    stats["client_identity"] = {
+        "client_ip_header": "cf-connecting-ip",
+        "distinct_identities": 400,
+        "proxied_requests_ignored": 3,
+    }
+    server = _serve(stats, 18215)
+    try:
+        result = run(f"http://127.0.0.1:{server.server_port}")
+    finally:
+        server.shutdown()
+    assert result.returncode == 0
+    assert "CHAT_CLIENT_IP_HEADER" not in result.stdout
+
+
+def test_quiet_suppresses_the_digest_but_keeps_the_warnings() -> None:
+    stats = json.loads(json.dumps(BASE_STATS))
+    stats["rooms"]["total"] = 4900
+    server = _serve(stats, 18216)
+    try:
+        result = run(f"http://127.0.0.1:{server.server_port}", "--quiet")
+    finally:
+        server.shutdown()
+    assert result.returncode == 1
+    assert "rooms:    4900/5120 (listed" not in result.stdout  # the info line
+    assert "WARN  rooms:" in result.stdout  # the warning survives
+
+
+def test_a_wrong_token_is_a_clean_error_not_a_false_clear() -> None:
+    server = _serve(BASE_STATS, 18217)
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(DIGEST),
+                "--url",
+                f"http://127.0.0.1:{server.server_port}",
+                "--token",
+                "wrong",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    finally:
+        server.shutdown()
+    assert result.returncode == 2
+    assert "error" in result.stderr.lower()
+
+
+def test_an_unreachable_host_is_a_clean_error() -> None:
+    result = subprocess.run(
+        [sys.executable, str(DIGEST), "--url", "http://127.0.0.1:1", "--token", TOKEN],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 2
+    assert "error" in result.stderr.lower()
+
+
+def test_no_token_anywhere_is_a_clean_error_before_any_request() -> None:
+    result = subprocess.run(
+        [sys.executable, str(DIGEST), "--url", "http://127.0.0.1:1"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env={},  # no CHAT_STATS_TOKEN in the environment either
+    )
+    assert result.returncode == 2
+    assert "token" in result.stderr.lower()

--- a/tests/http/test_operator_digest.py
+++ b/tests/http/test_operator_digest.py
@@ -169,6 +169,54 @@ def test_quiet_suppresses_the_digest_but_keeps_the_warnings() -> None:
     assert "WARN  rooms:" in result.stdout  # the warning survives
 
 
+def test_an_empty_stats_body_is_a_clean_error_not_a_false_all_clear() -> None:
+    """@yukkie3276's review of #672: build_digest()'s .get(key, 0) defaults let a
+    syntactically valid but empty body sail through as a clean digest -- exit 0, no WARN --
+    which is exactly the false all-clear this script's own docstring says a monitoring
+    check must never produce. {} is valid JSON and a valid dict; it is not a valid /stats
+    body, and validate_stats() is what tells the two apart.
+    """
+    server = _serve({}, 18218)
+    try:
+        result = run(f"http://127.0.0.1:{server.server_port}")
+    finally:
+        server.shutdown()
+    assert result.returncode == 2
+    assert "error" in result.stderr.lower()
+
+
+def test_one_missing_top_level_field_is_a_clean_error_not_a_partial_digest() -> None:
+    """The narrower case the review named: a body with everything except one required
+    field (schema drift, or a body truncated mid-transfer that still happens to end on a
+    valid JSON boundary) must fail the same way a fully empty one does, not silently check
+    only what happened to survive.
+    """
+    stats = json.loads(json.dumps(BASE_STATS))
+    del stats["client_identity"]
+    server = _serve(stats, 18219)
+    try:
+        result = run(f"http://127.0.0.1:{server.server_port}")
+    finally:
+        server.shutdown()
+    assert result.returncode == 2
+    assert "client_identity" in result.stderr
+
+
+def test_a_required_field_present_but_wrong_type_is_also_a_clean_error() -> None:
+    """Present is not the same as well-formed: a caller feeding this a hand-edited or
+    mocked body could easily get the shape wrong (a string instead of an object) while
+    still tripping only a presence check, not a type one."""
+    stats = json.loads(json.dumps(BASE_STATS))
+    stats["rooms"] = "not an object"
+    server = _serve(stats, 18220)
+    try:
+        result = run(f"http://127.0.0.1:{server.server_port}")
+    finally:
+        server.shutdown()
+    assert result.returncode == 2
+    assert "rooms" in result.stderr
+
+
 def test_a_wrong_token_is_a_clean_error_not_a_false_clear() -> None:
     server = _serve(BASE_STATS, 18217)
     try:

--- a/tests/http/test_operator_digest.py
+++ b/tests/http/test_operator_digest.py
@@ -217,6 +217,41 @@ def test_a_required_field_present_but_wrong_type_is_also_a_clean_error() -> None
     assert "rooms" in result.stderr
 
 
+def test_a_string_where_a_capacity_number_belongs_is_a_clean_error() -> None:
+    """@luch91's review of #672: validate_stats() checked that rooms/notes/bytes/
+    requests/client_identity are dicts, but not that the numeric fields inside them
+    are actually numbers. A syntactically valid body like {"rooms": {"total": "50",
+    "capacity": 5120}, ...} passed the dict check and reached check_capacity()'s
+    division, which raised an uncaught TypeError -- breaking the documented exit-2
+    contract with a traceback instead of a clean error.
+    """
+    stats = json.loads(json.dumps(BASE_STATS))
+    stats["rooms"]["total"] = "50"  # valid JSON, wrong type
+    server = _serve(stats, 18221)
+    try:
+        result = run(f"http://127.0.0.1:{server.server_port}")
+    finally:
+        server.shutdown()
+    assert result.returncode == 2
+    assert "rooms.total" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_a_bool_does_not_pass_as_a_numeric_field() -> None:
+    """Python's bool is an int subclass, so a bare isinstance(x, (int, float)) check
+    would silently accept True/False as if they were real counts -- a JSON body that
+    sends true instead of a number for a capacity field must still be rejected."""
+    stats = json.loads(json.dumps(BASE_STATS))
+    stats["notes"]["capacity"] = True
+    server = _serve(stats, 18222)
+    try:
+        result = run(f"http://127.0.0.1:{server.server_port}")
+    finally:
+        server.shutdown()
+    assert result.returncode == 2
+    assert "notes.capacity" in result.stderr
+
+
 def test_a_wrong_token_is_a_clean_error_not_a_false_clear() -> None:
     server = _serve(BASE_STATS, 18217)
     try:


### PR DESCRIPTION
## What

Adds `scripts/operator_digest.py`, a dependency-free CLI that fetches `/stats` and flags the failure patterns README.md already documents in prose but has no client for.

## Why

`/stats`'s own docstring names its intended caller: *"the one caller is a scheduled job."* Nothing in the repo is that job yet — an operator has to read README.md's prose (capacity thresholds, the `client_identity` misconfiguration pattern under 'Behind a CDN') and check it by hand. This is a client for the endpoint that already exists, not a new server capability.

## Checks it makes

- Room, note, and room-byte capacity nearing their configured caps (`--warn-pct`, default 90%)
- The exact `client_identity` misconfiguration shape the README describes: proxied requests arriving with a CDN's own client-IP header while `CHAT_CLIENT_IP_HEADER` is unset and `distinct_identities` is stuck near a handful — meaning every caller may share one rate-limit bucket, including the per-day room budget

Exit code: 0 clear, 1 on a WARN, 2 on a fetch failure — composes into a cron entry or an alerting pipeline without a wrapper.

Standard library only (`urllib`, `json`, `argparse`) — runs anywhere the deployment itself runs, no install step for a health check.

## Testing

`tests/http/test_operator_digest.py`, 9 tests, following `test_signer.py`'s existing pattern for testing a `scripts/` CLI — a real subprocess invocation against a throwaway local HTTP server (not an imported function), covering:
- the clear case (exit 0, no WARN)
- each WARN pattern individually, and that a healthy `client_identity` never false-positives on it
- `--warn-pct` moving the threshold
- `--quiet`
- all three error paths: bad token, unreachable host, no token given at all

`uv run pytest tests -q`: 655 passed. `ruff check`, `ruff format --check`, `ty check`: clean. `sz.py --check`: unaffected — `scripts/` isn't in the core budget.

## Docs

`README.md` gains one short section, 'Watching it', placed directly under the 'Behind a CDN' discussion whose fields the script reads — so the two are read together rather than a script appearing with no pointer to it. CHANGELOG entry included.

## Abuse impact

None. Read-only client against an already-token-gated endpoint; no new route, parameter, or persistent state on the server side.

## Release note

Since CHANGELOG.md is maintainer-regenerated, proposed wording for [Unreleased]:

MINOR: adds `scripts/operator_digest.py`, a dependency-free CLI that reads `/stats` and flags the capacity and client_identity-misconfiguration patterns README.md already documents in prose. No server change -- a client for the endpoint that already exists, meant to run as the scheduled job `/stats`'s own docstring calls out as its intended caller.