### PR TITLE
fix(mcp): reject swept-empty signed messages

### DIFF
--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -587,6 +587,14 @@ async def say_signed(
     # satisfies that, so nothing is read before the write.
     minted = signing.next_nonce()
     swept = signing.sweep(text)
+    if not swept and _signer is None and did is None and sig is None and nonce is None:
+        # A no-key caller receives the exact canonical string from _resolve_signature. An
+        # empty swept body cannot pass the service's semantic check, so do not hand an
+        # external signer a challenge that is guaranteed to fail when retried unchanged.
+        raise ToolError(
+            "empty text: nothing visible was left after the single-line sweep. "
+            "Send at least one visible character."
+        )
     did, sig, nonce = _resolve_signature(f"{room}|{minted}|{swept}", did, sig, nonce, minted)
     return await _post(
         f"/r/{_segment(room)}", {"did": did, "sig": sig, "nonce": str(nonce), "text": text}

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1039,6 +1039,36 @@ def test_with_no_key_and_no_signature_the_error_is_the_challenge(mcp):
     assert retried.is_error is False, text_of(retried)
 
 
+def test_no_key_does_not_issue_an_unusable_empty_text_challenge(mcp, monkeypatch):
+    """Whitespace/control-only input is rejected before challenge generation.
+
+    The service refuses the swept-empty body. Returning a challenge ending in an empty
+    text field would ask an external signer to sign a request that cannot succeed when
+    retried unchanged.
+    """
+    monkeypatch.setattr(mcp.module, "_signer", None)
+
+    reply = mcp.call("say_signed", {"room": "mb-inbox", "text": " \n\t "})
+
+    assert reply.is_error is True
+    message = text_of(reply)
+    assert "empty text" in message
+    assert "nothing visible was left" in message
+    assert "mb-inbox|" not in message
+
+
+def test_configured_key_leaves_empty_text_refusal_to_the_service(mcp, monkeypatch):
+    """Only challenge mode rejects swept-empty input locally; a configured signer still
+    sends the request so the service remains the authority for its semantic refusal."""
+    with_key(mcp, monkeypatch)
+
+    reply = mcp.call("say_signed", {"room": "mb-inbox", "text": " \n\t "})
+
+    assert reply.is_error is True
+    assert "empty text" in text_of(reply)
+    assert mcp.sent, "configured-signing mode must reach the service"
+
+
 def test_whoami_reports_the_identity_without_touching_the_network(mcp, monkeypatch):
     async def never(method, url, headers, body, timeout):
         raise AssertionError(f"the network was reached: {url}")


### PR DESCRIPTION
Fixes #758.

## What changed

When `say_signed` receives text that becomes empty after the MCP signing sweep, it now raises the same class of empty-text refusal before `_resolve_signature()` can return an external-signing challenge. A challenge ending in an empty text field cannot succeed when signed and retried unchanged.

Added a regression test covering whitespace/control-only input and retained the existing visible-text external-signing test. Added the required Unreleased changelog entry.

## Verification

- `python -m compileall -q mcp/src/technocore_mcp tests/test_mcp.py` — passed.
- `git diff --check` — passed.
- Focused pytest selection reached collection but cannot run in this Windows environment because `src/store.py` imports POSIX-only `fcntl` (`ModuleNotFoundError`), the repository's existing Windows MCP-test limitation.
- WSL is installed, but its Ubuntu environment has no `uv` or pytest, so no Linux test result is claimed.