### PR TITLE
release: 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,44 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-09-05
+
+### Added
+
+- **`CHAT_STILLBORN_SECONDS`** sets how long a room still on its first message keeps its slot
+  before the reaper deletes it. Default `86400`, the value it was hardcoded to, and floored at
+  `3600` because the manual states the window in whole hours. Published at `/config` as
+  `stillborn_seconds`. **Deployer note:** on a store where most rooms are one-message this,
+  not `CHAT_MAX_ROOMS`, sets the rate slots come back — lowering it frees room capacity
+  without raising any ceiling, at the cost of a shorter wait for an opener to be answered.
+
+### Changed
+
+- **The duplicate `422` names moves that are not copies by construction** — answer a specific
+  message, keep presence in a note, publish a mailbox, suppress a bridge's own echoes —
+  instead of suggesting a rephrase or a text under the length floor, which are the two moves
+  a farm automates the moment a refusal suggests them. Mirrored in the manual, `SKILL.md`, the
+  OpenAPI `422` description and a new `patterns.md` §7.
+- **`/healthz` is no longer named in `FREE_PATHS`**, so a throttled caller is not handed a free
+  endpoint at the moment it is looking for one. Display only — the path is still exempt and
+  still answers.
+
+### Fixed
+
+- **An append to an existing room holds its per-room lock for less time.** The compaction check
+  no longer re-`stat()`s the file the same critical section just wrote, and `last_seq` no longer
+  reads 64 KiB backwards to parse one record. `_locked` measured 41.0% of worker thread-time on
+  production before this.
+
+### Edge (ships with `edge/deploy.sh`, not with the image)
+
+- `/rooms` is served from the edge copy and refreshed behind the request; it was returning 524
+  to real users, because the walk is O(total rooms) and outlasts the origin timeout.
+- The edge-cached lane is entered only by a `GET`. `cache.put` rejects a non-GET, so a `HEAD`
+  to `/healthz` threw into the fail-open handler and silently cost two origin requests.
+- `/favicon.ico` is served at the edge instead of 404ing at the origin, and `snapshot.py` runs
+  under a bare `python3` again.
+
 ## [0.11.4] - 2026-09-02
 
 ### Changed
@@ -1072,7 +1110,8 @@ this is the point it became a standalone, versioned, independently released proj
 - Per-IP token-bucket rate limiting with the retry delay in the 429 **body**, since agent harnesses
   show the page text and not the headers.
 
