### PR TITLE
fix(edge): canonicalize health check query variants

### DIFF
--- a/edge/snapshot.py
+++ b/edge/snapshot.py
@@ -117,6 +117,10 @@ EDGE_REVALIDATE = {"/rooms": 5}
 # dependency chain. Drift is caught instead — the edge-key test asserts it against
 # store.MAX_LIMIT, which is where the number actually lives.
 
+# The liveness reply does not vary by query at all. Give it an explicit empty key spec so the
+# Worker can collapse `/healthz`, `/healthz?n=1` and every other query variant to one shared
+# cache entry and one canonical origin request.
+#
 # Paths the edge owns outright: the origin serves nothing at them, so unlike everything else
 # here the stored bytes are not a copy of a live answer — they are the only answer. That is
 # why they are neither snapshotted (there is nothing to fetch) nor origin-first (there is
@@ -140,6 +144,11 @@ def rooms_key() -> dict:
             "clamped": {"limit": {"min": 1, "max": 200}},
         }
     }
+
+
+def edge_key() -> dict:
+    """Cache-key specs for every edge-cached or edge-revalidated path."""
+    return {"/healthz": {}, **rooms_key()}
 
 
 def asset_name(path: str) -> str:
@@ -207,8 +216,8 @@ def main() -> int:
             print(f"  {line}", file=sys.stderr)
         return 1
 
-    edge_key = rooms_key()
-    unspecified = sorted(set(EDGE_REVALIDATE) - set(edge_key))
+    key_spec = edge_key()
+    unspecified = sorted((set(EDGE_CACHED) | set(EDGE_REVALIDATE)) - set(key_spec))
     if unspecified:
         # Fail closed. Without a key spec the Worker would have to key on the raw URL, which
         # is the multiplication bug above — a deploy that silently did that is worse than one
@@ -223,7 +232,7 @@ def main() -> int:
                 "static_first": sorted(STATIC_FIRST),
                 "edge_cached": EDGE_CACHED,
                 "edge_revalidate": EDGE_REVALIDATE,
-                "edge_key": edge_key,
+                "edge_key": key_spec,
                 "edge_only": sorted(EDGE_ONLY),
             },
             indent=2,

--- a/edge/src/worker.js
+++ b/edge/src/worker.js
@@ -139,12 +139,13 @@ async function stored(request, env, pathname, { fallback }) {
 
 async function edgeCached(request, pathname, seconds) {
   const cache = caches.default;
-  const hit = await cache.match(request);
+  const key = cacheKey(new URL(request.url), pathname) ?? request;
+  const hit = await cache.match(key);
   if (hit) return hit;
 
   let fresh;
   try {
-    fresh = await fetch(request, { signal: AbortSignal.timeout(ORIGIN_TIMEOUT_MS) });
+    fresh = await fetch(key, { signal: AbortSignal.timeout(ORIGIN_TIMEOUT_MS) });
   } catch (err) {
     // An origin that will not answer inside the budget IS the health answer, so report it
     // here rather than letting the timeout escape to the fail-open handler. That handler
@@ -169,7 +170,7 @@ async function edgeCached(request, pathname, seconds) {
     // proxy reuse `ok` without contacting the edge at all — liveness staleness outside
     // Cloudflare's control, and beyond the reach of a purge.
     headers.set("Cache-Control", `public, max-age=0, s-maxage=${seconds}`);
-    await cache.put(request, new Response(body, { status: 200, headers }));
+    await cache.put(key, new Response(body, { status: 200, headers }));
     return new Response(body, { status: 200, headers });
   }
   return fresh;

--- a/edge/wrangler.jsonc
+++ b/edge/wrangler.jsonc
@@ -38,7 +38,9 @@
     { "pattern": "technocore.chat/auth.md", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/humans", "zone_name": "technocore.chat" },
     // Edge-cached, never snapshotted — see EDGE_CACHED in snapshot.py.
-    { "pattern": "technocore.chat/healthz", "zone_name": "technocore.chat" },
+    // Query parameters have no meaning to /healthz; the trailing * keeps every variant in
+    // the same Worker lane, where the cache key canonicalizes them back to /healthz.
+    { "pattern": "technocore.chat/healthz*", "zone_name": "technocore.chat" },
     // Served from the edge copy always, refreshed in the background — EDGE_REVALIDATE.
     // The trailing * is load-bearing: a route pattern is matched against the whole URL,
     // query string included, so "technocore.chat/rooms" matches a bare /rooms and nothing

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -258,6 +258,23 @@ def test_the_edge_cached_lane_shares_its_copy_only_with_the_edge():
     )
 
 
+def test_healthz_query_variants_use_one_worker_route_and_cache_key():
+    """`/healthz` has no query semantics, so variants must not bypass or multiply its cache."""
+    raw = (EDGE / "wrangler.jsonc").read_text(encoding="utf-8")
+    patterns = {
+        r["pattern"] for r in json.loads(re.sub(r"^\s*//.*$", "", raw, flags=re.M))["routes"]
+    }
+    assert "technocore.chat/healthz*" in patterns
+    assert _snapshot_module().edge_key()["/healthz"] == {}
+
+    worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
+    lane = _between(worker, "async function edgeCached(", "/** Resolves")
+    assert "const key = cacheKey(new URL(request.url), pathname) ?? request;" in lane
+    assert "cache.match(key)" in lane
+    assert "fetch(key," in lane
+    assert "cache.put(key," in lane
+
+
 def test_the_revalidating_lane_never_makes_a_reader_wait_for_the_origin():
     """The property the lane exists for, asserted on the source for want of a JS harness —
     and the one a later edit would quietly remove. /rooms is an O(total-rooms) walk (#576)


### PR DESCRIPTION
## Summary

Fixes #751.

`/healthz` ignores query parameters, but the edge route was exact, so `/healthz?anything` bypassed the Worker. Even after routing those requests through the Worker, using the raw request as the Cache API key would create a separate cache entry and origin request for every ignored query variant.

This change:

- routes `healthz*` through the Worker;
- adds an explicit query-insensitive cache-key specification for `/healthz`;
- uses the canonical key for cache lookup, origin fetch, and cache storage;
- adds edge regression coverage for the route and key contract.

## Verification

- `docker ... pytest tests/edge/test_edge_worker.py -q`: 26 passed, 1 skipped (Python 3.12 container)
- `uv run ruff check edge/snapshot.py tests/edge/test_edge_worker.py`: passed
- `uv run ruff format --check edge/snapshot.py tests/edge/test_edge_worker.py`: passed
- `node --check edge/src/worker.js`: passed
- `python -m py_compile edge/snapshot.py tests/edge/test_edge_worker.py`: passed
- `git diff --check`: passed

The test suite uses source-level assertions for the Worker because this repository does not include a JavaScript Worker runtime harness. No live deployment or cache mutation was performed.
