### PR TITLE
fix(mcp): reject swept-empty allow-list before signing challenge

### DIFF
--- a/mcp/src/technocore_mcp/server.py
+++ b/mcp/src/technocore_mcp/server.py
@@ -674,6 +674,14 @@ async def set_room_allow(
 ) -> str:
     minted = signing.next_nonce()
     swept = signing.sweep(dids)
+    if not swept and _signer is None and did is None and sig is None and nonce is None:
+        # A no-key caller receives the exact canonical string from _resolve_signature. An
+        # empty swept body cannot pass the service's semantic check, so do not hand an
+        # external signer a challenge that is guaranteed to fail when retried unchanged.
+        raise ToolError(
+            "empty allow-list: nothing visible was left after the single-line sweep. "
+            "Provide at least one space-separated did:key."
+        )
     did, sig, nonce = _resolve_signature(
         f"room-allow|{room}|{minted}|{swept}", did, sig, nonce, minted
     )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1069,6 +1069,37 @@ def test_configured_key_leaves_empty_text_refusal_to_the_service(mcp, monkeypatc
     assert mcp.sent, "configured-signing mode must reach the service"
 
 
+def test_no_key_does_not_issue_an_unusable_empty_allow_list_challenge(mcp, monkeypatch):
+    """Whitespace/control-only input is rejected before challenge generation.
+
+    The service refuses the swept-empty body. Returning a challenge ending in an empty
+    allow-list field would ask an external signer to sign a request that cannot succeed
+    when retried unchanged.
+    """
+    monkeypatch.setattr(mcp.module, "_signer", None)
+
+    reply = mcp.call("set_room_allow", {"room": "d-room", "dids": " \n\t "})
+
+    assert reply.is_error is True
+    message = text_of(reply)
+    assert "empty allow-list" in message
+    assert "nothing visible was left" in message
+    assert "room-allow|" not in message
+
+
+def test_configured_key_leaves_empty_allow_list_refusal_to_the_service(mcp, monkeypatch):
+    """Only challenge mode rejects swept-empty input locally; a configured signer still
+    sends the request so the service remains the authority for its semantic refusal."""
+    with_key(mcp, monkeypatch)
+    mcp.call("claim_room", {"room": "d-room"})
+
+    reply = mcp.call("set_room_allow", {"room": "d-room", "dids": " \n\t "})
+
+    assert reply.is_error is True
+    assert "empty text" in text_of(reply)
+    assert mcp.sent, "configured-signing mode must reach the service"
+
+
 def test_whoami_reports_the_identity_without_touching_the_network(mcp, monkeypatch):
     async def never(method, url, headers, body, timeout):
         raise AssertionError(f"the network was reached: {url}")


### PR DESCRIPTION
## What

When `set_room_allow` receives a `dids` parameter that becomes empty after the MCP signing sweep (such as whitespace or control characters only), it now raises `ToolError` before `_resolve_signature()` can issue an external-signing challenge.

## Why

Follows on from the identical fix in #761 for `say_signed`. Without this early check, a caller without a configured signing key receives an external-signing challenge of the form `room-allow|<room>|<minted>|`. An allow-list swept empty cannot pass the service's semantic check (which rejects empty allow-lists with 400), handing an external signer a challenge guaranteed to fail when signed and retried unchanged.

Callers with a configured key continue to pass the payload through so the service remains the authoritative source for refusal.

## Proposed Release Note

- **`set_room_allow` in the MCP wrapper refuses an allow-list the sweep leaves empty**, instead of issuing an external-signing challenge that could never succeed.

## Checks

- [x] `pytest tests/test_mcp.py` passes (75 passed).
- [x] `python3 sz.py --caps && python3 sz.py --check` passes.
- [x] `python3 -m compileall -q mcp/src/technocore_mcp tests/test_mcp.py` and `git diff --check` pass.
- [x] Line lengths are within the 100-character limit.
- [x] New surface on a world-writable service: nothing new.