### PR TITLE
fix(edge): route versioned favicon URLs

### DIFF
--- a/edge/wrangler.jsonc
+++ b/edge/wrangler.jsonc
@@ -47,7 +47,9 @@
     // the request nobody makes. This is the only route whose reply depends on its query.
     { "pattern": "technocore.chat/rooms*", "zone_name": "technocore.chat" },
     // Owned by the edge, never served by the origin — see EDGE_ONLY in snapshot.py.
-    { "pattern": "technocore.chat/favicon.ico", "zone_name": "technocore.chat" },
+    // Query parameters have no meaning to the edge-owned icon; keep versioned URLs in the
+    // same Worker lane so the pathname-based asset lookup can answer them too.
+    { "pattern": "technocore.chat/favicon.ico*", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/robots.txt", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/sitemap.xml", "zone_name": "technocore.chat" },
     { "pattern": "technocore.chat/openapi.json", "zone_name": "technocore.chat" },

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -427,6 +427,19 @@ def test_a_path_whose_reply_varies_by_query_is_routed_with_a_wildcard():
         )
 
 
+def test_edge_owned_favicon_accepts_versioned_query_urls():
+    """The edge-only icon is pathname-selected, so cache-busting queries must stay routed."""
+    raw = (EDGE / "wrangler.jsonc").read_text(encoding="utf-8")
+    patterns = {
+        r["pattern"] for r in json.loads(re.sub(r"^\s*//.*$", "", raw, flags=re.M))["routes"]
+    }
+    assert "technocore.chat/favicon.ico*" in patterns
+    worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
+    lane = _between(worker, "if (EDGE_ONLY.has(pathname))", "let originResponse")
+    assert "stored(request, env, pathname" in lane
+    assert "pathname" in lane
+
+
 def test_an_edge_owned_path_is_not_snapshotted_and_not_origin_first():
     """EDGE_ONLY is the one lane whose stored bytes are not a copy of anything. The origin
     serves nothing at these paths, so snapshotting one would fetch a 404 and fail the deploy,


### PR DESCRIPTION
## Summary

Fixes #755.

The edge-owned `/favicon.ico` route was exact, so a conventional versioned URL such as `/favicon.ico?v=1` bypassed the Worker and reached the origin, which has no favicon route. The same pathname-based edge asset should serve both forms.

This change widens the route to `favicon.ico*` and adds a regression asserting that versioned favicon URLs remain in the edge-only lane. It does not add an origin route or change asset lookup/storage behavior.

## Verification

- `docker ... pytest tests/edge/test_edge_worker.py -q`: 26 passed, 1 skipped (Python 3.12 container)
- `uv run ruff check edge/snapshot.py tests/edge/test_edge_worker.py`: passed
- `uv run ruff format --check edge/snapshot.py tests/edge/test_edge_worker.py`: passed
- `node --check edge/src/worker.js`: passed
- `python -m py_compile edge/snapshot.py tests/edge/test_edge_worker.py`: passed
- `git diff --check`: passed

No live deployment or cache mutation was performed.
