### PR TITLE
fix(store): clamp the stillborn window to what the reaper can honour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,6 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
-### Fixed
-
-- **`CHAT_STILLBORN_SECONDS` is clamped to what the reaper can honour** — whole hours, and
-  never past the 7-day idle rule, which `_reapable` tests first. Out of range it clamps rather
-  than refusing to boot, and `/config` reports the clamped value. Before this, `864000` was
-  published as a ten-day window while the room still went on day seven, and `5400` was
-  published as one hour while the reaper waited ninety minutes.
-
 ## [0.12.0] - 2026-09-05
 
 ### Added
@@ -48,9 +40,6 @@ of the contract, not an implementation detail: agents parse it.
 
 ### Fixed
 
-- **The `/humans` room table has a deadline and a failure state.** It painted a header row
-  over nothing, sometimes forever: `loadRooms` had no `AbortSignal`, so a slow `/rooms` waited
-  on the browser's own timeout before the `.catch` could explain anything.
 - **An append to an existing room holds its per-room lock for less time.** The compaction check
   no longer re-`stat()`s the file the same critical section just wrote, and `last_seq` no longer
   reads 64 KiB backwards to parse one record. `_locked` measured 41.0% of worker thread-time on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`CHAT_STILLBORN_SECONDS` is clamped to what the reaper can honour** — whole hours, and
+  never past the 7-day idle rule, which `_reapable` tests first. Out of range it clamps rather
+  than refusing to boot, and `/config` reports the clamped value. Before this, `864000` was
+  published as a ten-day window while the room still went on day seven, and `5400` was
+  published as one hour while the reaper waited ninety minutes.
+
 ## [0.12.0] - 2026-09-05
 
 ### Added
@@ -40,6 +48,9 @@ of the contract, not an implementation detail: agents parse it.
 
 ### Fixed
 
+- **The `/humans` room table has a deadline and a failure state.** It painted a header row
+  over nothing, sometimes forever: `loadRooms` had no `AbortSignal`, so a slow `/rooms` waited
+  on the browser's own timeout before the `.catch` could explain anything.
 - **An append to an existing room holds its per-room lock for less time.** The compaction check
   no longer re-`stat()`s the file the same critical section just wrote, and `last_seq` no longer
   reads 64 KiB backwards to parse one record. `_locked` measured 41.0% of worker thread-time on

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1629,7 +1629,9 @@ def config_document(version: str) -> dict:
             "dupe_min_length": config.DUPE_MIN_LENGTH,
             "dupe_max_copies": config.DUPE_MAX_COPIES,
             "ephemeral_ttl_seconds": config.EPHEMERAL_TTL_SECONDS,
-            "stillborn_seconds": config.STILLBORN_SECONDS,
+            # store's, not config's: store clamps to whole hours within IDLE_SECONDS, and
+            # this document's whole promise is that it reports what the handlers enforce.
+            "stillborn_seconds": store.STILLBORN_SECONDS,
             "fsync": config.FSYNC,
             "rooms_cache_seconds": _published_number(config.ROOMS_CACHE_SECONDS),
             "note_stats_cache_seconds": _published_number(config.NOTE_STATS_CACHE_SECONDS),

--- a/src/store.py
+++ b/src/store.py
@@ -275,7 +275,17 @@ REAP_EVERY = 300
 # A knob (CHAT_STILLBORN_SECONDS) rather than the constant this was, because on a deployment
 # where most rooms are one-message it — not MAX_ROOMS — is what sets the room turnover rate.
 # The default is the 86400 it was hardcoded to, so an instance that sets nothing does not move.
-STILLBORN_SECONDS = config.STILLBORN_SECONDS
+#
+# Clamped HERE rather than in config.py because both bounds are this module's: the value has to
+# be the one the reaper enforces, and the reaper is below.
+#   - Capped at IDLE_SECONDS, because `_reapable` tests the idle rule FIRST. Anything larger is
+#     unreachable — set ten days and the documents promise ten while the room goes on day seven.
+#   - Floored to a whole hour, because the manual renders it in them (`__STILLBORN_HOURS__`) and
+#     both capacity refusals compute the same `// 3600`. At 5400 the reaper would wait 90
+#     minutes while every document promised one hour.
+# config.py holds the other half of the floor (>= 3600), and /config publishes THIS value, not
+# config's, so what an operator reads back is what the reaper does.
+STILLBORN_SECONDS = min(IDLE_SECONDS, config.STILLBORN_SECONDS) // 3600 * 3600
 STILLBORN_MESSAGES = 1
 
 # Room name classes. A name is a chain of leading `<class>-` markers followed by a body,

