### PR TITLE
fix(edge): the edge-cached lane is entered only by a GET

### DIFF
--- a/edge/src/worker.js
+++ b/edge/src/worker.js
@@ -136,8 +136,13 @@ async function route(request, env) {
 
     const pathname = new URL(request.url).pathname;
 
+    // GET only: the Cache API rejects a non-GET request, so a HEAD entering this lane
+    // would throw on `cache.put` and unwind to the fail-open handler, which fetches the
+    // origin a second time — two origin requests for the one path this lane exists to
+    // keep off the origin, and a swallowed exception hiding it. A HEAD falls through to
+    // the origin path below instead, which answers it in one request.
     const cacheFor = EDGE_CACHED_SECONDS[pathname];
-    if (cacheFor) return edgeCached(request, pathname, cacheFor);
+    if (cacheFor && request.method === "GET") return edgeCached(request, pathname, cacheFor);
 
     if (STATIC_FIRST.has(pathname)) {
       const copy = await stored(request, env, pathname, { fallback: false });

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -201,6 +201,26 @@ def test_the_static_first_set_is_a_subset_of_what_is_snapshotted():
     assert set(snapshot.STATIC_FIRST) <= set(snapshot.PATHS)
 
 
+def test_the_edge_cached_lane_is_entered_only_by_a_get():
+    """A source assertion, deliberately, and narrow — there is no JS harness in this repo.
+
+    `route` admits GET and HEAD. The Cache API does not: `cache.put` rejects a request whose
+    method is not GET. So a HEAD reaching this lane throws inside `edgeCached`, unwinds to
+    the fail-open handler, and that handler fetches the origin again — two origin requests
+    for `/healthz`, which is the one path this lane exists to keep off the origin, with the
+    throw swallowed so nothing reports it. A monitor polling with HEAD would defeat the lane
+    and never know.
+
+    Guarding the lane on GET is what keeps that from happening: a HEAD falls through to the
+    origin path, which answers it in a single request.
+    """
+    worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
+    assert 'if (cacheFor && request.method === "GET") return edgeCached(' in worker, (
+        "the edge-cached lane must be entered only by a GET — the Cache API rejects "
+        "a non-GET request, and the throw is swallowed by the fail-open handler"
+    )
+
+
 def test_the_edge_cached_lane_shares_its_copy_only_with_the_edge():
     """A source assertion, deliberately, and narrow.
 


### PR DESCRIPTION
## What changes for a caller

Nothing a caller can observe on a GET. A `HEAD /healthz` now reaches the origin once instead of twice, and the answer it gets is the same.

## Why

`route` admits GET **and** HEAD:

```js
if (request.method !== "GET" && request.method !== "HEAD") return fetch(request);
...
const cacheFor = EDGE_CACHED_SECONDS[pathname];
if (cacheFor) return edgeCached(request, pathname, cacheFor);
```

The Cache API does not. Cloudflare's [Cache API documentation](https://developers.cloudflare.com/workers/runtime-apis/cache/) lists, among the conditions under which `cache.put` throws, "The `request` passed is a method other than `GET`."

So a HEAD entering this lane misses `cache.match`, fetches the origin, gets a 200, and throws on `cache.put`. The throw is not caught inside `edgeCached` — the `try` there wraps only the `fetch` — so it unwinds to the fail-open handler in `export default`, which calls `fetch(request)` again.

Two consequences, and the second is the one that hides the first:

- **Two origin requests** for `/healthz`, which is the single path this lane exists to keep off the origin. #664 measured it at 2,478 of 2,480 requests arriving through the tunnel — 10.4% of all traffic, and ~1.78M origin requests a day the lane is meant to remove.
- **Silent.** The fail-open `catch (err)` returns without recording anything, so a monitor polling with HEAD defeats the lane on every request and nothing anywhere reports it.

## The fix

Guard the lane on GET. A HEAD falls through to the origin path below, which answers it in one request and already handles origin failure.

```js
const cacheFor = EDGE_CACHED_SECONDS[pathname];
if (cacheFor && request.method === "GET") return edgeCached(request, pathname, cacheFor);
```

Guarding at the route level rather than around `cache.put` is deliberate: a HEAD then reaches neither `cache.match` nor `cache.put`, so neither can throw, and that is verifiable by reading. Guarding only the `put` would leave `match` called with a non-GET request, whose behaviour I cannot execute here to confirm.

Traced what a HEAD does after the change: `/healthz` is in `EDGE_CACHED`, not in `STATIC_FIRST` and not in `snapshot.PATHS` (both pinned by existing tests), so it falls to the origin fetch with the 8s timeout, returns the origin's answer, and on origin failure `stored()` returns `null` for the un-snapshotted path and the handler returns the origin's own failure. One request, no throw, no invented answer.

## Test

A source assertion in `tests/edge/test_edge_worker.py`, following the one #664 added for `s-maxage`. There is no JS harness in this repository and nothing in `ci.yml` executes `edge/src/worker.js` — the `worker` job builds the MCP worker, which is a different file. I verified the assertion is not vacuous: with the one-line fix reverted it fails, and with it applied it passes.

## Abuse impact of new public surface

None. No route, parameter, header or response field is added, and no method is newly accepted — HEAD was already routed here and already answered, just twice.

## Compatibility

No behaviour change on GET. HEAD callers see the same status and headers from the origin as before; they simply stop being served through a lane that could not hold their response anyway.

## Proposed release note

> A `HEAD` request to an edge-cached path no longer costs two origin requests. The Cache API rejects a non-GET request, so a `HEAD` entering that lane threw and fell back to a second origin fetch; the lane is now entered only by a `GET`.

## Verification

Verified against `main` at `16a6128`.

| check | command | result |
|---|---|---|
| lint | `uv run ruff check .` | passed |
| format | `uv run ruff format --check .` | 81 files already formatted |
| types | `uv run ty check` | passed |
| tests | `uv run coverage run -m pytest tests -q` | 648 passed, 1 skipped |
| size | `uv run sz.py --caps` | exit 0 |
| example | `bash examples/beautiful_chat.sh` | exit 0 |

`CHANGELOG.md` and `sz-baseline.json` are untouched; the change is entirely in `extra` and adds no core code lines.

Found while reviewing #664 before it merged — the finding was in my review body rather than an inline comment and did not get picked up, so it shipped in 0.11.4. Raising it as its own PR rather than reopening that thread.
