### PR TITLE
Take store-sized work out of the reaper's lock spans

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -600,14 +600,18 @@ def note_path(root: Path, ns: str, key: str) -> Path:
 def _prune(d: Path | str) -> bool:
     """Drop empty directories under `d`, deepest first; True when `d` itself is now empty.
 
-    Sharding turns an emptied bucket into litter that never goes away on its own: a reaped
-    room leaves `rooms/<shard>/` behind, and every later walk pays to open it and find
-    nothing. Left alone that is a new unbounded resource — bounded only by the 256 buckets —
-    and it is also what would stop `_drop_emptied_namespaces` working at all, since a
-    namespace holding nothing but empty buckets is not an empty directory to rmdir.
+    Sharding turns an emptied bucket into litter that never goes away on its own: a drained
+    namespace keeps `<ns>/<shard>/` and every later walk pays to open it and find nothing.
+    Left alone that is a new unbounded resource, and it is also what would stop
+    `_drop_emptied_namespaces` working at all, since a namespace holding nothing but empty
+    buckets is not an empty directory to rmdir.
+
+    A namespace is the only thing walked this way now. A room bucket holds no directories, so
+    `_reap` rmdirs the buckets it emptied and nothing else — scanning all 256 of them under
+    the span every room create holds was most of what this pass used to block creates on.
 
     Never removes `d` itself: the caller owns that decision, because for a namespace it is
-    the last step and for `rooms/` it must not happen at all.
+    the last step.
     """
     empty = True
     try:
