### PR TITLE
build(sz): raise every core cap by 10 lines, and re-ratchet the baseline

### DIFF
--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,19 +1,19 @@
 {
   "core_total": 2316,
   "caps": {
-    "core/app.py": 1020,
-    "core/config.py": 63,
-    "core/didkey.py": 57,
-    "core/limit.py": 183,
-    "core/store.py": 1000,
-    "core_total": 3000
+    "core/app.py": 1030,
+    "core/config.py": 73,
+    "core/didkey.py": 67,
+    "core/limit.py": 193,
+    "core/store.py": 1010,
+    "core_total": 3010
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 2138,
+      "raw_lines": 2165,
       "code_lines": 1019,
-      "comment_lines": 305,
-      "tokens_per_line": 7.95
+      "comment_lines": 319,
+      "tokens_per_line": 8.01
     },
     "core/config.py": {
       "raw_lines": 367,
@@ -22,28 +22,28 @@
       "tokens_per_line": 12.86
     },
     "core/didkey.py": {
-      "raw_lines": 141,
-      "code_lines": 57,
-      "comment_lines": 37,
-      "tokens_per_line": 8.02
+      "raw_lines": 148,
+      "code_lines": 59,
+      "comment_lines": 42,
+      "tokens_per_line": 8.14
     },
     "core/limit.py": {
-      "raw_lines": 467,
+      "raw_lines": 498,
       "code_lines": 183,
       "comment_lines": 98,
-      "tokens_per_line": 8.39
+      "tokens_per_line": 8.51
     },
     "core/store.py": {
-      "raw_lines": 2762,
-      "code_lines": 994,
-      "comment_lines": 632,
-      "tokens_per_line": 8.06
+      "raw_lines": 2764,
+      "code_lines": 992,
+      "comment_lines": 636,
+      "tokens_per_line": 8.1
     },
     "extra/manifest.py": {
-      "raw_lines": 2261,
-      "code_lines": 1556,
+      "raw_lines": 2276,
+      "code_lines": 1571,
       "comment_lines": 266,
-      "tokens_per_line": 3.9
+      "tokens_per_line": 3.88
     }
   }
 }


### PR DESCRIPTION
## What

Raises each per-file core cap in `sz-baseline.json` by 10 lines, and regenerates the ratchet with `sz.py --update-baseline`. Only `sz-baseline.json` changes — no core code is touched, and nothing a caller of the service or the MCP wrapper sees changes.

```
core/app.py     1020 -> 1030      core/limit.py    183 ->  193
core/config.py    63 ->   73      core/store.py   1000 -> 1010
core/didkey.py    57 ->   67      core_total      3000 -> 3010
```

## Why

`main` is currently red. Merging #156 (`e7675dc`) put `core/didkey.py` at 59 code lines against a cap of 57, so `sz.py --check` fails twice over — for growth past the ratchet, and for the cap itself:

```
core code-lines grew vs sz-baseline.json: core/didkey.py 57 -> 59 (cap 57)
core code-lines past cap: core/didkey.py 59 > cap 57
```

The alternative was shaving two lines back off #156, which is the wrong trade: the leading-zero fix reads well as written, and CONTRIBUTING is explicit that a low line count is a constraint rather than a score.

Headroom before this was 1, 0, -2, 0 and 8 lines across the five core files, which is the condition #656 reports — ordinary changes were failing as cap breaches rather than as ratchet growth, so the ceiling stopped being a decision anyone made deliberately. 10 lines each restores that without moving `core_total` far (694 lines of headroom remain).

Caps are policy and were edited by hand; the `files` block is measurement and comes from `--update-baseline`, which carries caps forward untouched. That regeneration also absorbs drift already on `main` from earlier merges: `core/app.py` comment lines, and `core/store.py` down 994 -> 992, which the ratchet permits since it only moves down.

This is the maintainer-side half of the `sz-baseline.json` rule in CONTRIBUTING, so it deliberately does not come from a fork.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 750 passed, 1 skipped; 97.97% total
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — all clean
- [x] Docs that would now be wrong are updated: none — no documented behaviour changes
- [x] New surface on a world-writable service: nothing new — this is a build-time policy file with no runtime effect

`uv run sz.py --check` and `uv run sz.py --caps` both exit 0 with this applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sbowG1MTBENc8kd9tJknM

---
_Generated by [Claude Code](https://claude.ai/code/session_013sbowG1MTBENc8kd9tJknM)_