### PR TITLE
test(edge): assert every edge-served path is routed to the Worker

### DIFF
--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -74,6 +74,24 @@ def test_every_routed_path_is_either_snapshotted_or_deliberately_not():
     assert _wrangler_routes() - accounted == set()
 
 
+def test_every_edge_served_path_is_routed_to_the_worker():
+    """The third direction: a path in EDGE_CACHED, EDGE_REVALIDATE, or EDGE_ONLY that the
+    Worker never sees is a dead lane. The path was declared edge-served, but no wrangler
+    route delivers it, so every request falls through to the origin — the one thing the
+    lane exists to avoid.
+
+    The two tests above cover PATHS <= routes and routes <= accounted, but neither checks
+    that the three edge lanes are themselves routed. EDGE_REVALIDATE paths are not in PATHS
+    (they are live reads, not snapshots), so the PATHS <= routes test does not cover them.
+    """
+    snapshot = _snapshot_module()
+    edge_served = (
+        set(snapshot.EDGE_CACHED) | set(snapshot.EDGE_REVALIDATE) | set(snapshot.EDGE_ONLY)
+    )
+    unrouted = edge_served - _wrangler_routes()
+    assert not unrouted, f"edge paths not routed to the Worker: {sorted(unrouted)}"
+
+
 def test_a_liveness_path_is_never_snapshotted():
     """The invariant the third lane exists to hold.
 


### PR DESCRIPTION
## What

The routing tests in `tests/edge/test_edge_worker.py` checked two directions:
- `PATHS <= wrangler_routes` (every snapshotted path is routed)
- `wrangler_routes <= accounted` (every routed path is accounted for)

But neither checked that `EDGE_CACHED`, `EDGE_REVALIDATE`, or `EDGE_ONLY` paths are themselves routed. A path added to any of those sets without a wrangler route would pass all tests but be silently unrouted (dead lane).

## Why

`EDGE_REVALIDATE` paths (`/rooms`) are not in `PATHS`, so the `PATHS <= routes` test does not cover them. `EDGE_CACHED` and `EDGE_ONLY` paths are in the `accounted` set, but the `routes <= accounted` direction only catches routes that aren't accounted for, not accounted paths that aren't routed.

A path declared edge-served but not routed means every request falls through to the origin, which is the one thing the edge lane exists to avoid.

## How

Added `test_every_edge_served_path_is_routed_to_the_worker` asserting `EDGE_CACHED | EDGE_REVALIDATE | EDGE_ONLY <= wrangler_routes`.

Fixes #787.

## Checks

- `uv run ruff check .` and `uv run ruff format --check .` pass
- `uv run ty check` passes
- `uv run coverage run -m pytest tests -q` 771 passed, 1 skipped
- `uv run coverage report` 97.90%
- `uv run sz.py --check` 2317 <= 2317
- Negative verification: test fails when a fake path is added to EDGE_CACHED, EDGE_REVALIDATE, or EDGE_ONLY without a wrangler route