### PR TITLE
feat(edge): serve /rooms from the edge copy and refresh it behind the request

### DIFF
--- a/bench/rooms.py
+++ b/bench/rooms.py
@@ -58,6 +58,25 @@ from pathlib import Path
 # would only measure the setup. Set before `store` is imported: config reads env at import.
 os.environ.setdefault("CHAT_FSYNC", "0")
 
+
+def _requested(flag: str, argv: list[str]) -> str | None:
+    for i, a in enumerate(argv):
+        if a == flag and i + 1 < len(argv):
+            return argv[i + 1]
+        if a.startswith(flag + "="):
+            return a.split("=", 1)[1]
+    return None
+
+
+# --rooms is read here rather than from the parsed args, because MAX_ROOMS is an import-time
+# read of CHAT_MAX_ROOMS and the room-creation gate refuses past it: a ladder asking for more
+# rooms than the cap does not measure a bigger store, it dies in setup. The deployed cap is a
+# config value and not the code default, and since the walk is O(rooms on disk) it is the
+# single knob that decides what this benchmark is measuring. Raise both together or neither.
+_rooms = _requested("--rooms", sys.argv[1:])
+if _rooms:
+    os.environ["CHAT_MAX_ROOMS"] = _rooms
+
 SRC = str(Path(__file__).resolve().parents[1] / "src")
 sys.path.insert(0, SRC)
 

