### PR TITLE
fix(edge): a HEAD reply must never carry a body

### DIFF
--- a/edge/src/worker.js
+++ b/edge/src/worker.js
@@ -234,7 +234,17 @@ async function revalidating(request, ctx, pathname, seconds) {
 export default {
   async fetch(request, env, ctx) {
     try {
-      return await route(request, env, ctx);
+      const response = await route(request, env, ctx);
+      // One place, for every lane: stored() and revalidating() both build their reply from
+      // a GET regardless of the caller's own method, because the shared/stored copy is
+      // always a GET's — see test_a_head_request_can_never_become_the_stored_body for the
+      // half of this that protects the cache itself. This is the other half: a HEAD caller
+      // must never receive that GET's body back, which every lane above this line would
+      // otherwise do, since none of them checks the method on the way out.
+      if (request.method === "HEAD") {
+        return new Response(null, { status: response.status, headers: response.headers });
+      }
+      return response;
     } catch (err) {
       // Fail open. This Worker sits in front of the liveness endpoint now, so an exception
       // in it must not become the service looking dead: hand the request to the origin and

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -388,6 +388,30 @@ def test_a_head_request_can_never_become_the_stored_body():
     )
 
 
+def test_a_head_reply_never_carries_a_body():
+    """The other half of test_a_head_request_can_never_become_the_stored_body: that test
+    protects the shared cache from a HEAD's empty body landing in it. This protects the HEAD
+    caller itself -- stored() and revalidating() both build their reply from a GET's body
+    regardless of the request's own method (stored() always does env.ASSETS.fetch(new
+    URL(...)), a GET by construction; revalidating() serves the shared copy, which is always
+    a GET's), so without one central strip, a HEAD to any static-first, edge-only or
+    revalidating path would answer with content a HEAD must never carry -- most concretely
+    HEAD /rooms, the one EDGE_REVALIDATE_SECONDS path today, which would otherwise return
+    the full listing body on every HEAD.
+    """
+    worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
+    handler = _between(worker, "async fetch(request, env, ctx) {", "\n};")
+    assert 'request.method === "HEAD"' in handler, (
+        "the top-level handler must check for HEAD once, after route() decides what to serve"
+    )
+    assert "new Response(null" in handler, "a HEAD reply must be rebuilt with a null body"
+    # And the check has to run on every lane's output, not one: asserted by position, since
+    # a check placed only inside one branch of route() would silently miss the others.
+    assert handler.index("await route(") < handler.index('request.method === "HEAD"'), (
+        "the HEAD strip must apply to whatever route() returned, not pre-empt it"
+    )
+
+
 def test_the_snapshot_script_needs_nothing_but_the_standard_library():
     """deploy.sh runs it as `python3 snapshot.py`, not through uv. An import of the service's
     own modules drags the whole dependency chain in with it and the deploy dies at the


### PR DESCRIPTION
## What

`stored()` and `revalidating()` in `edge/src/worker.js` both build their reply from a GET regardless of the caller's own method: `stored()` always does `env.ASSETS.fetch(new URL(request.url))`, a GET by construction; `revalidating()` serves the shared copy, which is always a GET's. Neither checked the original request's method before returning a body-bearing `Response`.

## Why this is the other half of an already-covered concern

`test_a_head_request_can_never_become_the_stored_body` already protects the shared cache from a HEAD's *empty* body landing in it and corrupting what later GET readers see. This fixes the adjacent, previously-uncovered direction: a HEAD *caller* receiving a GET's *full* body back, which HTTP forbids a HEAD reply from carrying at all.

Most concretely: `HEAD /rooms` — the one `EDGE_REVALIDATE_SECONDS` path today (added in #674) — would answer with the complete room listing on every HEAD instead of an empty body. The same gap exists for anything in `STATIC_FIRST` or `EDGE_ONLY` too, since both go through `stored()`.

## Fix

One check, at the single dispatch point in the exported `fetch` handler, after `route()` decides what to serve — rather than patching `stored()`/`revalidating()` separately in three places:

```js
const response = await route(request, env, ctx);
if (request.method === "HEAD") {
  return new Response(null, { status: response.status, headers: response.headers });
}
return response;
```

Applies uniformly to every lane with one change.

## Testing

- New test `test_a_head_reply_never_carries_a_body`, following the existing source-text-assertion pattern this file already uses (no JS harness available, per `_between`'s own docstring)
- Verified the regression test actually catches the bug: reverted the fix locally, confirmed the test fails, restored the fix, confirmed it passes again
- `uv run pytest tests -q`: 665 passed
- `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check`: clean
- `python3 sz.py --check`: unaffected — `edge/` isn't in the core budget

## Release note

Since CHANGELOG.md is maintainer-regenerated, proposed wording for [Unreleased]:

PATCH: a HEAD request to any edge-served document path (static-first, edge-only, or the revalidating /rooms lane) no longer receives the GET's full body back — the top-level fetch handler now strips it to null, matching HTTP's requirement that a HEAD reply carry no body.

## Abuse impact

None. Pure correctness fix to an existing lane; no new route, parameter, or persistent state.