### PR TITLE
docs(edge): drop /robots.txt from the static-first lane in the prose (#665)

### DIFF
--- a/edge/README.md
+++ b/edge/README.md
@@ -15,7 +15,7 @@ which covers a restart and not an outage.
 
 | lane | paths | behaviour |
 |---|---|---|
-| **static-first** | `/skill.md`, `/patterns.md`, `/robots.txt` | served from the stored copy; the origin is not asked |
+| **static-first** | `/skill.md`, `/patterns.md` | served from the stored copy; the origin is not asked |
 | **origin-first** | the other fourteen | proxied; the stored copy is served only if the origin fails to answer |
 
 The split is whether a document's bytes depend on the running configuration.
@@ -29,7 +29,7 @@ copy of them in preference to the origin publishes the last upload's limits as c
 2026-09-01 three compose knobs changed on the box in one afternoon, none of them via a
 release.
 
-The static three are files, served unchanged with no substitution step in which
+The static two are files, served unchanged with no substitution step in which
 configuration could enter. `tests/edge/` asserts that against the bytes on disk rather than
 trusting the comment, and carries a control that fails if the origin-first documents ever
 stop quoting configuration — at which point the split has lost its reason.
@@ -38,10 +38,10 @@ stop quoting configuration — at which point the split has lost its reason.
 
 Because the failure that actually happened was not the origin being **down**, it was the
 origin being **slow**. The 2026-09-01 incident spent hours degraded rather than dead, and
-origin-first waits out its timeout before falling back — so the three documents a reader
+origin-first waits out its timeout before falling back — so the two documents a reader
 most needs in order to back off and retry would each have cost a multi-second stall.
 
-**The cost, accepted:** these three change on a *release*, so a stored copy is stale until
+**The cost, accepted:** these two change on a *release*, so a stored copy is stale until
 `deploy.sh` runs again. A release is a controlled moment where that is a checklist item; a
 compose edit is not, which is why nothing configuration-dependent is in this lane.
 

--- a/edge/src/worker.js
+++ b/edge/src/worker.js
@@ -2,7 +2,7 @@
  * Edge policy for the document surface: two lanes, chosen by whether a document's bytes
  * depend on the running configuration.
  *
- *   static-first  /skill.md, /patterns.md, /robots.txt
+ *   static-first  /skill.md, /patterns.md
  *                 Served from the stored copy without asking the origin. Nothing in them
  *                 comes from config — enforced by tests/edge/, which renders each under two
  *                 different configs and requires identical bytes.
@@ -20,10 +20,10 @@
  * Why the split rather than origin-first for everything: origin-first already survives an
  * outage, so the static lane is not about the origin being *down* — it is about the origin
  * being *slow*. That outage spent hours degraded rather than dead, and origin-first waits
- * out its timeout before falling back, so the three documents a reader most needs in order
+ * out its timeout before falling back, so the two documents a reader most needs in order
  * to back off and retry would each have cost a multi-second stall.
  *
- * The cost, accepted: the static three change on a release, so a stored copy is stale until
+ * The cost, accepted: the static two change on a release, so a stored copy is stale until
  * deploy.sh runs again. A release is a controlled moment; a compose edit is not.
  *
  * Not in front of /r/ or /kv/. Those are ~80% of traffic, are writes as often as reads, and

--- a/edge/wrangler.jsonc
+++ b/edge/wrangler.jsonc
@@ -21,7 +21,7 @@
 
   // Plain routes, NOT a custom domain: technocore.chat already has an origin — the chat
   // service, reached through a Cloudflare tunnel — and these attach in front of it for
-  // sixteen exact paths. mcp/worker uses `custom_domain` because the Worker *is* the origin
+  // the exact paths enumerated in `routes` below. mcp/worker uses `custom_domain` because the Worker *is* the origin
   // for its hostname; the opposite job, and the opposite setting.
   //
   // Enumerated per path rather than a prefix or a suffix. /r/ and /kv/ are ~80% of traffic


### PR DESCRIPTION
## What

`/robots.txt` is removed from the static-first lane in the three prose descriptions of the edge split (the lane table and text in `edge/README.md`, the docstring in `edge/src/worker.js`), and the route-count comment in `edge/wrangler.jsonc` points at the `routes` array instead of stating a number. No code change; nothing a caller sees changes.

## Why

Fixes #665. At `82d9429`, `edge/snapshot.py` defines `STATIC_FIRST` with two entries (`/skill.md`, `/patterns.md`) and keeps `/robots.txt` origin-first because its `Sitemap:` URL is built from `CHAT_PUBLIC_URL`; `tests/edge/test_edge_worker.py::test_robots_txt_moves_with_the_public_url_and_so_stays_origin_first` pins that. The docs still said three static paths. "The other fourteen" is correct at this revision (16 paths minus 2) and is left alone. The wrangler comment said "sixteen exact paths" while `routes` now lists 19 exact paths plus `/rooms*`, so the comment now defers to the array rather than carrying a count that has drifted twice.

## Checks

- [x] `uv run --frozen python -m pytest tests -q` (full suite, see CI) and `tests/edge`: 25 passed, 1 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` clean; no Python touched, so `ty` is unaffected
- [x] Docs that would now be wrong: this is the docs update; manual, `/skill.md`, `README.md`, `src/patterns.md`, `mcp/README.md` do not describe the edge lanes
- [x] New surface on a world-writable service: nothing new

🤖 Generated with [Claude Code](https://claude.com/claude-code)