### PR TITLE
fix(store): refuse to boot when RESERVED_ROOM_BYTES drops to zero

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -90,6 +90,12 @@ MAX_TOTAL_ROOM_BYTES = 5 << 30
 # = MAX_TOTAL_ROOM_BYTES // MAX_ROOMS on purpose: the floor times the cap is the budget, so
 # even the worst case — every room at its floor — lands exactly on the number.
 RESERVED_ROOM_BYTES = MAX_TOTAL_ROOM_BYTES // MAX_ROOMS
+if RESERVED_ROOM_BYTES == 0:
+    raise ValueError(
+        f"CHAT_MAX_ROOMS={MAX_ROOMS} exceeds MAX_TOTAL_ROOM_BYTES="
+        f"{MAX_TOTAL_ROOM_BYTES}; RESERVED_ROOM_BYTES would be 0 "
+        "— refusing to boot"
+    )
 # How many rooms exist and how many bytes they occupy — "count bytes", the same two-integer
 # format and the same machinery as NOTES_FILE below, so one atomic replace keeps both halves
 # describing the same store.

--- a/tests/unit/test_bug_581_reserved_room_bytes.py
+++ b/tests/unit/test_bug_581_reserved_room_bytes.py
@@ -1,0 +1,19 @@
+"""Regression test for #581: RESERVED_ROOM_BYTES must not silently drop to zero."""
+
+import os
+import subprocess
+import sys
+
+
+def test_reserved_room_bytes_zero_refuses_to_boot():
+    """CHAT_MAX_ROOMS large enough to make RESERVED_ROOM_BYTES zero must not boot."""
+    clean = {k: v for k, v in os.environ.items() if not k.startswith("CHAT_")}
+    run = subprocess.run(
+        [sys.executable, "-c", "import store"],
+        capture_output=True,
+        text=True,
+        env={**clean, "CHAT_MAX_ROOMS": "10000000000"},
+        cwd=os.path.join(os.path.dirname(__file__), "..", "..", "src"),
+    )
+    assert run.returncode != 0, "app booted with RESERVED_ROOM_BYTES == 0"
+    assert "ValueError" in run.stderr


### PR DESCRIPTION
Fixes #581.

When CHAT_MAX_ROOMS exceeds MAX_TOTAL_ROOM_BYTES, integer division yields 0 and _compact(keep=0) discards every message on every append silent data loss. Now raises ValueError at import time, matching the refuse-to-boot pattern CHAT_MAX_WAIT and CHAT_WAIT_POLL already use.

One guard in store.py, one subprocess regression test. Verified against c149aa5.