### PR TITLE
fix(humans): fail the job when the service never becomes healthy

### DIFF
--- a/.github/workflows/humans.yml
+++ b/.github/workflows/humans.yml
@@ -107,6 +107,7 @@ jobs:
             curl -fsS localhost:8099/healthz && break
             sleep 1
           done
+          curl -fsS localhost:8099/healthz || { echo "::error::service did not become healthy"; exit 1; }
 
       # The probe resolves `playwright` from tests/node_modules by walking up from its own
       # directory, so it runs in place with no move and no NODE_PATH (which ESM ignores).


### PR DESCRIPTION
## What

The browser job's "Start the service" step now fails when uvicorn never becomes healthy, instead of exiting 0 and letting the job reach the Playwright probe against a dead port. No service or MCP behavior changes; this is a CI failure-path fix only.

## Why

Closes #769. In `humans.yml` the readiness loop polls `/healthz` 30 times under `set -e`, but a failed `curl` is a non-final constituent of a `&&` list and the trailing `sleep 1` masks it, so the loop exits 0 when uvicorn never binds. The job then failed ~30s later as a probe ECONNREFUSED, which reads as a probe bug rather than a service that never started. A post-loop guard re-checks `/healthz` and exits 1 with a clear `::error::` when the service was not reached. Verified against `1c31dbe` (current `origin/main`). No open PR covers this; #754 and #97 touch different surfaces.

## Checks

- [ ] `uv run coverage run -m pytest tests -q && uv run coverage report` — n/a, workflow YAML only
- [ ] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — n/a, workflow YAML only
- [ ] Docs that would now be wrong are updated — none; this is a CI workflow fix, no served doc or manual change
- [x] New surface on a world-writable service: nothing new