--- a/bench/rooms.py
+++ b/bench/rooms.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""What a /rooms walk costs, and which half of it `limit` actually buys.
+
+Run: uv run python bench/rooms.py            (add --help for the knobs)
+
+`store.room_stats` does two things with very different shapes, and every question about
+/rooms turns on which of them dominates:
+
+1. **The walk.** One readdir over the room directory and one stat per room, to sort by
+   recency and total the bytes. O(rooms on disk); `limit` does not touch it.
+2. **The windows.** For the `limit` rooms actually shown, one bounded backwards read of
+   each room's tail (WINDOW_BYTES, WINDOW_MESSAGES) for `last_seq` and the engagement
+   aggregates. O(limit), memoized per room on `(st_mtime_ns, st_size)`.
+
+That memo is why the arms here matter more than the ladder. A room's entry dies the moment
+the room is written to, so the *recently active* rooms — exactly the ones a recency-sorted
+listing shows first — are the ones whose windows are least likely to be memoized. `cold` is
+that case, `warm` is an idle store, and production sits between them. Which end it sits
+nearer is what decides whether serving a smaller `limit` buys anything at all.
+
+Three things about how this is measured, each of which changes the number:
+
+1. **`store.room_stats`, not the endpoint.** The handler adds note stats and a rendering and
+   sits behind `_rooms_walk`'s LRU, which is keyed on `limit`; timing it through HTTP
+   measures that cache and the CDN in front of it. The walk is what this file is about.
+
+2. **The ladder runs ascending, and each point clears what it means to clear.** Measured
+   descending, every point warms the memo for the next and the cheap end reads as nearly
+   free. A curve collected that way cannot separate the walk from the windows, which is the
+   one thing it is collected to do.
+
+3. **The store is shaped like the real one, not filled uniformly.** Most rooms hold a
+   handful of records; a small head holds enough tail to fill a window. A store where every
+   room is deep overstates the windows, one where none are understates them. `--rooms` and
+   `--deep` are the two halves, and the head is written last so it sorts first.
+
+`--writers` adds threads appending to the head of the listing while the walk runs. It is not
+a proposal to change anything: it separates the walk's own work from time spent waiting on
+the per-room locks a writer holds, which no single-threaded arm can do.
+
+Builds its own store in a tempfile directory — never point it at a real one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import statistics
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+# Setup writes tens of thousands of records and the walk never fsyncs, so durability here
+# would only measure the setup. Set before `store` is imported: config reads env at import.
+os.environ.setdefault("CHAT_FSYNC", "0")
+
+SRC = str(Path(__file__).resolve().parents[1] / "src")
+sys.path.insert(0, SRC)
+
+import store  # noqa: E402
+
+LADDER = (1, 10, 25, 50, 100, 150, 200)
+
+
+def build(root: Path, rooms: int, deep: int, depth: int) -> float:
+    """A store of `rooms` rooms, the newest `deep` of them holding `depth` records each.
+
+    The deep rooms are written last, so they are the ones a recency-sorted listing reaches
+    first. That ordering is the whole point: a store whose deep rooms sort last would let
+    every limit below `rooms - deep` skip the tail reads entirely.
+    """
+    (root / "rooms").mkdir(parents=True, exist_ok=True)
+    t = time.perf_counter()
+    for i in range(max(0, rooms - deep)):
+        store._write_record(root, f"bench-s{i:06d}", "n0", "x")
+    for i in range(deep):
+        name = f"bench-d{i:06d}"
+        for j in range(depth):
+            store._write_record(root, name, f"n{j % 7}", "m" * 96)
+    return time.perf_counter() - t
+
+
+def once(root: Path, limit: int, cold: bool) -> float:
+    """One `room_stats` call. `cold` drops the window memo and nothing else — `_listable`
+    and the topic memo stay warm because in production they are: they survive writes."""
+    if cold:
+        store._cached_window.cache_clear()
+    t = time.perf_counter()
+    store.room_stats(root, limit=limit)
+    return time.perf_counter() - t
+
+
+def arm(root: Path, limit: int, cold: bool, reps: int) -> dict[str, float]:
+    if not cold:
+        store._cached_window.cache_clear()
+        store.room_stats(root, limit=limit)  # populate the memo; not measured
+    s = sorted(once(root, limit, cold) for _ in range(reps))
+    return {"median": statistics.median(s), "min": s[0], "max": s[-1]}
+
+
+def contended(root: Path, limit: int, reps: int, writers: int, deep: int) -> dict[str, float]:
+    """The cold arm again, with `writers` threads appending to the head of the listing.
+
+    Writers move the mtime of the rooms they touch, so they invalidate exactly the memo
+    entries the walk is about to want. That is not an artefact of the harness — it is the
+    production case, and it is why the contended arm is not simply the cold arm plus lock
+    wait.
+    """
+    stop = threading.Event()
+
+    def churn(k: int) -> None:
+        while not stop.is_set():
+            store._write_record(root, f"bench-d{k:06d}", "w", "churn")
+
+    threads = [
+        threading.Thread(target=churn, args=(i,), daemon=True)
+        for i in range(min(writers, max(1, deep)))
+    ]
+    for t in threads:
+        t.start()
+    try:
+        return arm(root, limit, True, reps)
+    finally:
+        stop.set()
+        for t in threads:
+            t.join(timeout=5)
+
+
+@dataclasses.dataclass
+class Row:
+    """One ladder point. The arms stay a dict because `--writers` decides how many there
+    are, but `limit` is its own field: it is arithmetic everywhere it is used."""
+
+    limit: int
+    arms: dict[str, dict[str, float]]
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--rooms", type=int, default=store.MAX_ROOMS, help="rooms on disk (default: the cap)"
+    )
+    p.add_argument("--deep", type=int, default=max(LADDER), help="how many hold a full window")
+    p.add_argument(
+        "--depth", type=int, default=store.WINDOW_MESSAGES, help="records in a deep room"
+    )
+    p.add_argument("--reps", type=int, default=5, help="timed calls per point")
+    p.add_argument("--writers", type=int, default=0, help="concurrent appenders, cold arm")
+    p.add_argument("--limits", type=int, nargs="+", default=list(LADDER))
+    p.add_argument("--json", action="store_true", help="emit the rows as JSON, not a table")
+    args = p.parse_args()
+
+    with tempfile.TemporaryDirectory(prefix="bench-rooms-") as tmp:
+        root = Path(tmp)
+        setup = build(root, args.rooms, args.deep, args.depth)
+        rows: list[Row] = []
+        for limit in sorted(args.limits):  # ascending: see the docstring
+            arms = {
+                "cold": arm(root, limit, True, args.reps),
+                "warm": arm(root, limit, False, args.reps),
+            }
+            if args.writers:
+                arms["contended"] = contended(root, limit, args.reps, args.writers, args.deep)
+            rows.append(Row(limit, arms))
+
+        meta = {
+            "rooms": args.rooms,
+            "deep": args.deep,
+            "depth": args.depth,
+            "reps": args.reps,
+            "writers": args.writers,
+            "window_bytes": store.WINDOW_BYTES,
+            "window_messages": store.WINDOW_MESSAGES,
+            "setup_seconds": round(setup, 1),
+        }
+        if args.json:
+            payload = [{"limit": r.limit, **r.arms} for r in rows]
+            print(json.dumps({"meta": meta, "rows": payload}, indent=2))
+            return 0
+
+        print(
+            f"{args.rooms} rooms, newest {args.deep} holding {args.depth} records "
+            f"(built in {setup:.1f}s); {args.reps} reps per point\n"
+        )
+        cols = ["cold", "warm"] + (["contended"] if args.writers else [])
+        print("limit  " + "".join(f"{c:>12}" for c in cols))
+        for r in rows:
+            print(
+                f"{r.limit:>5}  " + "".join(f"{r.arms[c]['median'] * 1000:>10.1f}ms" for c in cols)
+            )
+
+        # The limit-independent floor: at limit=1 the windows are one room, so what is left
+        # is the readdir and one stat per room. Everything above it is what `limit` buys.
+        if rows[0].limit == 1:
+            floor_ms = rows[0].arms["cold"]["median"] * 1000
+            top = rows[-1]
+            print(
+                f"\nwalk floor (limit=1, cold): {floor_ms:.1f}ms of the "
+                f"{top.arms['cold']['median'] * 1000:.1f}ms at limit={top.limit} — the rest "
+                f"is {top.limit - 1} window reads."
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/edge/snapshot.py
+++ b/edge/snapshot.py
@@ -89,44 +89,34 @@ STATIC_FIRST = {"/skill.md": "SKILL.md", "/patterns.md": "src/patterns.md"}
 EDGE_CACHED = {"/healthz": 10}
 
 # Served from the edge copy ALWAYS, refreshed in the background at most this often. Never
-# snapshotted: like /healthz these are live figures, and a stored answer for them would
-# outlive the service that produced it.
+# snapshotted: like /healthz these are live figures, and a stored answer would outlive the
+# service that produced it.
 #
-# This lane exists because /rooms cannot be made fast enough to wait for — and the reason is
-# not that the walk is expensive. bench/rooms.py measures it at tens of milliseconds on an
-# idle store, less than half of which is what `limit` buys; the same walk against concurrent
-# writers costs an order of magnitude more at *every* limit, including the limit that reads
-# no room tails at all. The cost is queueing, not work, so walking less does not remove it.
+# Not because the walk is expensive: bench/rooms.py measures it in the hundreds of
+# milliseconds, less than a tenth of which is what `limit` buys. Against concurrent writers it
+# costs an order of magnitude more at *every* limit, including the one that reads no room
+# tails. The cost is queueing, not work, so no cache window can be made reliably longer than
+# it and walking less does not help. Serving the copy and refreshing behind ctx.waitUntil()
+# is what stops a reader ever paying it.
 #
-# Plain caching cannot cover a cost with no upper bound. The origin's window is finite —
-# s-maxage plus stale-while-revalidate, both derived from CHAT_EDGE_CACHE_SECONDS — so
-# whenever a walk outlasts it the next reader pays the whole cost, and occupies an anyio
-# thread while doing so, which is the resource the box actually runs out of.
-#
-# Serving the stale copy unconditionally and refreshing behind ctx.waitUntil() inverts that:
-# no reader ever waits for a walk, and the data is as fresh as the origin can actually
-# produce rather than as fresh as we are willing to make people wait. The interval also
-# bounds how often the origin is asked, which is the part that frees the thread pool.
-EDGE_REVALIDATE = {"/rooms": 60}
+# The interval is short because /rooms is activity monitoring: `idle_seconds` and `last_seq`
+# are the payload, and a stale copy misreports exactly what a reader came for. It has a floor
+# rather than a target — test_the_refresh_interval_is_not_faster_than_the_origin_can_answer.
+EDGE_REVALIDATE = {"/rooms": 5}
 
-# What a /rooms cache key is made of. The handler reads exactly two query parameters and
-# clamps one of them, so /rooms?limit=999999999, /rooms?limit=200 and /rooms?limit=200&x=1
-# are one reply — and a cache keyed on the raw URL stores them as three, which hands a caller
-# a way to force a cold walk on every request by incrementing a digit. app.py fixed exactly
-# this for its own cache ("the key space is the reply space"); a lane that caches in front of
-# it has to carry the same fix, or it reintroduces the bug one layer out.
+# What a /rooms cache key is made of. The handler reads only `limit` and `format` and clamps
+# the first, so /rooms?limit=999999999, ?limit=200 and ?limit=200&x=1 are one reply — and a
+# key built from the raw URL stores them as three, letting a caller force a cold walk per
+# request by incrementing a digit. app.py fixed this for its own cache ("the key space is the
+# reply space"); a lane in front of it has to carry the same fix.
 #
 # `match` names a parameter that matters only when it equals one value: `format=json` picks
-# the rendering and every other value, a typo included, is ignored. `clamped` names a numeric
-# one and carries its bounds.
+# the rendering, every other value is ignored. `clamped` names a numeric one and its bounds.
 #
-# The ceiling is read from the tree rather than from the served schema, which is the opposite
-# of what this file does everywhere else and is deliberate: /rooms' `limit` is an *advisory*
-# parameter, so by the input doctrine it publishes no `minimum`/`maximum` at all — bounds in
-# a schema say a value outside them is refused, and this one clamps (test_input_doctrine.py
-# asserts their absence). store.MAX_LIMIT is a plain constant rather than a config knob, so
-# the checkout being deployed is an exact source for it, and the alternative is a second copy
-# of the number in JS.
+# The ceiling comes from the tree, not the served schema, which is the opposite of what this
+# file does elsewhere: `limit` is advisory, so by the input doctrine it publishes no
+# minimum/maximum — bounds mean refusal and this clamps (test_input_doctrine.py asserts their
+# absence). MAX_LIMIT is a constant rather than a knob, so the checkout is an exact source.
 ROOMS_KEY_MATCH = {"format": "json"}
 
 

--- a/edge/snapshot.py
+++ b/edge/snapshot.py
@@ -88,13 +88,16 @@ EDGE_CACHED = {"/healthz": 10}
 # snapshotted: like /healthz these are live figures, and a stored answer for them would
 # outlive the service that produced it.
 #
-# This lane exists because /rooms cannot be made fast enough to wait for. It is an
-# O(total-rooms) walk (technocore-chat#576) that measured 52.7% of worker thread-time at
-# 0.9 req/s, and a single uncached call took 32.6s. Plain caching cannot cover that: the
-# origin header is s-maxage=5 with stale-while-revalidate=25, a 30s window against a walk
-# that outlasts it, so the window always closes first and some reader pays the whole cost.
-# Worse, that reader occupies an anyio thread for the duration, which is why an unrelated
-# /r/<room> read on the same box measured 3.3s to 21.4s for 17 KB — queueing, not work.
+# This lane exists because /rooms cannot be made fast enough to wait for — and the reason is
+# not that the walk is expensive. bench/rooms.py measures it at tens of milliseconds on an
+# idle store, less than half of which is what `limit` buys; the same walk against concurrent
+# writers costs an order of magnitude more at *every* limit, including the limit that reads
+# no room tails at all. The cost is queueing, not work, so walking less does not remove it.
+#
+# Plain caching cannot cover a cost with no upper bound. The origin's window is finite —
+# s-maxage plus stale-while-revalidate, both derived from CHAT_EDGE_CACHE_SECONDS — so
+# whenever a walk outlasts it the next reader pays the whole cost, and occupies an anyio
+# thread while doing so, which is the resource the box actually runs out of.
 #
 # Serving the stale copy unconditionally and refreshing behind ctx.waitUntil() inverts that:
 # no reader ever waits for a walk, and the data is as fresh as the origin can actually

--- a/edge/snapshot.py
+++ b/edge/snapshot.py
@@ -26,6 +26,10 @@ import pathlib
 import sys
 import urllib.request
 
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))
+
+import store  # noqa: E402  — for MAX_LIMIT only; see ROOMS_KEY_MATCH below
+
 # Every route in app.py that renders a document. Deliberately explicit: this list and the
 # `routes` in wrangler.jsonc describe the same surface and are checked against each other
 # by test_edge_snapshot_covers_every_routed_document.
@@ -105,6 +109,36 @@ EDGE_CACHED = {"/healthz": 10}
 # bounds how often the origin is asked, which is the part that frees the thread pool.
 EDGE_REVALIDATE = {"/rooms": 60}
 
