### PR TITLE
fix(app): reject padded signed POST credentials

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1450,10 +1450,10 @@ async def room_post(request: Request) -> Response:
     # Every field the body schema publishes as a string is read through _field, so the type
     # the document promises is the type the handler gets — the credentials included, which
     # were `str()`-coerced here for the same reason `from`/`text` were (#427).
-    did, sent = _field(payload, "did").strip(), _field(payload, "text")
+    did, sent = _field(payload, "did"), _field(payload, "text")
     signer = None
     if did:
-        sig, nonce = _field(payload, "sig").strip(), _field(payload, "nonce").strip()
+        sig, nonce = _field(payload, "sig"), _field(payload, "nonce")
         body = store.clean_text(sent)
         signer = _signer(did, sig, nonce, f"{room}|{nonce}|{body}")
         if isinstance(signer, Response):
@@ -1732,10 +1732,10 @@ async def note_post(request: Request) -> Response:
     p = request.path_params
     ns, key = p["ns"], p["key"]
     value = store.clean_text(_field(payload, "value"), store.MAX_VALUE_CHARS)
-    did = _field(payload, "did").strip()
+    did = _field(payload, "did")
     signer = None
     if did:
-        sig, nonce = _field(payload, "sig").strip(), _field(payload, "nonce").strip()
+        sig, nonce = _field(payload, "sig"), _field(payload, "nonce")
         signer = _signer(did, sig, nonce, f"{ns}|{key}|{nonce}|{value}")
         if isinstance(signer, Response):
             return signer

--- a/tests/test_input_doctrine.py
+++ b/tests/test_input_doctrine.py
@@ -10,6 +10,7 @@ docs/design.md §3.5 — advisory parameters clamp, semantic ones refuse naming 
 from __future__ import annotations
 
 import _client
+import pytest
 
 client = _client.client  # the shared TestClient fixture
 
@@ -63,6 +64,69 @@ def test_427_a_non_string_from_is_refused_rather_than_str_coerced(client):
     # The same rule on the other free-form field, and on both POST lanes' shared reader.
     assert client.post("/r/type-check", json={"from": "b", "text": 12345}).status_code == 400
     assert client.post("/kv/plans/k", json={"value": ["x"]}).status_code == 400
+
+
+@pytest.mark.parametrize("lane", ["room", "note"])
+@pytest.mark.parametrize("field", ["did", "sig", "nonce"])
+@pytest.mark.parametrize("padding", ["leading", "trailing"])
+def test_740_signed_posts_refuse_padded_credentials(client, lane, field, padding):
+    """Credential whitespace violates the exact signed-lane schema and is semantic input:
+    refuse it as sent rather than trimming it into a different, valid identity assertion."""
+    did, sign = _client._keypair()
+    nonce = "7"
+    room = f"d-pad-{lane}-{field}-{padding}"
+    if lane == "room":
+        value = "signed"
+        credentials = {"did": did, "sig": sign(f"{room}|{nonce}|{value}"), "nonce": nonce}
+        url, payload = f"/r/{room}", {"text": value}
+    else:
+        value = did
+        credentials = {
+            "did": did,
+            "sig": sign(f"room-owners|{room}|{nonce}|{value}"),
+            "nonce": nonce,
+        }
+        url, payload = f"/kv/room-owners/{room}", {"value": value, "if_absent": True}
+    credentials[field] = (
+        f" {credentials[field]}" if padding == "leading" else f"{credentials[field]} "
+    )
+
+    response = client.post(url, json={**credentials, **payload})
+    assert response.status_code == 400, (lane, field, padding, response.text)
+    assert {"did": "did:key", "sig": "signature", "nonce": "nonce"}[
+        field
+    ] in response.text.splitlines()[0]
+    if lane == "room":
+        assert client.get(f"/r/{room}?format=json").json()["messages"] == []
+    else:
+        assert client.get(f"/kv/room-owners/{room}").status_code == 404
+        assert client.get(f"/kv/room-nonce/{room}").status_code == 404
+
+
+def test_740_signed_posts_still_accept_exact_credentials(client):
+    did, sign = _client._keypair()
+    room = "d-exact-note"
+
+    claim = client.post(
+        f"/kv/room-owners/{room}",
+        json={
+            "did": did,
+            "sig": sign(f"room-owners|{room}|1|{did}"),
+            "nonce": "1",
+            "value": did,
+            "if_absent": True,
+        },
+    )
+    assert claim.status_code == 200, claim.text
+    assert client.get(f"/kv/room-owners/{room}").text.splitlines()[-1] == did
+    assert client.get(f"/kv/room-nonce/{room}").text.splitlines()[-1] == "1"
+
+    message = _client._post_signed(client, "exact-message", did, sign, "signed", nonce=1)
+    assert message.status_code == 200, message.text
+    stored = client.get("/r/exact-message?format=json").json()["messages"]
+    assert [(record["from"], record["nonce"], record["text"]) for record in stored] == [
+        (did, 1, "signed")
+    ]
 
 
 def test_373_an_unsigned_post_without_from_names_from_not_the_room(client):


### PR DESCRIPTION
## What

Signed JSON POST requests now validate `did`, `sig`, and `nonce` exactly as received in both room and note lanes. Leading or trailing whitespace is rejected instead of being stripped into a different valid credential value.

Regression coverage exercises both lanes, all three fields, both padding directions, no-write behavior, and exact-credential success.

## Why

The OpenAPI schema publishes exact credential patterns and lengths, while the input doctrine requires semantic fields to be refused rather than normalized. Trimming made schema-invalid requests succeed and caused drift from the path-based signed lanes.

Fixes #740.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 760 passed, 1 skipped; 97.89% total coverage
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs remain accurate: this restores the already-documented exact credential shapes and semantic-input refusal rule
- [x] New surface on a world-writable service: nothing new
