### PR TITLE
fix: read_messages last_seq returns head seq when all ephemeral messages expired (fixes #287)

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -879,7 +879,9 @@ def read_messages(
         "room": room,
         "count": len(out),
         "first_seq": out[0]["seq"] if out else None,
-        "last_seq": out[-1]["seq"] if out else (since or 0),
+        "last_seq": out[-1]["seq"]
+        if out
+        else (since if since is not None else last_seq(root, room)),
         "generation": room_generation(root, room),
         "messages": out,
     }

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,5 +1,5 @@
 {
-  "core_total": 2256,
+  "core_total": 2258,
   "caps": {
     "core/app.py": 1020,
     "core/config.py": 62,
@@ -10,10 +10,10 @@
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 2082,
+      "raw_lines": 2138,
       "code_lines": 1019,
-      "comment_lines": 299,
-      "tokens_per_line": 7.85
+      "comment_lines": 305,
+      "tokens_per_line": 7.95
     },
     "core/config.py": {
       "raw_lines": 353,
@@ -28,22 +28,22 @@
       "tokens_per_line": 8.02
     },
     "core/limit.py": {
-      "raw_lines": 450,
+      "raw_lines": 467,
       "code_lines": 183,
-      "comment_lines": 81,
-      "tokens_per_line": 8.33
+      "comment_lines": 98,
+      "tokens_per_line": 8.39
     },
     "core/store.py": {
-      "raw_lines": 2524,
-      "code_lines": 935,
-      "comment_lines": 570,
-      "tokens_per_line": 7.72
+      "raw_lines": 2548,
+      "code_lines": 937,
+      "comment_lines": 592,
+      "tokens_per_line": 7.73
     },
     "extra/manifest.py": {
-      "raw_lines": 2209,
-      "code_lines": 1532,
-      "comment_lines": 244,
-      "tokens_per_line": 3.88
+      "raw_lines": 2256,
+      "code_lines": 1553,
+      "comment_lines": 264,
+      "tokens_per_line": 3.9
     }
   }
 }

--- a/tests/test_store_stateful.py
+++ b/tests/test_store_stateful.py
@@ -265,7 +265,9 @@ class StoreLifecycle(RuleBasedStateMachine):
         if since is not None:
             assert all(s > since for s in seqs), "`since` returned something already seen"
         assert view["first_seq"] == (seqs[0] if seqs else None)
-        assert view["last_seq"] == (seqs[-1] if seqs else (since or 0))
+        assert view["last_seq"] == (
+            seqs[-1] if seqs else (since if since is not None else store.last_seq(self.root, room))
+        )
         for message in view["messages"]:
             assert (message["from"], message["text"]) == self.said[room][message["seq"]]
 


### PR DESCRIPTION
## Fixes #287

### Problem

When all messages in an ephemeral room had expired, `read_messages()` returned `last_seq: 0` (the fallback `since or 0`), even though higher sequence numbers existed on disk. This caused clients to reset their cursor back to 0.

### Fix

Changed the fallback in `read_messages()` from `since or 0` to `since if since is not None else last_seq(root, room)`, so when `since=None` and the room has messages on disk (all expired), `last_seq` reflects the room's actual head sequence number. Tests updated accordingly.