### PR TITLE
fix: prevent stale note count persistence during capacity checks

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1918,14 +1918,16 @@ def _note_totals(d: Path, rebuild=_count_notes, persist=False, name=NOTES_FILE) 
 
     Read without the lock, like `counters`: replacement is atomic, so a reader sees the old
     bytes or the new ones. Reading is safe unserialised; *persisting* what the read rebuilt
-    is not, so `persist` is off by default and only `_check_note_capacity` turns it on —
-    that one runs inside the create gate, which IS this file's lock, and every other write of
-    a count file is under the same lock. A rebuild persisted from outside it would be a
-    snapshot of a walk, installed after a create had already reserved a higher figure against
-    the file, and the count would come out below the notes on disk: a low count admits writes
-    past MAX_NOTES_TOTAL until the next reap. Not persisting costs the walk again on the next
-    read, which is the old cost and the point — this degrades to what it replaced, and never
-    to a wrong number.
+    is not, so `persist` is off by default. `_check_note_capacity` is the only caller that
+    ever turns it on, and only via its own `locked` flag: `_create_gate` calls it once early,
+    unlocked, before anything is made, and once more inside the create gate, which IS this
+    file's lock, and every other write of a count file is under the same lock — only that
+    second, authoritative call passes `locked=True`. A rebuild persisted from outside that
+    lock would be a snapshot of a walk, installed after a create had already reserved a
+    higher figure against the file, and the count would come out below the notes on disk: a
+    low count admits writes past MAX_NOTES_TOTAL until the next reap. Not persisting costs
+    the walk again on the next read, which is the old cost and the point — this degrades to
+    what it replaced, and never to a wrong number.
 
     A zero is never persisted, and that is load-bearing rather than an optimization:
     `_write_note_count` creates the directory it writes into, so persisting the zero a
@@ -2084,7 +2086,26 @@ def _check_room_capacity(root: Path, path: Path) -> None:
         )
 
 
