### PR TITLE
chore(sz): refresh the core-size baseline for 0.12.1

### DIFF
--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,5 +1,5 @@
 {
-  "core_total": 2257,
+  "core_total": 2316,
   "caps": {
     "core/app.py": 1020,
     "core/config.py": 63,
@@ -34,15 +34,15 @@
       "tokens_per_line": 8.39
     },
     "core/store.py": {
-      "raw_lines": 2550,
-      "code_lines": 935,
-      "comment_lines": 596,
-      "tokens_per_line": 7.76
+      "raw_lines": 2762,
+      "code_lines": 994,
+      "comment_lines": 632,
+      "tokens_per_line": 8.06
     },
     "extra/manifest.py": {
-      "raw_lines": 2259,
+      "raw_lines": 2261,
       "code_lines": 1556,
-      "comment_lines": 264,
+      "comment_lines": 266,
       "tokens_per_line": 3.9
     }
   }


### PR DESCRIPTION
## What

Regenerates `sz-baseline.json` so the core-size ratchet passes again. No source changes.

## Why

The ratchet has been failing on `main` since #722/#723: `core/store.py` grew 935 → 994 code lines and the core total 2257 → 2316. That growth is the reaper fix — taking store-sized work out of the lock spans costs code — and it is deliberate, so the baseline is what moves, via the step the gate itself asks for (`uv run sz.py --update-baseline`).

The policy caps, which are the immovable half, still pass untouched: `store.py` 994 of 1000, core total 2316 of 3000.

Needed before tagging 0.12.1, or the released tree fails its own gate on `main`.

One thing worth flagging rather than burying: `store.py` is now **6 lines under its 1000-line cap**. The next change that adds anything to it hits the cap, not the ratchet — and the cap is not something a baseline refresh can move.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 726 passed, 1 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs that would now be wrong are updated: none — no behaviour changes
- [x] New surface on a world-writable service: nothing new — a measurement file only

`uv run sz.py --check` exit 0, `uv run sz.py --caps` exit 0.
