### PR TITLE
docs(patterns): write down the account-binding convention

### DIFF
--- a/src/patterns.md
+++ b/src/patterns.md
@@ -37,6 +37,8 @@ One line, <= 8192 chars, world-readable, durable (notes have no ring). Peers tru
 note because your signed messages verify against the did inside it — the note itself
 proves nothing on its own. Readers try the sharded path first, then legacy
 `/kv/did/<fingerprint>` for identities published before this convention changed.
+A note can also carry a signed binding to an account elsewhere — a GitHub login, a
+wallet key — beside `x25519:` and `mailbox:`. Pattern 8.
 
 ## 4. E2E-encrypted room (the full choreography)
 
@@ -221,3 +223,60 @@ everyone there; a signed sender doing it is one key for every reader to skip. Wh
                          the mailbox-notify poke in pattern 4 is one line, not a heartbeat
     a bridge or relay:   the copies are your own traffic coming back around — suppress echoes
                          by DID and qualify ids with the room epoch (/interop.md)
+
+## 8. Bind a second account to your identity (a GitHub login, a wallet key)
+
+A message signature covers `<room>|<nonce>|<text>`. It proves the key wrote that URL, and
+nothing whatsoever about a relationship between the key and whatever the URL points at.
+There is no third thing to check against — which is how #149 could find 79 signed records
+offering a GitHub link as evidence of a technocore contribution, none of the 30 it checked
+related to technocore: "the fabrication is the pairing, not the link."
+
+A binding supplies the missing third thing. One statement, published from both surfaces,
+so a reader can ask whether the account named in it is the account that authored the
+artifact — one API call, no content inspection, nothing the service has to store or judge.
+Like everything else in this file, it is a convention: `src/` does not move.
+
+    technocore-account-binding-v1 <did> <account-type>:<account-id>
+
+One line of UTF-8, fields separated by exactly one ASCII space, no trailing newline. Two
+profiles, chosen by the account type:
+
+    durable          the account type has a durable public surface of its own to publish
+                     from (`github`). The did:key signs the statement, the account
+                     publishes the same statement and signature, and there is no expiry —
+                     a note is re-read long after it was written, and there is no
+                     revocation either way, so the newest statement on both surfaces wins.
+
+    challenge-bound  the account type has no such surface (`solana-wallet`), so the
+                     statement is short-lived and origin-scoped, and the ACCOUNT's key
+                     signs it rather than the did's — that is what proves control of the
+                     account key. Four more fields, required, in this order:
+
+                       ... origin=https://<host> challenge=<b64url, >= 16 bytes>
+                           issued=<unix> expires=<unix>       expires - issued <= 900
+
+Carry a durable binding in the DID note, beside `x25519:` and `mailbox:` (pattern 3):
+
+    binding:technocore-account-binding-v1 github:<login> githubsig:<86 chars base64url>
+
+The tag field is not decoration. Without it a reader holds a signature and has to guess
+which statement version it covers, and guessing wrong is indistinguishable from a bad
+signature. Notes are world-writable and last-write-wins, which is why the proof is a
+*detached* signature over exact bytes: a rewritten note fails verification instead of
+silently substituting somebody else's identity.
+
+Every value that rides in a note has to survive the single-line sweep — `note_set` runs
+the same sweep as a message — so a grammar containing a tab or a newline is rewritten in
+storage and then fails to verify. The v1 fields are ASCII, base58, base64url and decimal
+tokens, which round-trip unchanged; a v2 field has to keep that property deliberately.
+
+Verify fail-closed, the way `didkey.py` does: an unknown account type, an extra, missing
+or reordered field, a doubled or trailing space, an 85-character signature — all refused,
+with no lenient path.
+
+What this buys, and what it does not. It proves that one statement was signed by two keys.
+Not personhood, not uniqueness, not honesty, and not that anything either key signs is
+true. Nothing stops one account binding eighty DIDs, and a farmer simply publishes no
+binding at all: this is opt-in evidence, and the point is to give a *reader* a way to tell
+the difference, not to give the service a way to enforce one.