--- a/tests/unit/test_config_knobs.py
+++ b/tests/unit/test_config_knobs.py
@@ -33,6 +33,7 @@ PROBE = (
     "'store.MAX_NOTES_TOTAL': store.MAX_NOTES_TOTAL, "
     "'config.STILLBORN_SECONDS': config.STILLBORN_SECONDS, "
     "'store.STILLBORN_SECONDS': store.STILLBORN_SECONDS, "
+    "'store.IDLE_SECONDS': store.IDLE_SECONDS, "
     "'config.MAX_WAITERS_TOTAL': config.MAX_WAITERS_TOTAL, "
     "'limit.MAX_WAITERS_TOTAL': limit.MAX_WAITERS_TOTAL, "
     "'app.MAX_WAITERS_TOTAL': app.MAX_WAITERS_TOTAL, "
@@ -139,6 +140,28 @@ def test_the_floors_hold() -> None:
     assert boot(CHAT_MAX_NOTES_TOTAL="-5")["config.MAX_NOTES_TOTAL"] == 20480
     floored_total = boot(CHAT_MAX_ROOMS="99", CHAT_MAX_NOTES_TOTAL="10")
     assert floored_total["config.MAX_NOTES_TOTAL"] == 396  # follows MAX_ROOMS, not 20480
+
+
+def test_the_stillborn_window_is_clamped_to_what_the_reaper_can_actually_honour() -> None:
+    """The published window has to be the enforced one, at both ends.
+
+    `_reapable` tests the idle rule first, so a window past IDLE_SECONDS is unreachable — the
+    room goes on day seven however many days the setting claims. And the manual renders the
+    window with `// 3600`, so a value that is not a whole hour reads low: 5400 would promise
+    one hour while the reaper waited ninety minutes. Both are the same defect, a document
+    disagreeing with the code, and store is where the clamp has to be because /config
+    publishes store's copy.
+    """
+    ceiling = boot(CHAT_STILLBORN_SECONDS="864000")  # ten days, past the seven-day idle rule
+    assert ceiling["store.STILLBORN_SECONDS"] == ceiling["store.IDLE_SECONDS"] == 604800
+    assert boot(CHAT_STILLBORN_SECONDS="5400")["store.STILLBORN_SECONDS"] == 3600
+    # 43201 is a second past a whole hour: the floor takes the hour, never the next one up.
+    assert boot(CHAT_STILLBORN_SECONDS="43201")["store.STILLBORN_SECONDS"] == 43200
+    # The invariant, not an instance of it: no setting can put the window past the idle rule.
+    for value in ("3600", "43200", "86400", "604800", "999999999"):
+        booted = boot(CHAT_STILLBORN_SECONDS=value)
+        assert booted["store.STILLBORN_SECONDS"] <= booted["store.IDLE_SECONDS"]
+        assert booted["store.STILLBORN_SECONDS"] % 3600 == 0
 
 
 def test_the_per_namespace_note_cap_moves_without_dragging_the_others() -> None:


### PR DESCRIPTION
Two review findings on #715, and they are one defect seen twice: the **published** window
could disagree with the **enforced** one. Neither affects a value in use — technocore.chat
runs 43200, which is inside both bounds — but a document that contradicts the code is the
thing this knob's floor already existed to prevent.

| Setting | Documents promised | Reaper actually did |
|---|---|---|
| `864000` (ten days) | ten days | day seven — `_reapable` tests the idle rule first |
| `5400` | one hour | ninety minutes — every render is `// 3600` |

### The fix

Clamp to whole hours within `IDLE_SECONDS`. In `store.py` rather than `config.py` because
both bounds are store's: `IDLE_SECONDS` is there and so is the reaper. `config.py` keeps the
`>= 3600` floor it already had.

`/config` now publishes **store's** copy rather than config's — that document's whole claim is
that it reports what the handlers enforce, so it has to read the clamped value.

Clamps rather than refusing to boot: every out-of-range value has an obvious intent
("longer"/"shorter"), and the result is readable at `/config`.

### Test

Asserts the invariant, not instances of it — across five settings from `3600` to `999999999`
the window is always `<= IDLE_SECONDS` and always a whole number of hours. `store.IDLE_SECONDS`
joins the boot probe so the ceiling cannot drift from the constant it tracks.

## Release notes, for a maintainer to fold in

`CHANGELOG.md` is untouched — an earlier revision of this PR edited it and a review correctly
pointed at CONTRIBUTING, so both notes live here instead.

**For `[Unreleased]` → `Fixed`:**

> - **`CHAT_STILLBORN_SECONDS` is clamped to what the reaper can honour** — whole hours, and
>   never past the 7-day idle rule, which `_reapable` tests first. Out of range it clamps rather
>   than refusing to boot, and `/config` reports the clamped value. Before this, `864000` was
>   published as a ten-day window while the room still went on day seven, and `5400` was
>   published as one hour while the reaper waited ninety minutes.

**A separate call, for `[0.12.0]` → `Fixed`** — this one is a maintainer's decision rather than
a contributor's, because v0.12.0 is already tagged, so it corrects the record for a released
version rather than describing a pending change. 798ad3c (#677) shipped in it and the section
has no line for it (found reviewing #716, after the tag):

> - **The `/humans` room table has a deadline and a failure state.** It painted a header row
>   over nothing, sometimes forever: `loadRooms` had no `AbortSignal`, so a slow `/rooms` waited
>   on the browser's own timeout before the `.catch` could explain anything.

### On #715's other finding — the sz-baseline edit

Not acted on, deliberately. That review asked to revert the `core/config.py` cap bump and
"resolve the cap through the prescribed primitive/extra-code route instead". There is no such
route for a knob: `config.py` is where knobs live, one knob is one assignment line, and the cap
sits at exactly the current count by construction — so *any* knob trips it. The two previous
knob PRs did exactly what #715 did, including the diff shape:

- #507 — "sz-baseline.json: core/config.py cap 61 -> 62 and core_total 2176 -> 2177 — one
  assignment line, **the decision the cap exists to force**."
- #308 — cap 58 -> 59, same pattern.

CI's own comment says the PR-time cap check exists so maintainers make that call deliberately.
Happy to revisit if the intent has changed.

(This PR needs no baseline change of its own — the clamp replaced a line, so `store.py` stayed
at 935 of its 1000 and `config.py` at 63 of 63.)

### Gates

```
ruff=0  ty=0  sz --caps=0
667 passed, 1 skipped
```
