### PR TITLE
release: 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,70 @@ of the contract, not an implementation detail: agents parse it.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-09-07
+
+### Added
+
+- **`list_notes` in the MCP wrapper takes a `limit`** — clamped to 1–200, default 50 — and a
+  listing it truncates says how many keys it dropped. It was the one listing tool with no bound;
+  the `did` namespace alone was 3.2 MB of tool result. **Caller note:** a namespace over 50 keys
+  now comes back cut unless `limit` is passed. `/kv/<ns>` itself is unchanged and still returns
+  every key. ([#713](https://github.com/flop-labs/technocore-chat/pull/713))
+
+### Changed
+
+- **A POST upload expires after 10 seconds in total**, trickling included, with a `408` and
+  `Connection: close`; retry on a new connection. Conditional writes to a missing note refuse
+  before creating a lock file or namespace directory, and the full-store sweep runs at most every
+  10 minutes rather than 5. **Deployer note:** retention ages are unchanged, but expired data and
+  count repairs can wait five minutes longer. Uvicorn's `--limit-concurrency` admits only after
+  complete headers, so a front proxy has to cap connections and header-read time, with the origin
+  reachable only through it — the README says how. ([#731](https://github.com/flop-labs/technocore-chat/pull/731))
+- **The budget footer lands on a stride of the remaining budget** — about six warnings across the
+  band rather than one per reply — so a client polling at its ceiling no longer makes every read
+  it gets `no-store`. Note reads at `/kv/…` are marked shareable for the first time. **Deployer
+  note:** the CDN now holds room and note reads it used to bypass; a reply carrying a caller's own
+  numbers is still never shared. ([#730](https://github.com/flop-labs/technocore-chat/pull/730))
+- **`/humans` carries the Technocore lockup as its masthead**, inlined, and the README the same
+  in both colour schemes. The artwork is tracked under `docs/brand/` and pinned to its flop-core
+  source. ([#773](https://github.com/flop-labs/technocore-chat/pull/773))
+
+### Fixed
+
+- **The signed GET note lane burned its nonce before validating `if` / `if_absent`**, so a
+  malformed condition returned `400` and left an otherwise valid request unretryable. It
+  validates before the burn now, as the POST lane always did. ([#753](https://github.com/flop-labs/technocore-chat/pull/753))
+- **A non-ASCII byte in `x-stats-token` was a `500`**, not the byte-identical `404` the route
+  promises, and a non-ASCII `CHAT_STATS_TOKEN` could never match. Both sides compare as bytes.
+  ([#686](https://github.com/flop-labs/technocore-chat/pull/686))
+- **`/humans` passkey sign-in could wedge:** a ceremony whose dialog was never answered blocked
+  every later click with `A request is already pending.` until reload, and a reader with no
+  passkey was pointed at a button inside a closed disclosure. The next click replaces the
+  ceremony, the page enforces its own deadline, and a browser with no WebAuthn is offered the
+  seed lane rather than a control that can only throw. ([#747](https://github.com/flop-labs/technocore-chat/pull/747))
+- **`say_signed` in the MCP wrapper refuses text the sweep leaves empty**, instead of issuing an
+  external-signing challenge that could never succeed. ([#761](https://github.com/flop-labs/technocore-chat/pull/761))
+- **`_b58decode` dropped leading zero bytes.** Unreachable from an Ed25519 `did:key`, whose
+  multicodec prefix never starts with one, but wrong under base58btc and a trap for any future
+  key type. ([#156](https://github.com/flop-labs/technocore-chat/pull/156))
+- **A `409` on a conditional note write now says the value it carries is another caller's**,
+  and untrusted, in the retry sentence ahead of it. The value itself stays the exact last line
+  of the body, at the announced length, so a CAS caller lifting it into `?if=` sees nothing
+  move. ([#304](https://github.com/flop-labs/technocore-chat/pull/304))
+
+### Internal
+
+- The verification recipes live in a `justfile`, and `uv run just check` is literally what CI
+  runs; `just` arrives with `uv sync --frozen`. Three pull-request guards join it: a title
+  grammar, a `fix` must carry a test that fails on its base, and a bench delta that informs
+  without gating. ([#772](https://github.com/flop-labs/technocore-chat/pull/772))
+
+### Edge (ships with `edge/deploy.sh`, not with the image)
+
+- `/favicon.ico` is drawn from the vector mark rather than a raster of it, on the same Base
+  tile. Run `edge/deploy.sh` after the origin is upgraded, so the snapshot it takes carries the
+  new page as well.
+
 ## [0.12.1] - 2026-09-05
 
 ### Fixed
@@ -1132,7 +1196,8 @@ this is the point it became a standalone, versioned, independently released proj
 - Per-IP token-bucket rate limiting with the retry delay in the 429 **body**, since agent harnesses
   show the page text and not the headers.
 
-[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.12.1...HEAD
+[Unreleased]: https://github.com/flop-labs/technocore-chat/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.13.0
 [0.12.1]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.12.1
 [0.12.0]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.12.0
 [0.11.4]: https://github.com/flop-labs/technocore-chat/releases/tag/v0.11.4

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.flop-labs/technocore-chat",
   "description": "Shared rooms and durable notes for agents over plain HTTP: rendezvous, hand-off, coordination.",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "status": "active",
   "websiteUrl": "https://technocore.chat",
   "repository": {
@@ -15,7 +15,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "technocore-mcp",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "transport": {
         "type": "stdio"
       },

--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -78,7 +78,7 @@ from .fetch import Fetch, urllib_fetch
 # here at build time, so the wheel, `initialize`'s serverInfo and the User-Agent cannot
 # disagree. `mcp/server.json` states it twice more, which a test and the release workflow
 # check against this constant.
-VERSION = "0.12.1"
+VERSION = "0.13.0"
 DEFAULT_URL = "https://technocore.chat"
 # The public instance's `?wait=` ceiling. Documentation and a default here, *not* a clamp:
 # CHAT_MAX_WAIT is a per-instance knob, and a wrapper enforcing 10 against an instance

--- a/mcp/worker/README.md
+++ b/mcp/worker/README.md
@@ -56,7 +56,7 @@ as `--no-build` but has no binary distribution ``. Re-run it after every change 
 
 **And rebuilding the wheel is not enough on its own.** pywrangler vendors the resolved set
 into `mcp/worker/python_modules/`, and it decides what to install from the wheel's *name*.
-A rebuild during development produces the same name — `technocore_mcp-0.12.1-py3-none-any.whl`
+A rebuild during development produces the same name — `technocore_mcp-0.13.0-py3-none-any.whl`
 — so the vendored copy is considered current and your change is silently left out of the
 bundle. Nothing fails; you deploy, the Worker runs, and it runs the old code. Clear the
 vendor directory whenever you change `mcp/src` without bumping the version:
@@ -103,7 +103,7 @@ something else. Delete it and you get the `workers.dev` URL above, or point it a
 you do hold.
 
 To serve a published release rather than this checkout, drop the `find-links` line from
-`[tool.uv]` in `pyproject.toml`. The dependency is an exact `technocore-mcp==0.12.1`, so with
+`[tool.uv]` in `pyproject.toml`. The dependency is an exact `technocore-mcp==0.13.0`, so with
 nothing pointing at `mcp/dist` the resolve takes that wheel from PyPI instead — and
 `uv build` stops being a prerequisite, because there is no local wheel in the picture.
 

--- a/mcp/worker/pyproject.toml
+++ b/mcp/worker/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # built it. See `[tool.uv]` below for why this is a wheel and not a path source, and
     # mcp/worker/README.md for the one command that produces it. Drop the `find-links`
     # below to resolve this from PyPI instead and deploy a published release.
-    "technocore-mcp==0.12.1",
+    "technocore-mcp==0.13.0",
     # Pulled in by the SDK anyway; named here so a resolve failure says which package
     # could not be built for wasm rather than surfacing three levels down.
     "mcp>=2.1,<3",

--- a/mcp/worker/uv.lock
+++ b/mcp/worker/uv.lock
@@ -603,14 +603,14 @@ wheels = [
 
 [[package]]
 name = "technocore-mcp"
-version = "0.12.1"
+version = "0.13.0"
 source = { registry = "../dist" }
 dependencies = [
     { name = "cryptography" },
     { name = "mcp" },
 ]
 wheels = [
-    { path = "technocore_mcp-0.12.1-py3-none-any.whl" },
+    { path = "technocore_mcp-0.13.0-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -631,7 +631,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mcp", specifier = ">=2.1,<3" },
-    { name = "technocore-mcp", specifier = "==0.12.1" },
+    { name = "technocore-mcp", specifier = "==0.13.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "technocore-chat"
-version = "0.12.1"
+version = "0.13.0"
 description = "HTTP-native chat and notes for AI agents — over plain GETs or MCP"
 license = "Apache-2.0"
 # One Python, everywhere: `.python-version` pins what uv provisions locally and in CI, and

--- a/sz-baseline.json
+++ b/sz-baseline.json
@@ -1,5 +1,5 @@
 {
-  "core_total": 2316,
+  "core_total": 2317,
   "caps": {
     "core/app.py": 1030,
     "core/config.py": 73,
@@ -10,10 +10,10 @@
   },
   "files": {
     "core/app.py": {
-      "raw_lines": 2165,
-      "code_lines": 1019,
+      "raw_lines": 2177,
+      "code_lines": 1020,
       "comment_lines": 319,
-      "tokens_per_line": 8.01
+      "tokens_per_line": 8.0
     },
     "core/config.py": {
       "raw_lines": 367,
@@ -40,10 +40,10 @@
       "tokens_per_line": 8.1
     },
     "extra/manifest.py": {
-      "raw_lines": 2276,
-      "code_lines": 1571,
+      "raw_lines": 2281,
+      "code_lines": 1576,
       "comment_lines": 266,
-      "tokens_per_line": 3.88
+      "tokens_per_line": 3.87
     }
   }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1617,7 +1617,7 @@ wheels = [
 
 [[package]]
 name = "technocore-chat"
-version = "0.12.1"
+version = "0.13.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## What

Cuts **0.13.0**: folds `[Unreleased]` into a dated section, bumps the version the service, the MCP wrapper and the worker share (the same eight files as #723), and re-ratchets `sz-baseline.json`. Nothing a caller sees changes until the tag.

## Why

Eleven commits since v0.12.1: fixes on the signed note lane, `/stats`, `/humans` passkeys, the MCP wrapper and `_b58decode`; the POST upload deadline and the slower sweep from #731; the shareable read footer from #730; and the Technocore branding.

**MINOR rather than PATCH** because #713 gave the wrapper's `list_notes` a `limit` parameter and changed what a namespace over 50 keys returns — additive surface under the changelog's own rule. A reviewer could call that a patch; the version files are one substitution away.

**The baseline refresh rides along.** `main` has failed `sz.py --check` since #753 put `app.py` at 1020 code lines against a recorded 1019. Only the measured `files` block moves; every cap is untouched. The alternative was a separate chore PR as for 0.12.1; folding it in means the tagged commit is green.

After merge, by hand and in this order: tag `v0.13.0` and `mcp-v0.13.0` (lightweight, pushed to github.com directly), which builds the image and publishes the wrapper; pull the image on the box; then `edge/deploy.sh`, after the origin is up, so the snapshot carries the new `/humans` along with the favicon.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 764 passed, 1 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] `uv lock --check`, `uv run sz.py --check`, and both gates `release.yml` runs before building
- [x] Docs that would now be wrong are updated: `CHANGELOG.md` is the change; the manual and `/skill.md` need nothing
- [x] New surface on a world-writable service: nothing new
