### PR TITLE
fix(limit): preserve bare duplicate-ref text

### DIFF
--- a/src/limit.py
+++ b/src/limit.py
@@ -145,11 +145,11 @@ def normalize_text(text: str) -> str:
     text = "".join(
         " " if unicodedata.category(c) in store.INVISIBLE_CATEGORIES else c for c in text
     )
-    # A duplicate 422's ref token (app._REF's shape, with the `&ref=` the body shows it
-    # behind, and nothing else), pasted into the text instead of the query string, is cut
-    # out so it can never be what makes a copy unique — neither on its own nor by taking
-    # the word it was glued to with it.
-    return " ".join(re.sub(r"(?:&?ref=)?422-[\da-f]{1,8}-[\da-f]{4}", " ", text.casefold()).split())
+    # A duplicate 422's ref token, pasted into the text instead of the query string, is
+    # cut out only when its documented `&ref=` marker is present. A bare token-shaped
+    # substring is ordinary caller text: the server has no state proving that it was
+    # issued as a duplicate reference, so removing it would merge distinct messages.
+    return " ".join(re.sub(r"&ref=422-[\da-f]{1,8}-[\da-f]{4}", " ", text.casefold()).split())
 
 
 def _dupe_key(room: str, text: str, min_length: int) -> tuple[str, bytes] | None:

--- a/tests/http/test_dupe_filter.py
+++ b/tests/http/test_dupe_filter.py
@@ -121,8 +121,8 @@ def test_the_ref_token_is_handed_out_seen_again_and_never_a_way_past_the_filter(
     body points at, and once (not twice) on a write that also creates a room — and the
     handler otherwise ignores it. Only the exact token shape is counted or logged: a
     forged value with a newline in it must not reach the operator's log at all. Pasted
-    into the text instead, glued to a word or not, the token is cut out before the copy
-    check — it must not be the thing that makes the sixth copy land."""
+    into the text with its documented `&ref=` marker, the token is cut out before the
+    copy check; a bare token-shaped substring remains caller content."""
     with _filter_on(DUPE_MAX_COPIES=1):
         assert _say(client, "lobby", "a", PHRASE).status_code == 200
         refused = _say(client, "lobby", "b", PHRASE)
@@ -144,8 +144,8 @@ def test_the_ref_token_is_handed_out_seen_again_and_never_a_way_past_the_filter(
     assert [ln for ln in lines if "ref=" + ref in ln] == lines and len(lines) == 3
     assert "path='/patterns.md'" in lines[1] and "forged" not in "".join(lines)
     with _filter_on(DUPE_MAX_COPIES=1):
-        assert _say(client, "lobby", "c", PHRASE + " " + ref).status_code == 422
-        assert _say(client, "lobby", "c", PHRASE + ref).status_code == 422  # glued to a word
+        assert _say(client, "lobby", "c", PHRASE + " " + ref).status_code == 200
+        assert _say(client, "lobby", "c", PHRASE + ref).status_code == 200  # glued to a word
         assert _say(client, "lobby", "c", "&ref=" + ref + " " + PHRASE).status_code == 422
 
 

--- a/tests/unit/test_dupe_ring.py
+++ b/tests/unit/test_dupe_ring.py
@@ -62,6 +62,17 @@ def test_normalisation_folds_case_whitespace_and_unicode_compatibility() -> None
     )
 
 
+def test_normalisation_only_removes_explicit_duplicate_ref_syntax() -> None:
+    """A bare token-shaped substring is caller content, not proof of a server ref."""
+    token = "422-deadbeef-abcd"
+    assert limit.normalize_text(f"incident {token} alpha") != limit.normalize_text(
+        "incident alpha"
+    )
+    assert limit.normalize_text(f"incident &ref={token} alpha") == limit.normalize_text(
+        "incident alpha"
+    )
+
+
 def test_the_length_floor_is_on_the_normalised_text() -> None:
     """The floor is the boundary: at or above it the filter applies, below it never
     does - the entire conversational-repeat class lives below it."""


### PR DESCRIPTION
Fixes #694.

## What changed

`limit.normalize_text()` now removes a duplicate reference only when the documented `&ref=422-...` marker is present. A bare token-shaped substring is ordinary caller text and remains part of the duplicate key; the service has no state proving that arbitrary text was issued as a duplicate reference.

Regression coverage now asserts both behaviors:

- bare `422-...` content remains distinct from text without it;
- explicit `&ref=...` content normalizes away;
- the HTTP duplicate-filter test preserves bare token-shaped messages while continuing to collapse the documented marker form.

## Verification

- Ruff check passed for all changed Python files.
- Ruff format check passed for all changed Python files.
- `git diff --check` passed.
- Python compilation passed.
- The repository pytest suite was not claimed locally: Windows cannot import the existing POSIX-only `fcntl` dependency, and the WSL dependency sync on the mounted worktree did not complete.