### PR TITLE
fix(edge): restore two fixes that missed the #674 squash

### DIFF
--- a/edge/snapshot.py
+++ b/edge/snapshot.py
@@ -26,10 +26,6 @@ import pathlib
 import sys
 import urllib.request
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))
-
-import store  # noqa: E402  — for MAX_LIMIT only; see ROOMS_KEY_MATCH below
-
 # Every route in app.py that renders a document. Deliberately explicit: this list and the
 # `routes` in wrangler.jsonc describe the same surface and are checked against each other
 # by test_edge_snapshot_covers_every_routed_document.
@@ -113,10 +109,13 @@ EDGE_REVALIDATE = {"/rooms": 5}
 # `match` names a parameter that matters only when it equals one value: `format=json` picks
 # the rendering, every other value is ignored. `clamped` names a numeric one and its bounds.
 #
-# The ceiling comes from the tree, not the served schema, which is the opposite of what this
-# file does elsewhere: `limit` is advisory, so by the input doctrine it publishes no
-# minimum/maximum — bounds mean refusal and this clamps (test_input_doctrine.py asserts their
-# absence). MAX_LIMIT is a constant rather than a knob, so the checkout is an exact source.
+# The ceiling is restated here rather than read from anywhere, which needs two excuses. It is
+# not taken from the served schema because `limit` is advisory: by the input doctrine it
+# publishes no minimum/maximum, since bounds mean refusal and this clamps
+# (test_input_doctrine.py asserts their absence). And it is not imported from store because
+# this file runs under bare python3 from deploy.sh and store pulls in the service's whole
+# dependency chain. Drift is caught instead — the edge-key test asserts it against
+# store.MAX_LIMIT, which is where the number actually lives.
 ROOMS_KEY_MATCH = {"format": "json"}
 
 
@@ -125,7 +124,7 @@ def rooms_key() -> dict:
     return {
         "/rooms": {
             "match": dict(ROOMS_KEY_MATCH),
-            "clamped": {"limit": {"min": 1, "max": store.MAX_LIMIT}},
+            "clamped": {"limit": {"min": 1, "max": 200}},
         }
     }
 

--- a/edge/wrangler.jsonc
+++ b/edge/wrangler.jsonc
@@ -40,7 +40,12 @@
     // Edge-cached, never snapshotted — see EDGE_CACHED in snapshot.py.
     { "pattern": "technocore.chat/healthz", "zone_name": "technocore.chat" },
     // Served from the edge copy always, refreshed in the background — EDGE_REVALIDATE.
