### PR TITLE
fix(manifest): XML-escape public URL in sitemap_xml

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -23,6 +23,7 @@ import base64
 import hashlib
 import re
 from datetime import UTC, datetime, timedelta
+from xml.sax.saxutils import escape as _xml_escape
 
 import config
 import didkey
@@ -2067,7 +2068,7 @@ def sitemap_xml(base: str) -> str:
     cannot fall back to relative paths. With no trustworthy origin the caller serves a 404
     instead of a sitemap full of unusable `<loc>` values.
     """
-    locs = "".join(f"  <url><loc>{_url(base, p)}</loc></url>\n" for p in SITEMAP_PATHS)
+    locs = "".join(f"  <url><loc>{_xml_escape(_url(base, p))}</loc></url>\n" for p in SITEMAP_PATHS)
     return (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'

--- a/tests/unit/test_bug_582_sitemap_escape.py
+++ b/tests/unit/test_bug_582_sitemap_escape.py
@@ -1,0 +1,10 @@
+"""Regression test for #582: sitemap_xml must XML-escape the public URL."""
+
+from manifest import sitemap_xml
+
+
+def test_sitemap_xml_escapes_ampersand():
+    """An & in CHAT_PUBLIC_URL must become &amp; in the sitemap."""
+    xml = sitemap_xml("https://example.com?a=1&b=2")
+    assert "&amp;" in xml, "bare & must be escaped as &amp;"
+    assert "?a=1&b=2" not in xml, "bare & must not appear in <loc>"


### PR DESCRIPTION
Fixes #582.

sitemap_xml() interpolated CHAT_PUBLIC_URL into <loc> elements without escaping an & in the URL produces malformed XML that validating crawlers reject. Now escaped via xml.sax.saxutils.escape.

One import, one line change, one regression test. Verified against 45921c3.