### PR TITLE
fix(mcp): describe read_docs page parameter (#698)

### DIFF
--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -707,7 +707,10 @@ PAGES = {
     structured_output=False,
 )
 async def read_docs(
-    page: Literal["manual", "patterns", "skill", "interop", "auth", "config"] = "manual",
+    page: Annotated[
+        Literal["manual", "patterns", "skill", "interop", "auth", "config"],
+        Field(description="Which manual page to read."),
+    ] = "manual",
 ) -> str:
     return await _get(PAGES[page])
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -374,6 +374,10 @@ def test_the_descriptions_the_model_reads_survive_the_generation(mcp):
         assert schemas[name]["properties"]["room"]["description"] == "Room name."
     assert "4096" in schemas["say"]["properties"]["text"]["description"]
     assert "TECHNOCORE_NICK" in schemas["say"]["properties"]["nick"]["description"]
+    assert schemas["read_docs"]["properties"]["page"]["description"] == "Which manual page to read."
+    for tool in tools:
+        for param_name, prop in tool.input_schema.get("properties", {}).items():
+            assert prop.get("description"), f"{tool.name}.{param_name} missing description"
     write_note = next(tool for tool in tools if tool.name == "write_note")
     assert "Send one condition, not both." in write_note.description
 


### PR DESCRIPTION
Resolves #698 (specifically finding 3).

### Description

In `mcp/src/technocore_mcp/server.py`, every parameter across the MCP tool suite defines a description in its `Field` except `read_docs.page`. This broke the input doctrine ("the sentences the model reads ... ride together in each parameter's Field") and meant models received an enum with no descriptive explanation.

This change:
1. Wraps `read_docs.page` in `Annotated[Literal[...], Field(description="Which manual page to read.")] = "manual"`.
2. Adds a targeted assertion in `tests/test_mcp.py` checking `read_docs.page` description.
3. Adds a universal assertion in `tests/test_mcp.py` asserting that every parameter across all published MCP tools has a non-empty description, guarding against parameter description omission across the entire server surface.

### Verification

- `env -u TECHNOCORE_SIGNING_KEY pytest tests/test_mcp.py` (68/68 passed)
- `pytest tests/test_input_doctrine.py` (7/7 passed)
- `python3 sz.py --caps && python3 sz.py --check` (clean, no core changes)