### PR TITLE
fix(mcp): bound list_notes so one namespace is not 3.2 MB of tool result (#698)

### DIFF
--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -276,6 +276,39 @@ async def _post(path: str, payload: dict[str, object]) -> str:
     return await _request("POST", path, payload=payload)
 
 
+# The one listing the service does not bound for us: `/kv/<ns>` has no limit parameter,
+# so an unclamped call hands back the whole namespace — 3.2 MB for `did` at its cap
+# (#698). read_room's range, because a caller has no reason to learn a second one.
+NOTES_LIMIT_DEFAULT, NOTES_LIMIT_MAX = 50, 200
+
+
+def _clamp_notes(body: str, limit: int | None) -> str:
+    """Return at most `limit` of a namespace listing's keys, saying so when it truncates.
+
+    `/kv/<ns>` takes no limit and ignores an unknown query parameter, so this cannot be
+    forwarded the way read_room's is — advertising a parameter the service does not
+    enforce is exactly what the input doctrine above forbids. The bound is applied to the
+    answer instead, and a truncated reply says what it dropped so the count is never
+    silently wrong.
+
+    Clamped the way the service clamps its own listing (`app._rooms`, via `_cursor`):
+    absent or negative is the default, 0 is 1, anything above the ceiling is the ceiling.
+    Only `/kv/`-prefixed lines are keys — a nearly-spent read budget adds a `#` line that
+    is not one, and must survive the truncation it is not part of.
+    """
+    lines = body.splitlines()
+    keys = [line for line in lines if line.startswith("/kv/")]
+    n = NOTES_LIMIT_DEFAULT if limit is None or limit < 0 else limit
+    n = min(n or 1, NOTES_LIMIT_MAX)
+    if len(keys) <= n:
+        return body
+    kept = keys[:n] + [line for line in lines if not line.startswith("/kv/")]
+    return "\n".join(kept) + (
+        f"\n\n{n} of {len(keys)} keys shown (limit {n}, max {NOTES_LIMIT_MAX}). "
+        "Read /kv/<namespace> directly for the whole listing."
+    )
+
+
 def _segment(value: str) -> str:
     """Path segment encoding. `safe=""` matters: a message containing `/` or `?` must not
     become extra path or a query string."""
@@ -513,14 +546,19 @@ async def write_note(
 @server.tool(
     name="list_notes",
     description=(
-        "List the keys in a note namespace. Namespaces themselves are never enumerable, and "
-        "keys beginning `p-` are never listed."
+        "List the keys in a note namespace, alphabetically. Namespaces themselves are never "
+        "enumerable, and keys beginning `p-` are never listed."
     ),
     annotations=READS,
     structured_output=False,
 )
-async def list_notes(namespace: Namespace) -> str:
-    return await _get(f"/kv/{_segment(namespace)}")
+async def list_notes(
+    namespace: Namespace,
+    limit: Annotated[
+        int | None, Field(description="How many keys, clamped to 1-200, default 50.")
+    ] = None,
+) -> str:
+    return _clamp_notes(await _get(f"/kv/{_segment(namespace)}"), limit)
 
 
 @server.tool(

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -294,15 +294,17 @@ def _clamp_notes(body: str, limit: int | None) -> str:
     Clamped the way the service clamps its own listing (`app._rooms`, via `_cursor`):
     absent or negative is the default, 0 is 1, anything above the ceiling is the ceiling.
     Only `/kv/`-prefixed lines are keys — a nearly-spent read budget adds a `#` line that
-    is not one, and must survive the truncation it is not part of.
+    is not one, and must survive the truncation it is not part of *in place*: the keys are
+    dropped where they sit rather than re-joined after the rest, so any framing the service
+    puts around a listing keeps its position relative to the keys it frames.
     """
     lines = body.splitlines()
-    keys = [line for line in lines if line.startswith("/kv/")]
+    keys = [i for i, line in enumerate(lines) if line.startswith("/kv/")]
     n = NOTES_LIMIT_DEFAULT if limit is None or limit < 0 else limit
     n = min(n or 1, NOTES_LIMIT_MAX)
     if len(keys) <= n:
         return body
-    kept = keys[:n] + [line for line in lines if not line.startswith("/kv/")]
+    kept = [ln for i, ln in enumerate(lines) if i < keys[n] or not ln.startswith("/kv/")]
     return "\n".join(kept) + (
         f"\n\n{n} of {len(keys)} keys shown (limit {n}, max {NOTES_LIMIT_MAX}). "
         "Read /kv/<namespace> directly for the whole listing."

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -467,14 +467,28 @@ def test_list_notes_bounds_a_large_namespace_and_says_what_it_dropped(mcp, tmp_p
     assert keys_for(-5) == mcp.module.NOTES_LIMIT_DEFAULT
 
 
-def test_clamp_notes_keeps_the_budget_line_a_truncation_is_not_part_of(mcp):
+def test_clamp_notes_keeps_a_non_key_line_where_the_service_put_it(mcp):
     """`budget_note` appends a `#` line once the read budget is nearly spent (limit.py:396).
-    It is not a key, so it must neither be counted as one nor dropped by the truncation."""
+    It is not a key, so it must neither be counted as one nor dropped by the truncation —
+    and it must keep its *position*, not merely survive.
+
+    Position rather than presence, because the two come apart: a clamp built as
+    `keys[:n] + [non-keys]` passes a presence check while moving every non-key line to the
+    end. `/kv/<ns>` carries no prefix today — `note_list` (app.py:1746) hands `respond` a
+    body of keys and a trailing note, and BANNER is prepended only by `note_read`
+    (app.py:1503) and `render` (app.py:436) — so the leading case below is a guard on a
+    listing that does not have one yet, not a description of one that does.
+    """
     budget = "# budget: 4 of 60 reads left this minute"
-    body = "\n".join(f"/kv/many/k{i:03d}" for i in range(60)) + "\n" + budget
-    out = mcp.module._clamp_notes(body, 10)
-    assert out.count("/kv/many/") == 10
-    assert "10 of 60 keys shown" in out and budget in out
+    keys = [f"/kv/many/k{i:03d}" for i in range(60)]
+
+    out = mcp.module._clamp_notes("\n".join(keys) + "\n" + budget, 10).splitlines()
+    assert out.count("/kv/many/k000") == 1 and len([x for x in out if x.startswith("/kv/")]) == 10
+    assert "10 of 60 keys shown" in "\n".join(out)
+    assert out.index(budget) > max(i for i, x in enumerate(out) if x.startswith("/kv/"))
+
+    framed = mcp.module._clamp_notes("\n".join(["!! FRAMING", ""] + keys), 10).splitlines()
+    assert framed.index("!! FRAMING") < min(i for i, x in enumerate(framed) if x.startswith("/kv/"))
 
 
 def test_list_notes_leaves_a_listing_under_the_bound_untouched(mcp):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -257,7 +257,7 @@ ADVERTISED = {
         },
         ["namespace", "key", "value"],
     ),
-    "list_notes": ({"namespace": "string"}, ["namespace"]),
+    "list_notes": ({"namespace": "string", "limit": "integer?"}, ["namespace"]),
     "read_docs": ({"page": "string"}, []),
     "say_signed": (
         {
@@ -432,6 +432,56 @@ def test_say_without_a_nick_falls_back_to_the_session_anon_name(mcp):
     # …and both overrides still win over the fallback: the env default, then the argument.
     mcp.call("say", {"room": "lobby", "text": "named", "nick": "alice"})
     assert "<~alice> named" in text_of(mcp.call("read_room", {"room": "lobby"}))
+
+
+def test_list_notes_bounds_a_large_namespace_and_says_what_it_dropped(mcp, tmp_path):
+    """#698: /kv/<ns> has no limit of its own, so an unbounded listing put the whole
+    namespace in one tool result — 3.2 MB for `did` at its cap. The bound is the
+    wrapper's, and a truncated answer has to name the total it truncated.
+
+    Seeded through the store rather than the write tool: 60 writes is past the write
+    lane's per-minute budget, and what is under test is the size of the answer.
+    """
+    import store
+
+    for i in range(60):
+        store.note_set(tmp_path, "many", f"k{i:03d}", "v")
+
+    default = text_of(mcp.call("list_notes", {"namespace": "many"}))
+    assert default.count("/kv/many/") == mcp.module.NOTES_LIMIT_DEFAULT
+    assert "50 of 60 keys shown" in default
+
+    asked = text_of(mcp.call("list_notes", {"namespace": "many", "limit": 10}))
+    assert asked.count("/kv/many/") == 10 and "10 of 60 keys shown" in asked
+
+    # Advisory, so out of range is clamped rather than refused — the doctrine the other
+    # listing tools follow, and the reason `limit` carries no JSON-Schema bound. The
+    # clamp is the service's own (`app._rooms`): negative is the default, 0 is 1.
+    def keys_for(limit):
+        return text_of(mcp.call("list_notes", {"namespace": "many", "limit": limit})).count(
+            "/kv/many/"
+        )
+
+    assert keys_for(9999) == min(mcp.module.NOTES_LIMIT_MAX, 60)
+    assert keys_for(0) == 1
+    assert keys_for(-5) == mcp.module.NOTES_LIMIT_DEFAULT
+
+
+def test_clamp_notes_keeps_the_budget_line_a_truncation_is_not_part_of(mcp):
+    """`budget_note` appends a `#` line once the read budget is nearly spent (limit.py:396).
+    It is not a key, so it must neither be counted as one nor dropped by the truncation."""
+    budget = "# budget: 4 of 60 reads left this minute"
+    body = "\n".join(f"/kv/many/k{i:03d}" for i in range(60)) + "\n" + budget
+    out = mcp.module._clamp_notes(body, 10)
+    assert out.count("/kv/many/") == 10
+    assert "10 of 60 keys shown" in out and budget in out
+
+
+def test_list_notes_leaves_a_listing_under_the_bound_untouched(mcp):
+    """The count line is what a truncation costs, so a listing that fits does not pay it."""
+    mcp.call("write_note", {"namespace": "few", "key": "only", "value": "v"})
+    body = text_of(mcp.call("list_notes", {"namespace": "few"}))
+    assert "/kv/few/only" in body and "keys shown" not in body
 
 
 def test_notes_round_trip_and_a_failed_condition_returns_the_current_value(mcp):


### PR DESCRIPTION
Resolves #698, finding 1. Findings 2 and 3 are deliberately out of scope: #703 has finding 3, and the reporter notes finding 2 is "arguably a service-side decision about `/kv/<ns>` rather than an MCP one".

## What

`list_notes` was the only listing tool with no bound. `read_room` takes `since` and `limit`; `list_rooms` takes `limit`. Measured on `mcp.technocore.chat` (0.11.1):

```
GET /kv/did   status=200 bytes=3277014
```

3.28 MB in one tool result, into a model's context. #510 reports `did` sitting at its 131,072 cap, so that is steady state rather than a spike.

## Why the bound is not forwarded

`/kv/<ns>` takes no `limit` and ignores an unknown query parameter — `note_list` (`app.py:1710-1719`) reads only `path_params`, and `store.list_notes` (`store.py:2543-2546`) returns the whole sorted list. Forwarding one the way `list_rooms` does would advertise a parameter the service does not enforce, which is what the module docstring's input doctrine forbids ("Whatever is advertised is enforced, and nothing else").

So the bound is applied to the answer, and three things keep that honest:

- **Clamped the way the service clamps its own listing.** `app._rooms` is `min(_cursor(q.get("limit"), 50) or 1, MAX_LIMIT)`, so absent or negative is the default, `0` is 1, and anything above the ceiling is the ceiling. `_clamp_notes` mirrors that rather than inventing a second rule.
- **A truncated reply names the total it dropped**, so the count is never silently wrong — the "hallucinated success" shape finding 2 is about.
- **Only `/kv/`-prefixed lines are keys.** Once the read budget is nearly spent, `budget_note` (`limit.py:396`) appends a `#` line that is not a key; it must neither be counted as one nor dropped by a truncation it is not part of. Pinned by a direct test.

A listing that fits under the bound is returned byte-for-byte as before.

## Judgment call worth flagging

The default of 50 changes what an existing caller gets back for a namespace over 50 keys. That is the bound the issue asks for, but it is a behaviour change — happy to leave the default unbounded and clamp only when `limit` is passed, if you would rather.

A server-side `?limit=` on `/kv/<ns>` is the larger fix and is not attempted here: it is new public API surface, and `core/app.py` is at 1019 of its 1020-line cap.

## Checks

- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 83 files already formatted
- `uv run ty check` — All checks passed
- `env -u TECHNOCORE_SIGNING_KEY uv run pytest tests -q` — **667 passed, 1 skipped**
- `uv run python sz.py --caps` — unchanged from main (`sz.py:44-45` scopes the policy to `src/*.py`, so `mcp/` adds no cap pressure)

Three new tests: the bound and what it reports, a listing under the bound left untouched, and the budget-line case above.
