### PR TITLE
fix(humans): unwedge passkey sign-in, and make enrolling one reachable

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -676,8 +676,12 @@ Enrolment and discovery are separate buttons, which is not a UI preference. Deci
 from stored state gets the case that matters exactly backwards: a reader whose site data was cleared
 — the one with the most to recover — looks like a first-timer, and would be handed a *second*
 passkey and a different DID, silently, while the identity they came back for sat unused in the
-authenticator. Two costs stay documented rather than hidden. The PRF output *is* the seed, so the
-authenticator's user verification is the whole gate (hence `required`, not `preferred`). And the
+authenticator. What discovery may do on finding nothing is *reveal* enrolment — the failure names
+that button, and naming a control folded inside a disclosure the reader has never opened is a dead
+end dressed as a next step. Revealing it is not performing it, and the distinction above survives:
+the reader still has to ask. Two costs stay documented rather than hidden. The PRF output *is* the
+seed, so the authenticator's user verification is the whole gate (hence `required`, not
+`preferred`). And the
 credential is scoped to the RP ID, so **moving this page to another domain destroys every identity
 derived this way** — which is why seed export stays available on the passkey path too.
 

--- a/src/humans.html
+++ b/src/humans.html
@@ -825,8 +825,27 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
 
   // Roughly 8% of men cannot separate red from green, so the failure state is carried by the
   // word "error" as well as by Error Red (DESIGN.md: red is never the only signal).
-  function say(msg) { status.textContent = msg; status.className = 'badge live'; }
-  function fail(msg) { status.textContent = 'error — ' + msg; status.className = 'badge err'; }
+  //
+  // One badge, two writers that want different things from it. The pump stamps `seq N` on
+  // it every time a poll lands — a heartbeat, and the right cadence for a live log. Every
+  // other caller writes to it because the reader did something and is owed an answer. Until
+  // these were told apart the heartbeat won every race in a room that was not idle: the one
+  // line explaining what a click was waiting for, and the error when it failed, were both
+  // gone inside a second. That is most of why a passkey ceremony the platform never
+  // surfaced looked like a button that did nothing at all.
+  //
+  // So an answer is held: long enough to read, short enough that the seq is not stranded on
+  // a page the reader has moved on from.
+  var HOLD_MS = 8000;
+  var holdUntil = 0;
+  function badge(msg, cls) { status.textContent = msg; status.className = cls; }
+  function say(msg) { holdUntil = Date.now() + HOLD_MS; badge(msg, 'badge live'); }
+  function fail(msg) {
+    holdUntil = Date.now() + HOLD_MS;
+    badge('error — ' + msg, 'badge err');
+  }
+  // The pump's own line, which never talks over an answer the reader is still reading.
+  function beat(msg) { if (Date.now() >= holdUntil) badge(msg, 'badge live'); }
 
   // Opening a room from the list has to actually take you there. The list is a screenful on
   // its own — more so on a phone, and it holds up to 200 rows — so filling a log several
@@ -1141,7 +1160,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
           }
         }
         restamp();
-        say('seq ' + since);
+        beat('seq ' + since);
         live(true);
         // A parked read that comes back instantly with nothing is the server declining to
         // park — every waiter slot is taken, and MAX_WAITERS_* degrades to an immediate
@@ -1345,14 +1364,39 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
               && typeof navigator.credentials.create === 'function');
   }
 
+  // One ceremony at a time, and the reader's newest click is the one that counts. WebAuthn
+  // allows a single outstanding request per document: a second get() while one is parked is
+  // rejected outright, with "A request is already pending." — a sentence about the page's
+  // own bookkeeping, handed to a reader who cannot see the thing it says is pending.
+  //
+  // And parked is where a request stays. The platform dialog is not always a dialog the
+  // reader gets to answer: on several of them it opens behind the browser window, or it is
+  // an OS sheet dismissed by the OS rather than by the page, or the ceremony is a hybrid
+  // one waiting on a phone that never joins. The promise does not reject in any of those —
+  // it simply never settles. Without the abort below that wedged the page for the life of
+  // the document: every later click reported the pending request, the reload nobody thinks
+  // to try was the only way out, and the button looked broken because for that reader it
+  // was. Aborting the outstanding request is what the signal is for, so clicking again
+  // means "try that again" — which is what the reader meant by it.
+  var ceremony = null;
+
+  // A backstop for the reader who clicks once and looks away: a ceremony nobody answers
+  // ends by saying so, rather than leaving `waiting for your passkey…` on screen forever.
+  // Generous, because the hybrid flow legitimately takes a while — scan a QR code, unlock a
+  // phone, approve there. Browsers clamp this to their own range; it is a hint, not a
+  // deadline, which is why the abort above is the mechanism and this is only the backstop.
+  var CEREMONY_MS = 120000;
+
   // The PRF output is read from a get(), never from the create(). Returning it at creation
   // time is optional in the spec and absent in several shipping browsers, so asking for it
   // there and trusting the answer is how this works on one engine and silently fails on the
   // next. One extra prompt on first setup, none afterwards.