-def _check_note_capacity(root: Path, ns_dir: Path, path: Path) -> None:
+def _note_capacity_checker(root: Path, ns_dir: Path, path: Path):
+    """A zero-arg `check` for `_create_gate`, which calls it twice per create attempt: an
+    early, unlocked call that must not persist a rebuilt count (it can race a concurrent
+    reservation and clobber it -- see `_note_totals`), and a later, locked call that is
+    authoritative and safe to persist. `_create_gate` always calls unlocked-then-locked in
+    that order for a single creation attempt, so a fresh closure's state tracks which call
+    this is without touching `_create_gate` or the room capacity check.
+    """
+    state = {"locked": False}
+
+    def check() -> None:
+        _check_note_capacity(root, ns_dir, path, locked=state["locked"])
+        state["locked"] = True
+
+    return check
+
+
+def _check_note_capacity(
+    root: Path, ns_dir: Path, path: Path, *, locked: bool = False
+) -> None:
     """Both note caps, neither of which walks any more. Existing notes always proceed, so a
     full namespace never silences agents already using it.
 
@@ -2106,7 +2127,7 @@ def _check_note_capacity(root: Path, ns_dir: Path, path: Path) -> None:
     # The namespace directory, passed in rather than taken from the note: `path.parent` is the
     # key's bucket now, and counting that would both compare the cap against ~1 note and drop
     # the namespace's `.notes-count` two levels below where every other reader looks for it.
-    if _note_totals(ns_dir, _ns_totals, persist=True)[0] >= MAX_NOTES_PER_NS:
+    if _note_totals(ns_dir, _ns_totals, persist=locked)[0] >= MAX_NOTES_PER_NS:
         raise _at_capacity(MAX_NOTES_PER_NS, "note")
     if _note_count(root) >= MAX_NOTES_TOTAL:
         raise StoreError(
@@ -2464,7 +2485,7 @@ def note_set(
     with _create_gate(
         root / NOTES_FILE,
         path,
-        lambda: _check_note_capacity(root, ns_dir, path),
+        _note_capacity_checker(root, ns_dir, path),
         lambda d: _count_new_note(root, ns_dir, len(value.encode("utf-8")), d),
     ):
         if expect_absent or expect is not None:

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -85,7 +85,7 @@ def test_the_per_namespace_count_is_rebuilt_once_and_then_stays_free(tmp_path, m
     fresh = store.note_path(tmp_path, "did", "brand-new")
 
     (ns / store.NOTES_FILE).unlink()  # what a reap leaves behind
-    rebuild = _scandir_calls(monkeypatch, lambda: store._check_note_capacity(tmp_path, ns, fresh))
+    rebuild = _scandir_calls(monkeypatch, lambda: store._check_note_capacity(tmp_path, ns, fresh, locked=True))
     # 2, not 1: the rebuild scan recurses, and one seeded note occupies one bucket — so the
     # namespace directory and that bucket. The cost grows with OCCUPIED buckets rather than
     # with notes, and one level of 256 bounds it at 257 reads however full the namespace
@@ -93,7 +93,7 @@ def test_the_per_namespace_count_is_rebuilt_once_and_then_stays_free(tmp_path, m
     assert rebuild == 2, "a dropped count must be rebuilt by scanning that namespace once"
     assert (ns / store.NOTES_FILE).exists(), "…and the rebuild must be persisted"
 
-    cached = _scandir_calls(monkeypatch, lambda: store._check_note_capacity(tmp_path, ns, fresh))
+    cached = _scandir_calls(monkeypatch, lambda: store._check_note_capacity(tmp_path, ns, fresh, locked=True))
     assert cached == 0, "every create after the rebuild is a file read"
 
 
@@ -299,6 +299,24 @@ def test_the_global_cap_binds_exactly_under_concurrent_processes(tmp_path) -> No
     assert store._note_count(root) == cap
 
 
+def test_unlocked_capacity_check_does_not_persist_rebuilt_count(tmp_path) -> None:
+    """The optimistic, unlocked capacity check must not persist a rebuilt snapshot."""
+    import store
+
+    store.note_set(tmp_path, "did", "seed", "v")
+    ns = tmp_path / "notes" / "did"
+    fresh = store.note_path(tmp_path, "did", "brand-new")
+    counter = ns / store.NOTES_FILE
+
+    counter.unlink()
+
+    store._check_note_capacity(tmp_path, ns, fresh, locked=False)
+    assert not counter.exists(), "an unlocked check must not persist a rebuilt count"
+
+    store._check_note_capacity(tmp_path, ns, fresh, locked=True)
+    assert counter.exists(), "a locked check must persist the rebuilt count"
+
+
 def test_a_refused_write_counts_nothing(tmp_path) -> None:
     """The count is a reservation, and a reservation nothing was written against is given
     back. `?if=<value>` against a key that does not exist reaches its CAS check *inside* the
@@ -399,8 +417,8 @@ def test_the_per_namespace_cap_holds_under_concurrent_creates(tmp_path, monkeypa
     monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 4)
     real_check = store._check_note_capacity
 
-    def slow_check(root, ns_dir, path):
-        real_check(root, ns_dir, path)
+    def slow_check(root, ns_dir, path, *, locked=False):
+        real_check(root, ns_dir, path, locked=locked)
         time.sleep(0.02)  # widen the count->write window every racer must lose
 
     monkeypatch.setattr(store, "_check_note_capacity", slow_check)

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -305,8 +305,8 @@ def test_note_cap_holds_under_concurrent_creates(tmp_path, monkeypatch):
     monkeypatch.setattr(store, "MAX_NOTES_TOTAL", 4)
     real_check = store._check_note_capacity
 
-    def slow_check(root, ns_dir, path):
-        real_check(root, ns_dir, path)
+    def slow_check(root, ns_dir, path, *, locked=False):
+        real_check(root, ns_dir, path, locked=locked)
         time.sleep(0.02)  # widen the count→write window every racer must lose
 
     monkeypatch.setattr(store, "_check_note_capacity", slow_check)


### PR DESCRIPTION
The per-namespace note capacity check runs twice per create attempt, once unlocked as an early check and once locked as the authoritative check, and both paths could previously persist a rebuilt `.notes-count`; if the unlocked rebuild finished after a concurrent writer had already persisted a newer count, the stale snapshot could overwrite it with a lower value and allow notes beyond `MAX_NOTES_PER_NS` until the next reap. This is fixed by ensuring only the authoritative locked check persists rebuilt counts, while the unlocked check only reads them. Added a deterministic regression test covering this behavior and updated the existing concurrency tests; the full suite is green except for one unrelated pre-existing `mcp` import dependency gap. Severity: **High** due to quota bypass, with no RCE, cross-tenant access, or direct financial impact
