### PR TITLE
fix(notes): validate signed conditions before nonce burn

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1706,10 +1706,11 @@ def note_write_signed(request: Request) -> Response:
     denied = _note_write_gate(ns, key, value, signer)
     if denied:
         return denied
+    condition = _condition(request.query_params)
     denied = _burn_nonce(key, nonce)
     if denied:
         return denied
-    meta = store.note_set(config.ROOT, ns, key, value, *_condition(request.query_params))
+    meta = store.note_set(config.ROOT, ns, key, value, *condition)
     return respond(
         request,
         meta,

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -968,6 +968,35 @@ def test_signed_note_get_covers_the_swept_value(client):
     assert client.get(f"/kv/room-nonce/{room}").text.strip().endswith("2")
 
 
+def test_invalid_signed_note_conditions_do_not_burn_a_nonce(client):
+    """A rejected condition must leave the signed write retryable on both lanes."""
+    owner, owner_sign = _keypair()
+    room = "d-condition-get"
+    assert _claim(client, room, owner, owner_sign).status_code == 200
+
+    value, _ = _keypair(seed=3)
+    signature = owner_sign(f"room-allow|{room}|2|{value}")
+    base = f"/kv/room-allow/{room}/set-signed/{owner}/{signature}/2/{value}"
+    invalid = client.get(f"{base}?if_absent=maybe")
+    assert invalid.status_code == 400 and "if_absent" in invalid.text
+    assert client.get(f"/kv/room-nonce/{room}").text.strip().endswith("1")
+    assert client.get(f"{base}?if_absent=1").status_code == 200
+    assert client.get(f"/kv/room-nonce/{room}").text.strip().endswith("2")
+
+    post_owner, post_sign = _keypair(seed=2)
+    post_room = "d-condition-post"
+    assert _claim(client, post_room, post_owner, post_sign).status_code == 200
+    payload = _signed_note_payload(
+        "room-allow", post_room, post_owner, post_sign, value, nonce=2, if_absent="maybe"
+    )
+    invalid = client.post(f"/kv/room-allow/{post_room}", json=payload)
+    assert invalid.status_code == 400 and "if_absent" in invalid.text
+    assert client.get(f"/kv/room-nonce/{post_room}").text.strip().endswith("1")
+    payload["if_absent"] = True
+    assert client.post(f"/kv/room-allow/{post_room}", json=payload).status_code == 200
+    assert client.get(f"/kv/room-nonce/{post_room}").text.strip().endswith("2")
+
+
 def test_a_replayed_ownership_url_cannot_roll_an_allow_list_back(client):
     owner, owner_sign = _keypair()
     friend, _ = _keypair(seed=2)


### PR DESCRIPTION
## Summary

Fixes #746.

The signed GET note lane burned its ownership nonce before validating `if` / `if_absent`. A malformed condition therefore returned `400` but made the otherwise valid signed request unretryable. The POST lane validated the condition before burning the nonce, so the two lanes had different nonce semantics.

This change validates the GET condition after the ownership gate and before `_burn_nonce`, then passes the validated condition to `note_set`. It adds a regression covering malformed-condition retry behavior on both GET and POST.

## Verification

- `docker run ... pytest tests/http/test_rooms.py -q`: 56 passed (Python 3.12 container)
- `uv run ruff check src/app.py tests/http/test_rooms.py`: passed
- `uv run ruff format --check src/app.py tests/http/test_rooms.py`: passed
- `uv run sz.py --check`: passed; `core/app.py` is at its existing 1020-line cap
- `git diff --check`: passed

The native Windows pytest run remains blocked before collection by the repository's existing `fcntl` import limitation. `uv run ty check` also reports the existing Windows `fcntl`/`os.fchmod` platform diagnostics; no unrelated portability changes are included here.