### PR TITLE
fix(sz): reject unlisted src files in enforcing modes

### DIFF
--- a/sz.py
+++ b/sz.py
@@ -43,6 +43,7 @@ from pathlib import Path
 
 CORE_FILES = ("src/app.py", "src/config.py", "src/didkey.py", "src/limit.py", "src/store.py")
 EXTRA_FILES = ("src/manifest.py",)
+POLICY_FILES = frozenset(CORE_FILES + EXTRA_FILES)
 BASELINE = Path(__file__).resolve().parent / "sz-baseline.json"
 # Token types that carry no code: layout, comments, and the encoding/end markers.
 _SKIP_TOKENS = {
@@ -126,6 +127,18 @@ def main():
     args = parser.parse_args()
 
     root = Path(__file__).resolve().parent
+    if args.check or args.caps:
+        unlisted = sorted(
+            str(path.relative_to(root))
+            for path in (root / "src").glob("*.py")
+            if str(path.relative_to(root)) not in POLICY_FILES
+        )
+        if unlisted:
+            print(
+                "size policy missing src files: " + ", ".join(unlisted),
+                file=sys.stderr,
+            )
+            return 1
     files = measure_all(root)
     core_total = sum(v["code_lines"] for k, v in files.items() if k.startswith("core/"))
     # {} rather than None when unneeded: every branch that subscripts baseline is guarded

--- a/tests/unit/test_size_policy.py
+++ b/tests/unit/test_size_policy.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parents[2]
+
+
+def test_enforcing_size_modes_reject_unlisted_src_python(tmp_path):
+    shutil.copy(ROOT / "sz.py", tmp_path / "sz.py")
+    shutil.copy(ROOT / "sz-baseline.json", tmp_path / "sz-baseline.json")
+    shutil.copytree(ROOT / "src", tmp_path / "src")
+    (tmp_path / "src" / "rogue.py").write_text("value = 1\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "sz.py", "--caps"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "size policy missing src files: src/rogue.py" in result.stderr
+
+
+def test_reporting_size_mode_still_reports_without_policy_completeness(tmp_path):
+    shutil.copy(ROOT / "sz.py", tmp_path / "sz.py")
+    shutil.copy(ROOT / "sz-baseline.json", tmp_path / "sz-baseline.json")
+    shutil.copytree(ROOT / "src", tmp_path / "src")
+    (tmp_path / "src" / "rogue.py").write_text("value = 1\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "sz.py"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "core total (code)" in result.stdout
+    assert result.stderr == ""


### PR DESCRIPTION
## Summary

Closes #638.

`sz.py --check` and `--caps` now fail closed when a Python file exists directly under `src/` but is absent from both the core and extra policy lists. This prevents a newly added source module from being silently unmeasured and uncapped. Plain report mode remains informational, so it still reports the measured table without forcing a classification.

## Verification

- Verified against `main` at `9861d01`.
- Added subprocess regressions for enforcing-mode rejection and report-mode compatibility.
- `uv run sz.py --caps`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run coverage run -m pytest tests -q`: 749 passed, 1 skipped
- `uv run coverage report`: 97.97% total coverage
- `git diff --check`

No new public service surface or abuse capability; this changes only the repository's size-policy enforcement script.