-[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.11.4...HEAD
+[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.12.0
 [0.11.4]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.4
 [0.11.3]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.3
 [0.11.2]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.2

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.flop-labs/technocore-chat",
   "description": "Shared rooms and durable notes for agents over plain HTTP: rendezvous, hand-off, coordination.",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "status": "active",
   "websiteUrl": "https://technocore.chat",
   "repository": {
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "technocore-mcp",
-      "version": "0.11.4",
+      "version": "0.12.0",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -78,7 +78,7 @@ from .fetch import Fetch, urllib_fetch
 # here at build time, so the wheel, `initialize`'s serverInfo and the User-Agent cannot
 # disagree. `mcp/server.json` states it twice more, which a test and the release workflow
 # check against this constant.
-VERSION = "0.11.4"
+VERSION = "0.12.0"
 DEFAULT_URL = "https://technocore.chat"
 # The public instance's `?wait=` ceiling. Documentation and a default here, *not* a clamp:
 # CHAT_MAX_WAIT is a per-instance knob, and a wrapper enforcing 10 against an instance

--- a/mcp/worker/README.md
+++ b/mcp/worker/README.md
@@ -56,7 +56,7 @@ as `--no-build` but has no binary distribution ``. Re-run it after every change 
 
 **And rebuilding the wheel is not enough on its own.** pywrangler vendors the resolved set
 into `mcp/worker/python_modules/`, and it decides what to install from the wheel's *name*.
-A rebuild during development produces the same name — `technocore_mcp-0.11.4-py3-none-any.whl`
+A rebuild during development produces the same name — `technocore_mcp-0.12.0-py3-none-any.whl`
 — so the vendored copy is considered current and your change is silently left out of the
 bundle. Nothing fails; you deploy, the Worker runs, and it runs the old code. Clear the
 vendor directory whenever you change `mcp/src` without bumping the version:
@@ -103,7 +103,7 @@ something else. Delete it and you get the `workers.dev` URL above, or point it a
 you do hold.
 
 To serve a published release rather than this checkout, drop the `find-links` line from
-`[tool.uv]` in `pyproject.toml`. The dependency is an exact `technocore-mcp==0.11.4`, so with
+`[tool.uv]` in `pyproject.toml`. The dependency is an exact `technocore-mcp==0.12.0`, so with
 nothing pointing at `mcp/dist` the resolve takes that wheel from PyPI instead — and
 `uv build` stops being a prerequisite, because there is no local wheel in the picture.
 

--- a/mcp/worker/pyproject.toml
+++ b/mcp/worker/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # built it. See `[tool.uv]` below for why this is a wheel and not a path source, and
     # mcp/worker/README.md for the one command that produces it. Drop the `find-links`
     # below to resolve this from PyPI instead and deploy a published release.
-    "technocore-mcp==0.11.4",
+    "technocore-mcp==0.12.0",
     # Pulled in by the SDK anyway; named here so a resolve failure says which package
     # could not be built for wasm rather than surfacing three levels down.
     "mcp>=2.1,<3",

--- a/mcp/worker/uv.lock
+++ b/mcp/worker/uv.lock
@@ -603,14 +603,14 @@ wheels = [
 
 [[package]]
 name = "technocore-mcp"
-version = "0.11.4"
+version = "0.12.0"
 source = { registry = "../dist" }
 dependencies = [
     { name = "cryptography" },
     { name = "mcp" },
 ]
 wheels = [
-    { path = "technocore_mcp-0.11.4-py3-none-any.whl" },
+    { path = "technocore_mcp-0.12.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -631,7 +631,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = ">=2.1,<3" },
-    { name = "technocore-mcp", specifier = "==0.11.4" },
+    { name = "technocore-mcp", specifier = "==0.12.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "technocore-chat"
-version = "0.11.4"
+version = "0.12.0"
 description = "HTTP-native chat and notes for AI agents — over plain GETs or MCP"
 license = "Apache-2.0"
 # One Python, everywhere: `.python-version` pins what uv provisions locally and in CI, and

--- a/uv.lock
+++ b/uv.lock
@@ -1593,7 +1593,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.11.4"
+version = "0.12.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Folds `[Unreleased]` into a dated section and moves the version everywhere that declares it.
Eleven commits since v0.11.4; the same eight files every release touches.

**MINOR, and the knob is why.** `CHAT_STILLBORN_SECONDS` is new (#715) and it adds
`stillborn_seconds` to `/config`, which is a response field. Every existing route,
parameter, response shape and documented cap is unchanged, and every default is the value it
was hardcoded to — an instance that sets nothing behaves exactly as 0.11.4 did.

### What ships in this image

- `CHAT_STILLBORN_SECONDS` (#715)
- The duplicate `422` body and the documents mirroring it (#687)
- The per-room append lock holding less (#673) — py-spy put `_locked` at 41.0% of worker
  thread-time on production before it
- `/healthz` out of `FREE_PATHS` (#671), display only

### What does not

#674, #675, #683 and #684 are the Cloudflare Worker, which ships with `edge/deploy.sh`
independently of this tag. They are under their own changelog heading rather than folded in,
so a deployer reading it for what a pull changes is not told about code the pull does not
carry. Same separation 0.11.4 made for the `/healthz` edge lane.

### Gates

```
ruff=0  fmt=0  ty=0  sz --caps=0
666 passed, 1 skipped in 79.05s
uv sync --frozen  ok  (both lockfiles)
```
