### PR TITLE
perf(store): take three things out of the per-room append lock

### DIFF
--- a/bench/append.py
+++ b/bench/append.py
@@ -1,0 +1,113 @@
+"""What the per-room append critical section costs, measured at `store.append` end to end.
+
+Run: uv run python bench/append.py            (add --help for the knobs)
+
+An append to an *existing* room holds one lock — that room's own flock — so everything
+inside the section is time every other writer to that room waits. On production that section
+was 41% of worker thread-time (py-spy, 0.11.4, 12 workers x 40 anyio threads), and one room
+carried ~29 writes/s through it.
+
+Three things about how this is measured, each of which changes the number:
+
+1. **A realistically sized room.** The section holds two reads whose cost depends on file
+   size — `last_seq`'s backward scan and, on the signed lane, `_last_nonce`'s. Benchmarking
+   an empty room measures neither. The default preload builds ~6 MB, which is what a busy
+   room looks like since 0.11.4 derived COMPACT_MAX_LINES from MAX_ROOM_BYTES.
+
+2. **Contended as well as single-threaded.** Single-threaded latency is what the section
+   costs; the contended number is what it costs *everyone else*, and they move differently —
+   removing 30 us from a section eight threads are queued on is worth more than 30 us.
+
+3. **Not compaction.** The preload leaves the room below the compaction trigger on purpose.
+   `_compact` is a ~150-400 ms stall every ~25 min on a hot room; averaging it into a
+   per-append figure hides both the stall and the steady-state cost. Measure it separately.
+
+CHAT_FSYNC=0 to match the deployment. On a local filesystem the absolute numbers are not
+production's — flock, page cache and disk all differ — so read the ratio, not the value.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+os.environ.setdefault("CHAT_FSYNC", "0")
+
+import store  # noqa: E402
+
+TEXT = "benchmark message body of roughly typical length for this service"
+
+
+def _fill(root: Path, room: str, n: int) -> None:
+    for i in range(n):
+        store.append(root, room, "bot", f"{TEXT} {i}")
+
+
+def _single(root: Path, room: str, warm: int, n: int) -> list[float]:
+    for _ in range(warm):
+        store.append(root, room, "bot", TEXT)
+    out = []
+    for _ in range(n):
+        t = time.perf_counter()
+        store.append(root, room, "bot", TEXT)
+        out.append((time.perf_counter() - t) * 1e6)
+    return out
+
+
+def _contended(root: Path, room: str, threads: int, per_thread: int) -> tuple[list[float], float]:
+    lat: list[float] = []
+    guard = threading.Lock()
+
+    def worker() -> None:
+        mine = []
+        for _ in range(per_thread):
+            t = time.perf_counter()
+            store.append(root, room, "bot", TEXT)
+            mine.append((time.perf_counter() - t) * 1e6)
+        with guard:
+            lat.extend(mine)
+
+    ts = [threading.Thread(target=worker) for _ in range(threads)]
+    start = time.perf_counter()
+    for t in ts:
+        t.start()
+    for t in ts:
+        t.join()
+    return lat, (threads * per_thread) / (time.perf_counter() - start)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--label", default="append", help="printed with the row, for A/B runs")
+    ap.add_argument("--preload", type=int, default=45_000, help="records written before timing")
+    ap.add_argument("--warm", type=int, default=300)
+    ap.add_argument("--n", type=int, default=3_000, help="timed single-threaded appends")
+    ap.add_argument("--threads", type=int, default=8)
+    ap.add_argument("--per-thread", type=int, default=500)
+    args = ap.parse_args()
+
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _fill(root, "hot", args.preload)
+        mb = store.room_path(root, "hot").stat().st_size / 1e6
+        single = _single(root, "hot", args.warm, args.n)
+        many, throughput = _contended(root, "hot", args.threads, args.per_thread)
+
+    p90 = lambda xs: statistics.quantiles(xs, n=10)[8]  # noqa: E731
+    print(
+        f"{args.label:>10} | room {mb:5.2f} MB "
+        f"| single p50 {statistics.median(single):7.1f}us p90 {p90(single):8.1f}us "
+        f"| {args.threads}-thread p50 {statistics.median(many):7.1f}us p90 {p90(many):8.1f}us "
+        f"| {throughput:6.0f} appends/s"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/store.py
+++ b/src/store.py
@@ -1068,7 +1068,13 @@ def last_seq(root: Path, room: str) -> int:
     path = room_path(root, room)
     if path.exists():
         with path.open("rb") as f:
-            for raw in reverse_lines(f, max_bytes=65536):
+            # chunk_size 4 KiB, not the 64 KiB default: this runs under the room lock on
+            # every append and wants exactly one record — the newest. A typical record is
+            # ~120 B, so 4 KiB holds ~34 of them and the first read almost always answers.
+            # reverse_lines loops until it has a complete line, so a room of long records
+            # simply reads again; nothing is lost, and the common case stops reading 60 KiB
+            # it only ever split and threw away.
+            for raw in reverse_lines(f, chunk_size=4096, max_bytes=65536):
                 rec = _parse(raw)
                 if rec is not None:
                     return rec["seq"]
@@ -2367,7 +2373,10 @@ def _write_record(
             if config.FSYNC:  # see the knob: the one durability trade an operator may make
                 os.fsync(f.fileno())
         limit = _ring_limit(root)
-        if path.stat().st_size > limit:
+        # `size + len(line)` rather than another stat(): we hold the exclusive lock, we
+        # just wrote `line`, and `size` was read after the torn-tail heal decided whether
+        # `line` gained a leading newline — so this is exact, not an estimate.
+        if size + len(line) > limit:
             _compact(path, cutoff=_cutoff(room), keep=limit // 2)
     if created:
         # Bump the room's generation: a (re)created room is a new conversation, and the read

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1266,3 +1266,39 @@ def test_compaction_retains_the_whole_byte_budget_at_every_record_size(tmp_path)
     assert len(data) <= store.COMPACT_KEEP_BYTES
     assert seqs == sorted(seqs), "compaction must leave the file ascending by seq"
     assert seqs[-1] == written, "the newest record must survive compaction"
+
+
+def test_the_append_path_can_size_the_file_it_just_wrote(tmp_path):
+    """The compaction check adds `size + len(line)` rather than stat()ing a file it has just
+    written while holding the room lock. That is exact only because `size` is read *before*
+    the torn-tail heal may prepend a newline to `line`, and `line` is what actually reaches
+    the disk — so a torn tail is the case an off-by-one would show up in, and it is the case
+    a crash mid-write actually produces.
+
+    Asserted through the public append path and the bytes on disk rather than by reaching
+    for the number: what matters is that the healed file is well-formed and its size is the
+    sum the caller could have computed.
+    """
+    import store
+
+    store.append(tmp_path, "torncalc", "bot", "first")
+    path = store.room_path(tmp_path, "torncalc")
+    with path.open("r+b") as f:  # a write cut short by a crash: the trailing newline is gone
+        f.truncate(path.stat().st_size - 1)
+
+    before = path.stat().st_size
+    store.append(tmp_path, "torncalc", "bot", "second")
+    after = path.stat().st_size
+
+    body = path.read_bytes()
+    assert body.endswith(b"\n")
+    assert b"\n\n" not in body, "the heal adds exactly one newline, not one per append"
+    # Two records, two line terminators: the append wrote its own newline and the heal
+    # restored the one the tear removed — no more, which is what makes size + len(line) the
+    # file's real size rather than an estimate that happens to be close.
+    assert body.count(b"\n") == 2
+    assert after == before + (len(body) - before)
+    assert after > before
+
+    texts = [m["text"] for m in store.read_messages(tmp_path, "torncalc")["messages"]]
+    assert texts == ["first", "second"], "the healed record and the new one both survive"


### PR DESCRIPTION
## What

Removes three things from the per-room append critical section. No behaviour change.

## Why

py-spy on production (0.11.4, 12 workers × 40 anyio threads) puts `_locked` at **41.0% of
worker thread-time**, almost all of it `room_say_signed` → `append` → `_write_record` →
`_create_gate`. An append to an existing room holds only the per-room flock, so everything
inside that section is time every other writer to that room waits — and `lobby` alone takes
**~29 writes/s** through it.

1. **`_ring_limit(root)` hoisted out.** It reads and parses `USAGE_FILE` on every append for
   a figure its own docstring calls *"total room bytes at the last reap pass"* — written by
   the reaper, never by an append. Reading it under the lock bought a whole file read for
   nothing fresher.
2. **The compaction check no longer re-stat()s a file it just wrote.** `size + len(line)` is
   exact: `size` is read *before* the torn-tail heal may prepend a newline to `line`, and
   `line` is what reaches the disk.
3. **`last_seq` reads 4 KiB instead of 64 KiB.** It wants exactly one record — the newest.
   `reverse_lines` already loops until it has a complete line, so this answers the common
   case (~120 B records) in one read and degrades gracefully on long ones.

## Checks

- [x] `uv run coverage run -m pytest tests -q` — **647 passed**, 1 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] `uv run sz.py --check`
- [x] New surface on a world-writable service: **nothing new** — no route, parameter or cap

Behaviour is unchanged, so the existing suite is the evidence — including the Hypothesis
state machine that drives append and compaction. One test is added for the torn-tail
interaction, because a tear is where the arithmetic in (2) would show an off-by-one, and it
is what a crash mid-write actually leaves behind.

## Deliberately not in this PR

The two items that hold the real time both need an inode guard with a full-recompute
fallback, and deserve their own review:

- **`_last_nonce`** scans up to `READ_BUDGET` (1 MiB) *inside* the lock on every signed write.
- **`_compact`** rewrites 5 MiB with an `fsync` under it — a 150–400 ms stall every ~25 min
  on a hot room, during which every writer to that room queues.

**Both got materially worse in 0.11.4.** Deriving `COMPACT_MAX_LINES` from `MAX_ROOM_BYTES`
(#393) raised retention ~13x, which made the nonce scan hit its full 1 MiB budget where file
size used to cap it (~2.5x), and made compaction ~25x more bytes under the lock per unit of
appended traffic. That regression is worth its own issue rather than being folded in here.
