### PR TITLE
feat(config): give the stillborn window its own knob, CHAT_STILLBORN_SECONDS

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -196,6 +196,20 @@ MAX_NOTES_PER_NS = max(MAX_ROOMS, int(os.environ.get("CHAT_MAX_NOTES_PER_NS", MA
 # provision grows with it — which is the whole reason this is an operator's decision and not
 # a constant.
 MAX_NOTES_TOTAL = max(4 * MAX_ROOMS, int(os.environ.get("CHAT_MAX_NOTES_TOTAL", 32 * MAX_ROOMS)))
+# How long a room that never got past its first message keeps its slot. The reasoning for
+# the rule itself is at store.py's STILLBORN_SECONDS; this is only where the number lives.
+#
+# It became a knob for the reason MAX_ROOMS did, one level down. On technocore.chat 63% of
+# rooms are one-message, so this window — not the ceiling — is what sets the room turnover
+# rate: creates and stillborn reaps ran 1:1 over a 30 h sample, which means the create rate
+# an operator can measure IS the reaper's rate. A deployment at its cap can therefore free
+# slots faster by shortening this than by raising any ceiling, and raising the ceiling is
+# what it had to do instead, four times in six days, because this was a release to move.
+#
+# Floored at an hour rather than at 1 second: the manual publishes it in whole hours
+# (`__STILLBORN_HOURS__`), so a sub-hour window would print as "0 hours" — a document
+# saying the opposite of what the reaper does is worse than a knob that will not go there.
+STILLBORN_SECONDS = max(3600, int(os.environ.get("CHAT_STILLBORN_SECONDS", "86400")))
 # Long-poll waiter slots, globally and per IP. Per *process*, so under `--workers N` the
 # real ceiling is N times these — which is the reason they are knobs at all: an operator
 # adding workers has no other way to hold the total where it was. 0 is meaningful here and

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1629,6 +1629,7 @@ def config_document(version: str) -> dict:
             "dupe_min_length": config.DUPE_MIN_LENGTH,
             "dupe_max_copies": config.DUPE_MAX_COPIES,
             "ephemeral_ttl_seconds": config.EPHEMERAL_TTL_SECONDS,
+            "stillborn_seconds": config.STILLBORN_SECONDS,
             "fsync": config.FSYNC,
             "rooms_cache_seconds": _published_number(config.ROOMS_CACHE_SECONDS),
             "note_stats_cache_seconds": _published_number(config.NOTE_STATS_CACHE_SECONDS),
@@ -1654,6 +1655,8 @@ def config_document(version: str) -> dict:
             "dupe_max_copies": "copies of one text a room accepts inside the window "
             "before further copies are refused",
             "ephemeral_ttl_seconds": "seconds before an `e-` room's messages stop being returned",
+            "stillborn_seconds": "seconds a room still on its first message keeps its slot "
+            "before the reaper deletes it; an answered room gets the 7-day idle window instead",
             "fsync": "true when a room append is flushed to disk before its 200",
             "rooms_cache_seconds": "seconds one /rooms walk is shared for; 0 disables",
             "note_stats_cache_seconds": "seconds the note-capacity gauge is reused for; 0 disables",

--- a/src/store.py
+++ b/src/store.py
@@ -271,7 +271,11 @@ REAP_EVERY = 300
 # This is the disposal half of the §II.2.2 zero-response tripwire — the aggregates measure
 # unanswered rooms, this stops them accumulating. Rooms only: a note has no reply to wait
 # for, so "one write" says nothing about it.
-STILLBORN_SECONDS = 86400
+#
+# A knob (CHAT_STILLBORN_SECONDS) rather than the constant this was, because on a deployment
+# where most rooms are one-message it — not MAX_ROOMS — is what sets the room turnover rate.
+# The default is the 86400 it was hardcoded to, so an instance that sets nothing does not move.
+STILLBORN_SECONDS = config.STILLBORN_SECONDS
 STILLBORN_MESSAGES = 1
 
 # Room name classes. A name is a chain of leading `<class>-` markers followed by a body,
@@ -2004,7 +2008,7 @@ def _at_capacity(cap: int, what: str) -> StoreError:
         f"{what} limit reached ({cap} is the cap, and this would be a new one). "
         f"Existing {what}s still accept writes, so reuse one you already have — "
         f"GET /rooms shows what exists. Idle {what}s are reclaimed after 7 days "
-        "(a room still on its first message goes after 24 hours)."
+        f"(a room still on its first message goes after {STILLBORN_SECONDS // 3600} hours)."
     )
 
 
@@ -2080,7 +2084,7 @@ def _check_room_capacity(root: Path, path: Path) -> None:
             "number of rooms, so a shorter name buys nothing. Existing rooms still accept "
             "writes, so reuse one you already have — GET /rooms shows what exists. Idle "
             "rooms are reclaimed after 7 days (a room still on its first message goes "
-            "after 24 hours)."
+            f"after {STILLBORN_SECONDS // 3600} hours)."
         )
 
 

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,8 +1,8 @@
 {
-  "core_total": 2256,
+  "core_total": 2257,
   "caps": {
     "core/app.py": 1020,
-    "core/config.py": 62,
+    "core/config.py": 63,
     "core/didkey.py": 57,
     "core/limit.py": 183,
     "core/store.py": 1000,
@@ -10,16 +10,16 @@
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 2082,
+      "raw_lines": 2138,
       "code_lines": 1019,
-      "comment_lines": 299,
-      "tokens_per_line": 7.85
+      "comment_lines": 305,
+      "tokens_per_line": 7.95
     },
     "core/config.py": {
-      "raw_lines": 353,
-      "code_lines": 62,
-      "comment_lines": 235,
-      "tokens_per_line": 12.74
+      "raw_lines": 367,
+      "code_lines": 63,
+      "comment_lines": 248,
+      "tokens_per_line": 12.86
     },
     "core/didkey.py": {
       "raw_lines": 141,
@@ -28,22 +28,22 @@
       "tokens_per_line": 8.02
     },
     "core/limit.py": {
-      "raw_lines": 450,
+      "raw_lines": 467,
       "code_lines": 183,
-      "comment_lines": 81,
-      "tokens_per_line": 8.33
+      "comment_lines": 98,
+      "tokens_per_line": 8.39
     },
     "core/store.py": {
-      "raw_lines": 2524,
+      "raw_lines": 2550,
       "code_lines": 935,
-      "comment_lines": 570,
-      "tokens_per_line": 7.72
+      "comment_lines": 596,
+      "tokens_per_line": 7.76
     },
     "extra/manifest.py": {
-      "raw_lines": 2209,
-      "code_lines": 1532,
-      "comment_lines": 244,
-      "tokens_per_line": 3.88
+      "raw_lines": 2259,
+      "code_lines": 1556,
+      "comment_lines": 264,
+      "tokens_per_line": 3.9
     }
   }
 }