-  function passkeyEnroll() {
+  function passkeyEnroll(signal) {
     return navigator.credentials.create({
+      signal: signal,
       publicKey: {
         challenge: crypto.getRandomValues(new Uint8Array(32)),
+        timeout: CEREMONY_MS,
         rp: { name: 'technocore.chat' },   // no id: it defaults to this origin, which is right
         user: {
           // Random, not derived from anything: an authenticator overwrites a credential that
@@ -1378,7 +1422,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
       // Unconstrained here, a reader who already has a passkey for this origin could press
       // "New passkey", get a credential created, and then be signed in as the older one —
       // a new key made and silently discarded, under a DID they did not just mint.
-      return passkeySeed([cred.rawId]);
+      return passkeySeed([cred.rawId], signal);
     });
   }
 
@@ -1386,10 +1430,12 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   // allowCredentials is the same as none per spec, so the discovery path stays exactly what
   // it was: the authenticator offers what it holds for this origin, which is what lets a
   // browser with nothing in localStorage get the identity back.
-  function passkeySeed(allow) {
+  function passkeySeed(allow, signal) {
     return navigator.credentials.get({
+      signal: signal,
       publicKey: {
         challenge: crypto.getRandomValues(new Uint8Array(32)),
+        timeout: CEREMONY_MS,
         userVerification: 'required',
         allowCredentials: (allow || []).map(function (id) {
           return { type: 'public-key', id: id };
@@ -1476,24 +1522,38 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   // identity they came back for still sitting in the authenticator. So discovery is a thing
   // they ask for, and enrolment is a thing they ask for, and neither happens by inference.
   function usePasskey(derive, working) {
+    // Replace whatever is outstanding before asking for anything new. Abort first and in
+    // its own statement: the browser refuses the second request while the first is still
+    // registered, so the order here is the whole point of it.
+    if (ceremony) { try { ceremony.abort(); } catch (e) { /* already settled */ } }
+    var ctl = new AbortController();
+    ceremony = ctl;
     say(working);
-    derive()
+    derive(ctl.signal)
       .then(function (seed) { return signIn(bytesHex(seed), 'passkey'); })
       .catch(function (e) {
-        // NotAllowedError covers both a cancelled prompt and "this authenticator has nothing
-        // for this site", which WebAuthn deliberately does not distinguish — so the message
-        // has to name both and point at the other button.
+        // The reader clicked again and this is the ceremony they replaced. Its successor is
+        // on screen saying what it is waiting for; reporting this one would talk over it.
+        if (e && e.name === 'AbortError') return;
+        // NotAllowedError covers a cancelled prompt, a ceremony that ran out its timeout,
+        // and "this authenticator has nothing for this site" — which WebAuthn deliberately
+        // does not distinguish — so the message has to name them and point at the other
+        // button.
         if (e && e.name === 'NotAllowedError') {
-          return fail('no passkey used — cancelled, or none saved for this site yet '
-                      + '(then: New passkey)');
+          return fail('no passkey used — cancelled, timed out, or none saved for this site '
+                      + 'yet (then: New passkey)');
         }
         fail(String(e.message || e));
-      });
+      })
+      // Settled either way: stop holding a controller whose request is over, so the next
+      // click starts clean instead of aborting a ghost.
+      .then(function () { if (ceremony === ctl) ceremony = null; });
   }
 
   keyPassEl.addEventListener('click', function () {
-    // No argument: discovery, across every passkey this origin holds.
-    usePasskey(function () { return passkeySeed(); }, 'waiting for your passkey…');
+    // No credential argument: discovery, across every passkey this origin holds.
+    usePasskey(function (signal) { return passkeySeed(null, signal); },
+               'waiting for your passkey…');
   });
 
   keyPassNewEl.addEventListener('click', function () {

--- a/src/humans.html
+++ b/src/humans.html
@@ -521,22 +521,25 @@
     </div>
     <p class="hint" id="keyhint">Sign in and your messages carry a <code>did:key</code> the
     server verifies — a name nobody else can post under, and the way into mailbox rooms and
-    room ownership. A passkey brings the same identity back on your other devices.</p>
+    room ownership. A passkey <em>is</em> that key: it derives the same <code>did:key</code>
+    every time and nothing is kept here, so the identity comes back when you return, and on
+    any device the passkey syncs to. No passkey for this site yet? Make one under
+    <strong>Other ways in</strong>.</p>
     <details id="keymore">
       <summary>Other ways in</summary>
       <div class="row">
-        <button id="keypassnew" class="btn-secondary">New passkey</button>
+        <button id="keypassnew" class="btn-secondary">Create a passkey</button>
         <button id="keynew" class="btn-secondary">Create a key</button>
         <input id="seed" placeholder="…or paste a 64-character hex seed" maxlength="64"
                spellcheck="false" autocomplete="off"
                aria-label="Ed25519 seed, 64 hex characters">
         <button id="keyuse" class="btn-secondary">Use seed</button>
       </div>
-      <p class="hint"><strong>New passkey</strong> enrols another one, a second identity
-      beside any you already hold. <strong>Create a key</strong> stores a key in this browser
-      and nowhere else — back it up or lose it. <strong>Use seed</strong> takes the 64 hex
-      characters <code>scripts/sign.py keygen</code> prints, so one identity works here and
-      on the command line.</p>
+      <p class="hint"><strong>Create a passkey</strong> enrols one — your first, or another
+      identity beside any you already hold. <strong>Create a key</strong> stores a key in
+      this browser and nowhere else — back it up or lose it. <strong>Use seed</strong> takes
+      the 64 hex characters <code>scripts/sign.py keygen</code> prints, so one identity works
+      here and on the command line.</p>
     </details>
   </div>
 
@@ -1540,8 +1543,20 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
         // does not distinguish — so the message has to name them and point at the other
         // button.
         if (e && e.name === 'NotAllowedError') {
+          // The message names a button, and until this line that button was inside a
+          // disclosure the reader had never opened — a dead end dressed as a next step. A
+          // first-timer clicks the one primary control, is told nothing is saved for this
+          // site, and is pointed at something not on screen. So open it: the way forward is
+          // the thing they were just told to press.
+          //
+          // On this branch and not by inference from stored state — the distinction §5.6
+          // turns on. Revealing enrolment is not performing it, and the reader still has to
+          // ask. It fires on a cancelled prompt too, which WebAuthn does not let anyone tell
+          // apart from an empty authenticator; opening a disclosure at someone who changed
+          // their mind is the cheaper of the two mistakes.
+          keyMoreEl.open = true;
           return fail('no passkey used — cancelled, timed out, or none saved for this site '
-                      + 'yet (then: New passkey)');
+                      + 'yet (then: Create a passkey)');
         }
         fail(String(e.message || e));
       })

--- a/src/humans.html
+++ b/src/humans.html
@@ -1385,12 +1385,20 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   // means "try that again" — which is what the reader meant by it.
   var ceremony = null;
 
-  // A backstop for the reader who clicks once and looks away: a ceremony nobody answers
-  // ends by saying so, rather than leaving `waiting for your passkey…` on screen forever.
-  // Generous, because the hybrid flow legitimately takes a while — scan a QR code, unlock a
-  // phone, approve there. Browsers clamp this to their own range; it is a hint, not a
-  // deadline, which is why the abort above is the mechanism and this is only the backstop.
+  // How long a ceremony nobody answers may run before it is ended and said so, rather than
+  // leaving `waiting for your passkey…` on screen forever. Generous, because the hybrid flow
+  // legitimately takes a while — scan a QR code, unlock a phone, approve there.
+  //
+  // Asked of the browser as `publicKey.timeout`, which is a *hint*: the spec lets a user
+  // agent clamp or ignore it, so it can request this bound and cannot be it. On an engine
+  // that ignores it the request stays pending for the life of the document, and with it the
+  // open-ended hold this ceremony takes on the badge — leaving "waiting for your passkey…"
+  // up for something that is never coming back, which is this page's original bug wearing
+  // the fix's own clothes. So the guarantee is the page's own deadline in usePasskey, and
+  // the grace below is how far behind the hint it sits: late enough that a browser honouring
+  // the hint gets to refuse in its own better words first (#747 review).
   var CEREMONY_MS = 120000;
+  var CEREMONY_GRACE_MS = 5000;
 
   // The PRF output is read from a get(), never from the create(). Returning it at creation
   // time is optional in the spec and absent in several shipping browsers, so asking for it
@@ -1540,12 +1548,31 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     // `seq N` back over the one line explaining the wait. That is the bug this whole change
     // is about, with a delay in front of it. The settle below hands the badge back.
     hold(Infinity);
+    // What makes that hold safe to leave open: the deadline above, enforced here rather than
+    // asked of the browser, so something ends this ceremony even when nothing else does.
+    // `timedOut` is a local the closure owns rather than a property on the controller — the
+    // two aborts below have to stay told apart, and not by writing to a platform object.
+    var timedOut = false;
+    var deadline = setTimeout(function () {
+      timedOut = true;
+      try { ctl.abort(); } catch (e) { /* already settled */ }
+    }, CEREMONY_MS + CEREMONY_GRACE_MS);
     derive(ctl.signal)
       .then(function (seed) { return signIn(bytesHex(seed), 'passkey'); })
       .catch(function (e) {
-        // The reader clicked again and this is the ceremony they replaced. Its successor is
-        // on screen saying what it is waiting for; reporting this one would talk over it.
-        if (e && e.name === 'AbortError') return;
+        // Two aborts arrive here and they are not the same event. The reader clicking again
+        // is a ceremony replaced: its successor is already on screen saying what it is
+        // waiting for, and reporting this one would talk over it. The deadline expiring is
+        // an outcome, and the one nobody else is left to report — returning silently there
+        // would hand the badge back to the heartbeat and call that an answer.
+        if (e && e.name === 'AbortError') {
+          if (timedOut) {
+            keyMoreEl.open = true;
+            return fail('the passkey prompt timed out with no answer — try again, or use '
+                        + 'Create a passkey, a key, or a seed');
+          }
+          return;
+        }
         // NotAllowedError covers a cancelled prompt, a ceremony that ran out its timeout,
         // and "this authenticator has nothing for this site" — which WebAuthn deliberately
         // does not distinguish — so the message has to name them and point at the other
@@ -1573,6 +1600,10 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
       // heartbeat. Skipped when this ceremony was replaced rather than finished — the
       // successor owns both, and its own hold is the one that should stand.
       .then(function () {
+        // Unconditionally, and before the early return: a deadline left armed on a ceremony
+        // that is over fires into nothing at best, and the point of it is that it is the one
+        // thing here not depending on the request settling.
+        clearTimeout(deadline);
         if (ceremony !== ctl) return;
         ceremony = null;
         hold(HOLD_MS);

--- a/src/humans.html
+++ b/src/humans.html
@@ -521,10 +521,10 @@
     </div>
     <p class="hint" id="keyhint">Sign in and your messages carry a <code>did:key</code> the
     server verifies — a name nobody else can post under, and the way into mailbox rooms and
-    room ownership. A passkey <em>is</em> that key: it derives the same <code>did:key</code>
-    every time and nothing is kept here, so the identity comes back when you return, and on
-    any device the passkey syncs to. No passkey for this site yet? Make one under
-    <strong>Other ways in</strong>.</p>
+    room ownership. <span id="passkeynote">A passkey <em>is</em> that key: it derives the same
+    <code>did:key</code> every time and nothing is kept here, so the identity comes back when
+    you return, and on any device the passkey syncs to. No passkey for this site yet? Make one
+    under <strong>Other ways in</strong>.</span></p>
     <details id="keymore">
       <summary>Other ways in</summary>
       <div class="row">
@@ -535,11 +535,11 @@
                aria-label="Ed25519 seed, 64 hex characters">
         <button id="keyuse" class="btn-secondary">Use seed</button>
       </div>
-      <p class="hint"><strong>Create a passkey</strong> enrols one — your first, or another
-      identity beside any you already hold. <strong>Create a key</strong> stores a key in
-      this browser and nowhere else — back it up or lose it. <strong>Use seed</strong> takes
-      the 64 hex characters <code>scripts/sign.py keygen</code> prints, so one identity works
-      here and on the command line.</p>
+      <p class="hint"><span id="passkeymore"><strong>Create a passkey</strong> enrols one —
+      your first, or another identity beside any you already hold. </span><strong>Create a
+      key</strong> stores a key in this browser and nowhere else — back it up or lose it.
+      <strong>Use seed</strong> takes the 64 hex characters <code>scripts/sign.py keygen</code>
+      prints, so one identity works here and on the command line.</p>
     </details>
   </div>
 
@@ -1477,7 +1477,18 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   var keyHintEl = document.getElementById('keyhint');
   var asEl = document.getElementById('as');
 
+  var passkeyMoreEl = document.getElementById('passkeymore');
   var SIGNED_OUT_HINT = keyHintEl.textContent;   // authored in the markup; kept verbatim
+
+  // The same paragraph with its passkey sentences taken out, for a browser that has no
+  // WebAuthn at all. There, promising an identity that comes back on your other devices and
+  // pointing at a button this page has just hidden is the page describing something it
+  // cannot do. Subtracted from the markup rather than authored a second time, so the two
+  // cannot drift, and taken now: renderIdentity writes this paragraph with textContent, so
+  // the span is gone after the first render.
+  var NO_PASSKEY_HINT = SIGNED_OUT_HINT
+    .replace(document.getElementById('passkeynote').textContent, '')
+    .replace(/\s+/g, ' ').trim();
 
   function renderIdentity() {
     var on = !!me;
@@ -1485,9 +1496,18 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     meEl.className = on ? 'badge key' : 'badge';
     meEl.title = on ? me.did : '';
     keyCopyEl.hidden = !on; keyOutEl.hidden = !on;
-    keyPassEl.hidden = on || !passkeyAvailable();
+    var canPasskey = passkeyAvailable();
+    keyPassEl.hidden = on || !canPasskey;
+    // Both passkey controls, not just the primary one. Hiding the way *in* while still
+    // offering the way to *enrol* leaves a browser with no WebAuthn a button that cannot do
+    // anything but throw, and what it throws is a raw engine string — this page telling a
+    // reader about its own internals because it forgot to check. The prose naming that
+    // button goes with it: an instruction pointing at nothing is worse than no instruction.
+    keyPassNewEl.hidden = on || !canPasskey;
+    passkeyMoreEl.hidden = !canPasskey;
     // The whole disclosure, not its buttons one at a time: signed in there is nothing behind
-    // it to want, and an empty "Other ways in" is a door onto a wall.
+    // it to want, and an empty "Other ways in" is a door onto a wall. Signed out it always
+    // holds something — a key and a seed work with no WebAuthn anywhere in the browser.
     keyMoreEl.hidden = on;
     if (on) keyMoreEl.open = false;
 
@@ -1506,7 +1526,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
             + 'tied to this domain. Copy the seed if you want one that outlives the domain.'
           : 'Signed in. Messages carry this did:key and the server verifies each one. Copy '
             + 'the seed to keep this identity — clearing site data loses it otherwise.')
-      : SIGNED_OUT_HINT;
+      : (canPasskey ? SIGNED_OUT_HINT : NO_PASSKEY_HINT);
     agentsEl.hidden = !on;
     if (on) loadDelegations();
   }

--- a/src/humans.html
+++ b/src/humans.html
@@ -842,11 +842,13 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   var HOLD_MS = 8000;
   var holdUntil = 0;
   function badge(msg, cls) { status.textContent = msg; status.className = cls; }
-  function say(msg) { holdUntil = Date.now() + HOLD_MS; badge(msg, 'badge live'); }
-  function fail(msg) {
-    holdUntil = Date.now() + HOLD_MS;
-    badge('error — ' + msg, 'badge err');
-  }
+  // How long the heartbeat stays off the badge. HOLD_MS is "long enough to read", which is
+  // the right answer for an outcome and the wrong one for a wait still in progress: a caller
+  // that is still working passes its own window and hands the badge back when it settles.
+  // Nothing that reports a result needs that — saying the result resets this by itself.
+  function hold(ms) { holdUntil = Date.now() + ms; }
+  function say(msg) { hold(HOLD_MS); badge(msg, 'badge live'); }
+  function fail(msg) { hold(HOLD_MS); badge('error — ' + msg, 'badge err'); }
   // The pump's own line, which never talks over an answer the reader is still reading.
   function beat(msg) { if (Date.now() >= holdUntil) badge(msg, 'badge live'); }
 
@@ -1532,6 +1534,12 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     var ctl = new AbortController();
     ceremony = ctl;
     say(working);
+    // Held for as long as this takes, not for a count of seconds. CEREMONY_MS allows two
+    // minutes because the cross-device flow legitimately runs that long — scan the code,
+    // walk to the phone, approve there — and a fixed window expiring mid-ceremony puts
+    // `seq N` back over the one line explaining the wait. That is the bug this whole change
+    // is about, with a delay in front of it. The settle below hands the badge back.
+    hold(Infinity);
     derive(ctl.signal)
       .then(function (seed) { return signIn(bytesHex(seed), 'passkey'); })
       .catch(function (e) {
@@ -1561,8 +1569,14 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
         fail(String(e.message || e));
       })
       // Settled either way: stop holding a controller whose request is over, so the next
-      // click starts clean instead of aborting a ghost.
-      .then(function () { if (ceremony === ctl) ceremony = null; });
+      // click starts clean instead of aborting a ghost, and let the badge go back to the
+      // heartbeat. Skipped when this ceremony was replaced rather than finished — the
+      // successor owns both, and its own hold is the one that should stand.
+      .then(function () {
+        if (ceremony !== ctl) return;
+        ceremony = null;
+        hold(HOLD_MS);
+      });
   }
 
   keyPassEl.addEventListener('click', function () {

--- a/tests/http/test_humans.py
+++ b/tests/http/test_humans.py
@@ -118,6 +118,42 @@ def test_the_note_framing_the_human_page_parses_is_a_contract(client, monkeypatc
         assert warned[-1].startswith("# budget:")
 
 
+def test_the_passkey_dead_end_names_a_button_the_page_actually_has(client):
+    """The page's instruction, checked against the page's own label.
+
+    WebAuthn cannot tell "you cancelled" from "this authenticator holds nothing for this
+    site", so discovery's failure has to name the way forward — and it names it in prose,
+    in a string six hundred lines from the button it is talking about. Relabel either one
+    and a reader with no passkey is told to press something that is not there, which is the
+    exact dead end the message exists to prevent. Two spellings of one label, so: pinned.
+
+    The reveal beside it is checked in the browser (tests/humans_ui_probe.mjs) — whether the
+    disclosure is actually open is a question about a rendered page, not about bytes.
+    """
+    import re as _re
+
+    body = client.get("/humans").text
+    label = _re.search(r'id="keypassnew"[^>]*>([^<]+)</button>', body)
+    assert label, "the enrolment button is gone"
+    assert f"(then: {label.group(1)})" in body
+
+
+def test_the_human_page_says_a_passkey_becomes_the_did_before_asking_for_one(client):
+    """Signed *out* is where this has to be said, and it is where it used to be missing.
+
+    The passkey is not a login here: there is no account behind it, and no server that knows
+    anything. It is a key-derivation function whose PRF output is the seed (design §5.6), so
+    what a reader is agreeing to when they press the button is that this authenticator will
+    *be* their did:key. The signed-in copy explained that; the signed-out copy, the only one
+    anybody reads before deciding, did not.
+    """
+    body = client.get("/humans").text
+    hint = body.split('id="keyhint"', 1)[1].split("</p>", 1)[0]
+    assert "did:key" in hint  # what the passkey turns into
+    assert "derives" in hint  # and that it is derived rather than stored
+    assert "nothing is kept here" in hint
+
+
 def test_human_page_caps_its_log_rows(client):
     body = client.get("/humans").text
     assert "MAX_ROWS = 200" in body

--- a/tests/humans_ui_probe.mjs
+++ b/tests/humans_ui_probe.mjs
@@ -25,7 +25,7 @@
  * Exits non-zero on the first failed check, so it is usable by hand before pushing as well
  * as by the workflow.
  *
- * Checked 2026-09-06, 121 checks, all passing — expected shape:
+ * Checked 2026-09-06, 125 checks, all passing — expected shape:
  *   desktop 900px   5 columns, copy icon is an <svg> with an accessible name
  *   copy            writes the #r/<room> permalink, swaps glyph + label, restores after 1.2s
  *   filter          narrows rows, counts against LOADED rooms, survives the 5s refresh
@@ -53,6 +53,9 @@
  *                   a ceremony nobody answers is replaced by the next click rather than
  *                   wedging the page, and holds the badge against the room's own heartbeat
  *                   for as long as it runs — then hands it back when it settles
+ *   deadline        an engine that ignores `publicKey.timeout` still ends the ceremony: the
+ *                   page's own deadline aborts it and says so, on a stubbed get() that never
+ *                   settles, with the clock skipping the two minutes
  *   delegation      two `delegate:` records are signed, published to the DID note path
  *                   beside an existing `mailbox:`, and both read back verified out of the
  *                   ONE line a note can hold; re-issuing replaces rather than appends; four
@@ -931,6 +934,56 @@ const browser = await chromium.launch({
 
   check("passkey + delegation: no page errors throughout",
         errors.length === 0, errors.join("; "));
+  await context.close();
+}
+
+
+// ------------------------------------------------------------- a deadline the page owns
+// `publicKey.timeout` is a hint: the spec lets a user agent clamp or ignore it, so it cannot
+// be what bounds a ceremony. This is the engine that ignores it — a get() that never settles
+// and honours only the AbortSignal, which is every real implementation's floor. Without a
+// deadline of the page's own the request stays pending for the life of the document, and the
+// open-ended hold keeps the badge on "waiting for your passkey…" for a ceremony that is
+// never coming back (#747 review).
+//
+// The clock skips the two minutes rather than spending them. The tab is reported hidden for
+// the same reason the pump checks it: with the poll parked, the only timer this section can
+// be measuring is the one under test.
+{
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const errors = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+  await page.clock.install();
+  await page.addInitScript(() => {
+    Object.defineProperty(document, "hidden", { get: () => true });
+    navigator.credentials.get = (opts) => new Promise((_, reject) => {
+      if (opts && opts.signal) {
+        opts.signal.addEventListener("abort", () => {
+          const e = new Error("signal aborted");
+          e.name = "AbortError";
+          reject(e);
+        });
+      }
+    });
+  });
+  await page.goto(`${BASE}/humans`, { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#identity:not([hidden])", { timeout: 8000 });
+
+  await page.click("#keypass");
+  await page.waitForTimeout(300);
+  check("deadline: the ceremony starts and says what it is waiting for",
+        (await page.textContent("#status")) === "waiting for your passkey…",
+        await page.textContent("#status"));
+
+  await page.clock.fastForward("02:10");
+  await page.waitForTimeout(500);
+  check("deadline: an engine that ignores the timeout hint still gets an answer",
+        (await page.textContent("#status")).includes("timed out with no answer"),
+        await page.textContent("#status"));
+  check("deadline: and the way back in is on screen with it",
+        await page.locator("#keypassnew").isVisible());
+  check("deadline: no page errors throughout", errors.length === 0, errors.join("; "));
   await context.close();
 }
 

--- a/tests/humans_ui_probe.mjs
+++ b/tests/humans_ui_probe.mjs
@@ -25,7 +25,7 @@
  * Exits non-zero on the first failed check, so it is usable by hand before pushing as well
  * as by the workflow.
  *
- * Checked 2026-09-06, 125 checks, all passing — expected shape:
+ * Checked 2026-09-07, 138 checks, all passing — expected shape:
  *   desktop 900px   5 columns, copy icon is an <svg> with an accessible name
  *   copy            writes the #r/<room> permalink, swaps glyph + label, restores after 1.2s
  *   filter          narrows rows, counts against LOADED rooms, survives the 5s refresh
@@ -56,6 +56,10 @@
  *   deadline        an engine that ignores `publicKey.timeout` still ends the ceremony: the
  *                   page's own deadline aborts it and says so, on a stubbed get() that never
  *                   settles, with the clock skipping the two minutes
+ *   no PRF          an authenticator without it is told apart from one that works, and nobody
+ *                   is signed in on a seed that never arrived
+ *   no WebAuthn     both passkey controls and the prose naming them are gone, and the seed
+ *                   lane still derives the DID scripts/sign.py does
  *   delegation      two `delegate:` records are signed, published to the DID note path
  *                   beside an existing `mailbox:`, and both read back verified out of the
  *                   ONE line a note can hold; re-issuing replaces rather than appends; four
@@ -984,6 +988,102 @@ const browser = await chromium.launch({
   check("deadline: and the way back in is on screen with it",
         await page.locator("#keypassnew").isVisible());
   check("deadline: no page errors throughout", errors.length === 0, errors.join("; "));
+  await context.close();
+}
+
+
+// ------------------------------------------------------ an authenticator without PRF
+// The PRF extension is what makes any of this work: its output *is* the seed. Plenty of
+// authenticators do not have it — security keys without `hmac-secret`, older platform ones —
+// and the page has a branch saying so, which until now had never run in a test. What it must
+// not do is leave a reader holding a credential that cannot derive a key without telling
+// them, or sign anybody in on a seed it never got.
+{
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const errors = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+  const cdp = await context.newCDPSession(page);
+  await cdp.send("WebAuthn.enable", { enableUI: false });
+  await cdp.send("WebAuthn.addVirtualAuthenticator", {
+    options: {
+      protocol: "ctap2", ctap2Version: "ctap2_1", transport: "internal",
+      hasResidentKey: true, hasUserVerification: true, hasPrf: false,
+      automaticPresenceSimulation: true, isUserVerified: true,
+    },
+  });
+  // localhost, not the IP: WebAuthn refuses a bare address as a relying party, and this
+  // section really does reach the authenticator.
+  await page.goto(`${BASE.replace("127.0.0.1", "localhost")}/humans`,
+                  { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#identity:not([hidden])", { timeout: 8000 });
+  await page.click("#keymore summary");
+  await page.click("#keypassnew");
+  await page.waitForTimeout(3000);
+
+  check("no PRF: the reader is told the authenticator cannot derive a key",
+        (await page.textContent("#status")).includes("no PRF support"),
+        await page.textContent("#status"));
+  check("no PRF: and is pointed at the lanes that do work",
+        (await page.textContent("#status")).includes("key or a seed"),
+        await page.textContent("#status"));
+  check("no PRF: nobody was signed in on a seed that never arrived",
+        (await page.textContent("#me")) === "Not signed in");
+  check("no PRF: and nothing was written to storage",
+        (await page.evaluate(() => localStorage.getItem("technocore.seed"))) === null);
+  check("no PRF: no page errors throughout", errors.length === 0, errors.join("; "));
+  await context.close();
+}
+
+// -------------------------------------------------------------- a browser without WebAuthn
+// §5.2 makes signing an upgrade and never a gate, and the same has to hold one level down:
+// no WebAuthn is not no identity, it is the seed lane. So the passkey controls go — *both*
+// of them, since a "Create a passkey" that can only throw is worse than no button — and the
+// prose naming them goes with them, while a pasted seed still yields the DID the command
+// line derives.
+{
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const errors = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+  await page.addInitScript(() => {
+    // `delete` alone will not do it for credentials: it is an accessor on Navigator.prototype,
+    // so shadow it with an own property instead.
+    delete window.PublicKeyCredential;
+    Object.defineProperty(navigator, "credentials", { value: undefined, configurable: true });
+  });
+  await page.goto(`${BASE}/humans`, { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#identity:not([hidden])", { timeout: 8000 });
+
+  check("no WebAuthn: the identity row still appears — Ed25519 is what it needs",
+        !(await page.locator("#identity").isHidden()));
+  check("no WebAuthn: the way in by passkey is gone",
+        !(await page.locator("#keypass").isVisible()));
+  await page.click("#keymore summary");
+  check("no WebAuthn: and so is enrolling one",
+        !(await page.locator("#keypassnew").isVisible()));
+  check("no WebAuthn: the prose no longer names a button that is not there",
+        !(await page.textContent("#keyhint")).includes("Other ways in"),
+        await page.textContent("#keyhint"));
+  check("no WebAuthn: nor promises an identity this browser cannot carry",
+        !(await page.textContent("#keyhint")).includes("passkey"),
+        await page.textContent("#keyhint"));
+
+  // The lanes that do not need WebAuthn are untouched, and the seed one still agrees with
+  // scripts/sign.py — the whole point of keeping it.
+  check("no WebAuthn: creating a key in the browser is still offered",
+        await page.locator("#keynew").isVisible());
+  const SEED = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+  const EXPECTED = "did:key:z6MkehRgf7yJbgaGfYsdoAsKdBPE3dj2CYhowQdcjqSJgvVd";
+  await page.fill("#seed", SEED);
+  await page.click("#keyuse");
+  await page.waitForFunction(
+    () => document.getElementById("me").textContent !== "Not signed in",
+    null, { timeout: 8000 });
+  check("no WebAuthn: and a pasted seed still yields the DID the signer derives",
+        (await page.getAttribute("#me", "title")) === EXPECTED,
+        await page.getAttribute("#me", "title"));
+  check("no WebAuthn: no page errors throughout", errors.length === 0, errors.join("; "));
   await context.close();
 }
 

--- a/tests/humans_ui_probe.mjs
+++ b/tests/humans_ui_probe.mjs
@@ -25,7 +25,7 @@
  * Exits non-zero on the first failed check, so it is usable by hand before pushing as well
  * as by the workflow.
  *
- * Checked 2026-09-06, 112 checks, all passing — expected shape:
+ * Checked 2026-09-06, 119 checks, all passing — expected shape:
  *   desktop 900px   5 columns, copy icon is an <svg> with an accessible name
  *   copy            writes the #r/<room> permalink, swaps glyph + label, restores after 1.2s
  *   filter          narrows rows, counts against LOADED rooms, survives the 5s refresh
@@ -46,8 +46,10 @@
  *                   invisible-character sweep matches the server's, the identity survives
  *                   a reload, and signing out lands back on the nickname lane
  *   passkey         a virtual authenticator with PRF enrols, derives a did:key, stores no
- *                   seed, and hands the SAME did:key back to a browser whose storage has
- *                   been wiped; discovery with nothing enrolled refuses instead of enrolling;
+ *                   seed, and hands the SAME did:key back three ways a reader comes back —
+ *                   a browser whose storage has been wiped, a reload with it intact, and a
+ *                   sign-out; discovery with nothing enrolled refuses instead of enrolling
+ *                   and opens the disclosure holding the button it tells them to press;
  *                   a ceremony nobody answers is replaced by the next click rather than
  *                   wedging the page, and says what it is waiting for loudly enough to
  *                   survive the room's own heartbeat on the same badge
@@ -680,6 +682,9 @@ const browser = await chromium.launch({
   await page.click("#keymore summary");
   check("passkey: and the disclosure reveals it",
         await page.locator("#keypassnew").isVisible());
+  // Folded away again: a first-timer has never opened it, and what follows is about what
+  // that reader can see.
+  await page.click("#keymore summary");
 
   // Discovery with nothing enrolled must explain itself and must not quietly enrol. This is
   // the branch that used to be reached by inference from stored state, and got it backwards.
@@ -690,6 +695,16 @@ const browser = await chromium.launch({
         await page.textContent("#status"));
   check("passkey: and signed nobody in",
         (await page.textContent("#me")) === "Not signed in");
+
+  // Pointing at a button is only a next step if the button is on screen. The reader with no
+  // passkey is the one who needs enrolment most and the one least likely to go looking for
+  // it behind a disclosure they have no reason to open.
+  check("passkey: the dead end opens the way out rather than naming it",
+        await page.locator("#keypassnew").isVisible());
+  check("passkey: and the message names that button exactly",
+        (await page.textContent("#status"))
+          .includes(await page.textContent("#keypassnew")),
+        `${await page.textContent("#status")} / ${await page.textContent("#keypassnew")}`);
 
   await page.click("#keypassnew");
   await signedIn();
@@ -742,6 +757,35 @@ const browser = await chromium.launch({
   await page.click("#keypass");
   await signedIn();
   check("passkey: the same passkey recovers the same DID from empty storage",
+        (await page.getAttribute("#me", "title")) === did,
+        await page.getAttribute("#me", "title"));
+
+  // Coming back later, in the same browser, with its storage untouched. The page will not
+  // re-derive a passkey identity on load and that is deliberate: deriving one costs a
+  // user-verification prompt, and demanding a fingerprint from a reader who came to watch a
+  // room would have earned being closed. So the promise is narrower and has to hold exactly
+  // — it starts signed out, and one click brings back the DID they left with rather than
+  // minting a new one.
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await ready();
+  check("passkey: coming back starts signed out rather than prompting on load",
+        (await page.textContent("#me")) === "Not signed in");
+  check("passkey: with nothing about the identity left in storage to restore it from",
+        (await page.evaluate(() => localStorage.getItem("technocore.seed"))) === null);
+  await page.click("#keypass");
+  await signedIn();
+  check("passkey: and one click hands back the same DID, not a new one",
+        (await page.getAttribute("#me", "title")) === did,
+        await page.getAttribute("#me", "title"));
+
+  // The same recovery without the reload: sign-out has to leave nothing behind, and the
+  // passkey has to be enough on its own to undo it.
+  await page.click("#keyout");
+  check("passkey: signing out drops the identity",
+        (await page.textContent("#me")) === "Not signed in");
+  await page.click("#keypass");
+  await signedIn();
+  check("passkey: and signing back in returns the same DID",
         (await page.getAttribute("#me", "title")) === did,
         await page.getAttribute("#me", "title"));
 

--- a/tests/humans_ui_probe.mjs
+++ b/tests/humans_ui_probe.mjs
@@ -25,7 +25,7 @@
  * Exits non-zero on the first failed check, so it is usable by hand before pushing as well
  * as by the workflow.
  *
- * Checked 2026-09-06, 119 checks, all passing — expected shape:
+ * Checked 2026-09-06, 121 checks, all passing — expected shape:
  *   desktop 900px   5 columns, copy icon is an <svg> with an accessible name
  *   copy            writes the #r/<room> permalink, swaps glyph + label, restores after 1.2s
  *   filter          narrows rows, counts against LOADED rooms, survives the 5s refresh
@@ -51,8 +51,8 @@
  *                   sign-out; discovery with nothing enrolled refuses instead of enrolling
  *                   and opens the disclosure holding the button it tells them to press;
  *                   a ceremony nobody answers is replaced by the next click rather than
- *                   wedging the page, and says what it is waiting for loudly enough to
- *                   survive the room's own heartbeat on the same badge
+ *                   wedging the page, and holds the badge against the room's own heartbeat
+ *                   for as long as it runs — then hands it back when it settles
  *   delegation      two `delegate:` records are signed, published to the DID note path
  *                   beside an existing `mailbox:`, and both read back verified out of the
  *                   ONE line a note can hold; re-issuing replaces rather than appends; four
@@ -751,6 +751,19 @@ const browser = await chromium.launch({
         (await page.textContent("#status")) === "waiting for your passkey…",
         await page.textContent("#status"));
 
+  // …and does not creep back over it later. A hold measured in seconds cannot be right for
+  // a wait CEREMONY_MS deliberately allows two minutes of: the cross-device flow is a reader
+  // walking to another room for their phone, and handing the badge back to `seq N` while
+  // they are still holding it is the original bug with a delay in front of it. Ten seconds
+  // and a second message, so a poll certainly lands after any few-second window would have
+  // lapsed (Codex review, #747).
+  await page.waitForTimeout(8000);
+  await fetch(`${BASE}/r/lobby/say/probe/still%20waiting`);
+  await page.waitForTimeout(2000);
+  check("passkey: nor once a short hold window would have lapsed",
+        (await page.textContent("#status")) === "waiting for your passkey…",
+        await page.textContent("#status"));
+
   // The whole point of replacing it rather than refusing it: the reader gets in on the next
   // click, from the same document, having reloaded nothing.
   await answers(true);
@@ -759,6 +772,17 @@ const browser = await chromium.launch({
   check("passkey: the same passkey recovers the same DID from empty storage",
         (await page.getAttribute("#me", "title")) === did,
         await page.getAttribute("#me", "title"));
+
+  // The hold that ceremony took is released, not leaked. It held the badge with no deadline
+  // — the only way to cover a two-minute wait honestly — so failing to hand it back would
+  // freeze the seq for the life of the document, which is the same badge lost to the same
+  // bug from the other direction. Past HOLD_MS from the sign-in line, with a poll after it.
+  await page.waitForTimeout(9000);
+  await fetch(`${BASE}/r/lobby/say/probe/heartbeat%20resumes`);
+  await page.waitForTimeout(2000);
+  check("passkey: and the badge goes back to the room once the ceremony settles",
+        /^seq \d+$/.test(await page.textContent("#status")),
+        await page.textContent("#status"));
 
   // Coming back later, in the same browser, with its storage untouched. The page will not
   // re-derive a passkey identity on load and that is deliberate: deriving one costs a

--- a/tests/humans_ui_probe.mjs
+++ b/tests/humans_ui_probe.mjs
@@ -25,7 +25,7 @@
  * Exits non-zero on the first failed check, so it is usable by hand before pushing as well
  * as by the workflow.
  *
- * Checked 2026-09-05, 109 checks, all passing — expected shape:
+ * Checked 2026-09-06, 112 checks, all passing — expected shape:
  *   desktop 900px   5 columns, copy icon is an <svg> with an accessible name
  *   copy            writes the #r/<room> permalink, swaps glyph + label, restores after 1.2s
  *   filter          narrows rows, counts against LOADED rooms, survives the 5s refresh
@@ -47,7 +47,10 @@
  *                   a reload, and signing out lands back on the nickname lane
  *   passkey         a virtual authenticator with PRF enrols, derives a did:key, stores no
  *                   seed, and hands the SAME did:key back to a browser whose storage has
- *                   been wiped; discovery with nothing enrolled refuses instead of enrolling
+ *                   been wiped; discovery with nothing enrolled refuses instead of enrolling;
+ *                   a ceremony nobody answers is replaced by the next click rather than
+ *                   wedging the page, and says what it is waiting for loudly enough to
+ *                   survive the room's own heartbeat on the same badge
  *   delegation      two `delegate:` records are signed, published to the DID note path
  *                   beside an existing `mailbox:`, and both read back verified out of the
  *                   ONE line a note can hold; re-issuing replaces rather than appends; four
@@ -649,13 +652,18 @@ const browser = await chromium.launch({
 
   const cdp = await context.newCDPSession(page);
   await cdp.send("WebAuthn.enable", { enableUI: false });
-  await cdp.send("WebAuthn.addVirtualAuthenticator", {
+  const { authenticatorId } = await cdp.send("WebAuthn.addVirtualAuthenticator", {
     options: {
       protocol: "ctap2", ctap2Version: "ctap2_1", transport: "internal",
       hasResidentKey: true, hasUserVerification: true, hasPrf: true,
       automaticPresenceSimulation: true, isUserVerified: true,
     },
   });
+  // A ceremony nobody answers. Turning presence off is the closest a virtual authenticator
+  // comes to the states that produced the bug below, and it is a faithful one: the request
+  // is issued, no dialog is answered, and the promise simply never settles.
+  const answers = (enabled) =>
+    cdp.send("WebAuthn.setAutomaticPresenceSimulation", { authenticatorId, enabled });
 
   const ready = () => page.waitForSelector("#identity:not([hidden])", { timeout: 8000 });
   const signedIn = () =>
@@ -698,6 +706,39 @@ const browser = await chromium.launch({
   await ready();
   check("passkey: a wiped browser starts signed out",
         (await page.textContent("#me")) === "Not signed in");
+  // A ceremony the reader never gets to answer is not an edge case: the platform dialog
+  // that opens behind the browser window, the OS sheet the OS itself dismissed, the hybrid
+  // flow whose phone never joined. None of those rejects the promise — it just never
+  // settles, and WebAuthn allows one outstanding request per document. So the page used to
+  // wedge: the second click was refused with the browser's own "A request is already
+  // pending.", a sentence about bookkeeping the reader cannot see, and it went on being
+  // refused until someone thought to reload. Clicking again has to mean "try that again".
+  await answers(false);
+  await page.click("#keypass");
+  await page.waitForTimeout(600);
+  check("passkey: a ceremony in flight says what it is waiting for",
+        (await page.textContent("#status")) === "waiting for your passkey…",
+        await page.textContent("#status"));
+
+  await page.click("#keypass");
+  await page.waitForTimeout(600);
+  check("passkey: clicking again replaces the parked ceremony instead of refusing it",
+        !(await page.textContent("#status")).includes("already pending"),
+        await page.textContent("#status"));
+
+  // The badge is shared with the pump, which stamps `seq N` on it every time a poll lands —
+  // about once a second in a room that is not idle. The line telling a reader what their
+  // click is waiting for, and the error when it fails, both have to outlive that; when they
+  // did not, a ceremony that never surfaced looked exactly like a button doing nothing.
+  await fetch(`${BASE}/r/lobby/say/probe/passkey%20heartbeat`);
+  await page.waitForTimeout(2000);
+  check("passkey: and the room's heartbeat does not wipe the answer",
+        (await page.textContent("#status")) === "waiting for your passkey…",
+        await page.textContent("#status"));
+
+  // The whole point of replacing it rather than refusing it: the reader gets in on the next
+  // click, from the same document, having reloaded nothing.
+  await answers(true);
   await page.click("#keypass");
   await signedIn();
   check("passkey: the same passkey recovers the same DID from empty storage",


### PR DESCRIPTION
## What

"Sign in with a passkey" does nothing, and a second click reports `A request is already pending.` until the page is reloaded. A reader with no passkey is then told to press **New passkey**, a button folded inside a disclosure they have never opened.

The in-flight ceremony is now held in an `AbortController` and the next click replaces it, bounded by a deadline the page enforces itself rather than by the advisory `publicKey.timeout`. The status badge is held for as long as the ceremony runs, so the room's `seq N` heartbeat cannot overwrite the line explaining the wait. Discovery's dead end opens the disclosure it names; the button is now **Create a passkey**, and the signed-out hint says what the signed-in one already did — the passkey *is* the `did:key`, derived every time, nothing kept here.

Covering the two passkey branches that had never run in a test found a third bug: on a browser with no WebAuthn, `passkeyAvailable()` hid the way in and left enrolment on offer, so the one control still there could only throw a raw engine string — and the prose still promised a synced identity and pointed at that button. Both controls and the sentences naming them now go together.

## Why

WebAuthn allows one outstanding request per document, and a ceremony whose dialog is never answered — opened behind the window, dismissed by the OS, a hybrid flow whose phone never joins — never settles. Reproduced in Chromium with presence simulation off.

Enrolment and discovery stay separate (§5.6): revealing enrolment is not performing it, and it is never inferred from stored state. §5.2 makes signing an upgrade and never a gate, and that holds one level down too — no WebAuthn is not no identity, it is the seed lane.

Thanks to the Codex review and @yukkie3276 — both findings were real, both reproduced before being fixed, and both are pinned by checks confirmed failing first.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 749 passed, 97.97%
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs updated: `docs/design.md` §5.6. Browser gate 138 checks, all passing; every regression check was confirmed to fail before its fix
- [x] New surface on a world-writable service: **nothing new** — browser-side only, no route, parameter or stored field changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wxcyyAnWH5VdztsE1sntA