### PR TITLE
fix(mcp): preserve large signing nonces

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -117,6 +117,9 @@ the two custody models that rule never forbade:
   answer with the exact canonical string to sign and a usable nonce — the challenge an external
   signer needs for the retry.
 
+  Pass an external nonce above `9007199254740991` as a 1-19 digit JSON string. Sending it as a JSON
+  number can lose integer precision in JavaScript clients and change the string the signature covers.
+
 `whoami` closes the loop on identity: besides the `did:key` it reports the exact `write_note` call
 that publishes it, because the sharded note path (patterns.md §3 — SHA-256 of the did:key, first 16
 hex, split 2/14) is the one part of that pattern a model cannot derive. Publishing is then an

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -295,6 +295,11 @@ Key = Annotated[str, Field(description="Note key.", pattern=NAME_PATTERN)]
 # is canonical base64url of 64 bytes.
 DID_PATTERN = r"^did:key:z6Mk[1-9A-HJ-NP-Za-km-z]{44}$"
 SIG_PATTERN = r"^[A-Za-z0-9_-]{85}[AQgw]$"
+NONCE_PATTERN = r"^[0-9]{1,19}$"
+# JSON numbers become IEEE-754 doubles in JavaScript MCP clients. Above this value an
+# integer can be rounded before the wrapper sees it, changing the canonical string that
+# an external signer covered. Larger service-valid nonces therefore travel as digits.
+JSON_SAFE_INTEGER = (1 << 53) - 1
 Did = Annotated[
     str | None,
     Field(
@@ -310,14 +315,21 @@ Sig = Annotated[
     ),
 ]
 Nonce = Annotated[
-    int | None,
-    Field(description="The nonce the signature covers. Must exceed the last one used."),
+    Annotated[str, Field(pattern=NONCE_PATTERN)]
+    | Annotated[int, Field(ge=0, le=JSON_SAFE_INTEGER)]
+    | None,
+    Field(
+        description=(
+            "The nonce the signature covers. Must exceed the last one used. Pass values "
+            "above 9007199254740991 as 1-19 decimal digits, not a JSON number."
+        )
+    ),
 ]
 
 
 def _resolve_signature(
-    canonical: str, did: str | None, sig: str | None, nonce: int | None, minted: int
-) -> tuple[str, str, int]:
+    canonical: str, did: str | None, sig: str | None, nonce: str | int | None, minted: int
+) -> tuple[str, str, str]:
     """The signed tools' three modes, decided in one place.
 
     All three externals given: pass them through — a signature is public data, and this is
@@ -327,11 +339,11 @@ def _resolve_signature(
     that "fails" is the request for a signature.
     """
     if did is not None and sig is not None and nonce is not None:
-        return did, sig, nonce
+        return did, sig, str(nonce)
     if did is not None or sig is not None or nonce is not None:
         raise ToolError("pass all three of did, sig and nonce, or none of them")
     if _signer is not None:
-        return _signer.did, _signer.sign(canonical), minted
+        return _signer.did, _signer.sign(canonical), str(minted)
     raise ToolError(
         "no signing identity: either set TECHNOCORE_SIGNING_KEY in the server config "
         "(a 32-byte Ed25519 seed, hex or base64url), or sign externally and retry with "

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -265,12 +265,17 @@ ADVERTISED = {
             "text": "string",
             "did": "string?",
             "sig": "string?",
-            "nonce": "integer?",
+            "nonce": "integer|string?",
         },
         ["room", "text"],
     ),
     "claim_room": (
-        {"room": "string", "did": "string?", "sig": "string?", "nonce": "integer?"},
+        {
+            "room": "string",
+            "did": "string?",
+            "sig": "string?",
+            "nonce": "integer|string?",
+        },
         ["room"],
     ),
     "set_room_allow": (
@@ -279,7 +284,7 @@ ADVERTISED = {
             "dids": "string",
             "did": "string?",
             "sig": "string?",
-            "nonce": "integer?",
+            "nonce": "integer|string?",
         },
         ["room", "dids"],
     ),