-    { "pattern": "technocore.chat/rooms", "zone_name": "technocore.chat" },
+    // The trailing * is load-bearing: a route pattern is matched against the whole URL,
+    // query string included, so "technocore.chat/rooms" matches a bare /rooms and nothing
+    // else. Every caller that matters sends one — /humans asks for ?format=json&limit=200
+    // and agents for ?format=json — so without it the lane is attached to the one form of
+    // the request nobody makes. This is the only route whose reply depends on its query.
+    { "pattern": "technocore.chat/rooms*", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/robots.txt", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/sitemap.xml", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/openapi.json", "zone_name": "technocore.chat" },

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -9,10 +9,12 @@ outage the Worker exists for.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
 import pathlib
 import re
+import sys
 
 import _client
 import pytest
@@ -370,3 +372,21 @@ def test_a_head_request_can_never_become_the_stored_body():
     assert origin.index("const canonical") < origin.index("await fetch("), (
         "the canonical GET must be what is fetched, not built after the fact"
     )
+
+
+def test_the_snapshot_script_needs_nothing_but_the_standard_library():
+    """deploy.sh runs it as `python3 snapshot.py`, not through uv. An import of the service's
+    own modules drags the whole dependency chain in with it and the deploy dies at the
+    snapshot step — which is the worst place for it, since wrangler then never runs and the
+    stored copies on disk are whatever the last deploy left. Restating a constant here and
+    gating it elsewhere is the trade this file makes for that.
+    """
+    tree = ast.parse((EDGE / "snapshot.py").read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):  # parsed, not grepped: prose in a docstring starts with "from"
+        if isinstance(node, ast.Import):
+            imported |= {a.name for a in node.names}
+        elif isinstance(node, ast.ImportFrom) and not node.level and node.module:
+            imported.add(node.module)
+    external = {m.split(".")[0] for m in imported} - set(sys.stdlib_module_names) - {"__future__"}
+    assert not external, f"snapshot.py must run under a bare python3, but imports {external}"

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -35,14 +35,18 @@ def _snapshot_module():
 
 
 def _wrangler_routes() -> set[str]:
-    """The path half of every route in wrangler.jsonc, as a URL path."""
+    """The path half of every route in wrangler.jsonc, as a URL path.
+
+    A trailing `*` is dropped: it decides *matching*, not which path is served, and every
+    caller of this helper is asking the second question.
+    """
     raw = (EDGE / "wrangler.jsonc").read_text(encoding="utf-8")
     stripped = re.sub(r"^\s*//.*$", "", raw, flags=re.M)
     config = json.loads(stripped)
     paths = set()
     for route in config["routes"]:
         _, _, path = route["pattern"].partition("/")
-        paths.add("/" + path)
+        paths.add("/" + path.rstrip("*"))
     return paths
 
 
@@ -390,3 +394,24 @@ def test_the_snapshot_script_needs_nothing_but_the_standard_library():
             imported.add(node.module)
     external = {m.split(".")[0] for m in imported} - set(sys.stdlib_module_names) - {"__future__"}
     assert not external, f"snapshot.py must run under a bare python3, but imports {external}"
+
+
+def test_a_path_whose_reply_varies_by_query_is_routed_with_a_wildcard():
+    """Route patterns are matched against the whole URL, query string included, so
+    `technocore.chat/rooms` matches a bare /rooms and not /rooms?format=json — the request
+    never reaches the Worker and the lane silently does nothing at all. That is how the first
+    deploy of this lane behaved: bare /rooms came back with x-edge-stamp and s-maxage=86400,
+    /rooms?format=json with the origin's own headers.
+
+    Only paths whose reply depends on the query need this, which is why the document routes
+    are exact: EDGE_KEY naming a path is what says its reply varies.
+    """
+    raw = (EDGE / "wrangler.jsonc").read_text(encoding="utf-8")
+    patterns = {
+        r["pattern"] for r in json.loads(re.sub(r"^\s*//.*$", "", raw, flags=re.M))["routes"]
+    }
+    for path in _snapshot_module().rooms_key():
+        assert f"technocore.chat{path}*" in patterns, (
+            f"{path}'s reply varies by query string, so its route must end in * or the "
+            "Worker never sees the requests that carry one"
+        )


### PR DESCRIPTION
## What

Restores two commits that were on `feat/edge-revalidate` but did not reach `main` — #674 was squash-merged at `b06dce8`, and these landed after. No new work; both are already running in production.

## Why

`main` cannot currently produce the Worker that is deployed:

- **`main` is undeployable.** `deploy.sh` runs `python3 snapshot.py`, not uv, and `main`'s copy imports `store` for `MAX_LIMIT` — which drags in the service's dependency chain and dies on `No module named 'nacl'`, at the snapshot step, so wrangler never runs. The ceiling is restated in `snapshot.py` instead (it cannot come from the served schema either — `limit` is advisory and by the input doctrine publishes no `minimum`/`maximum`), and the edge-key test already gates it against `store.MAX_LIMIT`.
- **The `/rooms` lane does nothing on `main`.** A Worker route pattern is matched against the whole URL, query string included, so `technocore.chat/rooms` matches a bare `/rooms` and nothing else — while `/humans` sends `?format=json&limit=200` and agents send `?format=json`. Measured on the first deploy: bare `/rooms` came back with `x-edge-stamp` and `s-maxage=86400`; `/rooms?format=json` came back with the origin's own `s-maxage=5, swr=25`, untouched.

Both failures are silent. The first stops a deploy after the previous copies are already on disk; the second leaves a lane that looks like it works because Cloudflare's ordinary cache rule sits in front of it.

Each comes with the gate that would have caught it: an `ast`-parsed import check on `snapshot.py`, and a wildcard-route check derived from `EDGE_KEY` rather than a hand-kept list.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 658 passed, 1 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: none
- [x] New surface on a world-writable service: nothing new — a route pattern widened to cover the query strings it was always meant to, and one import removed

Verified that `python3 edge/snapshot.py` (bare interpreter, no uv) completes against a local instance: `17 documents -> …`, `routing policy -> …`.