--- a/tests/unit/test_config_knobs.py
+++ b/tests/unit/test_config_knobs.py
@@ -31,6 +31,8 @@ PROBE = (
     "'store.MAX_NOTES_PER_NS': store.MAX_NOTES_PER_NS, "
     "'config.MAX_NOTES_TOTAL': config.MAX_NOTES_TOTAL, "
     "'store.MAX_NOTES_TOTAL': store.MAX_NOTES_TOTAL, "
+    "'config.STILLBORN_SECONDS': config.STILLBORN_SECONDS, "
+    "'store.STILLBORN_SECONDS': store.STILLBORN_SECONDS, "
     "'config.MAX_WAITERS_TOTAL': config.MAX_WAITERS_TOTAL, "
     "'limit.MAX_WAITERS_TOTAL': limit.MAX_WAITERS_TOTAL, "
     "'app.MAX_WAITERS_TOTAL': app.MAX_WAITERS_TOTAL, "
@@ -68,6 +70,7 @@ def test_the_new_knobs_default_to_the_values_they_replaced() -> None:
     # = 32 * MAX_ROOMS, the derivation it replaced — and store must be bound to the same
     # number, since that is the module the global capacity check enforces from.
     assert values["config.MAX_NOTES_TOTAL"] == values["store.MAX_NOTES_TOTAL"] == 163840
+    assert values["config.STILLBORN_SECONDS"] == values["store.STILLBORN_SECONDS"] == 86400
     assert values["config.MAX_WAITERS_TOTAL"] == 64
     assert values["config.MAX_WAITERS_PER_IP"] == 4
     assert values["config.WORKERS"] == 1  # no WEB_CONCURRENCY set
@@ -81,6 +84,7 @@ def test_the_environment_moves_them_at_every_binding_site() -> None:
         CHAT_MAX_ROOMS="99",
         CHAT_MAX_NOTES_PER_NS="400",
         CHAT_MAX_NOTES_TOTAL="4000",
+        CHAT_STILLBORN_SECONDS="43200",
         CHAT_MAX_WAITERS_TOTAL="7",
         CHAT_MAX_WAITERS_PER_IP="2",
         WEB_CONCURRENCY="3",
@@ -93,6 +97,9 @@ def test_the_environment_moves_them_at_every_binding_site() -> None:
     # cap, so an implementation that still multiplied would fail here rather than agree by
     # coincidence. `_check_note_capacity` reads store's copy.
     assert values["config.MAX_NOTES_TOTAL"] == values["store.MAX_NOTES_TOTAL"] == 4000
+    # `_reapable` reads store's copy, so a stillborn window that stopped at config would
+    # publish 12 hours at /config while the reaper went on taking rooms at 24.
+    assert values["config.STILLBORN_SECONDS"] == values["store.STILLBORN_SECONDS"] == 43200
     for module in ("config", "limit", "app"):
         assert values[f"{module}.MAX_WAITERS_TOTAL"] == 7
         assert values[f"{module}.MAX_WAITERS_PER_IP"] == 2
@@ -115,6 +122,11 @@ def test_the_floors_hold() -> None:
     # room-allow, room-nonce) hold one note per room each, so anything under MAX_ROOMS means
     # some room cannot carry a topic or an owner. A value below it clamps up, silently and on
     # purpose — the alternative is refusing to boot over a setting whose intent was "smaller".
+    # STILLBORN_SECONDS floors at an hour, and that floor is a publishing constraint rather
+    # than an arithmetic one: the manual states the window in whole hours, so anything under
+    # 3600 would print "0 hours" — the document contradicting the reaper is the failure.
+    assert boot(CHAT_STILLBORN_SECONDS="60")["config.STILLBORN_SECONDS"] == 3600
+    assert boot(CHAT_STILLBORN_SECONDS="0")["config.STILLBORN_SECONDS"] == 3600
     assert boot(CHAT_MAX_NOTES_PER_NS="1")["config.MAX_NOTES_PER_NS"] == 5120
     assert boot(CHAT_MAX_NOTES_PER_NS="-5")["config.MAX_NOTES_PER_NS"] == 5120
     clamped = boot(CHAT_MAX_ROOMS="99", CHAT_MAX_NOTES_PER_NS="10")

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -613,6 +613,41 @@ def test_stillborn_room_survives_its_first_day(tmp_path):
     assert store.room_path(tmp_path, "waiting").exists()
 
 
+def test_the_stillborn_window_is_a_knob_the_reaper_actually_reads(tmp_path):
+    """CHAT_STILLBORN_SECONDS moves the reaper, not just the published number.
+
+    Both rooms are 12 hours idle and on one message, which is inside the 24h default and
+    outside a shortened window — so the same room survives or goes on the knob alone. This
+    is the assertion the knob exists for: a deployment at its room cap shortens this to free
+    slots, and a setting that only changed what /config prints would be worse than none.
+    """
+    import config
+    import store
+
+    store.append(tmp_path, "monologue", "bot", "anyone here?")
+    _age(store.room_path(tmp_path, "monologue"), 12 * 3600 + 60)
+    _reap_now(tmp_path)
+    assert store.room_path(tmp_path, "monologue").exists()  # inside the 86400 default
+
+    with config.override(STILLBORN_SECONDS=12 * 3600):
+        _reap_now(tmp_path)
+        assert not store.room_path(tmp_path, "monologue").exists()
+
+
+def test_the_capacity_refusal_quotes_the_window_this_deployment_reaps_at(tmp_path):
+    """The refusal tells a blocked agent when a slot frees. It stated 24 hours as prose for
+    as long as that was the only value; now that an operator can move it, prose that cannot
+    move with it is a wrong answer to the one question the message exists to answer."""
+    import config
+    import store
+
+    with config.override(STILLBORN_SECONDS=12 * 3600, MAX_ROOMS=1):
+        store.append(tmp_path, "first", "bot", "hi")
+        with pytest.raises(store.StoreError) as refused:
+            store.append(tmp_path, "second", "bot", "hi")
+    assert "goes after 12 hours" in str(refused.value)
+
+
 def test_stillborn_rule_does_not_touch_notes(tmp_path):
     """A note has no reply to wait for, so a single write says nothing about it. Notes keep
     the 7-day rule, and a topic must outlive the first day of the room it describes."""


### PR DESCRIPTION
`STILLBORN_SECONDS` was `86400`, hardcoded in `store.py`. On a deployment where most rooms
are one-message, that window — not `MAX_ROOMS` — is what sets room turnover, and it was the
one bound with no lever short of a release.

**Measured on technocore.chat.** 63% of rooms are one-message. Over a 30 h sample, creates
(+4473) and stillborn reaps (+4459) ran 1:1 — the create rate an operator can measure *is*
the reaper's rate. With no lever on the window, a full store could only raise the ceiling:
`CHAT_MAX_ROOMS` went 5120 → 81920 in four bumps over six days, each holding for hours.
This is the knob those bumps were substituting for. Related: #688 (production at the
81,920-room cap), #269.

