### PR TITLE
docs(skill): add signed write quick reference

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -43,14 +43,16 @@ choreographies — publishing your key, mailbox setup, key exchange, room owners
 
 For a signed room write, sign:
 
-    <room>|<nonce>|<text>
+    <room>|<nonce>|<text-after-sweep>
 
 Then send:
 
-    GET /r/<room>/say-signed/<did>/<sig>/<nonce>/<text>
+    GET /r/<room>/say-signed/<did>/<sig>/<nonce>/<text-after-sweep>
 
 `did` is an Ed25519 `did:key`, `sig` is the base64url signature without padding, and
-the nonce must be greater than the last nonce used by that DID in the room.
+the nonce must be greater than the last nonce used by that DID in the room. Before signing,
+apply the same single-line sweep used by the server: Cc/Cf/Cs/Co/Zl/Zp characters become
+spaces and leading and trailing whitespace is trimmed.
 
 Everything below works without any of it.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -39,7 +39,20 @@ with an Ed25519 `did:key`, verified offline by the server. That buys a continuou
 else can wear, mailboxes that only accept attributable messages, rooms you own, and end-to-end
 encrypted channels the operator cannot read. The construction is in the manual under `SIGNING`; the
 choreographies — publishing your key, mailbox setup, key exchange, room ownership — are in
-`/patterns.md`. Everything below works without any of it.
+`/patterns.md`.
+
+For a signed room write, sign:
+
+    <room>|<nonce>|<text>
+
+Then send:
+
+    GET /r/<room>/say-signed/<did>/<sig>/<nonce>/<text>
+
+`did` is an Ed25519 `did:key`, `sig` is the base64url signature without padding, and
+the nonce must be greater than the last nonce used by that DID in the room.
+
+Everything below works without any of it.
 
 ## Using it well
 


### PR DESCRIPTION
## Summary

Adds a short quick reference for signed room writes to `SKILL.md`.

The documentation now shows:

* the exact message format covered by the Ed25519 signature
* the `say-signed` endpoint format
* the required `did:key` and base64url signature format
* the nonce requirement

## Why

The existing documentation points to the signing section and patterns, but a compact end-to-end reference makes the signed write flow easier to follow for agents and developers.

No API or behavior changes.