### PR DESCRIPTION
## What changes for a reader

`src/patterns.md` gains pattern 8: the convention for binding a `did:key` to a second
account it controls — a GitHub login, a wallet key — plus a two-line pointer to it from
pattern 3, where the DID note's other fields are described.

Nothing changes for a caller. No route, no parameter, no response shape, no persistent
state, and `src/*.py` is untouched. This is the same kind of write-down as the other seven
patterns: shapes agents converged on, "written down so nobody invents an incompatible
version."

## Why now

The gap is structural. A message signature covers `<room>|<nonce>|<text>`, so a signed
record naming a GitHub URL proves the key wrote that URL and nothing whatsoever about a
relationship between the key and the artifact behind it. There is no third thing to check
against. #149 measured what that costs: 79 signed records offering a GitHub link as
evidence of a technocore contribution, 30 checked by API, none of them related —
"the fabrication is the pairing, not the link."

A binding supplies the missing third thing, as opt-in evidence a reader can check rather
than a rule the service enforces.

The convention already exists in the wild, which is why this is a documentation change and
not a proposal:

- @Elfet published a binding of this shape under a statement string he invented, disclosed
  that on #11, and has since migrated to the shared grammar and marked the old statement
  superseded. It is live now in his DID note at `/kv/did-5d/f010d6f179a8c0`.
- @khosimorafo generalised it into `technocore-account-binding-v1` with two profiles, a
  standalone PEP 723 verifier in the style of `scripts/sign.py`, and deterministic vectors
  covering the negative cases:
  https://github.com/khosimorafo/technocore-chat/tree/account-binding-v1
- That verifier's own docstring hands this file the job: "Worked examples of both profiles
  composed into real flows belong in `src/patterns.md` alongside the other lane recipes."

Both of them said on #11 that they were not going to write this change and were waiting on
direction, so I am writing it rather than leaving the grammar to be converged on by
accident. The grammar here is @khosimorafo's, unchanged. The `binding:<tag>` note field is
@Elfet's, and his reason for it is the one the text gives: without the tag a reader holds a
signature and has to guess which statement version it covers, and guessing wrong is
indistinguishable from a bad signature.

## Relationship to open work

- **#11** — the issue this documents. Still open.
- **#12** — my own PR for the challenge-bound profile; the 900-second window in this text
  comes from it. **This PR does not depend on #12** and stands if #12 is narrowed or
  dropped, since the durable profile touches the server not at all.
- I found no other open pull request touching account bindings.

## Verified against

`9861d01cb42e10a5ffdffe3880338feaa4f56b3f` on `main`
(*fix(mcp): bound list_notes so one namespace is not 3.2 MB of tool result (#698) (#713)*).

## Checks

- `uv run sz.py --caps` passes. `patterns.md` is not a capped core file and the core totals
  are unchanged at 2314 / 3000.
- No Python changed, so `ruff check`, `ruff format --check` and `ty` have nothing to act on
  in this diff.
- The tests that read `/patterns.md` assert substrings — `E2E`, `choreography`, the
  `room-owners` claim URL, the replay-counter line — and that the unsigned
  `/set/<your did:key>?if_absent=1` form appears nowhere in the file. All still hold: the
  added text introduces no URL of that form and no `__PLACEHOLDER__` token.
- **I could not run the HTTP suite locally.** `src/store.py` imports `fcntl`, and on Windows
  every `client` fixture errors at setup on `main` too. CI is the real check for those.
- The contract job is unaffected: no route and no status code is added, so `src/manifest.py`
  does not move.

## Abuse impact

None new — no public surface is added. What the document itself is careful to say: a binding
proves one statement was signed by two keys, and nothing more. Not personhood, not
uniqueness, not honesty. Nothing stops one account binding eighty DIDs, and a farmer simply
publishes no binding at all. It gives a *reader* a way to tell the difference, not the
service a way to enforce one.

## Proposed release-note wording

DOCS: patterns.md writes down the account-binding convention — one statement signed from
both surfaces, binding a `did:key` to a GitHub login or a wallet key, with the durable form
carried as a `binding:` field in the DID note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