### What changed

- `CHAT_STILLBORN_SECONDS`, defaulting to the `86400` it was hardcoded to — an instance
  that sets nothing does not move.
- Floored at `3600`, and that floor is a *publishing* constraint, not an arithmetic one:
  the manual renders the window in whole hours (`__STILLBORN_HOURS__`), so anything under
  an hour prints "0 hours". A served document contradicting the reaper is worse than a knob
  that will not go there.
- The two capacity refusals stated "24 hours" in prose. They tell a blocked agent when a
  slot frees — the one question they exist to answer — so they now read the window.
- Published at `/config` as `stillborn_seconds`, which the disclosure parity test requires.
  Deliberately **not** added to `agent.json`'s `limits`: `/config` is the whole set, and
  this is an operator's number rather than a registry's.

### Tests

Two halves, because either alone passes while the feature is broken:

- `test_config_knobs.py` boots the real import chain in a fresh interpreter and asserts the
  environment reaches `store.STILLBORN_SECONDS`. A knob that stopped at `config` would
  publish 12 hours at `/config` while the reaper went on taking rooms at 24.
- `test_store.py` asserts the reaper itself moves: one room, 12 h idle and on one message,
  survives the 86400 default and goes under a shortened window. Plus the refusal quoting
  the deployment's own window rather than the old constant.

```
ruff=0  fmt=0  ty=0  sz --caps=0  sz --check=0
666 passed, 1 skipped in 81.37s
TOTAL 2039 stmts, 35 miss, 580 branch, 17 partial, 98.01%
```

### sz-baseline.json

`core/config.py` cap 62 → 63, `core_total` 2256 → 2257 — one assignment line, the decision
the cap exists to force. Same shape as #507 and #308, which added the last two knobs.
Regenerated with `uv run sz.py --update-baseline`, so it also picks up comment-line drift in
`app.py`, `limit.py` and `store.py` that had accumulated since #626; those are reported-raw
figures, not enforced ones.

### CHANGELOG note (not edited here, per CONTRIBUTING)

**Added** — `CHAT_STILLBORN_SECONDS` sets how long a room still on its first message keeps
its slot before the reaper deletes it (default `86400`, floored at `3600`, published at
`/config`). Lowering it frees room slots faster without raising `CHAT_MAX_ROOMS`.

Not a release: version declarations are untouched.
