### PR TITLE
fix(edge): bypass cache when refreshing rooms

### DIFF
--- a/edge/src/worker.js
+++ b/edge/src/worker.js
@@ -185,7 +185,10 @@ async function fromOrigin(request, key) {
   // ride along for the origin's rate accounting; nothing caller-specific is stored, because
   // the guard below refuses any reply that carries some.
   const canonical = new Request(key.url, { method: "GET", headers: request.headers });
-  const fresh = await fetch(canonical, { signal: AbortSignal.timeout(ORIGIN_REVALIDATE_MS) });
+  const fresh = await fetch(canonical, {
+    cf: { cacheTtl: 0 },
+    signal: AbortSignal.timeout(ORIGIN_REVALIDATE_MS),
+  });
   const body = await fresh.arrayBuffer();
   const headers = new Headers(fresh.headers);
   if (fresh.status !== 200) return { status: fresh.status, body, headers };

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -388,6 +388,16 @@ def test_a_head_request_can_never_become_the_stored_body():
     )
 
 
+def test_a_revalidation_fetch_expires_cloudflares_http_cache():
+    """The Cache API copy is the stale answer, not a source for its own refresh."""
+    origin = _between(
+        (EDGE / "src" / "worker.js").read_text(encoding="utf-8"),
+        "async function fromOrigin(",
+        "function fill(",
+    )
+    assert "cf: { cacheTtl: 0 }" in origin
+
+
 def test_the_snapshot_script_needs_nothing_but_the_standard_library():
     """deploy.sh runs it as `python3 snapshot.py`, not through uv. An import of the service's
     own modules drags the whole dependency chain in with it and the deploy dies at the


### PR DESCRIPTION
Addresses the demonstrated nested-cache restamp mechanism in #714.

## Problem

The `/rooms` edge lane serves its Cache API copy immediately and refreshes it in the background. `fromOrigin()` fetched the same public canonical URL without overriding Cloudflare's HTTP-cache TTL. The response it stores carries `s-maxage=86400`, so a refresh could receive an old shared-cache body, attach a new `x-edge-stamp`, and write the old body back as fresh.

Production showed that exact shape: the body stayed byte-stable while `x-edge-stamp` advanced. The later cross-colo measurements may also include origin-worker count differences; this patch only claims the edge refresh/cache defect reported here.

## Fix

Set the background subrequest's Cloudflare-native override to `cf: { cacheTtl: 0 }`. `cacheTtl` overrides response cache instructions; zero expires that HTTP-cache asset immediately. This is scoped to `fromOrigin()` only: `caches.default` remains the reader-facing copy, and single-flight, caller headers, the 120-second timeout, and stale-on-refresh-failure behavior are unchanged.

No dependency, binding, cache-buster key, or new abstraction.

## Review correction

The first head used standard `cache: "no-store"`. Review correctly noted Cloudflare only documents its cache-bypass guarantee for origins not hosted by Cloudflare. This revision uses the Cloudflare-specific cache override, whose documented semantics do not carry that origin restriction.

## Verification

Exact base: `2670ebb11ead1ab9b67307e518f8e8479fc9db47`

- Corrected regression test failed against the rejected `cache: "no-store"` head and passed with `cf.cacheTtl: 0`.
- `node --check edge/src/worker.js`
- Edge tests: **26 passed, 1 skipped**
- Full suite: **727 passed, 1 skipped**
- Coverage: **97.99%**
- Ruff, format, Ty, `sz.py --check`, and size caps passed.
- `git diff --check`, secret scan, dangerous-pattern scan, and unrelated-diff scan passed.

Cloudflare reference: https://developers.cloudflare.com/workers/runtime-apis/request/#requestinitcfproperties
