### PR TITLE
fix(manifest): reject out-of-range port numbers in public_base

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -91,6 +91,10 @@ def public_base(scheme: str, host: str, configured: str = "") -> str:
     if configured:
         return configured.rstrip("/")
     if host and _HOST_RE.fullmatch(host.lower()) and scheme in ("http", "https"):
+        if ":" in host:
+            port = int(host.rsplit(":", 1)[1])
+            if not (1 <= port <= 65535):
+                return ""
         return f"{scheme}://{host.lower()}"
     return ""
 

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -316,6 +316,12 @@ def test_public_base_rejects_a_host_that_matches_only_before_a_trailing_newline(
 
     assert manifest.public_base("https", "example.com") == "https://example.com"
     assert manifest.public_base("https", "example.com\n") == ""
+    assert manifest.public_base("https", "example.com:443") == "https://example.com:443"
+    assert manifest.public_base("http", "example.com:8080") == "http://example.com:8080"
+    assert manifest.public_base("http", "example.com:65535") == "http://example.com:65535"
+    assert manifest.public_base("http", "example.com:0") == ""
+    assert manifest.public_base("http", "example.com:65536") == ""
+    assert manifest.public_base("http", "example.com:99999") == ""
 
 
 def test_the_room_budget_is_published_where_agents_look(client):


### PR DESCRIPTION
## What
Reject out-of-range port numbers (not in 1..65535) in `public_base` when parsing the `Host` header.

## Why
`_HOST_RE` accepted up to 5 digits for the port (`:[0-9]{1,5}`), allowing invalid TCP ports like 0 or 99999. Echoing these into `/openapi.json`, `/sitemap.xml`, and the `Link` header causes standard URL parsers (e.g. `urllib.parse.urlsplit().port`) to raise `ValueError: Port out of range 0-65535`. Out-of-range ports now fall back to relative URLs like other unplausible hosts.

## Checks
- [x] `uv run sz.py --check` passes (core total 2314 <= baseline 2316)
- [x] Port boundary regressions added to `tests/http/test_docs.py`