+# What a /rooms cache key is made of. The handler reads exactly two query parameters and
+# clamps one of them, so /rooms?limit=999999999, /rooms?limit=200 and /rooms?limit=200&x=1
+# are one reply — and a cache keyed on the raw URL stores them as three, which hands a caller
+# a way to force a cold walk on every request by incrementing a digit. app.py fixed exactly
+# this for its own cache ("the key space is the reply space"); a lane that caches in front of
+# it has to carry the same fix, or it reintroduces the bug one layer out.
+#
+# `match` names a parameter that matters only when it equals one value: `format=json` picks
+# the rendering and every other value, a typo included, is ignored. `clamped` names a numeric
+# one and carries its bounds.
+#
+# The ceiling is read from the tree rather than from the served schema, which is the opposite
+# of what this file does everywhere else and is deliberate: /rooms' `limit` is an *advisory*
+# parameter, so by the input doctrine it publishes no `minimum`/`maximum` at all — bounds in
+# a schema say a value outside them is refused, and this one clamps (test_input_doctrine.py
+# asserts their absence). store.MAX_LIMIT is a plain constant rather than a config knob, so
+# the checkout being deployed is an exact source for it, and the alternative is a second copy
+# of the number in JS.
+ROOMS_KEY_MATCH = {"format": "json"}
+
+
+def rooms_key() -> dict:
+    """The /rooms cache-key spec, with the ceiling taken from the code being deployed."""
+    return {
+        "/rooms": {
+            "match": dict(ROOMS_KEY_MATCH),
+            "clamped": {"limit": {"min": 1, "max": store.MAX_LIMIT}},
+        }
+    }
+
 
 def asset_name(path: str) -> str:
     """Where a URL path is stored under public/.
@@ -165,6 +199,15 @@ def main() -> int:
             print(f"  {line}", file=sys.stderr)
         return 1
 
+    edge_key = rooms_key()
+    unspecified = sorted(set(EDGE_REVALIDATE) - set(edge_key))
+    if unspecified:
+        # Fail closed. Without a key spec the Worker would have to key on the raw URL, which
+        # is the multiplication bug above — a deploy that silently did that is worse than one
+        # that stops here, because nothing downstream would report it.
+        print(f"\nsnapshot FAILED: no cache-key spec for {unspecified}", file=sys.stderr)
+        return 1
+
     pathlib.Path(args.manifest).write_text(
         json.dumps(
             {
@@ -172,6 +215,7 @@ def main() -> int:
                 "static_first": sorted(STATIC_FIRST),
                 "edge_cached": EDGE_CACHED,
                 "edge_revalidate": EDGE_REVALIDATE,
+                "edge_key": edge_key,
             },
             indent=2,
             sort_keys=True,

--- a/edge/snapshot.py
+++ b/edge/snapshot.py
@@ -84,6 +84,24 @@ STATIC_FIRST = {"/skill.md": "SKILL.md", "/patterns.md": "src/patterns.md"}
 # minutes arrived through the tunnel, 10.4% of all traffic).
 EDGE_CACHED = {"/healthz": 10}
 
+# Served from the edge copy ALWAYS, refreshed in the background at most this often. Never
+# snapshotted: like /healthz these are live figures, and a stored answer for them would
+# outlive the service that produced it.
+#
+# This lane exists because /rooms cannot be made fast enough to wait for. It is an
+# O(total-rooms) walk (technocore-chat#576) that measured 52.7% of worker thread-time at
+# 0.9 req/s, and a single uncached call took 32.6s. Plain caching cannot cover that: the
+# origin header is s-maxage=5 with stale-while-revalidate=25, a 30s window against a walk
+# that outlasts it, so the window always closes first and some reader pays the whole cost.
+# Worse, that reader occupies an anyio thread for the duration, which is why an unrelated
+# /r/<room> read on the same box measured 3.3s to 21.4s for 17 KB — queueing, not work.
+#
+# Serving the stale copy unconditionally and refreshing behind ctx.waitUntil() inverts that:
+# no reader ever waits for a walk, and the data is as fresh as the origin can actually
+# produce rather than as fresh as we are willing to make people wait. The interval also
+# bounds how often the origin is asked, which is the part that frees the thread pool.
+EDGE_REVALIDATE = {"/rooms": 60}
+
 
 def asset_name(path: str) -> str:
     """Where a URL path is stored under public/.
