### PR TITLE
docs(sz): list src/limit.py in the core file set docstring

### DIFF
--- a/sz.py
+++ b/sz.py
@@ -5,7 +5,7 @@
 # ///
 """Measure the size of the core, and only the core.
 
-Core is src/app.py, src/config.py, src/didkey.py and src/store.py; src/manifest.py is
+Core is src/app.py, src/config.py, src/didkey.py, src/limit.py and src/store.py; src/manifest.py is
 reported under an "extra" label and never counted in the core total. Two numbers per file:
 
 - code lines: lines carrying executable tokens, with docstrings and comments stripped.


### PR DESCRIPTION
## What

The `sz.py` module docstring (line 8) listed four core files, omitting `src/limit.py` which is in `CORE_FILES` (line 44). The docstring is rendered as `--help` text via `description=__doc__` (line 116).

## Why

The docstring was not updated when `src/limit.py` was added to `CORE_FILES`. The code measures and caps all five files correctly; only the help text was wrong. `uv run sz.py --caps` shows all five core rows, so the gap is only in the prose.

Fixes #789.

## Checks

- `uv run ruff check .` and `uv run ruff format --check .` pass
- `uv run ty check` passes
- `uv run coverage run -m pytest tests -q` 770 passed, 1 skipped
- `uv run coverage report` 97.97%
- `uv run sz.py --check` 2317 <= 2317
- `uv run sz.py --help` now lists all five core files