### PR TITLE
Fix the per-namespace count race, and cut 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,28 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-09-05
+
+### Fixed
+
+- **The reap pass no longer holds a create span across work that scales with the store.** It
+  counted notes and rooms by a second walk under the note span — 29 s at 2.7M notes — and took
+  that span once per namespace, 10,114 times; production 0.12.0 spent 72.5% of CPU-time samples
+  blocked in `flock`, and 503s burst on the 300 s reap cycle. It now totals from the walk it
+  already makes and takes each span twice, plus once per namespace whose count disagrees with
+  that walk or that it emptied. **Deployer note:**
+  the global note and room counts are now fail-closed rather than exact — never below the disk,
+  high by at most the creates that landed during one pass, re-established each pass — and the
+  reaper runs one pass at a time service-wide, held on a new `.reaped.lock` file in the store
+  root. ([#722](https://github.com/flop-labs/technocore-chat/pull/722),
+  [#723](https://github.com/flop-labs/technocore-chat/pull/723))
+- **`CHAT_STILLBORN_SECONDS` is clamped to what the reaper can honour** — whole hours, and never
+  past the 7-day idle window, which `_reapable` tests first. Out of range it clamps rather than
+  refusing to boot, and `/config` publishes the clamped value rather than the raw setting: before
+  this, `864000` was published as a ten-day window while the room still went on day seven, and
+  `5400` was published as one hour while the reaper waited ninety minutes.
+  ([#717](https://github.com/flop-labs/technocore-chat/pull/717))
+
 ## [0.12.0] - 2026-09-05
 
 ### Added
@@ -1110,7 +1132,8 @@ this is the point it became a standalone, versioned, independently released proj
 - Per-IP token-bucket rate limiting with the retry delay in the 429 **body**, since agent harnesses
   show the page text and not the headers.
 
-[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.12.1...HEAD
+[0.12.1]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.12.1
 [0.12.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.12.0
 [0.11.4]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.4
 [0.11.3]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.3

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.flop-labs/technocore-chat",
   "description": "Shared rooms and durable notes for agents over plain HTTP: rendezvous, hand-off, coordination.",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "status": "active",
   "websiteUrl": "https://technocore.chat",
   "repository": {
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "technocore-mcp",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -78,7 +78,7 @@ from .fetch import Fetch, urllib_fetch
 # here at build time, so the wheel, `initialize`'s serverInfo and the User-Agent cannot
 # disagree. `mcp/server.json` states it twice more, which a test and the release workflow
 # check against this constant.
-VERSION = "0.12.0"
+VERSION = "0.12.1"
 DEFAULT_URL = "https://technocore.chat"
 # The public instance's `?wait=` ceiling. Documentation and a default here, *not* a clamp:
 # CHAT_MAX_WAIT is a per-instance knob, and a wrapper enforcing 10 against an instance

--- a/mcp/worker/README.md
+++ b/mcp/worker/README.md
@@ -56,7 +56,7 @@ as `--no-build` but has no binary distribution ``. Re-run it after every change 
 
 **And rebuilding the wheel is not enough on its own.** pywrangler vendors the resolved set
 into `mcp/worker/python_modules/`, and it decides what to install from the wheel's *name*.
-A rebuild during development produces the same name — `technocore_mcp-0.12.0-py3-none-any.whl`
+A rebuild during development produces the same name — `technocore_mcp-0.12.1-py3-none-any.whl`
 — so the vendored copy is considered current and your change is silently left out of the
 bundle. Nothing fails; you deploy, the Worker runs, and it runs the old code. Clear the
 vendor directory whenever you change `mcp/src` without bumping the version:
@@ -103,7 +103,7 @@ something else. Delete it and you get the `workers.dev` URL above, or point it a
 you do hold.
 
 To serve a published release rather than this checkout, drop the `find-links` line from
-`[tool.uv]` in `pyproject.toml`. The dependency is an exact `technocore-mcp==0.12.0`, so with
+`[tool.uv]` in `pyproject.toml`. The dependency is an exact `technocore-mcp==0.12.1`, so with
 nothing pointing at `mcp/dist` the resolve takes that wheel from PyPI instead — and
 `uv build` stops being a prerequisite, because there is no local wheel in the picture.
 

--- a/mcp/worker/pyproject.toml
+++ b/mcp/worker/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # built it. See `[tool.uv]` below for why this is a wheel and not a path source, and
     # mcp/worker/README.md for the one command that produces it. Drop the `find-links`
     # below to resolve this from PyPI instead and deploy a published release.
-    "technocore-mcp==0.12.0",
+    "technocore-mcp==0.12.1",
     # Pulled in by the SDK anyway; named here so a resolve failure says which package
     # could not be built for wasm rather than surfacing three levels down.
     "mcp>=2.1,<3",

--- a/mcp/worker/uv.lock
+++ b/mcp/worker/uv.lock
@@ -603,14 +603,14 @@ wheels = [
 
 [[package]]
 name = "technocore-mcp"
-version = "0.12.0"
+version = "0.12.1"
 source = { registry = "../dist" }
 dependencies = [
     { name = "cryptography" },
     { name = "mcp" },
 ]
 wheels = [
-    { path = "technocore_mcp-0.12.0-py3-none-any.whl" },
+    { path = "technocore_mcp-0.12.1-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -631,7 +631,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = ">=2.1,<3" },
-    { name = "technocore-mcp", specifier = "==0.12.0" },
+    { name = "technocore-mcp", specifier = "==0.12.1" },
 ]
 
 [package.metadata.requires-dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "technocore-chat"
-version = "0.12.0"
+version = "0.12.1"
 description = "HTTP-native chat and notes for AI agents — over plain GETs or MCP"
 license = "Apache-2.0"
 # One Python, everywhere: `.python-version` pins what uv provisions locally and in CI, and

--- a/src/store.py
+++ b/src/store.py
@@ -20,7 +20,7 @@ import time
 import unicodedata
 from collections import Counter
 from collections.abc import Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
@@ -1666,22 +1666,42 @@ def _sweep_orphan_locks(root: Path, now: float, touched: dict[str, set[str]]) ->
                 continue
 
 
-def _drop_emptied_namespaces(root: Path, per_ns: Counter[str], dirs: set[str]) -> None:
-    """Drop the per-namespace count of every namespace whose file disagrees with what this
-    pass walked, and remove the namespaces this pass emptied. One scandir of `notes/`, and an
-    acquisition only where there is something to heal.
+def _drop_emptied_namespaces(
+    root: Path, before_ns: dict[str, tuple[int, int] | None], per_ns: Counter[str], dirs: set[str]
+) -> None:
+    """Drop the per-namespace count of every namespace whose file did not hold still at what
+    this pass walked, and remove the namespaces this pass emptied. One scandir of `notes/`,
+    and an acquisition only where there is something to heal.
 
-    "The file does not equal the walk" is the whole predicate, and it is exactly the set that
-    needs healing. A per-namespace count moves only by a create's ±1 reservation, taken under
-    the span, and only this loop deletes it — so a file that agrees with a walk of its own
-    namespace has had no deletion behind it and is carrying no drift. What a mismatch catches
-    is everything a deletion-only rule missed: a create that reserved and then crashed before
-    writing leaves the figure one high with no give-back coming, and under CHAT_FSYNC=0 an
-    unclean shutdown can lose an increment and leave it low. Neither is reachable from the
-    deletions this pass made, and both are permanent against MAX_NOTES_PER_NS if nothing drops
-    the file. A file that will not parse is a mismatch too; one that is not there has nothing
-    to heal, and its next reader rebuilds by walking that namespace. The read takes no lock,
-    like every other read of a counter — a replace is atomic, so it sees old bytes or new.
+    The predicate is `before == walk == after`: the file as `_reap_pass` read it before the
+    walk, the notes the walk itself totalled for that namespace, and the file as it stands
+    now. Anything else is dropped — a file that will not parse included — while one absent at
+    both ends has nothing to heal, since its next reader rebuilds by walking that namespace.
+    What it is looking for is everything a deletion-only rule missed: a create that reserved
+    and then crashed before writing leaves the figure one high with no give-back coming, and
+    under CHAT_FSYNC=0 an unclean shutdown can lose an increment and leave it low. Neither is
+    reachable from the deletions this pass made, and both are permanent against
+    MAX_NOTES_PER_NS if nothing drops the file. Both reads are unlocked, like every other read
+    of a counter — a replace is atomic, so each sees the old bytes or the new — and the extra
+    one is the price of the third point: one more read per namespace per pass, no lock and no
+    stat, against a comparison that a single create can otherwise walk straight through.
+
+    Two points were not enough. A file already low by one, and a single create landing after
+    the walk passed that namespace, agree perfectly at the second: the walk totals K, the
+    create moves the file from K-1 to K and the disk to K+1, and the drift outlives a pass
+    that looked right. Read before the walk as well and that is a mismatch, K-1 against K.
+
+    What the third point buys, stated as what it does not buy. Agreement everywhere means the
+    file ended the pass where it started, so nothing landed during it but creates already
+    reserved at the before-read, and the walk cannot have counted more notes than the file
+    claimed at that moment. An over-high file therefore never agrees, and a namespace this
+    pass deleted in is in `dirs` and visited whatever its count says. A low file agrees only
+    by borrowing a reservation in flight at that first read — one that has moved the file and
+    not yet written its note — and then only if the walk misses exactly that note: an
+    undercount of one, surviving one pass. Reading with the creates waited out would close
+    that, and would mean holding the span across a read of every namespace, which is the hold
+    this branch exists to remove. It clears on any later pass whose reading does not land
+    inside a create, and MAX_NOTES_PER_NS is all it can over-admit against in between.
 
     The unlink is under the span, exclusively, and needs it every bit as much as the rmdir
     below does. Unlocked it puts a count *below* its notes: create 1 has reserved
@@ -1691,7 +1711,7 @@ def _drop_emptied_namespaces(root: Path, per_ns: Counter[str], dirs: set[str]) -
     and the namespace over-admits against MAX_NOTES_PER_NS until something rewrites the
     figure. Both creates hold the span shared, so only an exclusive holder is waited out for.
 
-    A create landing mid-walk shows up as a mismatch that heals nothing. It costs one unlink
+    A create landing mid-pass shows up as a mismatch that heals nothing. It costs one unlink
     and one rebuild scan by that namespace's next create — which is what every namespace paid
     on every pass when the drop was unconditional, and that version took this span once per
     namespace: 10,114 exclusive acquisitions of the lock every note create holds shared, the
@@ -1725,11 +1745,14 @@ def _drop_emptied_namespaces(root: Path, per_ns: Counter[str], dirs: set[str]) -
     try:
         with os.scandir(root / "notes") as namespaces:
             for ns in namespaces:
-                counts = _read_counts(Path(ns.path))
+                before, after = before_ns.get(ns.path), _read_counts(Path(ns.path))
                 file = f"{ns.path}{os.sep}{NOTES_FILE}"
-                # A count that will not parse is drift; one that is not there is not.
-                stale = counts[0] != per_ns[ns.path] if counts else os.access(file, os.F_OK)
-                if not (stale or ns.path in dirs):
+                # Steady at both ends and equal to the walk between them, or never there at
+                # all: nothing to heal. A file that will not parse reads as neither, and the
+                # `or` chain is why the access check costs a syscall only when it decides.
+                fresh = before and after and before[0] == per_ns[ns.path] == after[0]
+                settled = fresh or not (before or after or os.access(file, os.F_OK))
+                if settled and ns.path not in dirs:
                     continue
                 try:
                     with _locked((root / NOTES_FILE).with_suffix(".create")):
@@ -1804,6 +1827,12 @@ def _reap_pass(root: Path, now: float) -> None:
     # The same total for notes, split by namespace: what `_drop_emptied_namespaces` compares
     # each per-namespace count file against, so it drops the files that disagree and no others.
     per_ns: Counter[str] = Counter()
+    # And every per-namespace count as it stands before the walk, unlocked and without a stat:
+    # the drop compares all three, because a file and a walk that agree can still be a drift a
+    # create moved into place while the walk ran.
+    before_ns: dict[str, tuple[int, int] | None] = {}
+    with suppress(OSError), os.scandir(root / "notes") as entries:
+        before_ns = {e.path: _read_counts(Path(e.path)) for e in entries if e.is_dir()}
     # And the directories it emptied, which is the only place a bucket or a namespace can
     # need removing: nothing else in the store deletes.
     touched: dict[str, set[str]] = {"rooms": set(), "notes": set()}
@@ -1868,7 +1897,7 @@ def _reap_pass(root: Path, now: float) -> None:
     # is the whole point — every create in the service queues on these two files.
     _settle_count(root, NOTES_FILE, before[NOTES_FILE], kept["notes"])
     _settle_count(root, USAGE_FILE, before[USAGE_FILE], kept["rooms"])
-    _drop_emptied_namespaces(root, per_ns, touched["notes"])
+    _drop_emptied_namespaces(root, before_ns, per_ns, touched["notes"])
     _split_seq_state(root)  # once in the life of a store; a no-op every pass after
     # The buckets the pass emptied, one span acquisition each, for the mkdir-to-open reason
     # `_drop_emptied_namespaces` gives: `_locked` makes a bucket one `mkdir` before opening

--- a/src/store.py
+++ b/src/store.py
@@ -20,7 +20,7 @@ import time
 import unicodedata
 from collections import Counter
 from collections.abc import Iterator, Sequence
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
@@ -1505,7 +1505,8 @@ def _emptied(base: str, path: str, ns: bool) -> str:
     note its NAMESPACE and never the bucket the key landed in, because the namespace is the
     level the count file, the cap and the rmdir all live at (`_note_ns_dir`) and `_prune`
     reaches the buckets under it. Slices a known prefix for the same reason
-    `_guards_a_live_room` does: it runs once per deleted file and per swept lock.
+    `_guards_a_live_room` does: it runs once per note the walk sees — that is how the pass
+    totals a namespace — and again per deleted file and per swept lock.
     """
     return f"{base}{path[len(base) :].partition(os.sep)[0]}" if ns else os.path.dirname(path)
 
@@ -1665,43 +1666,48 @@ def _sweep_orphan_locks(root: Path, now: float, touched: dict[str, set[str]]) ->
                 continue
 
 
-def _drop_emptied_namespaces(root: Path, dirs: set[str]) -> None:
-    """Drop every per-namespace count, and then the namespaces this pass emptied. Two jobs
-    with two costs, which is why they are two loops.
+def _drop_emptied_namespaces(root: Path, per_ns: Counter[str], dirs: set[str]) -> None:
+    """Drop the per-namespace count of every namespace whose file disagrees with what this
+    pass walked, and remove the namespaces this pass emptied. One scandir of `notes/`, and an
+    acquisition only where there is something to heal.
 
-    The counts go unconditionally, for every namespace, because a deletion is not the only
-    thing one can be wrong about. A create reserves before it writes (see `_create_gate`), so
-    a crash in between leaves that namespace one high with no give-back coming, and under
-    CHAT_FSYNC=0 an unclean shutdown can lose an increment and leave it low. Neither is
-    reachable from the pass's own walk, and both are permanent against MAX_NOTES_PER_NS if
-    nothing drops the file: this is the only thing that heals them. The next create in that
-    namespace pays one scan to rebuild it and none after. Re-establishing each figure from a
-    walk would work too and is strictly more code to be wrong in; an unlink cannot be off by
-    one.
+    "The file does not equal the walk" is the whole predicate, and it is exactly the set that
+    needs healing. A per-namespace count moves only by a create's ±1 reservation, taken under
+    the span, and only this loop deletes it — so a file that agrees with a walk of its own
+    namespace has had no deletion behind it and is carrying no drift. What a mismatch catches
+    is everything a deletion-only rule missed: a create that reserved and then crashed before
+    writing leaves the figure one high with no give-back coming, and under CHAT_FSYNC=0 an
+    unclean shutdown can lose an increment and leave it low. Neither is reachable from the
+    deletions this pass made, and both are permanent against MAX_NOTES_PER_NS if nothing drops
+    the file. A file that will not parse is a mismatch too; one that is not there has nothing
+    to heal, and its next reader rebuilds by walking that namespace. The read takes no lock,
+    like every other read of a counter — a replace is atomic, so it sees old bytes or new.
 
-    Deliberately NOT under the span, which the rmdir below needs and this does not — one
-    scandir of `notes/` and an unlink apiece is the whole cost, and taking the span 10,114
-    times to make it is what put this pass at the top of the production lock profile. A create
-    racing the unlink is benign either way round. Landing between that create's read of the
-    file and its `+1`, the create re-persists the old figure plus one, and the next pass
-    unlinks it again: a drift survives one more interval and is never left lower than the
-    truth. Landing after `_check_note_capacity` rebuilt the file, `_count_new_note` finds
-    nothing to read and rebuilds by walking that one namespace, which is the right figure by
-    definition.
+    The unlink is under the span, exclusively, and needs it every bit as much as the rmdir
+    below does. Unlocked it puts a count *below* its notes: create 1 has reserved
+    (`_count_new_note` wrote K+1) and is still writing its note when the file goes; create 2
+    finds nothing to read, rebuilds by walking a namespace whose K+1'th note is not on disk
+    yet, persists K, and reserves K+1 against it. Two notes were made, the file moved by one,
+    and the namespace over-admits against MAX_NOTES_PER_NS until something rewrites the
+    figure. Both creates hold the span shared, so only an exclusive holder is waited out for.
 
-    The rmdir is the half that needs the span, and it visits `dirs` only — the namespaces this
-    pass deleted a note in or swept a lock in. Runs after `_sweep_orphan_locks`, which is what
-    puts a namespace back to notes and locks only and so lets the rmdir reach an emptied one —
-    and which reports what it emptied into the same set, so a namespace drained by an earlier
-    pass is still reached. It used to try every namespace, which meant 10,114 exclusive
-    acquisitions of one lock per pass, each queued against a stream of creates holding it
-    shared, on a store where all but a handful had nothing to remove. A namespace left empty by
-    neither a deletion nor a lock (a crash in the mkdir-to-open gap makes one) is not visited
-    any more; it costs one directory entry and the next create there moves back into it.
+    A create landing mid-walk shows up as a mismatch that heals nothing. It costs one unlink
+    and one rebuild scan by that namespace's next create — which is what every namespace paid
+    on every pass when the drop was unconditional, and that version took this span once per
+    namespace: 10,114 exclusive acquisitions of the lock every note create holds shared, the
+    single largest holder of blocked time in the production profile. In steady state this set
+    is empty or a handful.
 
-    Under the create span, taken exclusively, for a nearer reason than the count's. A create
-    makes its namespace directory inside `_locked`, one `mkdir` before the `open` that creates
-    the sidecar lock in it, and the directory is still empty in between — precisely what this
+    The rmdir visits `dirs` alone — the namespaces this pass deleted a note in or swept a lock
+    in. It runs after `_sweep_orphan_locks`, which is what puts a namespace back to notes and
+    locks only and so lets the rmdir reach an emptied one, and which reports what it emptied
+    into the same set, so a namespace drained by an earlier pass is still reached. One left
+    empty by neither a deletion nor a lock (a crash in the mkdir-to-open gap makes one) is not
+    removed; it costs one directory entry and the next create there moves back into it.
+
+    That half wants the span for a nearer reason than the count's. A create makes its
+    namespace directory inside `_locked`, one `mkdir` before the `open` that creates the
+    sidecar lock in it, and the directory is still empty in between — precisely what this
     rmdir looks for. Removing it in that gap does not merely lose a race, it fails the create:
     creating a file in a directory being removed is EINVAL on APFS, measured here and needing
     O_CREAT to reproduce at all, where a directory merely *gone* gives the ENOENT POSIX
@@ -1711,31 +1717,34 @@ def _drop_emptied_namespaces(root: Path, dirs: set[str]) -> None:
     exactly the gap to close.
 
     Per namespace rather than once around the loop: a create only ever needs the directory it
-    is entering to stand still, so holding the span across all 32 of them at the cap would
-    queue creates behind namespaces they have nothing to do with. Inside the `try` for the
-    reason this whole tail is best effort — `_reap` runs on the request path, and a pass that
-    cannot take the span must skip a cleanup, never fail the create that triggered it.
+    is entering to stand still, so holding the span across all of them would queue creates
+    behind namespaces they have nothing to do with. Inside the `try` for the reason this whole
+    tail is best effort — `_reap` runs on the request path, and a pass that cannot take the
+    span must skip a cleanup, never fail the create that triggered it.
     """
     try:
         with os.scandir(root / "notes") as namespaces:
             for ns in namespaces:
-                with suppress(OSError):  # a stray file, or a tree we may not write
-                    Path(ns.path, NOTES_FILE).unlink(missing_ok=True)
+                counts = _read_counts(Path(ns.path))
+                file = f"{ns.path}{os.sep}{NOTES_FILE}"
+                # A count that will not parse is drift; one that is not there is not.
+                stale = counts[0] != per_ns[ns.path] if counts else os.access(file, os.F_OK)
+                if not (stale or ns.path in dirs):
+                    continue
+                try:
+                    with _locked((root / NOTES_FILE).with_suffix(".create")):
+                        Path(file).unlink(missing_ok=True)
+                        if ns.path in dirs:
+                            # Buckets first: since sharding a namespace's notes sit a level
+                            # further down, so a drained namespace holds empty directories,
+                            # and rmdir refuses those exactly as it refuses notes. Without
+                            # this the namespace below never goes.
+                            _prune(ns.path)
+                            os.rmdir(ns.path)  # rmdir refuses a directory with entries
+                except OSError:
+                    continue  # a tree we may not write, or a create that got there first
     except OSError:
-        pass  # no notes yet, or nothing readable: either way there is no count to drop
-    for d in map(Path, dirs):
-        try:
-            with _locked((root / NOTES_FILE).with_suffix(".create")):
-                # Again, so the rmdir below still meets an empty directory on a pass whose
-                # scandir above could not read `notes/` at all.
-                (d / NOTES_FILE).unlink(missing_ok=True)
-                # Buckets first: since sharding a namespace's notes sit a level further down,
-                # so a drained namespace holds empty directories, and rmdir refuses those
-                # exactly as it refuses notes. Without this the namespace below never goes.
-                _prune(d)
-                d.rmdir()  # empty namespaces only: rmdir refuses a directory with entries
-        except OSError:
-            continue
+        pass  # no notes yet, or nothing readable: no count to heal and no namespace to drop
 
 
 def _reap(root: Path) -> None:
@@ -1792,12 +1801,16 @@ def _reap_pass(root: Path, now: float) -> None:
     # create waited out, so `_settle_count` can tell what was created while the walk ran.
     kept = {"rooms": [0, 0], "notes": [0, 0]}
     before = {name: _counted_at(root, name) for name in (USAGE_FILE, NOTES_FILE)}
+    # The same total for notes, split by namespace: what `_drop_emptied_namespaces` compares
+    # each per-namespace count file against, so it drops the files that disagree and no others.
+    per_ns: Counter[str] = Counter()
     # And the directories it emptied, which is the only place a bucket or a namespace can
     # need removing: nothing else in the store deletes.
     touched: dict[str, set[str]] = {"rooms": set(), "notes": set()}
     for sub, suffix, stillborn_rule in (("rooms", ".jsonl", True), ("notes", ".txt", False)):
         base = f"{root / sub}{os.sep}"
         held, emptied = kept[sub], touched[sub]
+        by_ns = sub == "notes"  # notes are counted per namespace as well as in total
         for entry in _walk(root / sub, suffix):
             try:
                 # One stat per entry, before any branch can skip it: a guard note is kept, so
@@ -1805,6 +1818,8 @@ def _reap_pass(root: Path, now: float) -> None:
                 st = entry.stat()
                 held[0] += 1
                 held[1] += st.st_size
+                if by_ns:
+                    per_ns[_emptied(base, entry.path, True)] += 1
                 if _guards_a_live_room(root, base, entry, now):
                     continue
                 if not _reapable(entry.path, now, stillborn_rule, st):
@@ -1836,7 +1851,9 @@ def _reap_pass(root: Path, now: float) -> None:
                         p.unlink(missing_ok=True)
                         held[0] -= 1
                         held[1] -= st.st_size
-                        emptied.add(_emptied(base, entry.path, sub == "notes"))
+                        emptied.add(d := _emptied(base, entry.path, by_ns))
+                        if by_ns:
+                            per_ns[d] -= 1
                         config._dbg(2, "reap", room=p.name, reason=reason)
                         if stillborn_rule:
                             reaped[f"reaped_{reason}"] += 1
@@ -1851,7 +1868,7 @@ def _reap_pass(root: Path, now: float) -> None:
     # is the whole point — every create in the service queues on these two files.
     _settle_count(root, NOTES_FILE, before[NOTES_FILE], kept["notes"])
     _settle_count(root, USAGE_FILE, before[USAGE_FILE], kept["rooms"])
-    _drop_emptied_namespaces(root, touched["notes"])
+    _drop_emptied_namespaces(root, per_ns, touched["notes"])
     _split_seq_state(root)  # once in the life of a store; a no-op every pass after
     # The buckets the pass emptied, one span acquisition each, for the mkdir-to-open reason
     # `_drop_emptied_namespaces` gives: `_locked` makes a bucket one `mkdir` before opening
@@ -2310,10 +2327,12 @@ def _create_gate(gate: Path, path: Path, check, counted):
       - `<gate>.create`, SHARED, spanning the whole create. It is never contended by another
         create; it exists so the reaper can take it exclusively and know that no create is
         between its reservation and its write. `_counted_at` and `_settle_count` need that to
-        bound the creates their walk could not see, and `_prune` and
-        `_drop_emptied_namespaces` need it because `_locked` below makes a directory one
-        `mkdir` before opening the sidecar lock inside it, and removing it in that gap fails
-        the write outright (ENOENT, or EINVAL on APFS) rather than merely losing a race.
+        bound the creates their walk could not see; `_prune` and `_drop_emptied_namespaces`
+        need it because `_locked` below makes a directory one `mkdir` before opening the
+        sidecar lock inside it, and removing it in that gap fails the write outright (ENOENT,
+        or EINVAL on APFS) rather than merely losing a race; and the same drop needs it to
+        unlink a per-namespace count, which between a create's reservation and its write would
+        be dropping a figure that create has already moved.
         The reaper takes it for two file operations at each end of its pass and never
         across the walk between them: a hold that long parks every create in the store.
       - `path`'s own sidecar lock, which the body would take anyway, taken *before* the

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -874,9 +874,11 @@ def test_a_pass_takes_the_note_span_a_constant_number_of_times(tmp_path, monkeyp
     the single largest holder of blocked time in the production profile.
 
     Two per pass now, whatever the store holds: one to read the counter with the creates
-    waited out, one to install what the walk measured. Parametrised rather than looped so a
-    failure names the size it failed at; both sizes must give the same number, which is the
-    whole claim.
+    waited out, one to install what the walk measured. Every namespace here holds exactly the
+    note its own count file claims, and a file that agrees with the walk is carrying no drift,
+    so the drop visits none of them. That predicate is what keeps this number constant; the
+    test below spends the one acquisition it does allow. Parametrised rather than looped so a
+    failure names the size it failed at; both sizes must give the same number, the whole claim.
     """
     import store
 
@@ -889,10 +891,11 @@ def test_a_pass_takes_the_note_span_a_constant_number_of_times(tmp_path, monkeyp
 
 
 def test_only_a_namespace_the_pass_emptied_costs_an_acquisition(tmp_path, monkeypatch) -> None:
-    """The other half: cheap must not mean nothing gets cleaned up. A count file may only be
-    wrong about a deletion, and this pass is the only thing that deletes, so the namespaces it
-    deleted in — plus the ones whose orphan lock it swept — are exactly the ones worth
-    visiting. One acquisition each, and none for the rest of the store.
+    """The other half: cheap must not mean nothing gets cleaned up. A namespace this pass
+    deleted in holds a count file the walk disagrees with and a directory that may now be
+    empty, so it costs the one acquisition that drops both — and the rest of the store, whose
+    files match what was walked, costs nothing. A pass with nothing to heal is back to the two
+    the counters take.
     """
     import store
 
@@ -911,6 +914,101 @@ def test_only_a_namespace_the_pass_emptied_costs_an_acquisition(tmp_path, monkey
     _due(tmp_path)
     settled = _exclusive_takes(monkeypatch, store.NOTES_FILE, lambda: store._reap(tmp_path))
     assert settled == 2, "and a pass with nothing to drop is back to the constant"
+
+
+def test_a_pass_cannot_drop_a_count_a_create_has_reserved_against(tmp_path, monkeypatch) -> None:
+    """Unlinking a per-namespace count outside the span puts that count *below* its notes.
+
+    Two creates and one pass, in the order that breaks it. Create 1 has reserved — the
+    namespace file says K+1 — and is still writing its note when the pass unlinks that file.
+    Create 2 then finds nothing to read, rebuilds by walking a namespace whose K+1'th note is
+    not on disk yet, persists K and reserves K+1 against it. Two notes were made, the file
+    moved by one, and the namespace over-admits against MAX_NOTES_PER_NS until something
+    rewrites the figure. Both creates hold the span shared, so only an exclusive holder is
+    waited out for: the unlink has to take it, exactly as the rmdir beside it does.
+
+    Built rather than timed. The pass is parked where it has just given the span back —
+    `_settle_count` done, the drop next — create 1 is parked between its reservation and its
+    note write, and create 2 runs in that window. Bounded waits throughout: with the unlink
+    under the span the pass cannot finish until create 1 does, so an unconditional wait on it
+    would hang instead of failing.
+    """
+    import store
+
+    store.note_set(tmp_path, "ns", "first", "v")  # what the pass's walk will see: one note
+    ns_dir = tmp_path / "notes" / "ns"
+    reserving = str(store.note_path(tmp_path, "ns", "second"))
+    at_the_drop, drop_on = threading.Event(), threading.Event()
+    reserved, create_done, pass_done = threading.Event(), threading.Event(), threading.Event()
+    real_settle, real_replace = store._settle_count, store._replace
+
+    def settle_then_park_where_the_span_is_free(root, name, before, kept):
+        real_settle(root, name, before, kept)
+        if name == store.NOTES_FILE:  # the count is installed and the span given back
+            at_the_drop.set()
+            drop_on.wait(5)
+
+    def replace_the_note_but_park_on_the_reservation(path, data, fsync=False):
+        if str(path) == reserving:  # create 1 only: every other write here passes through
+            reserved.set()
+            create_done.wait(5)
+        return real_replace(path, data, fsync)
+
+    def run_the_pass():
+        store._reap(tmp_path)
+        pass_done.set()
+
+    monkeypatch.setattr(store, "_settle_count", settle_then_park_where_the_span_is_free)
+    monkeypatch.setattr(store, "_replace", replace_the_note_but_park_on_the_reservation)
+    _due(tmp_path)
+    reaper = threading.Thread(target=run_the_pass)
+    reaper.start()
+    assert at_the_drop.wait(5), "premise: the pass reached the drop with no span held"
+    creator = threading.Thread(target=store.note_set, args=(tmp_path, "ns", "second", "v"))
+    creator.start()
+    assert reserved.wait(5), "premise: create 1 has counted and not yet written"
+
+    drop_on.set()
+    pass_done.wait(1.0)  # unfixed the unlink lands here; fixed the pass waits for the span
+    store.note_set(tmp_path, "ns", "third", "v")  # create 2, on whatever the file now says
+    create_done.set()
+    creator.join(10)
+    assert pass_done.wait(10), "the pass never completed"
+    monkeypatch.undo()
+
+    assert store._ns_totals(ns_dir)[0] == 3, "premise: three notes on disk"
+    assert store._note_totals(ns_dir, store._ns_totals)[0] == 3, (
+        "a namespace count below its notes over-admits against the per-namespace cap"
+    )
+    store.note_set(tmp_path, "ns", "fourth", "v")  # a dropped count is rebuilt by the next create
+    rebuilt = store._read_counts(ns_dir)
+    assert rebuilt and rebuilt[0] == store._ns_totals(ns_dir)[0] == 4, "and the file agrees"
+
+
+def test_a_drifted_namespace_count_is_healed_by_one_pass(tmp_path, monkeypatch) -> None:
+    """The other half of visiting only the namespaces a pass emptied: a count can be wrong
+    about something no deletion explains. A create reserves before it writes, so a crash in
+    between leaves the figure one high with no give-back coming, and under CHAT_FSYNC=0 an
+    unclean shutdown can lose an increment and leave it low. Neither is reachable from the
+    pass's deletions, and both are permanent against MAX_NOTES_PER_NS if nothing drops the
+    file — so the predicate is the walk, not the deletions: a file that disagrees with what
+    this pass walked is dropped, and its next reader rebuilds from the disk.
+    """
+    import store
+
+    store.note_set(tmp_path, "ns", "a", "v")
+    store.note_set(tmp_path, "ns", "b", "v")
+    ns_dir = tmp_path / "notes" / "ns"
+    (ns_dir / store.NOTES_FILE).write_text("5 0")  # a reservation whose create never landed
+
+    _due(tmp_path)
+    taken = _exclusive_takes(monkeypatch, store.NOTES_FILE, lambda: store._reap(tmp_path))
+    assert taken == 3, "the two counter acquisitions, plus the one namespace that drifted"
+    assert store._read_counts(ns_dir) is None, "a drifted count is dropped, not rewritten"
+
+    store.note_set(tmp_path, "ns", "c", "v")  # which rebuilds the file it found missing
+    healed = store._read_counts(ns_dir)
+    assert healed and healed[0] == store._ns_totals(ns_dir)[0] == 3, "healed in one pass"
 
 
 def test_a_reap_dropping_a_namespace_still_waits_for_a_create_entering_it(
@@ -952,12 +1050,12 @@ def test_a_reap_dropping_a_namespace_still_waits_for_a_create_entering_it(
         except BaseException as exc:  # noqa: BLE001 — recorded for the assertion, not hidden
             died.append(exc)
 
-    def drop_but_let_a_create_into_the_window_first(root, dirs):
+    def drop_but_let_a_create_into_the_window_first(root, per_ns, dirs):
         visited.extend(dirs)
         creator.append(threading.Thread(target=create))
         creator[0].start()
         at_the_window.wait(5)
-        return real_drop(root, dirs)
+        return real_drop(root, per_ns, dirs)
 
     monkeypatch.setattr(store, "open", open_the_sidecar_lock_but_park_in_the_window, raising=False)
     monkeypatch.setattr(

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -1011,6 +1011,49 @@ def test_a_drifted_namespace_count_is_healed_by_one_pass(tmp_path, monkeypatch) 
     assert healed and healed[0] == store._ns_totals(ns_dir)[0] == 3, "healed in one pass"
 
 
+def test_a_count_that_was_already_low_before_the_walk_is_dropped(tmp_path, monkeypatch) -> None:
+    """Comparing the file to the walk alone lets a single create cancel a drift.
+
+    A namespace one low — an increment lost to an unclean shutdown under CHAT_FSYNC=0 — and
+    exactly one create landing after the walk has passed it: the walk totals K, the create
+    moves the file from K-1 to K and the disk to K+1, and a file read only afterwards agrees
+    with the walk. The pass looks right, the namespace stays low, and nothing about the
+    coincidence stops it repeating on the next pass — which is the cap being breached by the
+    thing that was supposed to heal it.
+
+    So the file is read before the walk as well, and kept only if it held still at what the
+    walk saw. Here that reading is K-1 against a walk of K, which no create landing later can
+    talk out of. Driven from the orphan-lock sweep, which runs after both walks and holds no
+    span, so the create really is invisible to the walk rather than timed to be.
+    """
+    import store
+
+    store.note_set(tmp_path, "ns", "a", "v")
+    store.note_set(tmp_path, "ns", "b", "v")
+    ns_dir = tmp_path / "notes" / "ns"
+    (ns_dir / store.NOTES_FILE).write_text("1 0")  # the increment that never reached the disk
+    real_walk = store._walk
+    landed = []
+
+    def walk_but_land_a_create_once_the_notes_are_walked(d, suffix):
+        if suffix == ".txt.lock" and not landed:
+            landed.append(suffix)
+            store.note_set(tmp_path, "ns", "c", "v")  # +1 to the file, +1 to the disk
+        return real_walk(d, suffix)
+
+    monkeypatch.setattr(store, "_walk", walk_but_land_a_create_once_the_notes_are_walked)
+    _due(tmp_path)
+    store._reap(tmp_path)
+    monkeypatch.undo()
+
+    assert landed, "premise: the create landed after the walk had passed the namespace"
+    assert store._ns_totals(ns_dir)[0] == 3, "premise: three notes on disk"
+    assert store._read_counts(ns_dir) is None, "a count that was low before the walk is dropped"
+    store.note_set(tmp_path, "ns", "d", "v")
+    healed = store._read_counts(ns_dir)
+    assert healed and healed[0] == store._ns_totals(ns_dir)[0] == 4, "and the next create heals it"
+
+
 def test_a_reap_dropping_a_namespace_still_waits_for_a_create_entering_it(
     tmp_path, monkeypatch
 ) -> None:
@@ -1050,12 +1093,12 @@ def test_a_reap_dropping_a_namespace_still_waits_for_a_create_entering_it(
         except BaseException as exc:  # noqa: BLE001 — recorded for the assertion, not hidden
             died.append(exc)
 
-    def drop_but_let_a_create_into_the_window_first(root, per_ns, dirs):
+    def drop_but_let_a_create_into_the_window_first(root, before_ns, per_ns, dirs):
         visited.extend(dirs)
         creator.append(threading.Thread(target=create))
         creator[0].start()
         at_the_window.wait(5)
-        return real_drop(root, per_ns, dirs)
+        return real_drop(root, before_ns, per_ns, dirs)
 
     monkeypatch.setattr(store, "open", open_the_sidecar_lock_but_park_in_the_window, raising=False)
     monkeypatch.setattr(

--- a/uv.lock
+++ b/uv.lock
@@ -1593,7 +1593,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.12.0"
+version = "0.12.1"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

Two things, because the second packages the first. The reap pass drops a namespace's `.notes-count` under the exclusive create span again, but only for a namespace whose count file does not agree with the pass at both ends (a read before the walk, the walk's own total, a read after), or that the pass emptied. And the version moves to **0.12.1** in the eight files a release touches, folding `[Unreleased]` into a dated section. Nothing in the API changes; the tag is yours to push.

## Why

Follow-up to #722, which merged before this fix landed on its branch. Codex's review there found a real race in the unlocked unlink that commit shipped: create 1 has reserved (`+1` written to the namespace file) and is still writing its note when the reaper unlinks the file; create 2 finds no file, rebuilds by scanning a namespace whose newest note is not on disk yet, persists that figure and reserves against it. Two notes made, the file moved by one, and the per-namespace cap over-admits until something rewrites it. Both creates hold the span shared, so only an exclusive holder is waited out.

Judgment call: taking the span once per namespace is what #722 removed (10,114 acquisitions a pass in production), so the unlink is gated on a predicate instead. A count file that reads the same before the walk, equals the walk, and reads the same after has ended the pass where it started: an over-high file never agrees, and a namespace with a deletion is in the touched set regardless. Codex's second finding (a low file masked by one create landing after the walk) is what the before-read closes; the remaining one-note hole is stated in the docstring and clears on the next pass. In steady state the set is empty or a handful, the acquisition-count tests from #722 keep their constants, and a drifted namespace count now heals, which #722's touched-only version left permanent. Cost: two unlocked reads per namespace per pass.

`test_a_pass_cannot_drop_a_count_a_create_has_reserved_against` and `test_a_count_that_was_already_low_before_the_walk_is_dropped` rebuild the two interleavings and fail without the fix.

PATCH: no route, parameter, response shape, default or documented cap moved. The changelog's deployer note names the two things an operator sees, counts that are fail-closed rather than exact, and a new `.reaped.lock` in the store root.

**One thing for the maintainer.** `sz.py --check` has failed on main since #722 merged, because `src/store.py` grew past the recorded baseline (935 to 994, cap 1000). Pull requests run `sz.py --caps`, which passes, so it only shows on main. This branch does not touch `sz-baseline.json`, per AGENTS.md; regenerating it with `uv run sz.py --update-baseline` is what turns main green again.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` (726 passed, 1 skipped, with main merged in)
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: none affected (private functions only)
- [x] New surface on a world-writable service: nothing new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdcG7mXE6YqBKxPdKqzrf9