@@ -146,7 +164,12 @@ def main() -> int:
 
     pathlib.Path(args.manifest).write_text(
         json.dumps(
-            {"types": types, "static_first": sorted(STATIC_FIRST), "edge_cached": EDGE_CACHED},
+            {
+                "types": types,
+                "static_first": sorted(STATIC_FIRST),
+                "edge_cached": EDGE_CACHED,
+                "edge_revalidate": EDGE_REVALIDATE,
+            },
             indent=2,
             sort_keys=True,
         )

--- a/edge/src/worker.js
+++ b/edge/src/worker.js
@@ -41,10 +41,13 @@ const ORIGIN_TIMEOUT_MS = 8000;
 // (bench/rooms.py), which has no useful upper bound. Cutting it at the request timeout would
 // mean the copy never refreshes on a loaded box, which is exactly when it matters.
 const ORIGIN_REVALIDATE_MS = 120000;
-// How long the edge may hold a copy. Longer than the refresh interval by design: the lane,
-// not the header, decides freshness, and an expiry shorter than the refresh would drop the
-// copy that makes the whole thing non-blocking.
-const EDGE_HOLD_SECONDS = 3600;
+// How long the edge may hold a copy. Far longer than any refresh interval, and the size of
+// that gap is the point: the lane promises the stored copy is served however old it is, and
+// an expiry reachable during an origin outage breaks exactly that promise. The copy would
+// expire precisely when no refresh can replace it, and the next reader would be back to
+// waiting on the walk — the failure this lane exists to remove, reappearing in the one
+// situation it was built for. Staleness is bounded by refreshes succeeding, not by this.
+const EDGE_HOLD_SECONDS = 86400;
 
 const STATIC_FIRST = new Set(ROUTING.static_first);
 
@@ -65,11 +68,48 @@ const EDGE_CACHED_SECONDS = ROUTING.edge_cached ?? {};
 const EDGE_REVALIDATE_SECONDS = ROUTING.edge_revalidate ?? {};
 const STAMP = "x-edge-stamp";
 
-// One refresh per path per isolate. Workers isolates are per-PoP and short-lived, so this is
-// not a global lock — it does not need to be. What it prevents is the case that actually
-// bites: a burst of readers arriving on one PoP against an expired copy, each queueing its
-// own walk at an origin whose thread pool is the thing being protected.
+// The cache-key policy, from snapshot.py, which reads the bounds out of the served schema.
+// A path routed through this lane with no spec is served straight from the origin: keying on
+// the raw URL instead would let a caller multiply entries, which is the whole reason the
+// spec exists. Fail closed, never fall back to the broken key.
+const EDGE_KEY = ROUTING.edge_key ?? {};
+
+// One fill per cache key per isolate, covering the cold path as well as the refresh. Workers
+// isolates are per-PoP and short-lived, so this is not a global lock and does not need to be:
+// what it prevents is the case that actually bites, a burst of readers arriving on one PoP
+// with no copy or an expired one, each starting its own walk at an origin whose thread pool
+// is the thing being protected.
 const inFlight = new Map();
+
+/** The key a path's copy is stored under: the reply space, not the URL space.
+ *
+ * Only parameters the origin actually reads survive, so anything it ignores cannot multiply
+ * entries. Returns null when a value cannot be canonicalised, which means "no shared copy
+ * for this request" rather than "guess". */
+function cacheKey(url, pathname) {
+  const spec = EDGE_KEY[pathname];
+  if (!spec) return null;
+  const keep = new URLSearchParams();
+  for (const [name, wanted] of Object.entries(spec.match ?? {})) {
+    if (url.searchParams.get(name) === wanted) keep.set(name, wanted);
+  }
+  for (const [name, rule] of Object.entries(spec.clamped ?? {})) {
+    const raw = url.searchParams.get(name);
+    // Absent means the origin's own default, which is its own entry — one extra copy, not a
+    // way to make unboundedly many, so it needs no number restated here.
+    if (raw === null) continue;
+    // Only the narrow form both languages read identically is clamped here. Python's int()
+    // also takes underscores, signs, surrounding whitespace and non-ASCII digits, and a JS
+    // reimplementation of that grammar would be a second parser to keep in step — where a
+    // disagreement is not a miss but a wrong answer, one caller's row count served to
+    // another. Anything else gets no shared entry at all.
+    if (!/^[0-9]{1,9}$/.test(raw)) return null;
+    keep.set(name, String(Math.min(Number(raw) || rule.min, rule.max)));
+  }
+  keep.sort();
+  const query = keep.toString();
+  return new Request(url.origin + pathname + (query ? "?" + query : ""), { method: "GET" });
+}
 
 /** A 5xx is the origin failing to answer. A 4xx is the origin answering "no", which is a
  * real reply and must pass through untouched — serving a snapshot over a 404 or a 429 would
@@ -138,32 +178,54 @@ async function edgeCached(request, pathname, seconds) {
   return fresh;
 }
 
-async function fromOrigin(request, cache, pathname) {
+/** Resolves to the parts of a reply rather than to a Response, because one fill is shared by
+ * every reader waiting on it and a Response body can only be consumed once. */
+async function fromOrigin(request, key) {
   const fresh = await fetch(request, { signal: AbortSignal.timeout(ORIGIN_REVALIDATE_MS) });
-  if (fresh.status !== 200) return fresh;
   const body = await fresh.arrayBuffer();
   const headers = new Headers(fresh.headers);
+  if (fresh.status !== 200) return { status: fresh.status, body, headers };
+
+  // A reply the origin marked no-store is one caller's, not the shared copy: /rooms carries
+  // a budget footer once a caller's read allowance runs low, and the handler deliberately
+  // keeps that reply out of any shared cache. Overwriting the directive would publish one
+  // caller's pacing to every reader of this key for as long as the copy lived.
+  if (/(^|,)\s*(no-store|private)\b/i.test(headers.get("Cache-Control") ?? "")) {
+    return { status: 200, body, headers };
+  }
   headers.set(STAMP, String(Date.now()));
   // The edge copy outlives the origin's own short window on purpose: this lane decides when
   // to refresh, so a header that expires sooner would just hand the decision back.
   headers.set("Cache-Control", `public, max-age=0, s-maxage=${EDGE_HOLD_SECONDS}`);
-  await cache.put(request, new Response(body, { status: 200, headers }));
-  return new Response(body, { status: 200, headers });
+  await caches.default.put(key, new Response(body, { status: 200, headers }));
+  return { status: 200, body, headers };
 }
 
-async function revalidating(request, ctx, pathname, seconds) {
-  const cache = caches.default;
-  const hit = await cache.match(request);
+/** One origin walk per key, however many readers are waiting on it. */
+function fill(request, key) {
+  const pending = inFlight.get(key.url);
+  if (pending) return pending;
+  const job = fromOrigin(request, key).finally(() => inFlight.delete(key.url));
+  inFlight.set(key.url, job);
+  return job;
+}
 
-  if (!hit) return fromOrigin(request, cache, pathname);  // cold: someone has to be first
+const asResponse = (r) => new Response(r.body, { status: r.status, headers: r.headers });
+
+async function revalidating(request, ctx, pathname, seconds) {
+  const key = cacheKey(new URL(request.url), pathname);
+  // No canonical key for this request: serve it from the origin without touching the shared
+  // copy. Guessing a key would be worse than the walk this lane exists to avoid.
+  if (!key) return fetch(request, { signal: AbortSignal.timeout(ORIGIN_REVALIDATE_MS) });
+
+  const hit = await caches.default.match(key);
+  // Cold: someone has to be first, but only one of them. Every other reader arriving in the
+  // same window joins that fill instead of starting a walk of its own.
+  if (!hit) return asResponse(await fill(request, key));
 
   const stamp = Number(hit.headers.get(STAMP) || 0);
-  if (Date.now() - stamp > seconds * 1000 && !inFlight.has(pathname)) {
-    const job = fromOrigin(request, cache, pathname)
-      .catch(() => {})                      // a failed refresh keeps the copy we have
-      .finally(() => inFlight.delete(pathname));
-    inFlight.set(pathname, job);
-    ctx.waitUntil(job);
+  if (Date.now() - stamp > seconds * 1000) {
+    ctx.waitUntil(fill(request, key).catch(() => {}));  // a failed refresh keeps this copy
   }
   return hit;  // always, however old — waiting for this walk is the thing being removed
 }

--- a/edge/src/worker.js
+++ b/edge/src/worker.js
@@ -37,8 +37,9 @@ import ROUTING from "./routing.json";
 // answer than a late one.
 const ORIGIN_TIMEOUT_MS = 8000;
 // The revalidating lane gets its own, far longer budget: it is a background refresh nobody
-// is waiting on, and the walk it covers has measured over 30s. Cutting it at 8s would mean
-// the copy never refreshes at all on a loaded box, which is exactly when it matters.
+// is waiting on, and what it covers is queueing at a saturated origin rather than work
+// (bench/rooms.py), which has no useful upper bound. Cutting it at the request timeout would
+// mean the copy never refreshes on a loaded box, which is exactly when it matters.
 const ORIGIN_REVALIDATE_MS = 120000;
 // How long the edge may hold a copy. Longer than the refresh interval by design: the lane,
 // not the header, decides freshness, and an expiry shorter than the refresh would drop the

--- a/edge/src/worker.js
+++ b/edge/src/worker.js
@@ -36,17 +36,15 @@ import ROUTING from "./routing.json";
 // Generous: a slow document is still the correct document, and the snapshot is a worse
 // answer than a late one.
 const ORIGIN_TIMEOUT_MS = 8000;
-// The revalidating lane gets its own, far longer budget: it is a background refresh nobody
-// is waiting on, and what it covers is queueing at a saturated origin rather than work
-// (bench/rooms.py), which has no useful upper bound. Cutting it at the request timeout would
-// mean the copy never refreshes on a loaded box, which is exactly when it matters.
+// The revalidating lane gets a far longer budget: nobody is waiting on a background refresh,
+// and what it covers is queueing at a saturated origin rather than work (bench/rooms.py), so
+// it has no useful upper bound. Cutting it at the request timeout would mean the copy never
+// refreshes on a loaded box, which is exactly when it matters.
 const ORIGIN_REVALIDATE_MS = 120000;
-// How long the edge may hold a copy. Far longer than any refresh interval, and the size of
-// that gap is the point: the lane promises the stored copy is served however old it is, and
-// an expiry reachable during an origin outage breaks exactly that promise. The copy would
-// expire precisely when no refresh can replace it, and the next reader would be back to
-// waiting on the walk — the failure this lane exists to remove, reappearing in the one
-// situation it was built for. Staleness is bounded by refreshes succeeding, not by this.
+// How long the edge may hold a copy — far longer than any refresh interval, deliberately.
+// The lane serves the copy however old it is, so an expiry reachable during an origin outage
+// would drop it exactly when nothing can replace it, putting the next reader back on the
+// walk. Staleness is bounded by refreshes succeeding, not by this.
 const EDGE_HOLD_SECONDS = 86400;
 
 const STATIC_FIRST = new Set(ROUTING.static_first);
@@ -68,24 +66,18 @@ const EDGE_CACHED_SECONDS = ROUTING.edge_cached ?? {};
 const EDGE_REVALIDATE_SECONDS = ROUTING.edge_revalidate ?? {};
 const STAMP = "x-edge-stamp";
 
-// The cache-key policy, from snapshot.py, which reads the bounds out of the served schema.
-// A path routed through this lane with no spec is served straight from the origin: keying on
-// the raw URL instead would let a caller multiply entries, which is the whole reason the
-// spec exists. Fail closed, never fall back to the broken key.
+// The cache-key policy, from snapshot.py. A lane path with no spec goes straight to the
+// origin: keying on the raw URL instead is the bug the spec exists to prevent. Fail closed.
 const EDGE_KEY = ROUTING.edge_key ?? {};
 
-// One fill per cache key per isolate, covering the cold path as well as the refresh. Workers
-// isolates are per-PoP and short-lived, so this is not a global lock and does not need to be:
-// what it prevents is the case that actually bites, a burst of readers arriving on one PoP
-// with no copy or an expired one, each starting its own walk at an origin whose thread pool
-// is the thing being protected.
+// One fill per cache key per isolate, cold path included. Isolates are per-PoP, so this is
+// not a global lock and does not need to be: what it stops is a burst arriving on one PoP
+// with no copy or an expired one, each reader starting its own walk at the origin.
 const inFlight = new Map();
 
-/** The key a path's copy is stored under: the reply space, not the URL space.
- *
- * Only parameters the origin actually reads survive, so anything it ignores cannot multiply
- * entries. Returns null when a value cannot be canonicalised, which means "no shared copy
- * for this request" rather than "guess". */
+/** The key a copy is stored under: the reply space, not the URL space. Parameters the origin
+ * ignores are dropped so they cannot multiply entries. Null means "no shared copy for this
+ * request" — never a guess. */
 function cacheKey(url, pathname) {
   const spec = EDGE_KEY[pathname];
   if (!spec) return null;
@@ -95,14 +87,11 @@ function cacheKey(url, pathname) {
   }
   for (const [name, rule] of Object.entries(spec.clamped ?? {})) {
     const raw = url.searchParams.get(name);
-    // Absent means the origin's own default, which is its own entry — one extra copy, not a
-    // way to make unboundedly many, so it needs no number restated here.
+    // Absent means the origin's default: one extra entry, not unboundedly many.
     if (raw === null) continue;
-    // Only the narrow form both languages read identically is clamped here. Python's int()
-    // also takes underscores, signs, surrounding whitespace and non-ASCII digits, and a JS
-    // reimplementation of that grammar would be a second parser to keep in step — where a
-    // disagreement is not a miss but a wrong answer, one caller's row count served to
-    // another. Anything else gets no shared entry at all.
+    // Only the form both languages read identically. Python's int() also takes underscores,
+    // signs, whitespace and non-ASCII digits, and a disagreement there would not be a miss
+    // but a wrong answer — one caller's row count served to another.
     if (!/^[0-9]{1,9}$/.test(raw)) return null;
     keep.set(name, String(Math.min(Number(raw) || rule.min, rule.max)));
   }
@@ -181,25 +170,21 @@ async function edgeCached(request, pathname, seconds) {
 /** Resolves to the parts of a reply rather than to a Response, because one fill is shared by
  * every reader waiting on it and a Response body can only be consumed once. */
 async function fromOrigin(request, key) {
-  // Always a GET of the canonical URL, never the caller's own request. route() sends HEAD
-  // into this lane and cacheKey() normalises to a GET key, so fetching the caller's request
-  // would read a HEAD's empty body and store *that* under the GET key — every later GET for
-  // the same canonical query would then be served an empty /rooms until the copy was
-  // replaced, which at EDGE_HOLD_SECONDS is a day. Fetching the key also makes the stored
-  // body provably the reply that key names, rather than one that merely came back while the
-  // entry was being built. The caller's headers ride along so the origin still sees whose
-  // request this is for rate accounting; nothing caller-specific reaches the shared copy,
-  // because a reply that carries any is refused storage below.
+  // Always a GET of the canonical URL, never the caller's own request: route() admits HEAD
+  // and the key is a GET, so fetching the request would store a HEAD's empty body under it
+  // and every later GET would read an empty /rooms until the copy was replaced. Fetching the
+  // key also makes the stored body provably the reply that key names. The caller's headers
+  // ride along for the origin's rate accounting; nothing caller-specific is stored, because
+  // the guard below refuses any reply that carries some.
   const canonical = new Request(key.url, { method: "GET", headers: request.headers });
   const fresh = await fetch(canonical, { signal: AbortSignal.timeout(ORIGIN_REVALIDATE_MS) });
   const body = await fresh.arrayBuffer();
   const headers = new Headers(fresh.headers);
   if (fresh.status !== 200) return { status: fresh.status, body, headers };
 
-  // A reply the origin marked no-store is one caller's, not the shared copy: /rooms carries
-  // a budget footer once a caller's read allowance runs low, and the handler deliberately
-  // keeps that reply out of any shared cache. Overwriting the directive would publish one
-  // caller's pacing to every reader of this key for as long as the copy lived.
+  // A no-store reply is one caller's: /rooms carries a budget footer once a caller's read
+  // allowance runs low, and the handler keeps it out of any shared cache. Rewriting the
+  // directive would publish that caller's pacing to every reader of this key.
   if (/(^|,)\s*(no-store|private)\b/i.test(headers.get("Cache-Control") ?? "")) {
     return { status: 200, body, headers };
   }
@@ -224,13 +209,11 @@ const asResponse = (r) => new Response(r.body, { status: r.status, headers: r.he
 
 async function revalidating(request, ctx, pathname, seconds) {
   const key = cacheKey(new URL(request.url), pathname);
-  // No canonical key for this request: serve it from the origin without touching the shared
-  // copy. Guessing a key would be worse than the walk this lane exists to avoid.
+  // No canonical key: serve from the origin without touching the shared copy.
   if (!key) return fetch(request, { signal: AbortSignal.timeout(ORIGIN_REVALIDATE_MS) });
 
   const hit = await caches.default.match(key);
-  // Cold: someone has to be first, but only one of them. Every other reader arriving in the
-  // same window joins that fill instead of starting a walk of its own.
+  // Cold: someone has to be first, but only one of them — the rest join that fill.
   if (!hit) return asResponse(await fill(request, key));
 
   const stamp = Number(hit.headers.get(STAMP) || 0);

--- a/edge/src/worker.js
+++ b/edge/src/worker.js
@@ -36,6 +36,14 @@ import ROUTING from "./routing.json";
 // Generous: a slow document is still the correct document, and the snapshot is a worse
 // answer than a late one.
 const ORIGIN_TIMEOUT_MS = 8000;
+// The revalidating lane gets its own, far longer budget: it is a background refresh nobody
+// is waiting on, and the walk it covers has measured over 30s. Cutting it at 8s would mean
+// the copy never refreshes at all on a loaded box, which is exactly when it matters.
+const ORIGIN_REVALIDATE_MS = 120000;
+// How long the edge may hold a copy. Longer than the refresh interval by design: the lane,
+// not the header, decides freshness, and an expiry shorter than the refresh would drop the
+// copy that makes the whole thing non-blocking.
+const EDGE_HOLD_SECONDS = 3600;
 
 const STATIC_FIRST = new Set(ROUTING.static_first);
 
@@ -48,6 +56,19 @@ const STATIC_FIRST = new Set(ROUTING.static_first);
 // including the container healthcheck and the auto-updater's rollback probe (both on
 // 127.0.0.1, neither through this Worker), gets an uncached answer. Only the edge shares it.
 const EDGE_CACHED_SECONDS = ROUTING.edge_cached ?? {};
+
+// Paths served from the edge copy ALWAYS, refreshed behind ctx.waitUntil(). See snapshot.py,
+// which owns the policy. The stale copy is the answer; the refresh is a side effect nobody
+// waits for. `x-edge-stamp` carries when the copy was made, because the Cache API gives no
+// age of its own and `Age` is the CDN's, not this lane's.
+const EDGE_REVALIDATE_SECONDS = ROUTING.edge_revalidate ?? {};
+const STAMP = "x-edge-stamp";
+
+// One refresh per path per isolate. Workers isolates are per-PoP and short-lived, so this is
+// not a global lock — it does not need to be. What it prevents is the case that actually
+// bites: a burst of readers arriving on one PoP against an expired copy, each queueing its
+// own walk at an origin whose thread pool is the thing being protected.
+const inFlight = new Map();
 
 /** A 5xx is the origin failing to answer. A 4xx is the origin answering "no", which is a
  * real reply and must pass through untouched — serving a snapshot over a 404 or a 429 would
@@ -116,10 +137,40 @@ async function edgeCached(request, pathname, seconds) {
   return fresh;
 }
 
+async function fromOrigin(request, cache, pathname) {
+  const fresh = await fetch(request, { signal: AbortSignal.timeout(ORIGIN_REVALIDATE_MS) });
+  if (fresh.status !== 200) return fresh;
+  const body = await fresh.arrayBuffer();
+  const headers = new Headers(fresh.headers);
+  headers.set(STAMP, String(Date.now()));
+  // The edge copy outlives the origin's own short window on purpose: this lane decides when
+  // to refresh, so a header that expires sooner would just hand the decision back.
+  headers.set("Cache-Control", `public, max-age=0, s-maxage=${EDGE_HOLD_SECONDS}`);
+  await cache.put(request, new Response(body, { status: 200, headers }));
+  return new Response(body, { status: 200, headers });
+}
+
+async function revalidating(request, ctx, pathname, seconds) {
+  const cache = caches.default;
+  const hit = await cache.match(request);
+
+  if (!hit) return fromOrigin(request, cache, pathname);  // cold: someone has to be first
+
+  const stamp = Number(hit.headers.get(STAMP) || 0);
+  if (Date.now() - stamp > seconds * 1000 && !inFlight.has(pathname)) {
+    const job = fromOrigin(request, cache, pathname)
+      .catch(() => {})                      // a failed refresh keeps the copy we have
+      .finally(() => inFlight.delete(pathname));
+    inFlight.set(pathname, job);
+    ctx.waitUntil(job);
+  }
+  return hit;  // always, however old — waiting for this walk is the thing being removed
+}
+
 export default {
   async fetch(request, env, ctx) {
     try {
-      return await route(request, env);
+      return await route(request, env, ctx);
     } catch (err) {
       // Fail open. This Worker sits in front of the liveness endpoint now, so an exception
       // in it must not become the service looking dead: hand the request to the origin and
@@ -129,7 +180,7 @@ export default {
   },
 };
 
-async function route(request, env) {
+async function route(request, env, ctx) {
     // Only GET/HEAD are ever routed here, but a stray method must not be answered from a
     // stored copy: fall through to the origin and let it refuse.
     if (request.method !== "GET" && request.method !== "HEAD") return fetch(request);
@@ -138,6 +189,9 @@ async function route(request, env) {
 
     const cacheFor = EDGE_CACHED_SECONDS[pathname];
     if (cacheFor) return edgeCached(request, pathname, cacheFor);
+
+    const revalidateAfter = EDGE_REVALIDATE_SECONDS[pathname];
+    if (revalidateAfter) return revalidating(request, ctx, pathname, revalidateAfter);
 
     if (STATIC_FIRST.has(pathname)) {
       const copy = await stored(request, env, pathname, { fallback: false });

--- a/edge/src/worker.js
+++ b/edge/src/worker.js
@@ -181,7 +181,17 @@ async function edgeCached(request, pathname, seconds) {
 /** Resolves to the parts of a reply rather than to a Response, because one fill is shared by
  * every reader waiting on it and a Response body can only be consumed once. */
 async function fromOrigin(request, key) {
-  const fresh = await fetch(request, { signal: AbortSignal.timeout(ORIGIN_REVALIDATE_MS) });
+  // Always a GET of the canonical URL, never the caller's own request. route() sends HEAD
+  // into this lane and cacheKey() normalises to a GET key, so fetching the caller's request
+  // would read a HEAD's empty body and store *that* under the GET key — every later GET for
+  // the same canonical query would then be served an empty /rooms until the copy was
+  // replaced, which at EDGE_HOLD_SECONDS is a day. Fetching the key also makes the stored
+  // body provably the reply that key names, rather than one that merely came back while the
+  // entry was being built. The caller's headers ride along so the origin still sees whose
+  // request this is for rate accounting; nothing caller-specific reaches the shared copy,
+  // because a reply that carries any is refused storage below.
+  const canonical = new Request(key.url, { method: "GET", headers: request.headers });
+  const fresh = await fetch(canonical, { signal: AbortSignal.timeout(ORIGIN_REVALIDATE_MS) });
   const body = await fresh.arrayBuffer();
   const headers = new Headers(fresh.headers);
   if (fresh.status !== 200) return { status: fresh.status, body, headers };

--- a/edge/wrangler.jsonc
+++ b/edge/wrangler.jsonc
@@ -39,6 +39,8 @@
     { "pattern": "technocore.chat/humans", "zone_name": "technocore.chat" },
     // Edge-cached, never snapshotted — see EDGE_CACHED in snapshot.py.
     { "pattern": "technocore.chat/healthz", "zone_name": "technocore.chat" },
+    // Served from the edge copy always, refreshed in the background — EDGE_REVALIDATE.
+    { "pattern": "technocore.chat/rooms", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/robots.txt", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/sitemap.xml", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/openapi.json", "zone_name": "technocore.chat" },

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -223,14 +223,11 @@ def test_the_edge_cached_lane_shares_its_copy_only_with_the_edge():
 
 
 def test_the_revalidating_lane_never_makes_a_reader_wait_for_the_origin():
-    """The property the lane exists for, asserted on the source because there is no JS
-    harness here — and it is the one a later edit would quietly remove.
-
-    /rooms is an O(total-rooms) walk (technocore-chat#576) whose cost under concurrency is
-    dominated by queueing rather than by the walk itself — bench/rooms.py separates the two.
-    No cache window can be made reliably longer than a cost with no upper bound, so the reader
-    who arrives after the window closes pays all of it *and* holds an anyio thread while doing
-    so. Returning the stale copy unconditionally is what breaks that.
+    """The property the lane exists for, asserted on the source for want of a JS harness —
+    and the one a later edit would quietly remove. /rooms is an O(total-rooms) walk (#576)
+    whose cost under concurrency is queueing rather than work (bench/rooms.py), so no cache
+    window is reliably longer than it: whoever arrives after one closes pays the whole cost
+    and holds an anyio thread doing it. Returning the copy unconditionally is what breaks it.
     """
     worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
     lane = worker[worker.index("async function revalidating(") :]
@@ -240,21 +237,16 @@ def test_the_revalidating_lane_never_makes_a_reader_wait_for_the_origin():
     assert "fill(" in lane, "a burst on one PoP must not queue one walk per reader"
 
 
-def test_the_revalidating_lane_refreshes_less_often_than_the_cached_one():
-    """A revalidate interval inside the edge-cached window is a path in the wrong lane.
-
-    The two lanes differ in what they spend: EDGE_CACHED makes one reader wait for the origin
-    each time its window closes, EDGE_REVALIDATE never makes anyone wait and pays for that
-    with a copy that may be a whole interval old. Staleness is only worth buying for a path
-    the cheaper lane cannot cover, so an interval as short as a cached window is evidence the
-    path belongs in EDGE_CACHED instead.
+def test_the_refresh_interval_is_not_faster_than_the_origin_can_answer(client):
+    """/rooms is activity monitoring, so the interval wants to be short — `idle_seconds` and
+    `last_seq` are the payload and a stale copy misreports them. The floor is the origin's
+    own memo: inside CHAT_ROOMS_CACHE_SECONDS it re-walks nothing and returns what it already
+    has, so refreshing faster than that spends requests for an identical answer.
     """
-    snapshot = _snapshot_module()
-    longest_cached = max(snapshot.EDGE_CACHED.values(), default=0)
-    for path, seconds in snapshot.EDGE_REVALIDATE.items():
-        assert seconds > longest_cached, (
-            f"{path} refreshes every {seconds}s, inside the {longest_cached}s edge-cached "
-            "window — a path refreshed that often belongs in EDGE_CACHED"
+    published = client.get("/config").json()["settings"]["rooms_cache_seconds"]
+    for path, seconds in _snapshot_module().EDGE_REVALIDATE.items():
+        assert seconds >= published, (
+            f"{path} refreshes every {seconds}s, inside the origin's own {published}s window"
         )
 
 
@@ -265,9 +257,8 @@ def _between(text: str, start: str, end: str) -> str:
 
 
 def test_the_cold_fill_is_single_flighted_too():
-    """The refresh was deduplicated from the start and the cold path was not — but a cold PoP
-    is where a burst costs most, because there is no copy to serve and every reader would
-    otherwise start its own walk at the origin whose thread pool this lane protects.
+    """The refresh was deduplicated from the start and the cold path was not — yet a cold PoP
+    is where a burst costs most, having no copy to serve.
     """
     worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
     lane = _between(worker, "async function revalidating(", "export default")
@@ -278,9 +269,9 @@ def test_the_cold_fill_is_single_flighted_too():
 
 def test_a_caller_specific_reply_never_becomes_the_shared_copy():
     """/rooms carries a budget footer once a caller's read allowance runs low, and the handler
-    keeps that reply out of any shared cache on purpose (`return resp if note else
-    _edge_cacheable(resp)`). This lane rewrites Cache-Control on whatever it stores, so
-    without the check it would publish one caller's pacing to every reader of the key.
+    keeps that reply out of any shared cache (`return resp if note else _edge_cacheable`).
+    This lane rewrites Cache-Control on what it stores, so without the check it would publish
+    one caller's pacing to every reader of the key.
     """
     fill = _between(
         (EDGE / "src" / "worker.js").read_text(encoding="utf-8"),
@@ -293,10 +284,9 @@ def test_a_caller_specific_reply_never_becomes_the_shared_copy():
 
 
 def test_the_edge_hold_outlives_a_sustained_refresh_outage():
-    """An expiry reachable while refreshes are failing breaks the one promise this lane makes.
-    The copy would expire exactly when nothing can replace it and the next reader would be
-    back on the walk — the failure the lane exists to remove, in the situation it was built
-    for. The policy is that the copy survives a hundred consecutive failed refreshes.
+    """An expiry reachable while refreshes are failing drops the copy exactly when nothing can
+    replace it, putting the next reader back on the walk. The policy: the copy survives a
+    hundred consecutive failed refreshes.
     """
     worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
     found = re.search(r"EDGE_HOLD_SECONDS = (\d+)", worker)
@@ -314,12 +304,10 @@ def test_every_revalidating_path_has_a_cache_key_spec():
 
 
 def test_the_edge_key_is_the_reply_space_and_not_the_url_space(client):
-    """The edge copy is keyed on the clamped limit rather than on the raw query string. The
-    ceiling comes from store.MAX_LIMIT, so assert it against the handler's actual behaviour:
+    """Keyed on the clamped limit, not the raw query string — the bug app.py fixed for its own
+    cache ("?limit=200 and ?limit=1000000 are one reply and were two entries") one layer out.
+    The ceiling comes from store.MAX_LIMIT, so assert it against the handler's real behaviour:
     if the two ever parted, the edge would serve one caller's row count to another.
-
-    This is the bug app.py fixed for its own cache — "?limit=200 and ?limit=1000000 are one
-    reply and were two entries" — reappearing one layer out, so it is checked the same way.
     """
     rule = _snapshot_module().rooms_key()["/rooms"]
     limit = rule["clamped"]["limit"]
@@ -345,12 +333,10 @@ def test_the_edge_key_is_the_reply_space_and_not_the_url_space(client):
 
 
 def test_a_head_request_can_never_become_the_stored_body():
-    """route() sends HEAD into this lane and cacheKey() normalises it to a GET key, so a fill
-    that fetched the caller's own request would read a HEAD's empty body and store it under
-    that GET key — and every later GET for the same canonical query would be served an empty
-    /rooms until the copy was replaced, which at EDGE_HOLD_SECONDS is a day. There is no JS
-    harness here, so this asserts the property on the source: the fill fetches the key, which
-    is a GET by construction, and never the request it was handed.
+    """route() admits HEAD and cacheKey() normalises to a GET key, so a fill that fetched the
+    caller's request would store a HEAD's empty body under it and every later GET would read
+    an empty /rooms until the copy was replaced. Asserted on the source: the fill fetches the
+    key, a GET by construction, never the request it was handed.
     """
     origin = _between(
         (EDGE / "src" / "worker.js").read_text(encoding="utf-8"),

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -57,7 +57,7 @@ def test_every_routed_path_is_either_snapshotted_or_deliberately_not():
     whole point of them.
     """
     snapshot = _snapshot_module()
-    accounted = set(snapshot.PATHS) | set(snapshot.EDGE_CACHED)
+    accounted = set(snapshot.PATHS) | set(snapshot.EDGE_CACHED) | set(snapshot.EDGE_REVALIDATE)
     assert _wrangler_routes() - accounted == set()
 
 
@@ -69,9 +69,11 @@ def test_a_liveness_path_is_never_snapshotted():
     report a service that is gone as healthy, to every monitor watching it.
     """
     snapshot = _snapshot_module()
-    assert set(snapshot.EDGE_CACHED) & set(snapshot.PATHS) == set()
-    assert set(snapshot.EDGE_CACHED) & set(snapshot.STATIC_FIRST) == set()
+    live = set(snapshot.EDGE_CACHED) | set(snapshot.EDGE_REVALIDATE)
+    assert live & set(snapshot.PATHS) == set()
+    assert live & set(snapshot.STATIC_FIRST) == set()
     assert "/healthz" not in snapshot.PATHS
+    assert "/rooms" not in snapshot.PATHS
 
 
 def test_the_edge_cache_window_is_long_enough_to_be_worth_having():
@@ -216,3 +218,28 @@ def test_the_edge_cached_lane_shares_its_copy_only_with_the_edge():
     assert "max-age=0, s-maxage=${seconds}" in worker, (
         "the edge-cached copy must not carry a private max-age"
     )
+
+
+def test_the_revalidating_lane_never_makes_a_reader_wait_for_the_origin():
+    """The property the lane exists for, asserted on the source because there is no JS
+    harness here — and it is the one a later edit would quietly remove.
+
+    /rooms is an O(total-rooms) walk that measured 52.7% of worker thread-time at 0.9 req/s,
+    with a single uncached call taking 32.6s. Plain caching cannot cover a walk that outlasts
+    its own window: the reader who arrives after it closes pays the whole cost *and* holds an
+    anyio thread while doing so, which is why unrelated room reads on the same box measured
+    3.3s to 21.4s for 17 KB. Returning the stale copy unconditionally is what breaks that.
+    """
+    worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
+    lane = worker[worker.index("async function revalidating(") :]
+    lane = lane[: lane.index("export default")]
+    assert "return hit;" in lane, "the cached copy must be returned whatever its age"
+    assert "ctx.waitUntil(" in lane, "the refresh must not be awaited on the request path"
+    assert "inFlight" in lane, "a burst on one PoP must not queue one walk per reader"
+
+
+def test_the_revalidate_interval_outlives_the_walk_it_covers():
+    """A window shorter than the walk is the bug this lane replaces: the origin header is
+    s-maxage=5 with swr=25, a 30s budget against a 32.6s walk, so it always closed first."""
+    for path, seconds in _snapshot_module().EDGE_REVALIDATE.items():
+        assert seconds >= 30, f"{path} at {seconds}s is inside the measured walk time"

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -342,3 +342,25 @@ def test_the_edge_key_is_the_reply_space_and_not_the_url_space(client):
     assert listed(f"limit={limit['max']}") == listed(f"limit={limit['max'] * 100000}")
     # And zero means one, the handler's `or 1` — the edge arithmetic mirrors it exactly.
     assert listed("limit=0") == listed("limit=1")
+
+
+def test_a_head_request_can_never_become_the_stored_body():
+    """route() sends HEAD into this lane and cacheKey() normalises it to a GET key, so a fill
+    that fetched the caller's own request would read a HEAD's empty body and store it under
+    that GET key — and every later GET for the same canonical query would be served an empty
+    /rooms until the copy was replaced, which at EDGE_HOLD_SECONDS is a day. There is no JS
+    harness here, so this asserts the property on the source: the fill fetches the key, which
+    is a GET by construction, and never the request it was handed.
+    """
+    origin = _between(
+        (EDGE / "src" / "worker.js").read_text(encoding="utf-8"),
+        "async function fromOrigin(",
+        "function fill(",
+    )
+    assert "fetch(request" not in origin, "a fill must not fetch the caller's own request"
+    assert 'new Request(key.url, { method: "GET"' in origin, (
+        "the fill must fetch a GET of the canonical key it is about to write"
+    )
+    assert origin.index("const canonical") < origin.index("await fetch("), (
+        "the canonical GET must be what is fetched, not built after the fact"
+    )

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -224,11 +224,11 @@ def test_the_revalidating_lane_never_makes_a_reader_wait_for_the_origin():
     """The property the lane exists for, asserted on the source because there is no JS
     harness here — and it is the one a later edit would quietly remove.
 
-    /rooms is an O(total-rooms) walk that measured 52.7% of worker thread-time at 0.9 req/s,
-    with a single uncached call taking 32.6s. Plain caching cannot cover a walk that outlasts
-    its own window: the reader who arrives after it closes pays the whole cost *and* holds an
-    anyio thread while doing so, which is why unrelated room reads on the same box measured
-    3.3s to 21.4s for 17 KB. Returning the stale copy unconditionally is what breaks that.
+    /rooms is an O(total-rooms) walk (technocore-chat#576) whose cost under concurrency is
+    dominated by queueing rather than by the walk itself — bench/rooms.py separates the two.
+    No cache window can be made reliably longer than a cost with no upper bound, so the reader
+    who arrives after the window closes pays all of it *and* holds an anyio thread while doing
+    so. Returning the stale copy unconditionally is what breaks that.
     """
     worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
     lane = worker[worker.index("async function revalidating(") :]
@@ -238,8 +238,19 @@ def test_the_revalidating_lane_never_makes_a_reader_wait_for_the_origin():
     assert "inFlight" in lane, "a burst on one PoP must not queue one walk per reader"
 
 
-def test_the_revalidate_interval_outlives_the_walk_it_covers():
-    """A window shorter than the walk is the bug this lane replaces: the origin header is
-    s-maxage=5 with swr=25, a 30s budget against a 32.6s walk, so it always closed first."""
-    for path, seconds in _snapshot_module().EDGE_REVALIDATE.items():
-        assert seconds >= 30, f"{path} at {seconds}s is inside the measured walk time"
+def test_the_revalidating_lane_refreshes_less_often_than_the_cached_one():
+    """A revalidate interval inside the edge-cached window is a path in the wrong lane.
+
+    The two lanes differ in what they spend: EDGE_CACHED makes one reader wait for the origin
+    each time its window closes, EDGE_REVALIDATE never makes anyone wait and pays for that
+    with a copy that may be a whole interval old. Staleness is only worth buying for a path
+    the cheaper lane cannot cover, so an interval as short as a cached window is evidence the
+    path belongs in EDGE_CACHED instead.
+    """
+    snapshot = _snapshot_module()
+    longest_cached = max(snapshot.EDGE_CACHED.values(), default=0)
+    for path, seconds in snapshot.EDGE_REVALIDATE.items():
+        assert seconds > longest_cached, (
+            f"{path} refreshes every {seconds}s, inside the {longest_cached}s edge-cached "
+            "window — a path refreshed that often belongs in EDGE_CACHED"
+        )

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -17,6 +17,8 @@ import re
 import _client
 import pytest
 
+import store
+
 EDGE = pathlib.Path(__file__).resolve().parents[2] / "edge"
 
 client = _client.client  # the shared TestClient fixture
@@ -235,7 +237,7 @@ def test_the_revalidating_lane_never_makes_a_reader_wait_for_the_origin():
     lane = lane[: lane.index("export default")]
     assert "return hit;" in lane, "the cached copy must be returned whatever its age"
     assert "ctx.waitUntil(" in lane, "the refresh must not be awaited on the request path"
-    assert "inFlight" in lane, "a burst on one PoP must not queue one walk per reader"
+    assert "fill(" in lane, "a burst on one PoP must not queue one walk per reader"
 
 
 def test_the_revalidating_lane_refreshes_less_often_than_the_cached_one():
@@ -254,3 +256,89 @@ def test_the_revalidating_lane_refreshes_less_often_than_the_cached_one():
             f"{path} refreshes every {seconds}s, inside the {longest_cached}s edge-cached "
             "window — a path refreshed that often belongs in EDGE_CACHED"
         )
+
+
+def _between(text: str, start: str, end: str) -> str:
+    """One function's source, for the assertions there is no JS harness to make properly."""
+    body = text[text.index(start) :]
+    return body[: body.index(end)]
+
+
+def test_the_cold_fill_is_single_flighted_too():
+    """The refresh was deduplicated from the start and the cold path was not — but a cold PoP
+    is where a burst costs most, because there is no copy to serve and every reader would
+    otherwise start its own walk at the origin whose thread pool this lane protects.
+    """
+    worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
+    lane = _between(worker, "async function revalidating(", "export default")
+    assert "fromOrigin(" not in lane, "the lane must reach the origin only through fill()"
+    cold = lane[lane.index("if (!hit)") :]
+    assert "fill(" in cold[: cold.index("\n")], "the cold path must join the shared fill"
+
+
+def test_a_caller_specific_reply_never_becomes_the_shared_copy():
+    """/rooms carries a budget footer once a caller's read allowance runs low, and the handler
+    keeps that reply out of any shared cache on purpose (`return resp if note else
+    _edge_cacheable(resp)`). This lane rewrites Cache-Control on whatever it stores, so
+    without the check it would publish one caller's pacing to every reader of the key.
+    """
+    fill = _between(
+        (EDGE / "src" / "worker.js").read_text(encoding="utf-8"),
+        "async function fromOrigin(",
+        "function fill(",
+    )
+    assert fill.index("no-store") < fill.index("caches.default.put"), (
+        "the no-store check must come before the copy is stored, not after"
+    )
+
+
+def test_the_edge_hold_outlives_a_sustained_refresh_outage():
+    """An expiry reachable while refreshes are failing breaks the one promise this lane makes.
+    The copy would expire exactly when nothing can replace it and the next reader would be
+    back on the walk — the failure the lane exists to remove, in the situation it was built
+    for. The policy is that the copy survives a hundred consecutive failed refreshes.
+    """
+    worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
+    found = re.search(r"EDGE_HOLD_SECONDS = (\d+)", worker)
+    assert found, "the lane must declare how long the edge may hold a copy"
+    hold = int(found.group(1))
+    longest = max(_snapshot_module().EDGE_REVALIDATE.values(), default=0)
+    assert hold >= longest * 100, f"a {hold}s hold does not outlive a {longest}s refresh lapse"
+
+
+def test_every_revalidating_path_has_a_cache_key_spec():
+    """Without one the Worker would have to key on the raw URL, which is the bug below."""
+    snapshot = _snapshot_module()
+    spec = snapshot.rooms_key()
+    assert set(snapshot.EDGE_REVALIDATE) <= set(spec)
+
+
+def test_the_edge_key_is_the_reply_space_and_not_the_url_space(client):
+    """The edge copy is keyed on the clamped limit rather than on the raw query string. The
+    ceiling comes from store.MAX_LIMIT, so assert it against the handler's actual behaviour:
+    if the two ever parted, the edge would serve one caller's row count to another.
+
+    This is the bug app.py fixed for its own cache — "?limit=200 and ?limit=1000000 are one
+    reply and were two entries" — reappearing one layer out, so it is checked the same way.
+    """
+    rule = _snapshot_module().rooms_key()["/rooms"]
+    limit = rule["clamped"]["limit"]
+    assert limit["max"] == store.MAX_LIMIT
+    assert rule["match"] == {"format": "json"}
+    # The doctrine reason this number comes from the tree and not from the served schema:
+    # an advisory parameter publishes no bounds, because bounds mean refusal and this clamps.
+    schema = client.get("/openapi.json").json()["paths"]["/rooms"]["get"]["parameters"]
+    published = next(p for p in schema if p["name"] == "limit")["schema"]
+    assert "maximum" not in published and "minimum" not in published
+
+    for name in ("edgekey-a", "edgekey-b", "edgekey-c"):
+        client.get(f"/r/{name}/say/nick/hello")
+
+    def listed(query: str) -> list[str]:
+        payload = client.get(f"/rooms?format=json&{query}").json()
+        return [r["room"] for r in payload["rooms"]]
+
+    # Everything at or past the ceiling is one reply, which is what lets the key collapse it.
+    assert listed(f"limit={limit['max']}") == listed(f"limit={limit['max'] * 100000}")
+    # And zero means one, the handler's `or 1` — the edge arithmetic mirrors it exactly.
+    assert listed("limit=0") == listed("limit=1")


### PR DESCRIPTION
## What

A third Worker lane. `/rooms` is served from the edge copy **unconditionally, however old**,
and the refresh runs under `ctx.waitUntil()` where nobody is waiting for it.

## Why

**`/rooms` currently returns 524 to real users.** Measured from a browser against the live
site:

```
GET /humans                        → 200   (shell parseable at 523 ms)
GET /r/events?format=json&since=0  → 200   (9,572 ms)
GET /rooms?format=json&limit=200   → 524   ← Cloudflare origin timeout, >100s
```

`/humans` renders **"could not load room list"** and the room table stays empty. Three
consecutive walks at the origin also failed to finish inside a 200 s budget.

The walk is O(total rooms) (#576) and measured **52.7% of worker thread-time at 0.9 req/s**.
Caching cannot cover it as configured: the origin sends `s-maxage=5, stale-while-revalidate=25`
— a 30 s window against a walk that outlasts it — so the window always closes first and
whoever arrives next pays the whole cost.

That reader also **holds an anyio thread** while waiting, which is the part that hurts
everything else. An unrelated 17 KB `/r/lobby` read on the same box measured **3.33 s, 3.64 s,
13.04 s and 21.36 s**. A 6x spread on identical input is a queue, not work.

Raising `s-maxage` only moves the staleness — the reader still eventually waits. Serving the
stale copy unconditionally is what removes the wait:

- no reader ever waits for the walk, or sees a 524 from it
- the data is as fresh as the origin can actually produce, rather than as fresh as we are
  willing to make people wait
- the refresh interval bounds how often the origin is asked, which is what gives the thread
  pool back to every other read

## Design notes

- **Never snapshotted**, deliberately — like `/healthz` these are live figures, and a stored
  answer would outlive the service that produced it. `tests/edge/` pins that.
- **A failed refresh leaves the copy in place** rather than replacing it with an error.
- **In-isolate single-flight**, so a burst on one PoP does not queue one walk per reader.
  Isolates are per-PoP and short-lived, so this is not a global lock and does not need to be.
- Two constants that look large and are: the refresh gets a **120 s** origin budget because it
  is a background call covering a walk that has measured over 30 s — cutting it at the 8 s the
  other lanes use would mean it never refreshes on a loaded box, which is exactly when it
  matters. The edge holds the copy for an hour so the lane, not the header, decides freshness.

## Checks

- [x] `uv run coverage run -m pytest tests -q` — 649 passed
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] `uv run sz.py --check` — no core files touched
- [x] `node --check edge/src/worker.js`
- [x] New surface on a world-writable service: **nothing new** — no route, parameter or
      capability is added to the service; this changes where an existing public read is served
      from

## This is a tourniquet

`/rooms` timing out at 100 s is not a caching problem — it is an O(total-rooms) walk that has
outgrown every wrapper put in front of it. **#576 is the fix**, and there is a measured design
proposal on it (append-only index compacted by the reap walk: reads ~8x cheaper, writes flat).
This buys the service back today; it does not make the walk affordable.
