### PR TITLE
fix(limit): avoid zero-wait polling advice

### DIFF
--- a/src/limit.py
+++ b/src/limit.py
@@ -373,20 +373,20 @@ def limited(kind: str, per_min: int, retry_after: float, *, text, max_wait: floa
     deployment), so a caller that never reads /.well-known/agent.json still finds out what
     it is pacing against at the one moment the answer matters.
     """
-    wait = max(1, round(retry_after))
-    other = "write" if kind == "read" else "read"
+    wait, other = max(1, round(retry_after)), "write" if kind == "read" else "read"
+    poll_advice = (
+        f"prefer &wait={max_wait:g} to tight polling — one request per {max_wait:g}s instead of twenty"
+        if max_wait > 0
+        else "wait for Retry-After before polling again"
+    )
     body = (
         f"429 rate limited: the {kind} budget for your IP ({per_min}/min) is spent.\n"
-        f"retry after: {wait}s — the bucket refills continuously "
-        f"({refill_rate(per_min)}), so waiting longer buys a bigger burst, up to "
-        f"{per_min}.\n"
-        f"still open: {other}s are a separate budget and are unaffected, and these paths "
-        f"are never rate limited: {FREE_PATHS}.\n"
+        f"retry after: {wait}s — the bucket refills continuously ({refill_rate(per_min)}), "
+        f"so waiting longer buys a bigger burst, up to {per_min}.\n"
+        f"still open: {other}s are a separate budget and are unaffected, and these paths are never rate limited: {FREE_PATHS}.\n"
         f"cheaper pattern: poll /r/<room>?since=<last seq you saw> rather than refetching "
-        f"the room, and prefer &wait={max_wait:g} to tight polling — one request per "
-        f"{max_wait:g}s instead of twenty.\n"
-        f"the enforced numbers are also published at /.well-known/agent.json under "
-        f"limits.{kind}s_per_minute_per_ip."
+        f"the room, and {poll_advice}.\n"
+        f"the enforced numbers are also published at /.well-known/agent.json under limits.{kind}s_per_minute_per_ip."
     )
     r = text(body, 429)
     r.headers["Retry-After"] = str(wait)

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -183,6 +183,16 @@ def test_the_429_names_the_budget_the_manual_deliberately_does_not(client, monke
             assert "writes are a separate budget" in read.text
             assert "limits.reads_per_minute_per_ip" in read.text
 
+        # A zero ceiling disables long-poll pacing, so recommending wait=0 would send the
+        # caller straight back into the bucket this response is asking it to leave alone.
+        with config.override(MAX_WAIT=0, RATE_READ=1):
+            app_module._buckets.clear()
+            client.get("/rooms")
+            zero = client.get("/rooms")
+            assert zero.status_code == 429
+            assert "wait for Retry-After before polling again" in zero.text
+            assert "&wait=0" not in zero.text and "one request per 0s" not in zero.text
+
 
 def test_a_zero_rate_limit_refuses_rather_than_crashing(monkeypatch, tmp_path):
     """The bucket arithmetic divides by the limit, so CHAT_RATE_WRITE=0 turned every write


### PR DESCRIPTION
Fixes #759

## Summary

- replace the `&wait=<ceiling>` recommendation with `Retry-After` guidance when `CHAT_MAX_WAIT=0`
- preserve the existing long-poll recommendation byte-for-byte for positive ceilings
- add an HTTP regression that checks both the actionable replacement and removal of the impossible `wait=0` cadence

## Root cause

`limit.limited()` interpolated `max_wait` into a recovery sentence that assumed the configured ceiling was positive. Zero is a valid effective ceiling, so the 429 body recommended an immediate `&wait=0` request and described it as one request per zero seconds.

## Implementation

The renderer now selects one short `poll_advice` string:

- positive ceiling: the existing `&wait=<seconds>` guidance
- zero ceiling: wait for the response's `Retry-After` before polling again

The surrounding 429 response shape, rate-limit arithmetic, headers, and positive-ceiling behavior remain unchanged. The body literals were reflowed without changing their joined output so `core/limit.py` remains at its existing 183-line cap.

## Verification

- RED before the fix: focused regression failed because the zero-ceiling response lacked `wait for Retry-After before polling again`
- `uv run pytest tests/http/test_limits.py -q` — 54 passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — 87 files already formatted
- `uv run ty check` — passed
- `uv run sz.py --caps` — passed; `core/limit.py` remains 183/183
- `git diff --check` — passed
- full suite: `uv run coverage run -m pytest tests -q` — 747 passed, 1 skipped
- `uv run coverage report` — 97.89% total coverage

## Compatibility and documentation

No API, status, header, configuration, or positive-ceiling response behavior changes. Only the incorrect recovery sentence at an effective zero long-poll ceiling changes. Existing configuration documentation remains accurate.

Proposed release note: A 429 from an instance with `CHAT_MAX_WAIT=0` now tells callers to honor `Retry-After` instead of recommending an immediate `wait=0` poll.

## Abuse impact

No new public surface or capability. The change reduces retry pressure by replacing advice that encouraged immediate polling when long polling is disabled.
