### PR TITLE
fix(humans): give the room table a deadline and a failure state

### DIFF
--- a/src/humans.html
+++ b/src/humans.html
@@ -659,8 +659,13 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     var ctl = new AbortController();
     var timer = setTimeout(function () { ctl.abort(); }, ROOMS_DEADLINE_MS);
     fetch('/rooms?format=json&limit=200', { signal: ctl.signal })
-      .then(function (r) { clearTimeout(timer); return r.json(); })
-      .then(function (v) { roomsView = v; renderRooms(); })
+      // The timer is cleared after the parse, not after the headers. fetch() resolves as
+      // soon as the response head arrives, so clearing it on `r` would leave a stalled or
+      // dribbling body running until the browser's own timeout — the hang this deadline
+      // exists to end, moved one step later and harder to see. The signal reaches the body
+      // read too, so an abort here rejects the parse and lands in the catch below.
+      .then(function (r) { return r.json(); })
+      .then(function (v) { clearTimeout(timer); roomsView = v; renderRooms(); })
       .catch(function () {
         clearTimeout(timer);
         // Only when there is nothing else to show. This refreshes every 5 seconds, and

--- a/src/humans.html
+++ b/src/humans.html
@@ -648,11 +648,45 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   // No { cache: 'no-store' } on the polls: that option adds a request Cache-Control:
   // no-cache header, defeating the shared cache the server's s-maxage invites. The
   // response's max-age=0 already keeps the browser revalidating.
+  // A deadline, because /rooms has no useful upper bound on a loaded box. Its cost there is
+  // queueing at the origin rather than the walk itself (bench/rooms.py measures both), and
+  // the browser's own timeout is minutes. The catch below was always meant to explain a load
+  // that failed; without a deadline it does not run until the gateway gives up, so the
+  // honest report of "slow" arrives long after a reader has concluded the page is broken.
+  var ROOMS_DEADLINE_MS = 15000;
+
   function loadRooms() {
-    fetch('/rooms?format=json&limit=200')
-      .then(function (r) { return r.json(); })
+    var ctl = new AbortController();
+    var timer = setTimeout(function () { ctl.abort(); }, ROOMS_DEADLINE_MS);
+    fetch('/rooms?format=json&limit=200', { signal: ctl.signal })
+      .then(function (r) { clearTimeout(timer); return r.json(); })
       .then(function (v) { roomsView = v; renderRooms(); })
-      .catch(function () { statsEl.textContent = 'could not load room list'; });
+      .catch(function () {
+        clearTimeout(timer);
+        // Only when there is nothing else to show. This refreshes every 5 seconds, and
+        // replacing a list that loaded a moment ago with an error because one poll timed
+        // out would be a worse answer than the slightly stale one already on screen.
+        if (!roomsView) roomsProblem();
+      });
+  }
+
+  // The table's own failure state. Until this existed, a /rooms fetch that never resolved
+  // left roomsView null, renderRooms returned at its first line, and the page showed a
+  // header row over nothing for as long as the origin took — with no way for a reader to
+  // tell a slow service from a broken page. The message goes in the table as well as the
+  // stats line because the table is where the reader is already looking, and it names the
+  // way out: room reads are a different endpoint and stay fast when this one does not.
+  function roomsProblem() {
+    var message = 'Could not load the room list \u2014 the service is slow or unreachable. '
+                + 'Rooms still open by name in the Room box below.';
+    statsEl.textContent = message;
+    roomsBody.textContent = '';
+    var tr = document.createElement('tr'), td = document.createElement('td');
+    td.className = 'empty';
+    td.colSpan = 5;
+    td.textContent = message;
+    tr.appendChild(td);
+    roomsBody.appendChild(tr);
   }
 
   function matches(r, q) {


### PR DESCRIPTION
## What

The room table on `/humans` now gives up on `/rooms` after 15s and says so, in the table and the stats line. Nothing else about the page changes.

## Why

`/humans` paints fine — measured against production with Playwright at FCP ~300ms, with `/r/lobby` already back at 398ms — and then shows a header row over nothing, sometimes indefinitely. Two causes, both on the page:

- `loadRooms` had no `AbortSignal`. Its `.catch` was always meant to explain a failed load, but a fetch with no deadline waits on the browser's own timeout, so the explanation arrived long after a reader had concluded the page was broken.
- `renderRooms` returns at its first line when `roomsView` is null, so nothing was drawn at all. Its three empty-state messages all assume a payload arrived; none covers the case where none did.

`roomsProblem()` fires only when there is nothing already on screen — the table refreshes every 5s, and replacing a list that loaded a moment ago because one poll timed out would be worse than the slightly stale one.

The message names the way out, and it is real: room reads are a different endpoint and stay fast when this one does not.

Why `/rooms` is slow at all is #674 and #576, not this. This is the page telling the truth while that is true.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 647 passed, 1 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: none — no documented surface changes
- [x] New surface on a world-writable service: nothing new. No new endpoint, parameter or stored state; a client-side deadline only.

Verified with Playwright against a local instance, `/rooms` intercepted and never fulfilled:

```
[rooms OK]    fcp=76ms   table: "No rooms yet."
[rooms HANGS] fcp=32ms   table: "Could not load the room list — the service is
                                 slow or unreachable. Rooms still open by name
                                 in the Room box below."
```
