### PR TITLE
fix(limit): require &ref= syntax when dropping pasted ref tokens from dupe keys

### DIFF
--- a/src/limit.py
+++ b/src/limit.py
@@ -149,7 +149,7 @@ def normalize_text(text: str) -> str:
     # behind, and nothing else), pasted into the text instead of the query string, is cut
     # out so it can never be what makes a copy unique — neither on its own nor by taking
     # the word it was glued to with it.
-    return " ".join(re.sub(r"(?:&?ref=)?422-[\da-f]{1,8}-[\da-f]{4}", " ", text.casefold()).split())
+    return " ".join(re.sub(r"&ref=422-[\da-f]{1,8}-[\da-f]{4}", " ", text.casefold()).split())
 
 
 def _dupe_key(room: str, text: str, min_length: int) -> tuple[str, bytes] | None:

--- a/src/limit.py
+++ b/src/limit.py
@@ -142,14 +142,14 @@ def normalize_text(text: str) -> str:
     compatibility forms must decompose before casefolding for the two to agree.
     """
     text = unicodedata.normalize("NFKC", text)
-    text = "".join(
+    t = "".join(
         " " if unicodedata.category(c) in store.INVISIBLE_CATEGORIES else c for c in text
-    )
+    ).casefold()
     # A duplicate 422's ref token (app._REF's shape, with the `&ref=` the body shows it
     # behind, and nothing else), pasted into the text instead of the query string, is cut
     # out so it can never be what makes a copy unique — neither on its own nor by taking
     # the word it was glued to with it.
-    return " ".join(re.sub(r"&ref=422-[\da-f]{1,8}-[\da-f]{4}", " ", text.casefold()).split())
+    return " ".join(re.sub(r"&ref=422-[0-9a-f]{1,8}-[0-9a-f]{4}(?![\w-])", " ", t).split())
 
 
 def _dupe_key(room: str, text: str, min_length: int) -> tuple[str, bytes] | None:

--- a/tests/http/test_dupe_filter.py
+++ b/tests/http/test_dupe_filter.py
@@ -144,9 +144,11 @@ def test_the_ref_token_is_handed_out_seen_again_and_never_a_way_past_the_filter(
     assert [ln for ln in lines if "ref=" + ref in ln] == lines and len(lines) == 3
     assert "path='/patterns.md'" in lines[1] and "forged" not in "".join(lines)
     with _filter_on(DUPE_MAX_COPIES=1):
-        assert _say(client, "lobby", "c", PHRASE + " " + ref).status_code == 422
-        assert _say(client, "lobby", "c", PHRASE + ref).status_code == 422  # glued to a word
         assert _say(client, "lobby", "c", "&ref=" + ref + " " + PHRASE).status_code == 422
+        assert _say(client, "lobby", "c", PHRASE + " &ref=" + ref).status_code == 422
+        assert _say(client, "lobby", "c", PHRASE + "&ref=" + ref).status_code == 422  # glued &ref=
+        # Bare token without ref= syntax remains distinct and is not falsely refused:
+        assert _say(client, "lobby", "c", PHRASE + " " + ref).status_code == 200
 
 
 def test_the_threshold_itself_is_the_knob(client) -> None:

--- a/tests/http/test_dupe_filter.py
+++ b/tests/http/test_dupe_filter.py
@@ -149,6 +149,10 @@ def test_the_ref_token_is_handed_out_seen_again_and_never_a_way_past_the_filter(
         assert _say(client, "lobby", "c", PHRASE + "&ref=" + ref).status_code == 422  # glued &ref=
         # Bare token without ref= syntax remains distinct and is not falsely refused:
         assert _say(client, "lobby", "c", PHRASE + " " + ref).status_code == 200
+        # Extended token shapes (5th trailing hex digit, hyphen suffix) are not over-stripped:
+        assert _say(client, "lobby", "c", PHRASE + " &ref=" + ref + "e").status_code == 200
+        assert _say(client, "lobby", "c", PHRASE + " &ref=" + ref + "9").status_code == 200
+        assert _say(client, "lobby", "c", PHRASE + " &ref=" + ref + "-extra").status_code == 200
 
 
 def test_the_threshold_itself_is_the_knob(client) -> None:

--- a/tests/unit/test_dupe_ring.py
+++ b/tests/unit/test_dupe_ring.py
@@ -62,6 +62,60 @@ def test_normalisation_folds_case_whitespace_and_unicode_compatibility() -> None
     )
 
 
+def test_bare_token_shaped_text_retains_distinct_key_while_pasted_ref_is_cut() -> None:
+    """The documented pasted follow-up syntax (&ref=422-...) is cut out of message text
+    so it cannot buy a fresh duplicate slot. But legitimate bare tokens (such as incident
+    or ticket ids) remain distinct duplicate keys, and ordinary words ending in ref= or
+    malformed token shapes are not over-stripped."""
+    # Bare token stays distinct from text without it
+    phrase = "incident alpha report confirmed"
+    phrase_bare = "incident 422-deadbeef-abcd alpha report confirmed"
+    assert limit.normalize_text(phrase_bare) != limit.normalize_text(phrase)
+    assert limit.normalize_text(phrase_bare) == "incident 422-deadbeef-abcd alpha report confirmed"
+
+    # Documented pasted &ref= syntax is cut out (at middle, start, end, glued)
+    assert limit.normalize_text("hello &ref=422-deadbeef-abcd world") == "hello world"
+    assert limit.normalize_text("&ref=422-deadbeef-abcd") == ""
+    assert limit.normalize_text("&ref=422-deadbeef-abcd hello") == "hello"
+    assert limit.normalize_text("hello &ref=422-deadbeef-abcd") == "hello"
+    assert limit.normalize_text("hello&ref=422-deadbeef-abcd world") == "hello world"
+
+    # Uppercase handling (casefold runs first)
+    assert limit.normalize_text("&REF=422-DEADBEEF-ABCD") == ""
+    assert (
+        limit.normalize_text("INCIDENT 422-DEADBEEF-ABCD ALPHA")
+        == "incident 422-deadbeef-abcd alpha"
+    )
+
+    # Malformed tokens or words ending in ref= are not stripped
+    assert (
+        limit.normalize_text("incident brief=422-deadbeef-abcd alpha")
+        == "incident brief=422-deadbeef-abcd alpha"
+    )
+    assert (
+        limit.normalize_text("incident pref=422-deadbeef-abcd alpha")
+        == "incident pref=422-deadbeef-abcd alpha"
+    )
+    assert (
+        limit.normalize_text("incident &ref=422-deadbeef-xyz1 alpha")
+        == "incident &ref=422-deadbeef-xyz1 alpha"
+    )
+    assert (
+        limit.normalize_text("incident &ref=422-deadbeef00000000-abcd alpha")
+        == "incident &ref=422-deadbeef00000000-abcd alpha"
+    )
+
+    # In dupe_refused: filling the threshold with phrase does not reject
+    # the distinct legitimate message phrase_bare
+    limit._dupes.clear()
+    assert refused(phrase, now=0.0, max_copies=1) is False
+    assert refused(phrase, now=1.0, max_copies=1) is True
+    assert refused(phrase_bare, now=2.0, max_copies=1) is False
+    # But pasting documented &ref= into the duplicate message is rejected
+    assert refused(phrase + " &ref=422-deadbeef-abcd", now=3.0, max_copies=1) is True
+    limit._dupes.clear()
+
+
 def test_the_length_floor_is_on_the_normalised_text() -> None:
     """The floor is the boundary: at or above it the filter applies, below it never
     does - the entire conversational-repeat class lives below it."""

--- a/tests/unit/test_dupe_ring.py
+++ b/tests/unit/test_dupe_ring.py
@@ -79,6 +79,9 @@ def test_bare_token_shaped_text_retains_distinct_key_while_pasted_ref_is_cut() -
     assert limit.normalize_text("&ref=422-deadbeef-abcd hello") == "hello"
     assert limit.normalize_text("hello &ref=422-deadbeef-abcd") == "hello"
     assert limit.normalize_text("hello&ref=422-deadbeef-abcd world") == "hello world"
+    assert limit.normalize_text("prefix&ref=422-deadbeef-abcd") == "prefix"
+    assert limit.normalize_text("incident &ref=422-deadbeef-abcd. next") == "incident . next"
+    assert limit.normalize_text("incident &ref=422-deadbeef-abcd&other=1") == "incident &other=1"
 
     # Uppercase handling (casefold runs first)
     assert limit.normalize_text("&REF=422-DEADBEEF-ABCD") == ""
@@ -104,6 +107,32 @@ def test_bare_token_shaped_text_retains_distinct_key_while_pasted_ref_is_cut() -
         limit.normalize_text("incident &ref=422-deadbeef00000000-abcd alpha")
         == "incident &ref=422-deadbeef00000000-abcd alpha"
     )
+    # Extended token shapes (e.g. 5th hex digit) or non-token boundaries are not stripped
+    assert (
+        limit.normalize_text("incident &ref=422-deadbeef-abcde alpha")
+        == "incident &ref=422-deadbeef-abcde alpha"
+    )
+    assert (
+        limit.normalize_text("incident &ref=422-deadbeef-abcd9 alpha")
+        == "incident &ref=422-deadbeef-abcd9 alpha"
+    )
+    assert (
+        limit.normalize_text("incident &ref=422-deadbeef-abcdz alpha")
+        == "incident &ref=422-deadbeef-abcdz alpha"
+    )
+    assert (
+        limit.normalize_text("incident &ref=422-deadbeef-abcd_extra alpha")
+        == "incident &ref=422-deadbeef-abcd_extra alpha"
+    )
+    assert (
+        limit.normalize_text("incident &ref=422-deadbeef-abcd-extra alpha")
+        == "incident &ref=422-deadbeef-abcd-extra alpha"
+    )
+    # Unicode digits or word continuations that _REF rejects are not stripped
+    assert (
+        limit.normalize_text("incident &ref=422-deadbeef-٠١٢٣ alpha")
+        == "incident &ref=422-deadbeef-٠١٢٣ alpha"
+    )
 
     # In dupe_refused: filling the threshold with phrase does not reject
     # the distinct legitimate message phrase_bare
@@ -111,8 +140,12 @@ def test_bare_token_shaped_text_retains_distinct_key_while_pasted_ref_is_cut() -
     assert refused(phrase, now=0.0, max_copies=1) is False
     assert refused(phrase, now=1.0, max_copies=1) is True
     assert refused(phrase_bare, now=2.0, max_copies=1) is False
+    # Extended token values remain distinct and are not falsely refused:
+    assert refused(phrase + " &ref=422-deadbeef-abcde", now=3.0, max_copies=1) is False
+    assert refused(phrase + " &ref=422-deadbeef-abcd9", now=4.0, max_copies=1) is False
+    assert refused(phrase + " &ref=422-deadbeef-abcd-extra", now=5.0, max_copies=1) is False
     # But pasting documented &ref= into the duplicate message is rejected
-    assert refused(phrase + " &ref=422-deadbeef-abcd", now=3.0, max_copies=1) is True
+    assert refused(phrase + " &ref=422-deadbeef-abcd", now=6.0, max_copies=1) is True
     limit._dupes.clear()
 
 


### PR DESCRIPTION
Fixes #694

### Context & Motivation
PR #687 added stripping of 422 follow-up ref tokens in `limit.normalize_text()` to prevent callers from pasting the server-issued query parameter into message text to buy a fresh duplicate-ring slot. In that implementation, stripping was written to cover the bare `422-<hex>-<hex>` token shape as well.

However, as reported in #694, making `ref=` optional creates severe false-positive duplicate collisions: legitimate messages containing bare token-shaped identifiers (e.g. incident or ticket references like `"incident 422-deadbeef-abcd alpha"`) have that token erased from their duplicate key. When the token-less form fills the duplicate window, the distinct message with the incident token receives a false-positive 422 refusal.

Furthermore, following review feedback, the normalizer pattern must be strictly bounded on the right and aligned to `app._REF`'s ASCII token grammar so that extended or malformed caller text (e.g. `&ref=422-deadbeef-abcde`, `&ref=422-deadbeef-abcd9`, or `&ref=422-deadbeef-abcd-extra`) is not partially stripped into an invalid remnant.

This PR intentionally revises and narrows that portion of #687: duplicate key normalization only strips the documented `&ref=422-...` parameter syntax ending at a non-token/right-hand boundary, rather than bare matching token shapes or longer extended identifiers.

Verified against upstream `main` at `e0e58fc2bf4c92cee87a4ad7e6b5db2847f9f13a`.

### Solution
Narrow and bound the stripping pattern in `src/limit.py`:
```python
re.sub(r"&ref=422-[0-9a-f]{1,8}-[0-9a-f]{4}(?![\w-])", " ", t)
```
- Uses `[0-9a-f]` to align with `app._REF`'s ASCII hex grammar (avoiding over-stripping Unicode digits).
- Uses `(?![\w-])` to enforce a clean right-hand boundary: extended fifth hex digits, non-hex letters, underscores, and hyphen continuations remain caller text instead of having their prefix stripped.
- Preserves stripping of genuine documented `&ref=` tokens when followed by whitespace, punctuation, query-param `&`, or end of string.

### Compatibility
This intentionally narrows one behavior introduced by #687: a bare `422-<hex>-<hex>` substring is no longer special to duplicate normalization. Stored text, HTTP schemas, and the documented ref query parameter are unchanged.

### Abuse Impact
The server-issued/documented `&ref=422-...` form is still stripped from duplicate keys, so following the 422 guidance cannot create a fresh duplicate slot. A caller can make text distinct by adding a bare visible token, but arbitrary visible content already changes the duplicate key; `normalize_text` deliberately avoids fuzzy or over-broad folding because false positives reject legitimate messages.

### Proposed Release Note
Duplicate filtering no longer strips bare 422-shaped text; only the documented &ref= follow-up form is ignored when computing duplicate keys.

### Verification
- **Regression proof**: On unpatched `origin/main`, `"incident 422-deadbeef-abcd alpha"` collapsed into `"incident alpha"`, failing the regression assertions with `assert 'incident alpha report confirmed' != 'incident alpha report confirmed'` and `assert 422 == 200`. On patched code, both pass.
- **Unit suite** (`tests/unit/test_dupe_ring.py`): confirms bare token-shaped text retains distinct keys, words ending in `ref=` are not stripped, extended token shapes (`abcde`, `abcd9`, `abcdz`, `_extra`, `-extra`, Unicode) remain intact, and documented pasted `&ref=` syntax is stripped at start, middle, end, glued, and with punctuation or `&`.
- **HTTP suite** (`tests/http/test_dupe_filter.py`): confirms messages with bare tokens or extended shapes (`...e`, `...9`, `...-extra`) are not falsely refused at duplicate limits, while pasted documented `&ref=` continues to be refused.
- **Full test suite**: 766 passed, 1 skipped in 257s (97.97% coverage).
- **All gates passed**: `ruff check`, `ruff format --check`, `ty check`, `sz.py --caps` (core code lines: 2317 <= 3010 cap; `core/limit.py` code lines: 183 <= 193 cap).
