### PR TITLE
fix(delegation): verify signatures before ranking so a forged record cannot supersede a real one

### DIFF
--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -295,14 +295,26 @@ def check_note(root: str, body: str) -> int:
     """
     key, live, now = public_key(root), 0, int(time.time())
     records = delegations(body)
-    current = newest(records)
+    # Verify all signatures once, so newest() ranks only records that actually
+    # verify. Without this, a forged record with a high nonce in a world-writable
+    # note suppresses a real grant as SUPERSEDED. The note is writable by anyone,
+    # so a forged line is the ordinary case, and it must not compete with real ones.
+    ok = []
     for i, (agent, scope, expires, nonce, sig) in enumerate(records):
         try:
             key.verify(
                 base64.urlsafe_b64decode(sig + "=="),
                 delegation(root, agent, scope, expires, nonce).encode(),
             )
+            ok.append(i)
         except (InvalidSignature, ValueError, TypeError):
+            ok.append(-1)
+    verified = [i for i in ok if i >= 0]
+    current = newest([records[i] for i in verified])
+    # newest() returns indices into the verified sublist; map back to the original.
+    current = {verified[j] for j in current}
+    for i, (agent, scope, expires, nonce, _sig) in enumerate(records):
+        if ok[i] < 0:
             # Not "invalid": *forged, or for somebody else*. A record that fails here was
             # signed by a key that is not this root, which in a note anyone can write to is
             # the ordinary case and not an error.

--- a/src/humans.html
+++ b/src/humans.html
@@ -1884,21 +1884,38 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     var root = me.did;
     return notePath(root).then(readNote).then(function (note) {
       var found = parseDelegations(note), now = Date.now() / 1000;
-      var current = newest(found);
-      return Promise.all(found.map(function (d, i) {
-        // Verify first, expiry second. A forged line's expiry is whatever the forger typed,
-        // so reporting it as merely "expired" would dignify a signature that was never this
-        // key's in the first place.
-        return verifyDelegation(root, d).then(
-          function (ok) {
-            return { d: d, state: !ok ? 'forged'
-                                      : !DIGITS_RE.test(d.expires) ? 'expired'
-                                      : Number(d.expires) <= now ? 'expired'
-                                      : current[i] ? 'live' : 'superseded' };
-          },
-          function () { return { d: d, state: 'forged' }; }
-        );
-      }));
+      // Verify all records first, so newest() ranks only records that actually
+      // verify. Without this, a forged record with a high nonce in a world-writable
+      // note suppresses a real grant as superseded.
+      return Promise.all(found.map(function (d) {
+        return verifyDelegation(root, d).then(function (ok) { return ok; }, function () { return false; });
+      })).then(function (verified) {
+        var verifiedRecords = found.filter(function (_, i) { return verified[i]; });
+        var current = newest(verifiedRecords);
+        // current is a set of indices into verifiedRecords; map back to found indices.
+        var currentInFound = {};
+        var vi = 0;
+        found.forEach(function (d, i) {
+          if (verified[i]) {
+            if (current[vi]) currentInFound[i] = true;
+            vi++;
+          }
+        });
+        return Promise.all(found.map(function (d, i) {
+          // Verify first, expiry second. A forged line's expiry is whatever the forger typed,
+          // so reporting it as merely "expired" would dignify a signature that was never this
+          // key's in the first place.
+          return verifyDelegation(root, d).then(
+            function (ok) {
+              return { d: d, state: !ok ? 'forged'
+                                        : !DIGITS_RE.test(d.expires) ? 'expired'
+                                        : Number(d.expires) <= now ? 'expired'
+                                        : currentInFound[i] ? 'live' : 'superseded' };
+            },
+            function () { return { d: d, state: 'forged' }; }
+          );
+        }));
+      });
     }).then(renderDelegations, function (e) {
       renderDelegations([]);
       fail('could not read delegations — ' + String(e.message || e));

--- a/tests/unit/test_delegation.py
+++ b/tests/unit/test_delegation.py
@@ -288,6 +288,29 @@ def test_putting_a_superseded_grant_back_does_not_restore_it(sign, capsys):
     assert "SUPERSEDED " + agent_did + " *" in out
 
 
+def test_a_forged_record_cannot_supersede_a_valid_one(sign, capsys):
+    """The note is world-writable, so anyone can append a record with a higher nonce and a
+    bad signature. newest() ranks by nonce across ALL records, including forged ones, so
+    without a signature filter the forged record's higher nonce suppresses the real grant
+    as SUPERSEDED — and check_note reports 0 live delegations instead of 1.
+
+    The fix: only records whose signatures verify may compete in newest().
+    """
+    root, agent = _key(ROOT_SEED), _key(AGENT_SEED)
+    agent_did = sign.did_of(agent)
+    real = _line(sign, root, agent_did, scope="*", nonce="5")
+    forged = (
+        f"{sign.DELEGATE_TOKEN} {agent_did} r:lobby 9999999999 999 "
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    )
+
+    assert sign.check_note(sign.did_of(root), f"{real} {forged}") == 1
+    out = capsys.readouterr().out
+    assert "OK         " + agent_did + " *" in out
+    assert "FORGED" in out
+    assert "SUPERSEDED" not in out
+
+
 def test_superseding_is_per_agent_and_never_across_them(sign, capsys):
     """A high nonce for one agent must not retire another agent's grant. Two agents, two
     live delegations, whatever the nonces look like beside each other."""
@@ -316,6 +339,10 @@ def test_the_page_supersedes_and_replaces_the_same_way(page, sign):
     assert "rank >= best[agent][0]" in _signer_source()
     # And the publish path drops the agent's previous grant rather than appending to it.
     assert "withoutAgent(previous, agent)" in page
+    # Both sides verify before ranking, so a forged record with a high nonce cannot
+    # suppress a real grant. See test_a_forged_record_cannot_supersede_a_valid_one.
+    assert "verifiedRecords" in page
+    assert "verified = [i for i in ok if i >= 0]" in _signer_source()
 
 
 def _signer_source() -> str:


### PR DESCRIPTION
## What

`newest()` ranked all delegation records by nonce, including forged ones whose signatures do not verify. A forged record with a higher nonce in a world-writable note suppressed a valid delegation as SUPERSEDED, causing `check_note` to report 0 live delegations instead of 1. The same bug existed in the browser-side `loadDelegations`.

## Why

The DID note is world-writable, so anyone can append a record with a higher nonce and a bad signature. The forged record is correctly reported as FORGED, but the real delegation it outranks was reported as SUPERSEDED instead of OK. This lets an attacker suppress any delegation by writing a forged record with a higher nonce to the note.

## How

Verify all signatures before calling `newest()`, so only verified records compete in the nonce ranking. In `scripts/sign.py`, cache verification results in `ok[]` and filter `newest()` input to verified records, avoiding double verification. In `src/humans.html`, add a first `Promise.all` round to verify all records before ranking, then map indices back for the reporting round.

Fixes #782.

## Checks

- `uv run ruff check .` and `uv run ruff format --check .` pass
- `uv run ty check` passes
- `uv run coverage run -m pytest tests -q` 771 passed, 1 skipped
- `uv run coverage report` 97.90%
- `uv run sz.py --check` 2317 <= 2317
- `node tests/humans_ui_probe.mjs 8099` 138/138 checks passed (with fresh CHAT_ROOT)
- Regression test `test_a_forged_record_cannot_supersede_a_valid_one` fails before fix, passes after

## Note

PR #728 fixes a different bug in the same function (nonce precision via `Number()` vs `BigInt()`). The two fixes are independent but will likely conflict on merge since both modify `newest()` callers and `tests/unit/test_delegation.py`.