@@ -335,12 +340,13 @@ ANNOTATED = {
 
 
 def named(schema: dict) -> str:
-    """The one word a property's schema says about its type, optional arms folded in."""
+    """The effective types in a property's schema, optional arms folded in."""
     if "type" in schema:
         return schema["type"]
     arms = [arm for arm in schema["anyOf"] if arm.get("type") != "null"]
-    assert len(arms) == 1, schema
-    return arms[0]["type"] + "?"
+    nullable = len(arms) != len(schema["anyOf"])
+    types = "|".join(sorted(arm["type"] for arm in arms))
+    return types + ("?" if nullable else "")
 
 
 def test_every_tool_is_listed_with_a_usable_schema(mcp):
@@ -376,6 +382,20 @@ def test_the_descriptions_the_model_reads_survive_the_generation(mcp):
     assert "TECHNOCORE_NICK" in schemas["say"]["properties"]["nick"]["description"]
     write_note = next(tool for tool in tools if tool.name == "write_note")
     assert "Send one condition, not both." in write_note.description
+
+
+def test_signed_nonce_schema_preserves_values_past_javascript_integer_precision(mcp):
+    """A signature covers the nonce's exact digits, so a JavaScript client must not be
+    invited to round a service-valid 19-digit value through its JSON number type."""
+    schemas = {tool.name: tool.input_schema for tool in mcp.tools()}
+    for name in ("say_signed", "claim_room", "set_room_allow"):
+        nonce = schemas[name]["properties"]["nonce"]
+        arms = {arm.get("type"): arm for arm in nonce["anyOf"]}
+        assert set(arms) == {"string", "integer", "null"}
+        assert arms["string"]["pattern"] == mcp.module.NONCE_PATTERN
+        assert arms["integer"]["minimum"] == 0
+        assert arms["integer"]["maximum"] == mcp.module.JSON_SAFE_INTEGER
+        assert "decimal digits" in nonce["description"]
 
 
 def test_every_tool_publishes_its_effect_annotations(mcp):
@@ -933,6 +953,48 @@ def test_an_external_signature_passes_through_without_a_server_key(mcp):
     )
     assert reply.is_error is False, text_of(reply)
     assert swept in text_of(mcp.call("read_room", {"room": "mb-inbox"}))
+
+
+def test_an_external_signature_keeps_a_19_digit_nonce_exact(mcp):
+    """The decimal-string arm carries every service-valid nonce without JSON rounding."""
+    from _client import _keypair
+
+    assert mcp.module._signer is None
+    did, sign = _keypair(seed=5)
+    nonce = "1750000000000000001"
+    canonical = f"mb-inbox|{nonce}|large nonce"
+    reply = mcp.call(
+        "say_signed",
+        {
+            "room": "mb-inbox",
+            "text": "large nonce",
+            "did": did,
+            "sig": sign(canonical),
+            "nonce": nonce,
+        },
+    )
+    assert reply.is_error is False, text_of(reply)
+
+
+def test_an_unsafe_json_integer_nonce_is_refused_before_the_network(mcp):
+    """A rounded number must fail locally with the schema pointing callers to strings."""
+    from _client import _keypair
+
+    did, sign = _keypair(seed=6)
+    nonce = mcp.module.JSON_SAFE_INTEGER + 1
+    before = len(mcp.sent)
+    reply = mcp.call(
+        "say_signed",
+        {
+            "room": "mb-inbox",
+            "text": "unsafe numeric nonce",
+            "did": did,
+            "sig": sign(f"mb-inbox|{nonce}|unsafe numeric nonce"),
+            "nonce": nonce,
+        },
+    )
+    assert reply.is_error is True
+    assert len(mcp.sent) == before
 
 
 def test_a_partial_external_signature_is_refused_before_the_network(mcp, monkeypatch):


### PR DESCRIPTION
## What

MCP signed tools now accept external nonces as either safe JSON integers or 1-19 digit strings. Values are normalized to exact decimal strings before forwarding, and unsafe JSON integers are rejected before a request.

## Why

The service permits 19-digit nonces, but JavaScript JSON numbers above 9007199254740991 can round before the wrapper sees them. That changes the signed canonical string and causes a valid external signature to fail.

## Checks

- [ ] Full coverage suite (requires POSIX fcntl; unavailable on local Windows)
- [x] ruff check . and ruff format --check .
- [x] ty check mcp/src/technocore_mcp/server.py
- [x] Targeted schema/transport and signed-lane tests
- [x] Affected docs updated
- [x] New world-writable surface: nothing new