@@ -1490,6 +1494,16 @@ def _guards_a_live_room(root: Path, base: str, entry: os.DirEntry[str], now: flo
         return False  # no room left to guard
 
 
+def _emptied(base: str, path: str, ns: bool) -> str:
+    """The directory a deletion of `path` may have left empty — for a room its bucket, for a
+    note its NAMESPACE and never the bucket the key landed in, because the namespace is the
+    level the count file, the cap and the rmdir all live at (`_note_ns_dir`) and `_prune`
+    reaches the buckets under it. Slices a known prefix for the same reason
+    `_guards_a_live_room` does: it runs once per deleted file and per swept lock.
+    """
+    return f"{base}{path[len(base) :].partition(os.sep)[0]}" if ns else os.path.dirname(path)
+
+
 def _counted_at(root: Path, name: str) -> tuple[int, int] | None:
     """`name`'s totals as of an instant with no create in flight, or None if the file did not
     parse. The reading taken *before* the reap walk, to be handed to `_settle_count` after it.
@@ -1600,10 +1614,15 @@ def _split_seq_state(root: Path) -> None:
         pass
 
 
-def _sweep_orphan_locks(root: Path, now: float) -> None:
+def _sweep_orphan_locks(root: Path, now: float, touched: dict[str, set[str]]) -> None:
     """Unlink sidecar locks whose data file is gone and that have been idle as long as any
     reaped room. `now` is the caller's, so every reapability decision in one pass is made
     against one instant rather than a clock that moves through it.
+
+    Records what it emptied into `touched`, beside what the reap loop deleted, because a
+    swept lock is usually the last thing standing between a namespace or a bucket and being
+    empty — the deletion that drained it happened a pass or more ago, so without this the
+    directory would be empty and never looked at again.
 
     Sidecar locks are deliberately *not* removed with their data file: unlinking one a writer
     holds splits the lock domain, and the next writer locks a fresh inode. Sweeping the
@@ -1614,6 +1633,7 @@ def _sweep_orphan_locks(root: Path, now: float) -> None:
     bounded by the room cap: at most a week of churn in empty files.
     """
     for sub, suffix in (("rooms", ".jsonl.lock"), ("notes", ".txt.lock")):
+        base = f"{root / sub}{os.sep}"
         for entry in _walk(root / sub, suffix):
             try:
                 # Slicing `.lock` off the name is `Path.with_suffix("")` without the Path,
@@ -1630,21 +1650,33 @@ def _sweep_orphan_locks(root: Path, now: float) -> None:
                 if os.access(data, os.F_OK) or now - entry.stat().st_mtime <= IDLE_SECONDS:
                     continue
                 os.unlink(entry.path)
+                touched[sub].add(_emptied(base, entry.path, sub == "notes"))
             except OSError:
                 continue
 
 
-def _drop_emptied_namespaces(root: Path) -> None:
+def _drop_emptied_namespaces(root: Path, dirs: set[str]) -> None:
     """Drop each per-namespace count, and then the namespace itself if that leaves it empty.
+    `dirs` is the namespaces this pass deleted a note in or swept a lock in, and nothing else.
 
     Runs after `_sweep_orphan_locks`, which is what puts a namespace back to notes and locks
-    only and so lets the rmdir here reach an emptied one.
+    only and so lets the rmdir here reach an emptied one — and which reports what it emptied
+    into the same set, so a namespace drained by an earlier pass is still reached.
 
-    The counts go unconditionally. This pass is the only thing that deletes notes, so it is
-    also the only thing those counts can be wrong about — dropping them means a count file
-    never outlives a deletion, and the next create in that namespace pays one scan to rebuild
-    it and none after. Re-establishing each figure from the walk would work too and is
-    strictly more code to be wrong in; an unlink cannot be off by one.
+    The counts go unconditionally, and only for those namespaces. This pass is the only thing
+    that deletes notes, so a deletion is the only thing a count can be wrong about, and the
+    namespaces a deletion happened in are exactly this set: dropping the count means it never
+    outlives a deletion, and the next create in that namespace pays one scan to rebuild it and
+    none after. Re-establishing each figure from the walk would work too and is strictly more
+    code to be wrong in; an unlink cannot be off by one.
+
+    It used to iterate every namespace instead, which is what made this the single largest
+    holder of blocked time in production: 10,114 exclusive acquisitions of one lock per pass,
+    each one queued against a stream of creates holding it shared, on a store where all but a
+    handful of namespaces had nothing to clean. What is left is one acquisition per directory
+    the pass actually emptied — usually none. A namespace left empty by neither a deletion nor
+    a lock (a crash in the mkdir-to-open gap makes one) is not visited any more; it costs one
+    directory entry and the next create in that namespace moves back into it.
 
     Under the create span, taken exclusively, for a nearer reason than the count's. A create
     makes its namespace directory inside `_locked`, one `mkdir` before the `open` that creates
@@ -1663,7 +1695,7 @@ def _drop_emptied_namespaces(root: Path) -> None:
     reason this whole tail is best effort — `_reap` runs on the request path, and a pass that
     cannot take the span must skip a cleanup, never fail the create that triggered it.
     """
-    for d in (root / "notes").glob("*"):
+    for d in map(Path, dirs):
         try:
             with _locked((root / NOTES_FILE).with_suffix(".create")):
                 (d / NOTES_FILE).unlink(missing_ok=True)
@@ -1703,9 +1735,12 @@ def _reap(root: Path) -> None:
     # create waited out, so `_settle_count` can tell what was created while the walk ran.
     kept = {"rooms": [0, 0], "notes": [0, 0]}
     before = {name: _counted_at(root, name) for name in (USAGE_FILE, NOTES_FILE)}
+    # And the directories it emptied, which is the only place a bucket or a namespace can
+    # need removing: nothing else in the store deletes.
+    touched: dict[str, set[str]] = {"rooms": set(), "notes": set()}
     for sub, suffix, stillborn_rule in (("rooms", ".jsonl", True), ("notes", ".txt", False)):
         base = f"{root / sub}{os.sep}"
-        held = kept[sub]
+        held, emptied = kept[sub], touched[sub]
         for entry in _walk(root / sub, suffix):
             try:
                 # One stat per entry, before any branch can skip it: a guard note is kept, so
@@ -1744,6 +1779,7 @@ def _reap(root: Path) -> None:
                         p.unlink(missing_ok=True)
                         held[0] -= 1
                         held[1] -= st.st_size
+                        emptied.add(_emptied(base, entry.path, sub == "notes"))
                         config._dbg(2, "reap", room=p.name, reason=reason)
                         if stillborn_rule:
                             reaped[f"reaped_{reason}"] += 1
@@ -1751,24 +1787,27 @@ def _reap(root: Path) -> None:
                 continue  # racing writer or vanished file: next pass picks it up
     if any(reaped.values()):  # one lock for the whole pass, not one per deleted room
         _bump(root, **reaped)
-    _sweep_orphan_locks(root, now)
+    _sweep_orphan_locks(root, now, touched)
     # Both counts after the deletions and after the orphan-lock sweep, so each figure
     # describes the disk as it now is. Each is one exclusive acquisition of its own span held
     # for a read and a replace; nothing that scales with the store happens inside either, which
     # is the whole point — every create in the service queues on these two files.
     _settle_count(root, NOTES_FILE, before[NOTES_FILE], kept["notes"])
     _settle_count(root, USAGE_FILE, before[USAGE_FILE], kept["rooms"])
-    _drop_emptied_namespaces(root)
+    _drop_emptied_namespaces(root, touched["notes"])
     _split_seq_state(root)  # once in the life of a store; a no-op every pass after
-    # The buckets, under the room span for the mkdir-to-open reason `_drop_emptied_namespaces`
-    # gives: `_locked` makes a bucket one `mkdir` before opening the sidecar lock inside it,
-    # and removing it in that gap fails the create outright. After the sweep, so `_prune` can
-    # reach a bucket whose last orphan lock has just gone.
-    try:
-        with _locked((root / USAGE_FILE).with_suffix(".create")):
-            _prune(root / "rooms")
-    except OSError:
-        pass  # best effort: a pass that cannot take the span leaves the litter to the next
+    # The buckets the pass emptied, one span acquisition each, for the mkdir-to-open reason
+    # `_drop_emptied_namespaces` gives: `_locked` makes a bucket one `mkdir` before opening
+    # the sidecar lock inside it, and removing it in that gap fails the create outright. This
+    # was `_prune(rooms)`, a scandir of all 256 buckets and everything in them under the span
+    # every create in the store queues on; a bucket only ever needs removing if this pass
+    # emptied it. After the sweep, so a bucket whose last orphan lock has just gone is reached.
+    for d in touched["rooms"] - {str(root / "rooms")}:  # a flat legacy room's dirname IS that
+        try:
+            with _locked((root / USAGE_FILE).with_suffix(".create")):
+                os.rmdir(d)  # empty buckets only: rmdir refuses a directory with entries
+        except OSError:
+            continue  # best effort, like the rest of the tail: the next pass tries again
 
 
 def snapshots(root: Path) -> list[dict]:

--- a/src/store.py
+++ b/src/store.py
@@ -109,15 +109,14 @@ RESERVED_ROOM_BYTES = MAX_TOTAL_ROOM_BYTES // MAX_ROOMS
 #
 # What that trades away is exactness, deliberately and with the same fail-closed doctrine
 # NOTES_FILE already documents. The reservation moves before the file is created, so a crash in
-# between over-counts and refuses a create that was allowed. `_reconcile_note_count`'s room
-# equivalent — the reaper's own rewrite below — is a snapshot of a walk that cannot see a
-# reservation whose file has not landed yet, so a rewrite racing creates lands low by at most
-# the creates in flight at that instant, once per REAP_EVERY, and the next pass re-establishes
-# it. The resulting overshoot on MAX_ROOMS is bounded by in-flight creates and does not
-# accumulate: every subsequent check reads the higher figure and refuses. Rooms can afford that
-# where notes cannot, because MAX_ROOMS bounds the walks and the *byte* budget bounds the disk
-# — and a room is created empty, so an overshoot of N rooms is N sidecar locks of disk, not N
-# rings.
+# between over-counts and refuses a create that was allowed. The reaper's own rewrite
+# (`_settle_count`) is a walk that cannot see a reservation whose file has not landed yet, so
+# it adds back whatever this file grew by while it walked: the figure lands high by at most the
+# creates that landed during that pass, once per REAP_EVERY, and the next pass re-establishes
+# it. The resulting overshoot on MAX_ROOMS is bounded by those creates and does not accumulate:
+# every subsequent check reads the higher figure and refuses. Rooms can afford that where notes
+# cannot, because MAX_ROOMS bounds the walks and the *byte* budget bounds the disk — and a room
+# is created empty, so an overshoot of N rooms is N sidecar locks of disk, not N rings.
 USAGE_FILE = ".usage"
 # How many notes exist and how many bytes they occupy, so neither the global note cap nor
 # the /rooms gauge walks every namespace — the same trade USAGE_FILE already makes for room
@@ -149,10 +148,13 @@ USAGE_FILE = ".usage"
 # The invariant that makes an incremental count safe: `_reap` is the ONLY thing that
 # deletes (there is no delete route — the manual says so), so between reaps the note count
 # only grows, and the single grower is the create path that writes this file. `_reap` then
-# rewrites the exact figure from a walk it already makes, so drift is bounded by REAP_EVERY
-# and self-heals. That rewrite takes the create span too — being the only deleter makes the
-# walk exact against *deletions* and nothing else; a create counted but not yet written is
-# invisible to it, so the creates have to be held still for the figure to be true.
+# rewrites the figure by totalling the walk it already makes, so drift is bounded by
+# REAP_EVERY and self-heals. Being the only deleter makes that walk exact against *deletions*
+# and nothing else; a create counted but not yet written is invisible to it. Rather than hold
+# the creates still for the length of a walk that now costs half a minute, the pass reads this
+# file with the creates waited out at both ends and adds back what it grew by in between —
+# fail-closed by construction, at the price of running high by one pass's creates
+# (`_counted_at` and `_settle_count` carry the arithmetic).
 #
 # That walk is `sized` now, for the byte half — one stat per note on a REAP_EVERY timer, on
 # a pass that already stats every note to decide what is idle, bought so that `note_stats`
@@ -1422,7 +1424,9 @@ def _stillborn(path: Path | str) -> bool:
     return True
 
 
-def _reapable(path: Path | str, now: float, stillborn_rule: bool) -> str | None:
+def _reapable(
+    path: Path | str, now: float, stillborn_rule: bool, st: os.stat_result | None = None
+) -> str | None:
     """Which threshold retires `path`, or None if neither does yet.
 
     Returns the reason rather than a bool so the caller can count the two rules apart:
@@ -1435,8 +1439,14 @@ def _reapable(path: Path | str, now: float, stillborn_rule: bool) -> str | None:
     first call, and `DirEntry.stat()` caches — handing one in would make that recheck return
     the pre-lock answer and unlink a room somebody had just written to. Passing a path is
     what makes the stale read unrepresentable rather than merely avoided.
+
+    `st` is the one stat a caller is allowed to hand in, and it is for the FIRST call only:
+    the reap loop stats every entry anyway to total what it keeps, so reusing that stat here
+    costs one syscall per file instead of two. The recheck under the lock passes nothing, so
+    the paragraph above still describes the call it is about — a cached stat there is the
+    bug; here it is the stat the caller took a moment earlier and would otherwise repeat.
     """
-    idle = now - os.stat(path).st_mtime
+    idle = now - (os.stat(path) if st is None else st).st_mtime
     if idle > IDLE_SECONDS:
         return "idle"
     if stillborn_rule and idle > STILLBORN_SECONDS and _stillborn(path):
@@ -1480,38 +1490,62 @@ def _guards_a_live_room(root: Path, base: str, entry: os.DirEntry[str], now: flo
         return False  # no room left to guard
 
 
-def _reconcile_note_count(root: Path) -> None:
-    """Rewrite the note count from a walk, under the create gate. Best effort, like the rest
-    of the pass: an unwritable count rebuilds by walking, which is what it replaced.
+def _counted_at(root: Path, name: str) -> tuple[int, int] | None:
+    """`name`'s totals as of an instant with no create in flight, or None if the file did not
+    parse. The reading taken *before* the reap walk, to be handed to `_settle_count` after it.
 
-    Runs after the deletions, so the figure reflects the disk as it now is — and the lock is
-    what makes that "as it now is" true rather than nearly true. A create writes its `+1`
-    reservation and its note at two different moments, and a walk landing between them sees
-    neither the note nor any reason to expect one. It then rewrites the count *low*, and a low
-    count admits a note the cap should refuse. Being the only deleter makes the walk exact
-    against deletions and nothing else; the creates have to be held still for the figure to be
-    true, and this is what holds them.
-
-    The *span* lock, taken exclusively — not the counter lock a create holds only while it
-    reserves. A create holds `.notes-count.create` shared from before its reservation until
-    after its note is on disk (see `_create_gate`), so taking it exclusively here waits out
-    every create already in flight and keeps the next one out until the walk has been
-    installed. That is the property this always had, when the same guarantee came from a
-    service-wide mutex that also made every create wait for every other one. Shared holders do
-    not block each other, so the cost moved off the create path and onto this pass alone.
-
-    `_replace` settles which writer may stage a file. This settles which one wins.
-
-    The cost is the walk: ~450 ms at a completely full store and linear in occupancy below
-    that, on a pass that already costs half a second. `_reap` is throttled to once per
-    REAP_EVERY per process and every write path calls it — `note_set` before it knows whether
-    it has a create or an overwrite, `_write_record` on every room message — so the pass that
-    crosses the interval pays this wherever it arrives from, and a note create arriving while
-    it runs waits on the span. Bought because a cap that can be breached is not a cap.
+    The exclusive span is what makes the instant meaningful. A create holds
+    `<name>.create` shared from before it writes its `+1` reservation until after its file is
+    on disk (see `_create_gate`), so taking it exclusively waits every in-flight create out:
+    every reservation in the figure this returns has its file on disk, and the walk that
+    follows will see it. That is the property the reaper used to buy by holding the same span
+    across the whole walk — 29 s at production size, with every create in the service queued
+    behind it. It costs one read now, and the span is released before the walk starts.
     """
     try:
-        with _locked((root / NOTES_FILE).with_suffix(".create")):
-            _write_note_count(root, *_count_notes(root))
+        with _locked((root / name).with_suffix(".create")):
+            return _read_counts(root, name)
+    except OSError:
+        return None
+
+
+def _settle_count(root: Path, name: str, before: tuple[int, int] | None, kept: list[int]) -> None:
+    """Install what this pass measured for `name` — NOTES_FILE for notes, USAGE_FILE for
+    rooms. Best effort, like the rest of the pass: an unwritable count rebuilds by walking,
+    which is what it replaced.
+
+    `kept` is the count and the byte total the reap loop accumulated as it went — the files
+    it saw and did not delete. No directory is read twice for it: the pass already stats every
+    entry to decide what is idle, and that stat is the size too. `_count_notes` and
+    `_count_rooms` stay as the rebuild every reader falls back to when a counter file cannot
+    be parsed; this pass simply no longer needs one of its own.
+
+    A walk cannot see a create that has reserved but not yet written, and a figure below the
+    disk admits a write the cap should refuse — so this fails closed rather than aiming to be
+    exact. Whatever the counter grew by between `_counted_at`'s read and this one is added
+    back: every create the walk could have missed reserved against the file inside that
+    window, so `after - before` bounds them from above and 0 from below. The result is exact
+    on a quiet store, high by at most the creates that landed during the pass on a busy one,
+    and re-established from a fresh walk on the next pass, so the error never accumulates. A
+    `before` that did not parse — a lost or pre-format counter file, the case `_note_totals`
+    answers by walking — has no window to offer, so the walk stands as its own baseline and
+    the only thing the counter can still do is hold the figure up.
+
+    What it gives up is the exactness a 29 s exclusive hold bought. The one direction it can
+    be low is a reservation given back — a `?if=` refusal on a fresh key counts -1 — landing
+    in the same pass as a create the walk missed, which cancel in `after - before` and leave
+    the figure one short until the next pass rewrites it. One note of slack for one interval,
+    against every create in the store blocking on the walk once per REAP_EVERY.
+    """
+    try:
+        with _locked((root / name).with_suffix(".create")):
+            after = _read_counts(root, name)
+            # A `before` that did not parse leaves no window to measure, so the walk is its
+            # own baseline: the figure can then be raised to what the counter already claims
+            # but never dropped below it, which is the fail-closed half without the window.
+            base = before or kept
+            made = [0, 0] if after is None else [max(0, after[i] - base[i]) for i in (0, 1)]
+            _write_note_count(root, kept[0] + made[0], kept[1] + made[1], name=name)
     except OSError:
         pass
 
@@ -1663,13 +1697,25 @@ def _reap(root: Path) -> None:
     # Rooms only: the stillborn rule is a room rule, so folding reaped notes into the same
     # two counters would make "idle" mean two different things in one number.
     reaped = {"reaped_idle": 0, "reaped_stillborn": 0}
+    # What the walk below leaves behind, counted and measured as it goes — the figures the two
+    # counter files are rewritten from, taken from the stat this pass makes anyway rather than
+    # from a second walk of the same tree under a lock. `before` is each file read with every
+    # create waited out, so `_settle_count` can tell what was created while the walk ran.
+    kept = {"rooms": [0, 0], "notes": [0, 0]}
+    before = {name: _counted_at(root, name) for name in (USAGE_FILE, NOTES_FILE)}
     for sub, suffix, stillborn_rule in (("rooms", ".jsonl", True), ("notes", ".txt", False)):
         base = f"{root / sub}{os.sep}"
+        held = kept[sub]
         for entry in _walk(root / sub, suffix):
             try:
+                # One stat per entry, before any branch can skip it: a guard note is kept, so
+                # it counts, and the idle check below reuses this rather than taking its own.
+                st = entry.stat()
+                held[0] += 1
+                held[1] += st.st_size
                 if _guards_a_live_room(root, base, entry, now):
                     continue
-                if not _reapable(entry.path, now, stillborn_rule):
+                if not _reapable(entry.path, now, stillborn_rule, st):
                     continue
                 # The Path is built here and not in the walk: everything above this line
                 # works on the entry scandir already had, and a live pass reaches this
@@ -1696,6 +1742,8 @@ def _reap(root: Path) -> None:
                             room = p.name[: -len(".jsonl")]
                             _set_seq_entry(root, room, max(0, last_seq(root, room)))
                         p.unlink(missing_ok=True)
+                        held[0] -= 1
+                        held[1] -= st.st_size
                         config._dbg(2, "reap", room=p.name, reason=reason)
                         if stillborn_rule:
                             reaped[f"reaped_{reason}"] += 1
@@ -1703,28 +1751,24 @@ def _reap(root: Path) -> None:
                 continue  # racing writer or vanished file: next pass picks it up
     if any(reaped.values()):  # one lock for the whole pass, not one per deleted room
         _bump(root, **reaped)
-    _reconcile_note_count(root)
     _sweep_orphan_locks(root, now)
+    # Both counts after the deletions and after the orphan-lock sweep, so each figure
+    # describes the disk as it now is. Each is one exclusive acquisition of its own span held
+    # for a read and a replace; nothing that scales with the store happens inside either, which
+    # is the whole point — every create in the service queues on these two files.
+    _settle_count(root, NOTES_FILE, before[NOTES_FILE], kept["notes"])
+    _settle_count(root, USAGE_FILE, before[USAGE_FILE], kept["rooms"])
     _drop_emptied_namespaces(root)
     _split_seq_state(root)  # once in the life of a store; a no-op every pass after
-    # The room figures, and then the buckets — one span, because both want the same thing that
-    # `_reconcile_note_count` wants and there is no reason to wait for it twice. Creates are
-    # held off for the length of this block (they hold the same span shared), which is what
-    # makes the walk's answer true rather than nearly true, and what keeps a bucket from being
-    # removed inside a creator's mkdir-to-open gap. Both after the deletions and after the
-    # orphan-lock sweep, so the walk sees the disk as it now is and `_prune` can reach a bucket
-    # the sweep has just emptied.
-    #
-    # One extra walk of the rooms directory (~13 ms at the cap) on a pass that already costs
-    # half a second, bought because the alternative is walking it on every append — and, since
-    # #578, on every room create as well: this is now the only thing that establishes the room
-    # COUNT that MAX_ROOMS is enforced against, not just the byte budget.
+    # The buckets, under the room span for the mkdir-to-open reason `_drop_emptied_namespaces`
+    # gives: `_locked` makes a bucket one `mkdir` before opening the sidecar lock inside it,
+    # and removing it in that gap fails the create outright. After the sweep, so `_prune` can
+    # reach a bucket whose last orphan lock has just gone.
     try:
         with _locked((root / USAGE_FILE).with_suffix(".create")):
-            _write_note_count(root, *_count_rooms(root), name=USAGE_FILE)
             _prune(root / "rooms")
     except OSError:
-        pass  # a missing usage file reads as no pressure, which fails open, not closed
+        pass  # best effort: a pass that cannot take the span leaves the litter to the next
 
 
 def snapshots(root: Path) -> list[dict]:
@@ -1922,6 +1966,24 @@ def _ns_totals(d: Path) -> tuple[int, int]:
     return _scan(d, ".txt", sized=True)
 
 
+def _read_counts(d: Path, name: str = NOTES_FILE) -> tuple[int, int] | None:
+    """The two integers in a counter file, or None when there is nothing there to trust.
+
+    One parser for all three readers, because "cannot be trusted" has to mean the same thing
+    to each of them: a missing file, an unreadable one, a single-integer file from a build
+    before the byte half existed, a negative from a torn write. What they differ on is the
+    answer to that — `_note_totals` walks, `room_bytes_used` reads it as no pressure, and the
+    reaper writes what its own walk saw — and each one says why.
+    """
+    try:
+        count, size = (d / name).read_text(encoding="utf-8").split()
+        if int(count) >= 0 and int(size) >= 0:
+            return int(count), int(size)
+    except (OSError, ValueError):
+        pass
+    return None
+
+
 def _note_totals(d: Path, rebuild=_count_notes, persist=False, name=NOTES_FILE) -> tuple[int, int]:
     """(notes, bytes) without walking — or by walking, when the file cannot be trusted.
 
@@ -1947,12 +2009,9 @@ def _note_totals(d: Path, rebuild=_count_notes, persist=False, name=NOTES_FILE) 
     supposed not to create (see the rejection test). An empty namespace is also the cheapest
     possible walk, so there is nothing to cache.
     """
-    try:
-        count, size = (d / name).read_text(encoding="utf-8").split()
-        if int(count) >= 0 and int(size) >= 0:
-            return int(count), int(size)
-    except (OSError, ValueError):
-        pass
+    cached = _read_counts(d, name)
+    if cached is not None:
+        return cached
     totals = rebuild(d)
     if persist and totals[0]:
         try:
@@ -2033,14 +2092,11 @@ def room_bytes_used(root: Path) -> int:
     room in the store back to its floor on the strength of a parse error. The first reap
     rewrites it in the two-integer format and it never parses short again.
 
-    Deliberately not `_note_totals`, which rebuilds by walking what it cannot parse: this runs
-    on the append path, and a walk of every room per write is the cost the file exists to
-    avoid.
+    Shares `_read_counts`' parse and deliberately not `_note_totals`, which rebuilds by
+    walking what that parse rejects: this runs on the append path, and a walk of every room
+    per write is the cost the file exists to avoid.
     """
-    try:
-        return int((root / USAGE_FILE).read_text(encoding="utf-8").split()[1])
-    except (OSError, ValueError, IndexError):
-        return 0
+    return (_read_counts(root, USAGE_FILE) or (0, 0))[1]
 
 
 def _ring_limit(root: Path) -> int:
@@ -2157,11 +2213,13 @@ def _create_gate(gate: Path, path: Path, check, counted):
 
       - `<gate>.create`, SHARED, spanning the whole create. It is never contended by another
         create; it exists so the reaper can take it exclusively and know that no create is
-        between its reservation and its write. `_reconcile_note_count` needs that to rewrite
-        a count from a walk without losing a create the walk could not see, and `_prune` and
+        between its reservation and its write. `_counted_at` and `_settle_count` need that to
+        bound the creates their walk could not see, and `_prune` and
         `_drop_emptied_namespaces` need it because `_locked` below makes a directory one
         `mkdir` before opening the sidecar lock inside it, and removing it in that gap fails
         the write outright (ENOENT, or EINVAL on APFS) rather than merely losing a race.
+        The reaper takes it for two file operations at each end of its pass and never
+        across the walk between them: a hold that long parks every create in the store.
       - `path`'s own sidecar lock, which the body would take anyway, taken *before* the
         counter so that "does this file exist" is a settled question for the name being
         created. That is what keeps two racers on ONE name counting one note: the loser

--- a/src/store.py
+++ b/src/store.py
@@ -20,7 +20,7 @@ import time
 import unicodedata
 from collections import Counter
 from collections.abc import Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
@@ -153,8 +153,9 @@ USAGE_FILE = ".usage"
 # and nothing else; a create counted but not yet written is invisible to it. Rather than hold
 # the creates still for the length of a walk that now costs half a minute, the pass reads this
 # file with the creates waited out at both ends and adds back what it grew by in between —
-# fail-closed by construction, at the price of running high by one pass's creates
-# (`_counted_at` and `_settle_count` carry the arithmetic).
+# fail-closed by construction, at the price of running high by however many of that pass's
+# creates the walk happened to see (`_counted_at` and `_settle_count` carry the arithmetic,
+# and `_reap` runs one pass at a time so the window is a window).
 #
 # That walk is `sized` now, for the byte half — one stat per note on a REAP_EVERY timer, on
 # a pass that already stats every note to decide what is idle, bought so that `note_stats`
@@ -635,8 +636,13 @@ def _locked(target: Path, shared: bool = False, nb: bool = False):
     file inode without writers holding a lock on the orphan.
 
     `nb` adds LOCK_NB, which raises BlockingIOError (EAGAIN) instead of waiting when the
-    lock is held. Only `_bump` takes it: everything else here is holding the lock to make a
+    lock is held. `_bump` takes it because it is holding the lock to record a delta that a
+    later writer can carry instead; everything else here is holding the lock to make a
     decision that has to be made, and would have to wait again anyway.
+
+    `nb` is also how `_reap` keeps one pass running at a time: it takes its own marker file
+    that way and gives up rather than queueing, because a caller that cannot get it is one
+    whose work is already being done.
 
     `shared` takes LOCK_SH instead, which is what lets a lock mean "a create is in flight"
     without meaning "one create at a time" (see `_create_gate`): any number of holders
@@ -1537,29 +1543,33 @@ def _settle_count(root: Path, name: str, before: tuple[int, int] | None, kept: l
     A walk cannot see a create that has reserved but not yet written, and a figure below the
     disk admits a write the cap should refuse — so this fails closed rather than aiming to be
     exact. Whatever the counter grew by between `_counted_at`'s read and this one is added
-    back: every create the walk could have missed reserved against the file inside that
-    window, so `after - before` bounds them from above and 0 from below. The result is exact
-    on a quiet store, high by at most the creates that landed during the pass on a busy one,
-    and re-established from a fresh walk on the next pass, so the error never accumulates. A
-    `before` that did not parse — a lost or pre-format counter file, the case `_note_totals`
-    answers by walking — has no window to offer, so the walk stands as its own baseline and
-    the only thing the counter can still do is hold the figure up.
+    back. Both readings wait every create out, so the window between them holds whole creates
+    and nothing part-done: a reservation given back (a `?if=` refusal on a fresh key counts
+    -1) is bracketed by the same two readings as its own `+1`, and `after - before` is exactly
+    the number that landed. Each of those is either in `kept` or missed by the walk, so the
+    figure written is the truth plus however many of them the walk happened to see — never
+    below the disk, exact on a quiet store, and re-established from a fresh walk on the next
+    pass, so the error never accumulates. `_reap` runs one pass at a time service-wide, which
+    is what keeps this a window and not an interleaving of two.
 
-    What it gives up is the exactness a 29 s exclusive hold bought. The one direction it can
-    be low is a reservation given back — a `?if=` refusal on a fresh key counts -1 — landing
-    in the same pass as a create the walk missed, which cancel in `after - before` and leave
-    the figure one short until the next pass rewrites it. One note of slack for one interval,
-    against every create in the store blocking on the walk once per REAP_EVERY.
+    A `before` that did not parse — a lost or pre-format counter file, the case `_note_totals`
+    answers by walking — offers no window at all. The walk is then the whole answer, except
+    that the count may still be raised to what the counter claims, since creates that reserved
+    against it are on the disk whether this walk saw them or not. Not the byte half: those
+    bytes may be ones a racing rebuild measured before this pass deleted them, and the gauge
+    they feed fails open by doctrine (see `room_bytes_used`) where the count fails closed.
     """
     try:
         with _locked((root / name).with_suffix(".create")):
-            after = _read_counts(root, name)
-            # A `before` that did not parse leaves no window to measure, so the walk is its
-            # own baseline: the figure can then be raised to what the counter already claims
-            # but never dropped below it, which is the fail-closed half without the window.
-            base = before or kept
-            made = [0, 0] if after is None else [max(0, after[i] - base[i]) for i in (0, 1)]
-            _write_note_count(root, kept[0] + made[0], kept[1] + made[1], name=name)
+            # An unreadable reading at either end leaves no window at all, and both branches
+            # below then write the walk: `before` for one, the walk against itself for the other.
+            after = _read_counts(root, name) or before or kept
+            if before is None:
+                total, size = max(kept[0], after[0]), kept[1]
+            else:
+                total = kept[0] + max(0, after[0] - before[0])
+                size = kept[1] + max(0, after[1] - before[1])
+            _write_note_count(root, total, size, name=name)
     except OSError:
         pass
 
@@ -1656,27 +1666,38 @@ def _sweep_orphan_locks(root: Path, now: float, touched: dict[str, set[str]]) ->
 
 
 def _drop_emptied_namespaces(root: Path, dirs: set[str]) -> None:
-    """Drop each per-namespace count, and then the namespace itself if that leaves it empty.
-    `dirs` is the namespaces this pass deleted a note in or swept a lock in, and nothing else.
+    """Drop every per-namespace count, and then the namespaces this pass emptied. Two jobs
+    with two costs, which is why they are two loops.
 
-    Runs after `_sweep_orphan_locks`, which is what puts a namespace back to notes and locks
-    only and so lets the rmdir here reach an emptied one — and which reports what it emptied
-    into the same set, so a namespace drained by an earlier pass is still reached.
+    The counts go unconditionally, for every namespace, because a deletion is not the only
+    thing one can be wrong about. A create reserves before it writes (see `_create_gate`), so
+    a crash in between leaves that namespace one high with no give-back coming, and under
+    CHAT_FSYNC=0 an unclean shutdown can lose an increment and leave it low. Neither is
+    reachable from the pass's own walk, and both are permanent against MAX_NOTES_PER_NS if
+    nothing drops the file: this is the only thing that heals them. The next create in that
+    namespace pays one scan to rebuild it and none after. Re-establishing each figure from a
+    walk would work too and is strictly more code to be wrong in; an unlink cannot be off by
+    one.
 
-    The counts go unconditionally, and only for those namespaces. This pass is the only thing
-    that deletes notes, so a deletion is the only thing a count can be wrong about, and the
-    namespaces a deletion happened in are exactly this set: dropping the count means it never
-    outlives a deletion, and the next create in that namespace pays one scan to rebuild it and
-    none after. Re-establishing each figure from the walk would work too and is strictly more
-    code to be wrong in; an unlink cannot be off by one.
+    Deliberately NOT under the span, which the rmdir below needs and this does not — one
+    scandir of `notes/` and an unlink apiece is the whole cost, and taking the span 10,114
+    times to make it is what put this pass at the top of the production lock profile. A create
+    racing the unlink is benign either way round. Landing between that create's read of the
+    file and its `+1`, the create re-persists the old figure plus one, and the next pass
+    unlinks it again: a drift survives one more interval and is never left lower than the
+    truth. Landing after `_check_note_capacity` rebuilt the file, `_count_new_note` finds
+    nothing to read and rebuilds by walking that one namespace, which is the right figure by
+    definition.
 
-    It used to iterate every namespace instead, which is what made this the single largest
-    holder of blocked time in production: 10,114 exclusive acquisitions of one lock per pass,
-    each one queued against a stream of creates holding it shared, on a store where all but a
-    handful of namespaces had nothing to clean. What is left is one acquisition per directory
-    the pass actually emptied — usually none. A namespace left empty by neither a deletion nor
-    a lock (a crash in the mkdir-to-open gap makes one) is not visited any more; it costs one
-    directory entry and the next create in that namespace moves back into it.
+    The rmdir is the half that needs the span, and it visits `dirs` only — the namespaces this
+    pass deleted a note in or swept a lock in. Runs after `_sweep_orphan_locks`, which is what
+    puts a namespace back to notes and locks only and so lets the rmdir reach an emptied one —
+    and which reports what it emptied into the same set, so a namespace drained by an earlier
+    pass is still reached. It used to try every namespace, which meant 10,114 exclusive
+    acquisitions of one lock per pass, each queued against a stream of creates holding it
+    shared, on a store where all but a handful had nothing to remove. A namespace left empty by
+    neither a deletion nor a lock (a crash in the mkdir-to-open gap makes one) is not visited
+    any more; it costs one directory entry and the next create there moves back into it.
 
     Under the create span, taken exclusively, for a nearer reason than the count's. A create
     makes its namespace directory inside `_locked`, one `mkdir` before the `open` that creates
@@ -1695,9 +1716,18 @@ def _drop_emptied_namespaces(root: Path, dirs: set[str]) -> None:
     reason this whole tail is best effort — `_reap` runs on the request path, and a pass that
     cannot take the span must skip a cleanup, never fail the create that triggered it.
     """
+    try:
+        with os.scandir(root / "notes") as namespaces:
+            for ns in namespaces:
+                with suppress(OSError):  # a stray file, or a tree we may not write
+                    Path(ns.path, NOTES_FILE).unlink(missing_ok=True)
+    except OSError:
+        pass  # no notes yet, or nothing readable: either way there is no count to drop
     for d in map(Path, dirs):
         try:
             with _locked((root / NOTES_FILE).with_suffix(".create")):
+                # Again, so the rmdir below still meets an empty directory on a pass whose
+                # scandir above could not read `notes/` at all.
                 (d / NOTES_FILE).unlink(missing_ok=True)
                 # Buckets first: since sharding a namespace's notes sit a level further down,
                 # so a drained namespace holds empty directories, and rmdir refuses those
@@ -1716,6 +1746,22 @@ def _reap(root: Path) -> None:
     it doubles as the answer to namespace squatting: a hard cap alone would let an attacker
     park MAX_ROOMS junk rooms forever. Eviction-by-idleness expires the junk without ever
     letting one caller evict another's *active* room.
+
+    One pass at a time across the whole service, which the timestamp alone did not buy:
+    reading the marker and touching it are two unserialised operations, so two of the ~230
+    workers arriving together on an interval boundary both passed the check — and a walk that
+    takes longer than REAP_EVERY is overlapped by the next writer however the check is
+    written. Two passes interleaved write a count *below* the disk: the second deletes and
+    settles while the first is still walking, and the first then installs a figure measured
+    against a window the second has already spent (see `_settle_count`). So the marker
+    carries a lock as well as a timestamp, taken non-blocking around the whole pass — a caller
+    that cannot have it is one whose work is already being done, and the throttle would have
+    refused it a moment later anyway. Nothing else ever takes this lock, so it orders against
+    nothing and cannot deadlock.
+
+    The throttle itself stays outside that lock, and the touch with it, exactly where they
+    were: the lock is a mutex on the pass, not on the marker, and arming the throttle before
+    the walk starts is what keeps a 30 s pass from being re-run by the very next writer.
     """
     marker = root / ".reaped"
     now = time.time()
@@ -1726,6 +1772,17 @@ def _reap(root: Path) -> None:
         pass
     root.mkdir(parents=True, exist_ok=True)
     marker.touch()
+    try:
+        with _locked(marker, nb=True):
+            _reap_pass(root, now)
+    except BlockingIOError:
+        return  # a pass is already running in another worker; nothing here waits for it
+
+
+def _reap_pass(root: Path, now: float) -> None:
+    """One pass, under the marker lock and past the throttle — see `_reap`, which owns both.
+    `now` is that caller's instant, so every reapability decision in the pass is made against
+    one clock rather than one that moves through it."""
     # Rooms only: the stillborn rule is a room rule, so folding reaped notes into the same
     # two counters would make "idle" mean two different things in one number.
     reaped = {"reaped_idle": 0, "reaped_stillborn": 0}

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -725,3 +725,119 @@ def test_the_byte_gauge_tracks_creates_and_a_reap_settles_overwrites(tmp_path, m
     monkeypatch.setattr(store, "REAP_EVERY", 0)
     store._reap(tmp_path)
     assert store.note_stats(tmp_path)["bytes"] == 17, "and a reap settles it"
+
+
+# ------------------------------------------------------------------ the reaper's lock spans
+
+
+def _due(root: Path) -> None:
+    """Make the next pass due without setting REAP_EVERY to 0. The distinction matters here:
+    these tests drive writes from inside a pass, and with the interval at 0 every one of those
+    writes would start a nested pass of its own and the thing being measured would be two."""
+    (root / ".reaped").unlink(missing_ok=True)
+
+
+def _span(root: Path, name: str):
+    return (root / name).with_suffix(".create")
+
+
+def test_a_reap_never_holds_a_create_span_across_its_walk(tmp_path, monkeypatch) -> None:
+    """The contention this pass was profiled for. `_reconcile_note_count` held
+    `.notes-count.create` exclusively around a walk of every note — 29 s at production size —
+    and the tail block held `.usage.create` around a sized scan of every room. Every create in
+    the service takes those spans shared, so once per REAP_EVERY every writer in the store
+    queued behind a walk of the whole store: 72.5% of all CPU samples were threads parked in
+    `fcntl.flock`.
+
+    Asked as a property rather than a timing. From inside the walk, try both spans shared and
+    non-blocking: a `BlockingIOError` means somebody holds one exclusively, and the only
+    candidate is the pass that is walking. A regression here does not fail a functional test —
+    it just makes the service slow at scale — which is why it is pinned.
+    """
+    import store
+
+    _seed(tmp_path, 4)
+    store.append(tmp_path, "room", "bot", "hi")
+    real_walk = store._walk
+    held = []
+
+    def walk_but_probe_both_spans_first(d, suffix):
+        for name in (store.NOTES_FILE, store.USAGE_FILE):
+            try:
+                with store._locked(_span(tmp_path, name), shared=True, nb=True):
+                    pass
+            except BlockingIOError:
+                held.append(f"{name} during {suffix}")
+        return real_walk(d, suffix)
+
+    monkeypatch.setattr(store, "_walk", walk_but_probe_both_spans_first)
+    _due(tmp_path)
+    store._reap(tmp_path)
+
+    assert not held, f"the pass walked while holding a create span: {held}"
+
+
+def test_a_reap_counts_from_the_walk_it_already_makes(tmp_path, monkeypatch) -> None:
+    """The walk the reaper does to find idle files and the walk it did to count them were the
+    same walk, made twice — the second one under the span. It stats every entry either way, so
+    the count and the byte total are already in hand.
+
+    `_count_notes` and `_count_rooms` stay, because a counter file that cannot be parsed still
+    has to be rebuilt from somewhere; they are simply not on this path any more. Both halves
+    are asserted against the disk afterwards, so "cheaper" cannot mean "wrong".
+    """
+    import store
+
+    _seed(tmp_path, 3)
+    store.append(tmp_path, "room", "bot", "hi")
+    store.note_set(tmp_path, "ns0", "second", "value")
+    walked = []
+    monkeypatch.setattr(store, "_count_notes", lambda root: walked.append("notes") or (0, 0))
+    monkeypatch.setattr(store, "_count_rooms", lambda root: walked.append("rooms") or (0, 0))
+    _due(tmp_path)
+    store._reap(tmp_path)
+    monkeypatch.undo()
+
+    assert walked == [], f"the pass walked the store a second time for {walked}"
+    assert store._read_counts(tmp_path, store.NOTES_FILE) == store._count_notes(tmp_path)
+    assert store._read_counts(tmp_path, store.USAGE_FILE) == store._count_rooms(tmp_path)
+
+
+def test_a_create_the_walk_could_not_see_leaves_the_count_at_or_above_the_disk(
+    tmp_path, monkeypatch
+) -> None:
+    """The bound that replaces exactness, held to in the direction that matters.
+
+    Counting from an unlocked walk means a create can land after the walk has passed the
+    place it would have appeared. Writing what the walk saw would then put the count *below*
+    the disk, and a low count admits a note the cap should refuse — the same breach the old
+    exclusive hold existed to prevent. So the pass reads the counter with the creates waited
+    out at both ends and adds back what it grew by in between.
+
+    Driven from the orphan-lock sweep, which runs after both walks and before either count is
+    installed, so the create really is invisible to the walk rather than timed to be.
+    """
+    import store
+
+    store.note_set(tmp_path, "ns", "first", "v")
+    real_walk = store._walk
+    creator = []
+
+    def walk_but_let_a_create_land_after_the_walks(d, suffix):
+        if suffix == ".txt.lock" and not creator:
+            creator.append(
+                threading.Thread(target=store.note_set, args=(tmp_path, "ns", "unseen", "v"))
+            )
+            creator[0].start()
+            creator[0].join(10)  # the pass holds no span here, so this cannot deadlock
+        return real_walk(d, suffix)
+
+    monkeypatch.setattr(store, "_walk", walk_but_let_a_create_land_after_the_walks)
+    _due(tmp_path)
+    store._reap(tmp_path)
+
+    assert creator and not creator[0].is_alive(), "premise: the create finished inside the pass"
+    on_disk = store._count_notes(tmp_path)
+    assert on_disk[0] == 2, "premise: the walk had already passed the namespace"
+    assert store._note_count(tmp_path) >= on_disk[0], "a count below the disk breaches the cap"
+    assert store._note_totals(tmp_path) == on_disk, "and the create is counted exactly once"

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -841,3 +841,132 @@ def test_a_create_the_walk_could_not_see_leaves_the_count_at_or_above_the_disk(
     assert on_disk[0] == 2, "premise: the walk had already passed the namespace"
     assert store._note_count(tmp_path) >= on_disk[0], "a count below the disk breaches the cap"
     assert store._note_totals(tmp_path) == on_disk, "and the create is counted exactly once"
+
+
+def _exclusive_takes(monkeypatch, name: str, work) -> int:
+    """How many times `work` takes `<name>.create` exclusively. The unit that matters for this
+    lock: shared holders coexist, so it is the exclusive acquisitions that every create in the
+    store queues behind, and the old shape took one per namespace on every pass."""
+    import store
+
+    taken = 0
+    real = store._locked
+
+    def counting(target, shared=False, nb=False):
+        nonlocal taken
+        if not shared and target.name == f"{name}.create":
+            taken += 1
+        return real(target, shared, nb)
+
+    monkeypatch.setattr(store, "_locked", counting)
+    work()
+    monkeypatch.setattr(store, "_locked", real)
+    return taken
+
+
+@pytest.mark.parametrize("namespaces", [4, 30])
+def test_a_pass_takes_the_note_span_a_constant_number_of_times(tmp_path, monkeypatch, namespaces):
+    """`_drop_emptied_namespaces` took `.notes-count.create` exclusively once per namespace,
+    every pass, and dropped a count file that nothing had deleted from. At 10,114 namespaces
+    that is 10,114 exclusive acquisitions of the one lock every note create holds shared —
+    the single largest holder of blocked time in the production profile.
+
+    Two per pass now, whatever the store holds: one to read the counter with the creates
+    waited out, one to install what the walk measured. Parametrised rather than looped so a
+    failure names the size it failed at; both sizes must give the same number, which is the
+    whole claim.
+    """
+    import store
+
+    root = tmp_path / f"store{namespaces}"
+    _seed(root, namespaces)
+    _due(root)
+    taken = _exclusive_takes(monkeypatch, store.NOTES_FILE, lambda: store._reap(root))
+
+    assert taken == 2, f"{namespaces} namespaces cost {taken} exclusive acquisitions, not 2"
+
+
+def test_only_a_namespace_the_pass_emptied_costs_an_acquisition(tmp_path, monkeypatch) -> None:
+    """The other half: cheap must not mean nothing gets cleaned up. A count file may only be
+    wrong about a deletion, and this pass is the only thing that deletes, so the namespaces it
+    deleted in — plus the ones whose orphan lock it swept — are exactly the ones worth
+    visiting. One acquisition each, and none for the rest of the store.
+    """
+    import store
+
+    _seed(tmp_path, 8)
+    drained = tmp_path / "notes" / "ns3"
+    aged = time.time() - store.IDLE_SECONDS - 60
+    for path in drained.rglob("*"):  # its note and the sidecar lock the sweep then reclaims
+        os.utime(path, (aged, aged))
+
+    _due(tmp_path)
+    emptying = _exclusive_takes(monkeypatch, store.NOTES_FILE, lambda: store._reap(tmp_path))
+    assert emptying == 3, "the two counter acquisitions, plus the one namespace it emptied"
+    assert not drained.exists(), "…and the emptied namespace really was dropped"
+    assert store.note_get(tmp_path, "ns4", "seed") == "v", "while the rest is untouched"
+
+    _due(tmp_path)
+    settled = _exclusive_takes(monkeypatch, store.NOTES_FILE, lambda: store._reap(tmp_path))
+    assert settled == 2, "and a pass with nothing to drop is back to the constant"
+
+
+def test_a_reap_dropping_a_namespace_still_waits_for_a_create_entering_it(
+    tmp_path, monkeypatch
+) -> None:
+    """The mkdir-to-open race, moved to where the pass now goes. Visiting only the namespaces
+    it emptied does not make the rmdir safe: those are precisely the directories a create can
+    be halfway into, and `_locked` makes a namespace and its bucket one `mkdir` before the
+    `open` that creates the sidecar lock inside them. Removing them in that gap fails the
+    create outright — ENOENT, or EINVAL on APFS — on a path it had just made.
+
+    The window is built rather than waited for: the create is started where the pass is about
+    to take the span, and parked between the mkdir and the open until the pass is done. Unfixed
+    the rmdir sweeps the bucket the create just made and the create dies on the open; fixed the
+    pass blocks on the span the create holds shared, the park times out, and the create
+    completes. The bounded wait is what keeps that from being a deadlock.
+    """
+    import store
+
+    store.note_set(tmp_path, "doomed", "old", "v")
+    aged = time.time() - store.IDLE_SECONDS - 60
+    for path in (tmp_path / "notes" / "doomed").rglob("*"):
+        os.utime(path, (aged, aged))
+
+    at_the_window, reap_done = threading.Event(), threading.Event()
+    creator, died, visited = [], [], []
+    real_open, real_drop = open, store._drop_emptied_namespaces
+    sidecar = f"{store.note_path(tmp_path, 'doomed', 'fresh')}.lock"
+
+    def open_the_sidecar_lock_but_park_in_the_window(path, *a, **kw):
+        if str(path) == sidecar:
+            at_the_window.set()
+            reap_done.wait(1.0)  # unfixed the pass gets past here; fixed it is stuck on the span
+        return real_open(path, *a, **kw)
+
+    def create():
+        try:
+            store.note_set(tmp_path, "doomed", "fresh", "v")
+        except BaseException as exc:  # noqa: BLE001 — recorded for the assertion, not hidden
+            died.append(exc)
+
+    def drop_but_let_a_create_into_the_window_first(root, dirs):
+        visited.extend(dirs)
+        creator.append(threading.Thread(target=create))
+        creator[0].start()
+        at_the_window.wait(5)
+        return real_drop(root, dirs)
+
+    monkeypatch.setattr(store, "open", open_the_sidecar_lock_but_park_in_the_window, raising=False)
+    monkeypatch.setattr(
+        store, "_drop_emptied_namespaces", drop_but_let_a_create_into_the_window_first
+    )
+    _due(tmp_path)
+    store._reap(tmp_path)
+    reap_done.set()
+
+    assert visited == [str(tmp_path / "notes" / "doomed")], "premise: the pass visits it"
+    assert at_the_window.is_set(), "premise: the create reached the mkdir/open window"
+    creator[0].join(10)
+    assert not died, f"the reap killed a create it raced: {died!r}"
+    assert store.note_get(tmp_path, "doomed", "fresh") == "v", "the create it raced must survive"

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -73,10 +73,12 @@ def test_a_new_note_reads_the_same_number_of_directories_at_any_store_size(
 
 
 def test_the_per_namespace_count_is_rebuilt_once_and_then_stays_free(tmp_path, monkeypatch):
-    """The count file is not durable state: `_reap` drops every one of them, because a
-    deletion pass is the only thing that can make one wrong. So the shape a flood actually
-    sees is one rebuild scan per namespace per reap interval, then nothing — not one scan
-    per create, and never a count that outlived the notes it counted.
+    """The count file is not durable state: `_reap` drops every one of them, because more
+    than one thing can leave one wrong and none of them announces itself — a reap deleting
+    the notes it counted, a create that crashed between its reservation and its write, an
+    increment lost to an unclean shutdown. So the shape a flood actually sees is one rebuild
+    scan per namespace per reap interval, then nothing — not one scan per create, and never a
+    count that outlived the notes it counted.
     """
     import store
 
@@ -970,3 +972,43 @@ def test_a_reap_dropping_a_namespace_still_waits_for_a_create_entering_it(
     creator[0].join(10)
     assert not died, f"the reap killed a create it raced: {died!r}"
     assert store.note_get(tmp_path, "doomed", "fresh") == "v", "the create it raced must survive"
+
+
+def test_a_second_reap_pass_gives_up_rather_than_overlapping_the_first(tmp_path, monkeypatch):
+    """Two passes running at once write a count *below* the disk, which is the one direction
+    that breaches a cap.
+
+    Reading the marker and touching it are two unserialised operations, and a pass can outlast
+    REAP_EVERY on its own, so at an interval boundary two of the ~230 workers really do both
+    start one. Interleaved, they lose creates: the first reads `before` as C, the second
+    deletes D notes and settles C-D, the first's walk then runs against the smaller store and
+    keeps C-D, N creates land past its cursor, and the first writes
+    (C-D) + max(0, (C-D+N) - C) = C-D against a disk holding C-D+N.
+
+    The marker carries a non-blocking lock around the whole pass, so the second caller returns
+    instead. Asserted on the walks themselves rather than on a timing, and joined with a bound
+    so a pass that queues for the lock fails here rather than hanging the suite.
+    """
+    import store
+
+    store.note_set(tmp_path, "ns", "k", "v")
+    monkeypatch.setattr(store, "REAP_EVERY", 0)  # the throttle refuses nobody: only the lock can
+    real_walk = store._walk
+    walked, second = [], []
+
+    def walk_but_run_a_second_pass_from_inside_the_first(d, suffix):
+        walked.append(threading.current_thread().name)
+        if not second:
+            second.append(threading.Thread(target=store._reap, args=(tmp_path,), name="second"))
+            second[0].start()
+            second[0].join(10)  # it has to give up on its own: this thread holds the marker
+        return real_walk(d, suffix)
+
+    monkeypatch.setattr(store, "_walk", walk_but_run_a_second_pass_from_inside_the_first)
+    _due(tmp_path)
+    store._reap(tmp_path)
+
+    assert second and not second[0].is_alive(), "the second pass queued instead of giving up"
+    assert walked, "premise: the first pass walked"
+    assert "second" not in walked, f"two passes walked the store at once: {walked}"
+    assert store._note_totals(tmp_path) == store._count_notes(tmp_path), "and the count holds"

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -403,6 +403,27 @@ def test_a_reap_that_prunes_buckets_never_meets_a_create_gate_it_already_holds(
     assert done, "a write deadlocked on a gate the reap it triggered was already holding"
 
 
+def test_a_pass_that_emptied_no_bucket_never_scans_the_bucket_tree(tmp_path, monkeypatch):
+    """Pruning used to mean `_prune(rooms)`: a scandir of all 256 buckets and everything in
+    them, held under `.usage.create` — the span every room create takes shared. It ran on
+    every pass, on a store where a pass typically empties no bucket at all, and it is 39.4% of
+    the blocked time in the production profile paired with the note span beside it.
+
+    A bucket can only need removing if this pass emptied it, so an untouched tree is not read
+    at all. The pruning itself is still pinned by the two tests around this one.
+    """
+    import store
+
+    store.append(tmp_path, "keeper", "bot", "hi")
+    pruned = []
+    monkeypatch.setattr(store, "_prune", lambda d: bool(pruned.append(str(d))))
+    monkeypatch.setattr(store, "REAP_EVERY", 0)
+    store._reap(tmp_path)
+
+    assert pruned == [], f"a pass that reaped nothing still scanned {pruned}"
+    assert store.room_path(tmp_path, "keeper").exists()
+
+
 def test_pruning_keeps_the_bucket_of_a_room_that_survived(tmp_path, monkeypatch):
     """The other half of the pruning claim, and the one the all-rooms-reaped case cannot
     make: a pass that removed occupied buckets as happily as empty ones would pass that test


### PR DESCRIPTION
## What

The reap pass no longer holds either create span (`.notes-count.create`, `.usage.create`) across anything that scales with the store. It counts notes and rooms from the idle walk it already makes instead of a second walk under the lock, and it only takes the span for the namespaces and buckets it actually emptied instead of once per namespace. Callers see fewer 503 bursts; nothing in the API changes.

## Why

Profiling 0.12.0 on technocore.chat (2026-09-05, 124k rooms, 2.68M notes, 10,114 namespaces): 72.5% of CPU-time samples were threads blocked in `flock`. Two holders: `_drop_emptied_namespaces` took the note span exclusively once per namespace (10,114 acquisitions a pass, each a full stop for every create), and `_reconcile_note_count` held it for the whole `_count_notes` walk (29 s). The room tail did the same with `_count_rooms` + `_prune(rooms)` under the room span (1.3 s). 503s clustered on the 300 s reap cycle (51 and 60 in consecutive passes, zero between).

Judgment call: the count is no longer exact under a long hold. It is read with creates waited out at both ends of the pass and the walk gets whatever the counter grew by in between added back, so it is never below the disk, high by at most the creates the walk happened to see, and re-established each pass. That bound needs passes not to overlap, so the pass now holds a non-blocking lock on the `.reaped` marker for its duration: one pass service-wide, where the stat-then-touch throttle let two workers start one at the same boundary. Per-namespace count files are still unlinked every pass (their only self-heal), just without the span.

Synthetic before/after, one pass at steady state (2,000 namespaces × 20 notes, 5,000 rooms):

| | before | after |
|---|---|---|
| `.notes-count.create` exclusive acquisitions | 2,001 | 2 |
| `.notes-count.create` longest hold | 372 ms | 0.4 ms |
| `.usage.create` longest hold | 25 ms | 0.3 ms |

At 6,000 namespaces the before column was 6,001 / 631 ms; the after column is unchanged. The walk itself still runs inline once per `REAP_EVERY` (unlocked now); making it incremental or scaling the interval with store size is a separate change.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` (676 passed, 1 skipped, 97.98%)
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: none affected (private functions only; `docs/store.md` needed no regeneration)
- [x] New surface on a world-writable service: nothing new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdcG7mXE6YqBKxPdKqzrf9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdcG7mXE6YqBKxPdKqzrf9)_