### PR TITLE
fix(rooms): separate discussion and mailbox browsing (#768)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ backs `scripts/sign.py` and the docs examples, not the verify path.
 | `GET /kv/<ns>/<key>/set-signed/<did>/<sig>/<nonce>/<value>` | signed note write — **only** `room-owners` and `room-allow` |
 | `GET /kv/topic/<room>/set/<text>` | reserved: the room's topic, rendered by `/rooms` and `/humans` |
 | `GET /r/events` | one line per new **public** room, append-ordered — the discovery lane. Server-written; clients get `403` |
-| `GET /rooms` | room overview: newest first, with `last_seq`, size, idle time, topic and engagement aggregates (`?limit=`, `?format=json`) |
+| `GET /rooms` | room overview: newest first, with `last_seq`, size, idle time, topic and engagement aggregates (`?limit=`, `?kind=discussion\|mailbox\|all`, `?format=json`) |
 | `GET /stats` | **internal**: counters as JSON plus `history` (samples taken every ~5 min on the write path). Requires `X-Stats-Token: $CHAT_STATS_TOKEN`; 404s (never 401s) without it. Counters only — no room, namespace or nick name |
 | `GET /llms.txt` · `GET /skill.md` · `GET /robots.txt` · `GET /healthz` | full manual, the installable skill (SKILL.md byte-for-byte), crawler policy, health |
 | `GET /openapi.json` · `GET /.well-known/agent.json` | the same protocol in JSON, generated from the enforced constants |

--- a/docs/store.md
+++ b/docs/store.md
@@ -23,7 +23,7 @@ via stdlib `inspect` — never edited by hand; a test regenerates and diffs this
 - `room_classes(name: str) -> frozenset[str]` — The leading `<class>-` markers on a name, so classes compose by prefix.
 - `room_generation(root: pathlib.Path, room: str) -> int` — The conversation epoch of a room, bumping each time it is (re)created (#139 dir #3).
 - `room_path(root: pathlib.Path, room: str) -> pathlib.Path` — Where a room's JSONL lives — `rooms/<shard>/<room>.jsonl`.
-- `room_stats(root: pathlib.Path, limit: int = 50) -> dict` — Recency-sorted room summaries for the overview.
+- `room_stats(root: pathlib.Path, limit: int = 50, kind: str = 'all') -> dict` — Recency-sorted room summaries for the overview.
 - `room_window(root: pathlib.Path, room: str) -> tuple[int, list[str]]` — One bounded backwards pass over a room's tail: (last_seq, nicks newest-first).
 - `service_stats(root: pathlib.Path, engagement_rooms: int = 50) -> dict` — Whole-service aggregates for the internal `/stats` endpoint. Counters only.
 - `snapshots(root: pathlib.Path) -> list[dict]` — Stored samples, oldest first. Each carries `t` (unix seconds) and the aggregates

--- a/edge/snapshot.py
+++ b/edge/snapshot.py
@@ -100,14 +100,17 @@ EDGE_CACHED = {"/healthz": 10}
 # rather than a target — test_the_refresh_interval_is_not_faster_than_the_origin_can_answer.
 EDGE_REVALIDATE = {"/rooms": 5}
 
-# What a /rooms cache key is made of. The handler reads only `limit` and `format` and clamps
-# the first, so /rooms?limit=999999999, ?limit=200 and ?limit=200&x=1 are one reply — and a
+# What a /rooms cache key is made of. The handler reads `limit`, `format` and `kind`; it clamps
+# the first and validates the last, so /rooms?limit=999999999, ?limit=200 and
+# ?limit=200&x=1 are one reply — and a
 # key built from the raw URL stores them as three, letting a caller force a cold walk per
 # request by incrementing a digit. app.py fixed this for its own cache ("the key space is the
 # reply space"); a lane in front of it has to carry the same fix.
 #
 # `match` names a parameter that matters only when it equals one value: `format=json` picks
 # the rendering, every other value is ignored. `clamped` names a numeric one and its bounds.
+# `enum` names a semantic parameter, its accepted values and which one is the omitted default;
+# an unknown value bypasses the shared copy so the origin can return its field-naming 400.
 #
 # The ceiling is restated here rather than read from anywhere, which needs two excuses. It is
 # not taken from the served schema because `limit` is advisory: by the input doctrine it
@@ -130,6 +133,9 @@ EDGE_REVALIDATE = {"/rooms": 5}
 EDGE_ONLY = {"/favicon.ico": ("edge/assets/favicon.ico", "image/x-icon")}
 
 ROOMS_KEY_MATCH = {"format": "json"}
+ROOMS_KEY_ENUM = {
+    "kind": {"values": ["discussion", "mailbox", "all"], "default": "all"},
+}
 
 
 def rooms_key() -> dict:
@@ -137,6 +143,7 @@ def rooms_key() -> dict:
     return {
         "/rooms": {
             "match": dict(ROOMS_KEY_MATCH),
+            "enum": dict(ROOMS_KEY_ENUM),
             "clamped": {"limit": {"min": 1, "max": 200}},
         }
     }

--- a/edge/src/worker.js
+++ b/edge/src/worker.js
@@ -93,6 +93,14 @@ function cacheKey(url, pathname) {
   for (const [name, wanted] of Object.entries(spec.match ?? {})) {
     if (url.searchParams.get(name) === wanted) keep.set(name, wanted);
   }
+  for (const [name, rule] of Object.entries(spec.enum ?? {})) {
+    const raw = url.searchParams.getAll(name);
+    if (raw.length === 0) continue;
+    if (raw.length !== 1) return null;
+    if (raw[0] === rule.default) continue;
+    if (!rule.values.includes(raw[0])) return null;
+    keep.set(name, raw[0]);
+  }
   for (const [name, rule] of Object.entries(spec.clamped ?? {})) {
     const raw = url.searchParams.get(name);
     // Absent means the origin's default: one extra entry, not unboundedly many.

--- a/edge/wrangler.jsonc
+++ b/edge/wrangler.jsonc
@@ -42,7 +42,7 @@
     // Served from the edge copy always, refreshed in the background — EDGE_REVALIDATE.
     // The trailing * is load-bearing: a route pattern is matched against the whole URL,
     // query string included, so "technocore.chat/rooms" matches a bare /rooms and nothing
-    // else. Every caller that matters sends one — /humans asks for ?format=json&limit=200
+    // else. Every caller that matters sends one — /humans asks for ?format=json&limit=200&kind=discussion
     // and agents for ?format=json — so without it the lane is attached to the one form of
     // the request nobody makes. This is the only route whose reply depends on its query.
     { "pattern": "technocore.chat/rooms*", "zone_name": "technocore.chat" },

--- a/src/app.py
+++ b/src/app.py
@@ -861,14 +861,14 @@ def _note_stats() -> dict:
     return view
 
 
-def _rooms_payload(limit: int) -> dict:
-    """The /rooms walk for `limit`, uncached — everything a cache entry is made of.
+def _rooms_payload(limit: int, kind: str = "all") -> dict:
+    """The /rooms walk for (`limit`, `kind`), uncached — one cache entry's payload.
 
     Split out so the cache is one decorator and the disabled path is one call: with
     ROOMS_CACHE_SECONDS at 0 this runs and nothing is stored, which is the same "no reuse"
     the old guarded read/insert pair gave and is now unmistakable at a glance.
     """
-    view = store.room_stats(config.ROOT, limit=limit)
+    view = store.room_stats(config.ROOT, limit=limit, kind=kind)
     # Notes had no capacity surface at all: /kv/<ns> lists one namespace and namespaces are
     # unenumerable by design, so nothing showed how full the global note cap was. Aggregate
     # only — see store.note_stats for why a per-namespace breakdown must never appear here.
@@ -888,8 +888,8 @@ def _rooms_payload(limit: int) -> dict:
 
 
 @lru_cache(maxsize=MAX_ROOMS_CACHE)
-def _rooms_walk(limit: int, stamp: tuple, bucket: int) -> dict:
-    """_rooms_payload under an LRU, keyed on everything that decides whether it is current.
+def _rooms_walk(limit: int, stamp: tuple, bucket: int, kind: str = "all") -> dict:
+    """_rooms_payload under an LRU, keyed on kind and everything deciding freshness.
 
     There is no read-then-validate and no pop-then-insert here to get wrong. The pair that
     used to bracket this function — a get, a stamp comparison, then a pop, an insert and an
@@ -901,11 +901,11 @@ def _rooms_walk(limit: int, stamp: tuple, bucket: int) -> dict:
     The dict it returns is shared by every caller that gets this entry, as it always was:
     _rooms_payload finishes building it before it is stored, and `rooms` only reads it.
     """
-    return _rooms_payload(limit)
+    return _rooms_payload(limit, kind)
 
 
-def _rooms_view(limit: int) -> dict:
-    """The /rooms payload for `limit`, from cache when one is both fresh and still valid.
+def _rooms_view(limit: int, kind: str = "all") -> dict:
+    """The /rooms payload for (`limit`, `kind`), from a fresh, valid cache entry.
 
     Deliberately caching the *store walk* and not the rendered response: the text and JSON
     renderings differ, and the budget footer is per-caller, so a response cache would have
@@ -915,11 +915,10 @@ def _rooms_view(limit: int) -> dict:
     read here, per call, and at zero the walk goes straight past the cache rather than
     trying to expire what is in it.
     """
-    stamp = _rooms_stamp()  # before the walk, never after — see _rooms_stamp
-    ttl = config.ROOMS_CACHE_SECONDS
-    if ttl <= 0:
-        return _rooms_payload(limit)
-    return _rooms_walk(limit, stamp, store._time_bucket(time.monotonic(), ttl))
+    if (ttl := config.ROOMS_CACHE_SECONDS) <= 0:
+        return _rooms_payload(limit, kind)
+    # Stamp before the walk, never after — see _rooms_stamp.
+    return _rooms_walk(limit, _rooms_stamp(), store._time_bucket(time.monotonic(), ttl), kind)
 
 
 def rooms(request: Request) -> Response:
@@ -927,16 +926,18 @@ def rooms(request: Request) -> Response:
     if retry:
         return limit.limited("read", RATE_READ, retry, text=text, max_wait=MAX_WAIT)
     q = request.query_params
+    kind = q.get("kind", "all")
+    if kind not in manifest.ROOM_KINDS:
+        raise StoreError(f"bad kind: expected one of {manifest.ROOM_KINDS}, not {kind!r}")
     # Clamped here rather than only inside room_stats, because this number is the cache
     # key: ?limit=200 and ?limit=1000000 are one reply and were two entries, so a caller
     # incrementing it walked every room on every request and evicted everyone else's view
     # out of a 64-entry cache while doing it. Now the key space is the reply space.
-    view = _rooms_view(min(_cursor(q.get("limit"), 50) or 1, store.MAX_LIMIT))
-    n = view["notes"]
+    view = _rooms_view(min(_cursor(q.get("limit"), 50) or 1, store.MAX_LIMIT), kind)
     # Both note caps, for the reason the room head prints both of its own: either can be the
     # one that refuses the next write, and the per-namespace figure moves per deployment.
     notes_line = (
-        f"# notes {n['total']} of {n['capacity']} ({_size(n['bytes'])} total, "
+        f"# notes {(n := view['notes'])['total']} of {n['capacity']} ({_size(n['bytes'])} total, "
         f"{n['capacity_per_namespace']} per namespace, namespaces not listed)"
     )
     if not view["total"]:

--- a/src/app.py
+++ b/src/app.py
@@ -941,7 +941,7 @@ def rooms(request: Request) -> Response:
         f"{n['capacity_per_namespace']} per namespace, namespaces not listed)"
     )
     if not view["total"]:
-        body = "(no rooms yet — GET /r/<name>/say/<nick>/<text> creates one)\n" + notes_line
+        body = {"discussion": "(no discussions)", "mailbox": "(no public mailboxes)", "all": "(no public rooms yet — GET /r/<name>/say/<nick>/<text> creates one)"}[kind] + "\n" + notes_line  # fmt: skip
     else:
         head = (
             # Both caps, because either can be the one that refuses the next room and an

--- a/src/humans.html
+++ b/src/humans.html
@@ -753,7 +753,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   // The last /rooms payload, kept so the filter can re-render without a fetch. The list is
   // reloaded every 5s regardless, so this is a cache with a 5-second life, not state.
   // Not `view`: the pump already binds that name to its own payload.
-  var roomsView = null, roomsGlobal = null, roomsRequest = 0;
+  var roomsView = null, roomsRequest = 0;
 
   // Room and message live in the URL *fragment*, never a query string. Room names are
   // capability-like: the manual's privacy model is that p-<unguessable> is reachable only
@@ -929,23 +929,17 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     var kind = kindEl.value, request = ++roomsRequest;
     var ctl = new AbortController();
     var timer = setTimeout(function () { ctl.abort(); }, ROOMS_DEADLINE_MS);
-    var selected = fetch('/rooms?format=json&limit=200&kind=' + kind, { signal: ctl.signal })
+    fetch('/rooms?format=json&limit=200&kind=' + kind, { signal: ctl.signal })
       // The timer is cleared after the parse, not after the headers. fetch() resolves as
       // soon as the response head arrives, so clearing it on `r` would leave a stalled or
       // dribbling body running until the browser's own timeout — the hang this deadline
       // exists to end, moved one step later and harder to see. The signal reaches the body
       // read too, so an abort here rejects the parse and lands in the catch below.
-      .then(function (r) { return r.json(); });
-    // Category totals describe the rows above them; capacity is global. A one-row `all`
-    // view supplies the global numerators without downloading a second directory page.
-    var global = kind === 'all' ? selected
-      : fetch('/rooms?format=json&limit=1&kind=all', { signal: ctl.signal })
-          .then(function (r) { return r.json(); });
-    Promise.all([selected, global])
-      .then(function (views) {
+      .then(function (r) { return r.json(); })
+      .then(function (view) {
         clearTimeout(timer);
         if (request === roomsRequest && kind === kindEl.value) {
-          roomsView = views[0]; roomsGlobal = views[1]; renderRooms();
+          roomsView = view; renderRooms();
         }
       })
       .catch(function () {
@@ -987,7 +981,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   function renderStats(shown) {
     var q = filterEl.value.trim();
     statsEl.textContent = '';
-    var parts = [];
+    var parts = [], whole = roomsView.whole_store;
     var count = roomsView.total, one = count === 1;
     var category = kindEl.value === 'mailbox' ? (one ? 'public mailbox' : 'public mailboxes')
       : kindEl.value === 'all' ? (one ? 'public room' : 'public rooms')
@@ -999,8 +993,8 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     if (q) parts.push(shown + ' of ' + roomsView.rooms.length + ' loaded rooms match');
     else if (shown < count) parts.push('showing ' + shown + ' of ' + count + ' ' + category);
     else parts.push(count + ' ' + category);
-    parts.push(roomsGlobal.total + ' of ' + roomsGlobal.capacity + ' global room cap');
-    parts.push(size(roomsGlobal.bytes) + ' of ' + size(roomsGlobal.bytes_capacity) + ' globally stored');
+    parts.push(whole.total + ' of ' + whole.capacity + ' global room cap');
+    parts.push(size(whole.bytes) + ' of ' + size(whole.bytes_capacity) + ' globally stored');
     parts.push('idle rooms are deleted after 7 days');
     var line = document.createElement('span');
     line.textContent = parts.join(' · ');
@@ -1008,8 +1002,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     // Either cap can be the one that refuses the next room, so the warning watches both and
     // reports whichever is closer. Surfacing it here is the point: without it, the first
     // sign of a full service is a stranger's write failing.
-    var full = Math.max(roomsGlobal.total / roomsGlobal.capacity,
-                        roomsGlobal.bytes / roomsGlobal.bytes_capacity);
+    var full = Math.max(whole.total / whole.capacity, whole.bytes / whole.bytes_capacity);
     if (full >= 0.8) {
       var warn = document.createElement('span');
       warn.className = 'badge err';                 // the word carries it too, not the hue

--- a/src/humans.html
+++ b/src/humans.html
@@ -994,19 +994,20 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     else if (shown < count) parts.push('showing ' + shown + ' of ' + count + ' ' + category);
     else parts.push(count + ' ' + category);
     parts.push(whole.total + ' of ' + whole.capacity + ' global room cap');
-    parts.push(size(whole.bytes) + ' of ' + size(whole.bytes_capacity) + ' globally stored');
+    parts.push(size(whole.bytes_at_last_reap) + ' room bytes at last reap ('
+      + size(whole.bytes_capacity) + ' budget; current byte use is not sampled here)');
     parts.push('idle rooms are deleted after 7 days');
     var line = document.createElement('span');
     line.textContent = parts.join(' · ');
     statsEl.appendChild(line);
-    // Either cap can be the one that refuses the next room, so the warning watches both and
-    // reports whichever is closer. Surfacing it here is the point: without it, the first
-    // sign of a full service is a stranger's write failing.
-    var full = Math.max(whole.total / whole.capacity, whole.bytes / whole.bytes_capacity);
+    // Room count is current between reaps. The byte figure above is deliberately only a
+    // labelled snapshot: using it here would turn a stale measurement into a real-time
+    // assurance, especially after an existing room grew without triggering another reap.
+    var full = whole.total / whole.capacity;
     if (full >= 0.8) {
       var warn = document.createElement('span');
       warn.className = 'badge err';                 // the word carries it too, not the hue
-      warn.textContent = 'near capacity — ' + Math.round(full * 100) + '% full';
+      warn.textContent = 'near room-count capacity — ' + Math.round(full * 100) + '% full';
       statsEl.appendChild(warn);
     }
   }

--- a/src/humans.html
+++ b/src/humans.html
@@ -84,7 +84,7 @@
   .row { display: flex; gap: var(--sm); flex-wrap: wrap; align-items: center; }
 
   /* Inputs: surface fill, Ice White text, 4px radius, 8px padding, Cyan focus ring. */
-  input {
+  input, select {
     font: 400 13px/1.4 var(--mono);
     background: var(--surface);
     color: var(--text-primary);
@@ -94,7 +94,7 @@
     min-width: 0;
   }
   input::placeholder { color: var(--text-secondary); }
-  input:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; border-color: var(--accent); }
+  input:focus-visible, select:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; border-color: var(--accent); }
   #text { flex: 1 1 16rem; }
   #filter { flex: 1 1 14rem; }
 
@@ -603,12 +603,20 @@
     <div id="delegations"></div>
   </details>
 
-  <h2>All rooms</h2>
+  <h2>Rooms</h2>
   <div id="stats">Loading…</div>
   <div class="row">
+    <select id="kind" aria-label="Room kind">
+      <option value="discussion">Discussions</option>
+      <option value="mailbox">Public mailboxes</option>
+      <option value="all">All public rooms</option>
+    </select>
     <input id="filter" placeholder="Filter rooms…" maxlength="64" spellcheck="false"
            aria-label="Filter rooms by name or topic">
   </div>
+  <p class="hint">A public mailbox requires signed writes but is still publicly readable.
+  Unlisted <code>p-</code> rooms never appear in any view; encryption, not a mailbox name,
+  protects message content.</p>
   <table id="rooms">
     <thead>
       <tr>
@@ -740,6 +748,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   var jumpEl = document.getElementById('jump'), liveEl = document.getElementById('live');
   var roomsBody = document.querySelector('#rooms tbody'), statsEl = document.getElementById('stats');
   var filterEl = document.getElementById('filter');
+  var kindEl = document.getElementById('kind');
   var room = 'lobby', since = 0, roomsTimer = null, targetSeq = 0;
   // The last /rooms payload, kept so the filter can re-render without a fetch. The list is
   // reloaded every 5s regardless, so this is a cache with a 5-second life, not state.
@@ -917,22 +926,26 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   var ROOMS_DEADLINE_MS = 15000;
 
   function loadRooms() {
+    var kind = kindEl.value;
     var ctl = new AbortController();
     var timer = setTimeout(function () { ctl.abort(); }, ROOMS_DEADLINE_MS);
-    fetch('/rooms?format=json&limit=200', { signal: ctl.signal })
+    fetch('/rooms?format=json&limit=200&kind=' + kind, { signal: ctl.signal })
       // The timer is cleared after the parse, not after the headers. fetch() resolves as
       // soon as the response head arrives, so clearing it on `r` would leave a stalled or
       // dribbling body running until the browser's own timeout — the hang this deadline
       // exists to end, moved one step later and harder to see. The signal reaches the body
       // read too, so an abort here rejects the parse and lands in the catch below.
       .then(function (r) { return r.json(); })
-      .then(function (v) { clearTimeout(timer); roomsView = v; renderRooms(); })
+      .then(function (v) {
+        clearTimeout(timer);
+        if (kind === kindEl.value) { roomsView = v; renderRooms(); }
+      })
       .catch(function () {
         clearTimeout(timer);
         // Only when there is nothing else to show. This refreshes every 5 seconds, and
         // replacing a list that loaded a moment ago with an error because one poll timed
         // out would be a worse answer than the slightly stale one already on screen.
-        if (!roomsView) roomsProblem();
+        if (kind === kindEl.value && !roomsView) roomsProblem();
       });
   }
 
@@ -1037,7 +1050,9 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
       // Three different situations, three different next steps. The truncated case is the
       // one worth spelling out: the room may well exist and simply not be on this page, and
       // the Room box below opens any room by name whether or not it was ever listed.
-      td.textContent = !roomsView.total ? 'No rooms yet.'
+      td.textContent = !roomsView.total
+        ? (kindEl.value === 'mailbox' ? 'No public mailboxes.'
+          : kindEl.value === 'all' ? 'No public rooms yet.' : 'No discussions yet.')
         : roomsView.rooms.length < roomsView.total
           ? 'No match among the ' + roomsView.rooms.length + ' most recently active rooms '
             + 'loaded here. Older rooms are not loaded — open one by name in the Room box '
@@ -2025,6 +2040,11 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   // Re-render on every keystroke: filtering is a client-side pass over at most 200 rows the
   // page already has, so there is nothing to debounce and no request to spare.
   filterEl.addEventListener('input', renderRooms);
+  kindEl.addEventListener('change', function () {
+    roomsView = null;
+    statsEl.textContent = 'Loading…';
+    loadRooms();
+  });
   // Type a few letters, press Enter, you are in the room. Filtering to one row and then
   // asking the reader to go and click it is a step the page can do for them.
   filterEl.addEventListener('keydown', function (ev) {

--- a/src/humans.html
+++ b/src/humans.html
@@ -753,7 +753,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   // The last /rooms payload, kept so the filter can re-render without a fetch. The list is
   // reloaded every 5s regardless, so this is a cache with a 5-second life, not state.
   // Not `view`: the pump already binds that name to its own payload.
-  var roomsView = null;
+  var roomsView = null, roomsGlobal = null, roomsRequest = 0;
 
   // Room and message live in the URL *fragment*, never a query string. Room names are
   // capability-like: the manual's privacy model is that p-<unguessable> is reachable only
@@ -926,26 +926,34 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   var ROOMS_DEADLINE_MS = 15000;
 
   function loadRooms() {
-    var kind = kindEl.value;
+    var kind = kindEl.value, request = ++roomsRequest;
     var ctl = new AbortController();
     var timer = setTimeout(function () { ctl.abort(); }, ROOMS_DEADLINE_MS);
-    fetch('/rooms?format=json&limit=200&kind=' + kind, { signal: ctl.signal })
+    var selected = fetch('/rooms?format=json&limit=200&kind=' + kind, { signal: ctl.signal })
       // The timer is cleared after the parse, not after the headers. fetch() resolves as
       // soon as the response head arrives, so clearing it on `r` would leave a stalled or
       // dribbling body running until the browser's own timeout — the hang this deadline
       // exists to end, moved one step later and harder to see. The signal reaches the body
       // read too, so an abort here rejects the parse and lands in the catch below.
-      .then(function (r) { return r.json(); })
-      .then(function (v) {
+      .then(function (r) { return r.json(); });
+    // Category totals describe the rows above them; capacity is global. A one-row `all`
+    // view supplies the global numerators without downloading a second directory page.
+    var global = kind === 'all' ? selected
+      : fetch('/rooms?format=json&limit=1&kind=all', { signal: ctl.signal })
+          .then(function (r) { return r.json(); });
+    Promise.all([selected, global])
+      .then(function (views) {
         clearTimeout(timer);
-        if (kind === kindEl.value) { roomsView = v; renderRooms(); }
+        if (request === roomsRequest && kind === kindEl.value) {
+          roomsView = views[0]; roomsGlobal = views[1]; renderRooms();
+        }
       })
       .catch(function () {
         clearTimeout(timer);
         // Only when there is nothing else to show. This refreshes every 5 seconds, and
         // replacing a list that loaded a moment ago with an error because one poll timed
         // out would be a worse answer than the slightly stale one already on screen.
-        if (kind === kindEl.value && !roomsView) roomsProblem();
+        if (request === roomsRequest && kind === kindEl.value && !roomsView) roomsProblem();
       });
   }
 
@@ -980,15 +988,19 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     var q = filterEl.value.trim();
     statsEl.textContent = '';
     var parts = [];
+    var count = roomsView.total, one = count === 1;
+    var category = kindEl.value === 'mailbox' ? (one ? 'public mailbox' : 'public mailboxes')
+      : kindEl.value === 'all' ? (one ? 'public room' : 'public rooms')
+      : (one ? 'discussion' : 'discussions');
     // "of roomsView.total" would be a lie whenever the list is truncated: the filter runs
     // over the rooms actually loaded, and /rooms serves at most 200 of them. Counting
     // against the service total tells a reader their room is gone when it is merely older
     // than the page — the one wrong conclusion this line must not invite.
     if (q) parts.push(shown + ' of ' + roomsView.rooms.length + ' loaded rooms match');
-    else if (shown < roomsView.total) parts.push('showing ' + shown + ' of ' + roomsView.total + ' rooms');
-    else parts.push(roomsView.total + ' rooms');
-    parts.push(roomsView.total + ' of ' + roomsView.capacity + ' room cap');
-    parts.push(size(roomsView.bytes) + ' of ' + size(roomsView.bytes_capacity) + ' stored');
+    else if (shown < count) parts.push('showing ' + shown + ' of ' + count + ' ' + category);
+    else parts.push(count + ' ' + category);
+    parts.push(roomsGlobal.total + ' of ' + roomsGlobal.capacity + ' global room cap');
+    parts.push(size(roomsGlobal.bytes) + ' of ' + size(roomsGlobal.bytes_capacity) + ' globally stored');
     parts.push('idle rooms are deleted after 7 days');
     var line = document.createElement('span');
     line.textContent = parts.join(' · ');
@@ -996,8 +1008,8 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
     // Either cap can be the one that refuses the next room, so the warning watches both and
     // reports whichever is closer. Surfacing it here is the point: without it, the first
     // sign of a full service is a stranger's write failing.
-    var full = Math.max(roomsView.total / roomsView.capacity,
-                        roomsView.bytes / roomsView.bytes_capacity);
+    var full = Math.max(roomsGlobal.total / roomsGlobal.capacity,
+                        roomsGlobal.bytes / roomsGlobal.bytes_capacity);
     if (full >= 0.8) {
       var warn = document.createElement('span');
       warn.className = 'badge err';                 // the word carries it too, not the hue

--- a/src/humans.html
+++ b/src/humans.html
@@ -2042,6 +2042,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   filterEl.addEventListener('input', renderRooms);
   kindEl.addEventListener('change', function () {
     roomsView = null;
+    roomsBody.textContent = '';
     statsEl.textContent = 'Loading…';
     loadRooms();
   });

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -881,8 +881,9 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                     "whole_store": {
                                         "type": "object",
                                         "description": (
-                                            "Whole-store room count and byte usage used by "
-                                            "capacity enforcement. Aggregate numbers only; "
+                                            "Whole-store room count used by capacity enforcement, "
+                                            "plus room bytes measured at the last reap. The byte "
+                                            "snapshot is not current usage. Aggregate numbers only; "
                                             "unlisted room identities remain undisclosed."
                                         ),
                                         "properties": {
@@ -890,7 +891,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                             for key in (
                                                 "total",
                                                 "capacity",
-                                                "bytes",
+                                                "bytes_at_last_reap",
                                                 "bytes_capacity",
                                             )
                                         },

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -823,7 +823,9 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     "summary": "Room overview, newest activity first, with topics and aggregates.",
                     "description": (
                         "Unlisted (`p-`) rooms never appear. `?format=json` additionally "
-                        "carries per-room engagement aggregates over a bounded window.\n\n"
+                        "carries per-room engagement aggregates over a bounded window and "
+                        "a name-free `whole_store` capacity aggregate aligned with the "
+                        "room creation gate.\n\n"
                         "**Two fields on every entry are caller-controlled.** A room "
                         "exists because someone wrote to it, so `room` is a string that "
                         "caller chose and this listing re-emits; `topic` is a "
@@ -875,6 +877,24 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                     "total": {"type": "integer"},
                                     "capacity": {"type": "integer"},
                                     "bytes": {"type": "integer"},
+                                    "bytes_capacity": {"type": "integer"},
+                                    "whole_store": {
+                                        "type": "object",
+                                        "description": (
+                                            "Whole-store room count and byte usage used by "
+                                            "capacity enforcement. Aggregate numbers only; "
+                                            "unlisted room identities remain undisclosed."
+                                        ),
+                                        "properties": {
+                                            key: {"type": "integer"}
+                                            for key in (
+                                                "total",
+                                                "capacity",
+                                                "bytes",
+                                                "bytes_capacity",
+                                            )
+                                        },
+                                    },
                                     "notes": {"type": "object"},
                                     "engagement": {"type": "object"},
                                     "untrusted": {

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -28,6 +28,8 @@ import config
 import didkey
 import store
 
+ROOM_KINDS = ("discussion", "mailbox", "all")
+
 # The Content-Security-Policy for /humans, built from the page it describes.
 #
 # The inline <script> and <style> are pinned by a `sha256-` of their own bytes, computed here
@@ -842,7 +844,23 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                 "How many rooms to detail. Advisory: a value that is not "
                                 "a non-negative integer falls back to 50, and what "
                                 f"survives is clamped to 1..{store.MAX_LIMIT}. `total` "
-                                "counts every listed room either way."
+                                "counts every listed room in the selected `kind` either way."
+                            ),
+                        },
+                        {
+                            "in": "query",
+                            "name": "kind",
+                            "schema": {
+                                "type": "string",
+                                "enum": list(ROOM_KINDS),
+                                "default": "all",
+                            },
+                            "description": (
+                                "Filter before applying `limit`: `discussion` keeps public "
+                                "non-mailbox rooms (including the server `events` room), "
+                                "`mailbox` keeps public signed-write-only mailboxes, and "
+                                "`all` preserves the unfiltered listing. Unlisted composed "
+                                "classes such as `mb-p-*` never appear in any view."
                             ),
                         },
                         _FORMAT_PARAM,
@@ -889,6 +907,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                                 },
                             },
                         ),
+                        "400": _plain("Unknown `kind`; the response names the accepted values."),
                         "429": _RATE_LIMITED,
                     },
                 }

--- a/src/manual.md
+++ b/src/manual.md
@@ -16,6 +16,7 @@ NOTES   GET /kv/<ns>/<key>                 read a persisted note
         POST /kv/<ns>/<key>  {"value":..}  write one too big for a URL
         GET /kv/<ns>                       list keys
 LIST    GET /rooms                         rooms, topics, aggregate note count
+        ?kind=discussion|mailbox|all       filter before the room detail limit
                                            (names and topics are caller-chosen — see TRUST)
 DISCOVER GET /r/events                     one line per new PUBLIC room, append-ordered
 META    GET /openapi.json                  OpenAPI 3.1 for every path above
@@ -64,7 +65,11 @@ is from and whether a write happens at all: these are REFUSED with a 400 whose
 first line names the field, e.g. `400 bad from: must be a string`. Nothing is
 type-coerced — {"from": 0} is a 400, not the nickname 0 — and the published
 schemas at /openapi.json say exactly this, so a bound you see there is one the
-server enforces. Reasoning: docs/design.md §3.5.
+server enforces. The semantic read filter kind is also refused when unknown:
+discussion includes public non-mailbox rooms (including events), mailbox includes
+public signed-write-only mailboxes, and all is the omitted/default behaviour. The
+filter is applied before limit; p- composed rooms remain unlisted in every view.
+Reasoning: docs/design.md §3.5.
 
 CONDITIONAL NOTES: unconditional writes are last-write-wins, so two agents doing
 read-modify-write on one note lose an update.

--- a/src/store.py
+++ b/src/store.py
@@ -1357,8 +1357,9 @@ def room_stats(root: Path, limit: int = DEFAULT_LIMIT, kind: str = "all") -> dic
         # the room count and out of disk, or the reverse. A reader shown only `capacity`
         # cannot tell which, and /humans renders exactly what this returns.
         "bytes_capacity": MAX_TOTAL_ROOM_BYTES,
-        # The exact count/byte pair the create gate enforces, names deliberately absent.
-        "whole_store": {"total": whole_total, "capacity": MAX_ROOMS, "bytes": whole_bytes, "bytes_capacity": MAX_TOTAL_ROOM_BYTES},
+        # The room count is current between reaps; bytes are the explicitly named cached
+        # measurement used by the create/compaction gates. Names deliberately stay absent.
+        "whole_store": {"total": whole_total, "capacity": MAX_ROOMS, "bytes_at_last_reap": whole_bytes, "bytes_capacity": MAX_TOTAL_ROOM_BYTES},
         "engagement": _rollup(windows),
     }
     # fmt: on

--- a/src/store.py
+++ b/src/store.py
@@ -1303,8 +1303,13 @@ def _cached_topic(root: str, room: str, stamp: tuple, now: float) -> str | None:
     return _topics_memo(root, room, stamp, _time_bucket(now, ttl))
 
 
-def room_stats(root: Path, limit: int = DEFAULT_LIMIT) -> dict:
+def room_stats(root: Path, limit: int = DEFAULT_LIMIT, kind: str = "all") -> dict:
     """Recency-sorted room summaries for the overview.
+
+    `kind` partitions the already-listable population before `limit`: discussion includes
+    every public non-mailbox room (including `events`), mailbox includes every public room
+    carrying the `mb` class, and all preserves the original population. An unlisted
+    composed class is excluded before that choice and therefore cannot leak through it.
 
     `size` and `idle` come free from the directory stat; `last_seq` and the engagement
     aggregates cost one small tail read, computed only for the rooms actually shown and
@@ -1315,7 +1320,7 @@ def room_stats(root: Path, limit: int = DEFAULT_LIMIT) -> dict:
     entries = []
     for e in _walk(root / "rooms", ".jsonl"):
         name = e.name[: -len(".jsonl")]
-        if not _listable(name):
+        if not _listable(name) or ((kind == "mailbox") != is_mailbox(name) and kind != "all"):
             continue
         try:
             st = e.stat()

--- a/src/store.py
+++ b/src/store.py
@@ -1346,6 +1346,8 @@ def room_stats(root: Path, limit: int = DEFAULT_LIMIT, kind: str = "all") -> dic
                 **_engagement(nicks),
             }
         )
+    whole_total, whole_bytes = _note_totals(root, _count_rooms, name=USAGE_FILE)
+    # fmt: off
     return {
         "rooms": shown,
         "total": len(entries),
@@ -1355,8 +1357,11 @@ def room_stats(root: Path, limit: int = DEFAULT_LIMIT, kind: str = "all") -> dic
         # the room count and out of disk, or the reverse. A reader shown only `capacity`
         # cannot tell which, and /humans renders exactly what this returns.
         "bytes_capacity": MAX_TOTAL_ROOM_BYTES,
+        # The exact count/byte pair the create gate enforces, names deliberately absent.
+        "whole_store": {"total": whole_total, "capacity": MAX_ROOMS, "bytes": whole_bytes, "bytes_capacity": MAX_TOTAL_ROOM_BYTES},
         "engagement": _rollup(windows),
     }
+    # fmt: on
 
 
 def service_stats(root: Path, engagement_rooms: int = 50) -> dict:
@@ -1377,8 +1382,7 @@ def service_stats(root: Path, engagement_rooms: int = 50) -> dict:
     # `ownable`, not `owned`: the `d-` prefix only makes a room *claimable* — until
     # /kv/room-owners/<room> exists the write gate treats it as an ordinary open room, so
     # counting the class as owned would overstate adoption.
-    keys = ("total", "listed", "unlisted", "open", "mailbox", "ownable", "ephemeral")
-    rooms = dict.fromkeys(keys, 0)
+    rooms = dict.fromkeys(("total", "listed", "unlisted", "open", "mailbox", "ownable", "ephemeral"), 0)  # fmt: skip
     room_bytes = 0
     for e in _walk(root / "rooms", ".jsonl"):
         name = e.name[: -len(".jsonl")]
@@ -1396,12 +1400,11 @@ def service_stats(root: Path, engagement_rooms: int = 50) -> dict:
                 rooms[key] += 1
         if not classes:
             rooms["open"] += 1
-    notes = note_stats(root)
     return {
         "rooms": {**rooms, "capacity": MAX_ROOMS},
         "bytes": {
             "rooms": room_bytes,
-            "notes": notes["bytes"],
+            "notes": (notes := note_stats(root))["bytes"],
             # The worst case a deployment budgets its disk against, exposed so a reader can
             # see headroom without knowing the constants. MAX_TOTAL_ROOM_BYTES rather than
             # MAX_ROOMS * MAX_ROOM_BYTES: the product stopped being the bound when the room

--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -19,6 +19,7 @@ import sys
 import _client
 import pytest
 
+import manifest
 import store
 
 EDGE = pathlib.Path(__file__).resolve().parents[2] / "edge"
@@ -349,6 +350,13 @@ def test_the_edge_key_is_the_reply_space_and_not_the_url_space(client):
     limit = rule["clamped"]["limit"]
     assert limit["max"] == store.MAX_LIMIT
     assert rule["match"] == {"format": "json"}
+    assert rule["enum"]["kind"] == {
+        "values": list(manifest.ROOM_KINDS),
+        "default": "all",
+    }
+    worker = (EDGE / "src" / "worker.js").read_text(encoding="utf-8")
+    assert "rule.values.includes(raw[0])" in worker and "raw[0] === rule.default" in worker
+    assert "raw.length !== 1" in worker, "duplicate semantic parameters must bypass the cache"
     # The doctrine reason this number comes from the tree and not from the served schema:
     # an advisory parameter publishes no bounds, because bounds mean refusal and this clamps.
     schema = client.get("/openapi.json").json()["paths"]["/rooms"]["get"]["parameters"]

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -820,6 +820,7 @@ def test_every_refusal_is_provoked_and_every_provoked_refusal_is_documented(clie
     # (openapi path, method, expected status, the request that produces it)
     cases = [
         # Reads.
+        ("/rooms", "get", 400, lambda: client.get("/rooms?kind=unknown")),
         ("/r/{room}", "get", 400, lambda: client.get("/r/UPPER")),
         ("/r/{room}/export", "get", 400, lambda: client.get("/r/UPPER/export")),
         ("/kv/{ns}", "get", 400, lambda: client.get("/kv/UPPER")),
@@ -1044,6 +1045,12 @@ def test_every_published_limit_is_one_the_server_actually_honours(client, monkey
 
         # (the bound as published, a request using it at its extreme)
         checks = [
+            (
+                '{"enum": ["discussion", "mailbox", "all"]}',
+                lambda: [
+                    _ok(client, f"/rooms?kind={kind}") for kind in ("discussion", "mailbox", "all")
+                ],
+            ),
             (
                 '{"pattern": "^[a-z0-9][a-z0-9_-]{0,47}$"}',
                 lambda: _ok(client, f"/r/{longest_name}"),

--- a/tests/http/test_humans.py
+++ b/tests/http/test_humans.py
@@ -406,3 +406,11 @@ def test_human_page_pauses_polling_while_the_tab_is_hidden(client):
     page = client.get("/humans").text
     assert "document.hidden" in page
     assert "visibilitychange" in page
+
+
+def test_human_page_browses_discussions_before_public_mailboxes(client):
+    body = client.get("/humans").text
+    assert '<option value="discussion">Discussions</option>' in body
+    assert '<option value="mailbox">Public mailboxes</option>' in body
+    assert "/rooms?format=json&limit=200&kind=" in body
+    assert "requires signed writes but is still publicly readable" in body

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -605,7 +605,7 @@ def test_oversize_and_empty_input_fail_closed(client):
     assert client.get("/r/lobby/say/bot/%20%20").status_code == 400  # whitespace-only
     assert client.post("/r/lobby", json={"from": "bot", "text": "x" * 4097}).status_code == 400
     assert client.get("/kv/ns/k/set/" + "y" * 8193).status_code == 400
-    assert client.get("/rooms").text.strip().startswith("(no rooms")  # nothing was created
+    assert client.get("/rooms").text.strip().startswith("(no public rooms")  # nothing was created
 
 
 def test_a_full_length_message_is_accepted(client):
@@ -627,7 +627,7 @@ def test_oversize_body_is_refused_before_it_is_buffered(client):
 
     r = client.post("/r/lobby", content=b"x" * (app_module.MAX_BODY + 1))
     assert r.status_code == 413 and "too large" in r.text
-    assert "no rooms yet" in client.get("/rooms").text  # nothing was written
+    assert "no public rooms yet" in client.get("/rooms").text  # nothing was written
 
 
 def test_chunked_body_is_stopped_at_the_same_cap_and_says_how_to_split_it(client):

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -473,7 +473,7 @@ def test_rooms_overview_hides_private_rooms_and_survives_an_empty_store(client):
         "whole_store": {
             "total": 0,
             "capacity": store.MAX_ROOMS,
-            "bytes": 0,
+            "bytes_at_last_reap": 0,
             "bytes_capacity": store.MAX_TOTAL_ROOM_BYTES,
         },
         "notes": {
@@ -573,7 +573,7 @@ def test_rooms_whole_store_capacity_counts_unlisted_without_naming_them(
     whole = {
         "total": 10,
         "capacity": 10,
-        "bytes": store._count_rooms(tmp_path)[1],
+        "bytes_at_last_reap": store._count_rooms(tmp_path)[1],
         "bytes_capacity": store.MAX_TOTAL_ROOM_BYTES,
     }
     assert all(view["whole_store"] == whole for view in views.values())
@@ -585,7 +585,41 @@ def test_rooms_whole_store_capacity_counts_unlisted_without_naming_them(
     whole = schema["paths"]["/rooms"]["get"]["responses"]["200"]["content"]["application/json"][
         "schema"
     ]["properties"]["whole_store"]
-    assert set(whole["properties"]) == {"total", "capacity", "bytes", "bytes_capacity"}
+    assert set(whole["properties"]) == {
+        "total",
+        "capacity",
+        "bytes_at_last_reap",
+        "bytes_capacity",
+    }
+
+
+def test_rooms_labels_stale_whole_store_bytes_after_an_existing_room_grows(
+    client, tmp_path, monkeypatch
+):
+    """The hot-path byte gauge is a last-reap snapshot, never current occupancy.
+
+    Existing rooms keep accepting writes between reaps, so their files can grow while
+    USAGE_FILE stays unchanged. /rooms must name that weaker guarantee explicitly rather
+    than hand /humans a value it could present as live capacity headroom.
+    """
+    import app as app_module
+    import store
+
+    monkeypatch.setattr(store, "MAX_ROOMS", 100)
+    monkeypatch.setattr(store, "MAX_TOTAL_ROOM_BYTES", 1_000)
+    monkeypatch.setattr(store, "RESERVED_ROOM_BYTES", 10)
+    assert client.get("/r/p-hidden/say/bot/seed-record").status_code == 200
+    store._reap_pass(tmp_path, store.time.time())
+    cached = store.room_bytes_used(tmp_path)
+
+    assert client.get(f"/r/p-hidden/say/bot/{'x' * 4096}").status_code == 200
+    live = store._count_rooms(tmp_path)[1]
+    app_module._rooms_walk.cache_clear()
+    whole = client.get("/rooms?kind=all&format=json").json()["whole_store"]
+
+    assert cached < 800 <= live
+    assert whole["bytes_at_last_reap"] == cached
+    assert "bytes" not in whole
 
 
 def test_rooms_text_empty_state_names_the_selected_kind(client):

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -470,6 +470,12 @@ def test_rooms_overview_hides_private_rooms_and_survives_an_empty_store(client):
         "capacity": store.MAX_ROOMS,
         "bytes": 0,
         "bytes_capacity": store.MAX_TOTAL_ROOM_BYTES,
+        "whole_store": {
+            "total": 0,
+            "capacity": store.MAX_ROOMS,
+            "bytes": 0,
+            "bytes_capacity": store.MAX_TOTAL_ROOM_BYTES,
+        },
         "notes": {
             "total": 0,
             "bytes": 0,
@@ -540,6 +546,46 @@ def test_rooms_kind_filters_before_the_detail_limit(client, tmp_path):
         "default": "all",
     }
     assert "before applying `limit`" in kind["description"] and "400" in operation["responses"]
+
+
+def test_rooms_whole_store_capacity_counts_unlisted_without_naming_them(
+    client, tmp_path, monkeypatch
+):
+    import app as app_module
+    import store
+
+    monkeypatch.setattr(store, "MAX_ROOMS", 10)
+    assert client.get("/r/discussion/say/bot/hello").status_code == 200
+    for i in range(8):
+        assert client.get(f"/r/p-hidden-{i}/say/bot/hello").status_code == 200
+    store._reap_pass(tmp_path, store.time.time())
+    app_module._rooms_walk.cache_clear()
+
+    views = {
+        kind: client.get(f"/rooms?kind={kind}&format=json").json()
+        for kind in ("discussion", "mailbox", "all")
+    }
+    assert {kind: view["total"] for kind, view in views.items()} == {
+        "discussion": 2,  # the public room plus the server's events room
+        "mailbox": 0,
+        "all": 2,
+    }
+    whole = {
+        "total": 10,
+        "capacity": 10,
+        "bytes": store._count_rooms(tmp_path)[1],
+        "bytes_capacity": store.MAX_TOTAL_ROOM_BYTES,
+    }
+    assert all(view["whole_store"] == whole for view in views.values())
+    assert "p-hidden" not in client.get("/rooms?kind=all&format=json").text
+    refused = client.get("/r/eleventh/say/bot/no-room")
+    assert refused.status_code == 400 and "room limit reached" in refused.text
+
+    schema = client.get("/openapi.json").json()
+    whole = schema["paths"]["/rooms"]["get"]["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]["properties"]["whole_store"]
+    assert set(whole["properties"]) == {"total", "capacity", "bytes", "bytes_capacity"}
 
 
 def test_rooms_text_empty_state_names_the_selected_kind(client):

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -506,6 +506,42 @@ def test_rooms_overview_limits_the_tail_reads_it_does(client, tmp_path):
         assert client.get(f"/rooms?limit={bad}&format=json").status_code == 200
 
 
+def test_rooms_kind_filters_before_the_detail_limit(client, tmp_path):
+    import store
+
+    client.get("/r/discussion/say/bot/hello")
+    for room in ("mb-first", "e-mb-second", "mb-e-third"):
+        store._write_record(tmp_path, room, "bot", "hello")
+    for room in ("mb-p-secret", "p-mb-secret", "e-mb-p-secret", "e-p-mb-secret"):
+        store._write_record(tmp_path, room, "bot", "hidden")
+
+    original = client.get("/rooms?limit=2&format=json").json()
+    assert original == client.get("/rooms?kind=all&limit=2&format=json").json()
+
+    discussion = client.get("/rooms?kind=discussion&limit=2&format=json").json()
+    assert [row["room"] for row in discussion["rooms"]] == ["events", "discussion"]
+    assert discussion["total"] == 2
+
+    mailboxes = client.get("/rooms?kind=mailbox&limit=2&format=json").json()
+    assert [row["room"] for row in mailboxes["rooms"]] == ["mb-e-third", "e-mb-second"]
+    assert mailboxes["total"] == 3
+    assert not {"mb-p-secret", "p-mb-secret", "e-mb-p-secret", "e-p-mb-secret"} & {
+        row["room"] for row in mailboxes["rooms"]
+    }
+
+    bad = client.get("/rooms?kind=unknown")
+    assert bad.status_code == 400 and "bad kind" in bad.text and "discussion" in bad.text
+
+    operation = client.get("/openapi.json").json()["paths"]["/rooms"]["get"]
+    kind = next(parameter for parameter in operation["parameters"] if parameter["name"] == "kind")
+    assert kind["schema"] == {
+        "type": "string",
+        "enum": ["discussion", "mailbox", "all"],
+        "default": "all",
+    }
+    assert "before applying `limit`" in kind["description"] and "400" in operation["responses"]
+
+
 def test_engagement_reports_no_data_rather_than_zero_for_an_empty_window(client, tmp_path):
     (tmp_path / "rooms").mkdir(parents=True)
     (tmp_path / "rooms" / "junk.jsonl").write_bytes(b"not a record\n")

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -463,7 +463,7 @@ def test_rooms_overview_hides_private_rooms_and_survives_an_empty_store(client):
     import app
     import store
 
-    assert "no rooms yet" in client.get("/rooms").text
+    assert "no public rooms yet" in client.get("/rooms").text
     assert client.get("/rooms?format=json").json() == {
         "rooms": [],
         "total": 0,
@@ -540,6 +540,23 @@ def test_rooms_kind_filters_before_the_detail_limit(client, tmp_path):
         "default": "all",
     }
     assert "before applying `limit`" in kind["description"] and "400" in operation["responses"]
+
+
+def test_rooms_text_empty_state_names_the_selected_kind(client):
+    expected = {
+        "discussion": "(no discussions)",
+        "mailbox": "(no public mailboxes)",
+        "all": "(no public rooms yet — GET /r/<name>/say/<nick>/<text> creates one)",
+    }
+    for kind, first_line in expected.items():
+        assert client.get(f"/rooms?kind={kind}").text.splitlines()[0] == first_line
+    assert client.get("/rooms").text.splitlines()[0] == expected["all"]
+
+    # An empty category is not an empty service: this is the misleading case the wording
+    # must keep distinct after the kind filter is applied.
+    client.get("/r/discussion/say/bot/hello")
+    mailbox = client.get("/rooms?kind=mailbox").text.splitlines()[0]
+    assert mailbox == expected["mailbox"] and "no public rooms" not in mailbox
 
 
 def test_engagement_reports_no_data_rather_than_zero_for_an_empty_window(client, tmp_path):

--- a/tests/humans_ui_probe.mjs
+++ b/tests/humans_ui_probe.mjs
@@ -25,11 +25,13 @@
  * Exits non-zero on the first failed check, so it is usable by hand before pushing as well
  * as by the workflow.
  *
- * Checked 2026-09-08, 144 checks, all passing — expected shape:
+ * Checked 2026-09-09, 154 checks, all passing — expected shape:
  *   desktop 900px   5 columns, copy icon is an <svg> with an accessible name
  *   copy            writes the #r/<room> permalink, swaps glyph + label, restores after 1.2s
  *   filter          narrows rows, counts against LOADED rooms, survives the 5s refresh
  *   category        removes stale room targets while the next category request is pending
+ *                   and rejects older same-kind responses after category ABA or overlapping polls
+ *   capacity        category counts stay scoped; global occupancy and warnings do not change views
  *   open a room     scrolls the Room heading into view
  *   Enter in filter opens the top match
  *   mobile 390px    4 columns (byte column dropped), no horizontal scroll at 320-1280px
@@ -197,7 +199,7 @@ const browser = await chromium.launch({
   const context = await browser.newContext({ viewport: { width: 900, height: 1200 } });
   const page = await context.newPage();
   page.setDefaultTimeout(5000);
-  const view = (room) => ({
+  const view = (room, values = {}) => Object.assign({
     rooms: [{ room, count: 1, first_seq: 1, last_seq: 1, bytes: 100, idle_seconds: 0, topic: "" }],
     total: 1,
     capacity: 5120,
@@ -212,7 +214,7 @@ const browser = await chromium.launch({
     },
     notes: { total: 0, bytes: 0, capacity: 163840, capacity_per_namespace: 5120 },
     untrusted: { fields: ["room", "topic"], note: "test data" },
-  });
+  }, values);
   let releaseNew;
   const newGate = new Promise((resolve) => { releaseNew = resolve; });
   let markPending;
@@ -263,6 +265,100 @@ const browser = await chromium.launch({
   await page.fill("#room", "lobby");
   await newRoom.click();
   check("the new category's row remains clickable", (await page.inputValue("#room")) === "mb-new-room");
+  await page.close();
+
+  async function staleRace(categoryABA) {
+    const racePage = await context.newPage();
+    racePage.setDefaultTimeout(5000);
+    let releaseOld;
+    const oldGate = new Promise((resolve) => { releaseOld = resolve; });
+    let markOldStarted;
+    const oldStarted = new Promise((resolve) => { markOldStarted = resolve; });
+    let markOldReturned;
+    const oldReturned = new Promise((resolve) => { markOldReturned = resolve; });
+    let discussionCalls = 0;
+    await racePage.route("**/rooms?*", async (route) => {
+      const kind = new URL(route.request().url()).searchParams.get("kind");
+      if (kind === "all") {
+        await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(view("global-room")) });
+      } else if (kind === "mailbox") {
+        await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(view("mb-current")) });
+      } else if (++discussionCalls === 1) {
+        markOldStarted();
+        await oldGate;
+        await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(view("stale-discussion")) });
+        markOldReturned();
+      } else {
+        await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(view("fresh-discussion")) });
+      }
+    });
+    await racePage.goto(`${BASE}/humans`, { waitUntil: "domcontentloaded" });
+    await oldStarted;
+    if (categoryABA) {
+      await racePage.selectOption("#kind", "mailbox");
+      await racePage.locator(".btn-ghost", { hasText: "mb-current" }).waitFor();
+      await racePage.selectOption("#kind", "discussion");
+    } else {
+      await racePage.evaluate(() => document.dispatchEvent(new Event("visibilitychange")));
+    }
+    await racePage.locator(".btn-ghost", { hasText: "fresh-discussion" }).waitFor();
+    const before = await racePage.locator("#rooms tbody .btn-ghost").first().innerText();
+    releaseOld();
+    await oldReturned;
+    await racePage.waitForTimeout(100);
+    const result = {
+      before,
+      fresh: await racePage.locator(".btn-ghost", { hasText: "fresh-discussion" }).count(),
+      stale: await racePage.locator(".btn-ghost", { hasText: "stale-discussion" }).count(),
+      discussionCalls,
+    };
+    await racePage.close();
+    return result;
+  }
+
+  console.log("room response generations");
+  const categoryABA = await staleRace(true);
+  check("a newer discussion response renders after category ABA",
+        categoryABA.before === "fresh-discussion" && categoryABA.discussionCalls === 2);
+  check("the old pre-ABA response cannot replace it", categoryABA.fresh === 1 && categoryABA.stale === 0);
+  const sameKind = await staleRace(false);
+  check("a newer overlapping same-kind response renders",
+        sameKind.before === "fresh-discussion" && sameKind.discussionCalls === 2);
+  check("the older same-kind response cannot replace it", sameKind.fresh === 1 && sameKind.stale === 0);
+
+  console.log("global capacity across category views");
+  const capacityPage = await context.newPage();
+  capacityPage.setDefaultTimeout(5000);
+  await capacityPage.route("**/rooms?*", async (route) => {
+    const kind = new URL(route.request().url()).searchParams.get("kind");
+    const payload = kind === "discussion"
+      ? view("only-discussion", { total: 1, capacity: 100, bytes: 1, bytes_capacity: 100 })
+      : kind === "mailbox"
+        ? view("mb-one-of-many", { total: 90, capacity: 100, bytes: 90, bytes_capacity: 100 })
+        : view("global-room", { total: 91, capacity: 100, bytes: 91, bytes_capacity: 100 });
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(payload) });
+  });
+  await capacityPage.goto(`${BASE}/humans`, { waitUntil: "domcontentloaded" });
+  const globalUse = "91 of 100 global room cap";
+  const warning = "near capacity — 91% full";
+  await capacityPage.locator("#stats", { hasText: "1 discussion" }).waitFor();
+  check("discussion view keeps its category count", (await capacityPage.locator("#stats").innerText()).includes("1 discussion"));
+  check("discussion view uses global capacity and warns",
+        (await capacityPage.locator("#stats").innerText()).includes(globalUse)
+        && (await capacityPage.locator("#stats .badge.err").innerText()) === warning);
+  await capacityPage.selectOption("#kind", "mailbox");
+  await capacityPage.locator("#stats", { hasText: "90 public mailboxes" }).waitFor();
+  check("mailbox view keeps its category count", (await capacityPage.locator("#stats").innerText()).includes("90 public mailboxes"));
+  check("mailbox view keeps the same global warning",
+        (await capacityPage.locator("#stats").innerText()).includes(globalUse)
+        && (await capacityPage.locator("#stats .badge.err").innerText()) === warning);
+  await capacityPage.selectOption("#kind", "all");
+  await capacityPage.locator("#stats", { hasText: "91 public rooms" }).waitFor();
+  check("all view names its public-room total", (await capacityPage.locator("#stats").innerText()).includes("91 public rooms"));
+  check("all view keeps the same global warning",
+        (await capacityPage.locator("#stats").innerText()).includes(globalUse)
+        && (await capacityPage.locator("#stats .badge.err").innerText()) === warning);
+  await capacityPage.close();
   await context.close();
 }
 

--- a/tests/humans_ui_probe.mjs
+++ b/tests/humans_ui_probe.mjs
@@ -25,10 +25,11 @@
  * Exits non-zero on the first failed check, so it is usable by hand before pushing as well
  * as by the workflow.
  *
- * Checked 2026-09-07, 138 checks, all passing — expected shape:
+ * Checked 2026-09-08, 144 checks, all passing — expected shape:
  *   desktop 900px   5 columns, copy icon is an <svg> with an accessible name
  *   copy            writes the #r/<room> permalink, swaps glyph + label, restores after 1.2s
  *   filter          narrows rows, counts against LOADED rooms, survives the 5s refresh
+ *   category        removes stale room targets while the next category request is pending
  *   open a room     scrolls the Room heading into view
  *   Enter in filter opens the top match
  *   mobile 390px    4 columns (byte column dropped), no horizontal scroll at 320-1280px
@@ -188,6 +189,80 @@ const browser = await chromium.launch({
   check("Enter opens the top match", (await page.inputValue("#room")) === "standup");
 
   check("no page errors", errors.length === 0, errors.join("; "));
+  await context.close();
+}
+
+// ---------------------------------------------------------- category switch loading window
+{
+  const context = await browser.newContext({ viewport: { width: 900, height: 1200 } });
+  const page = await context.newPage();
+  page.setDefaultTimeout(5000);
+  const view = (room) => ({
+    rooms: [{ room, count: 1, first_seq: 1, last_seq: 1, bytes: 100, idle_seconds: 0, topic: "" }],
+    total: 1,
+    capacity: 5120,
+    bytes: 100,
+    bytes_capacity: 5368709120,
+    engagement: {
+      window_cap: 200,
+      windowed_messages: 1,
+      zero_response_share: 0,
+      nick_diversity: 1,
+      windowed_note_to_message_ratio: 0,
+    },
+    notes: { total: 0, bytes: 0, capacity: 163840, capacity_per_namespace: 5120 },
+    untrusted: { fields: ["room", "topic"], note: "test data" },
+  });
+  let releaseNew;
+  const newGate = new Promise((resolve) => { releaseNew = resolve; });
+  let markPending;
+  const pendingSeen = new Promise((resolve) => { markPending = resolve; });
+  await page.route("**/rooms?*", async (route) => {
+    const kind = new URL(route.request().url()).searchParams.get("kind");
+    if (kind === "mailbox") {
+      markPending();
+      await newGate;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(view("mb-new-room")),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(view("old-room")),
+    });
+  });
+  await page.goto(`${BASE}/humans`, { waitUntil: "domcontentloaded" });
+  const oldRoom = page.locator("#rooms tbody .btn-ghost", { hasText: "old-room" });
+  await oldRoom.waitFor();
+
+  console.log("category switch loading window");
+  await page.selectOption("#kind", "mailbox");
+  await pendingSeen;
+  check("old row is removed while the new category is pending", (await oldRoom.count()) === 0);
+  await page.fill("#filter", "old-room");
+  await page.press("#filter", "Enter");
+  check("Enter cannot open the old category's room", (await page.inputValue("#room")) === "lobby");
+  const staleClick = await oldRoom.click({ timeout: 250 }).then(() => true, () => false);
+  check("the old category has no clickable navigation target", !staleClick);
+
+  const response = page.waitForResponse((r) =>
+    new URL(r.url()).searchParams.get("kind") === "mailbox",
+  );
+  releaseNew();
+  await response;
+  await page.fill("#filter", "mb-new-room");
+  const newRoom = page.locator("#rooms tbody .btn-ghost", { hasText: "mb-new-room" });
+  await newRoom.waitFor();
+  check("the new category's row appears after its response", (await newRoom.count()) === 1);
+  await page.press("#filter", "Enter");
+  check("Enter opens the new category's first room", (await page.inputValue("#room")) === "mb-new-room");
+  await page.fill("#room", "lobby");
+  await newRoom.click();
+  check("the new category's row remains clickable", (await page.inputValue("#room")) === "mb-new-room");
   await context.close();
 }
 

--- a/tests/humans_ui_probe.mjs
+++ b/tests/humans_ui_probe.mjs
@@ -205,6 +205,7 @@ const browser = await chromium.launch({
     capacity: 5120,
     bytes: 100,
     bytes_capacity: 5368709120,
+    whole_store: { total: 1, capacity: 5120, bytes: 100, bytes_capacity: 5368709120 },
     engagement: {
       window_cap: 200,
       windowed_messages: 1,
@@ -279,9 +280,7 @@ const browser = await chromium.launch({
     let discussionCalls = 0;
     await racePage.route("**/rooms?*", async (route) => {
       const kind = new URL(route.request().url()).searchParams.get("kind");
-      if (kind === "all") {
-        await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(view("global-room")) });
-      } else if (kind === "mailbox") {
+      if (kind === "mailbox") {
         await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(view("mb-current")) });
       } else if (++discussionCalls === 1) {
         markOldStarted();
@@ -331,32 +330,37 @@ const browser = await chromium.launch({
   capacityPage.setDefaultTimeout(5000);
   await capacityPage.route("**/rooms?*", async (route) => {
     const kind = new URL(route.request().url()).searchParams.get("kind");
+    const whole_store = { total: 10, capacity: 10, bytes: 95, bytes_capacity: 100 };
     const payload = kind === "discussion"
-      ? view("only-discussion", { total: 1, capacity: 100, bytes: 1, bytes_capacity: 100 })
+      ? view("only-discussion", { total: 2, capacity: 10, bytes: 2, bytes_capacity: 100, whole_store })
       : kind === "mailbox"
-        ? view("mb-one-of-many", { total: 90, capacity: 100, bytes: 90, bytes_capacity: 100 })
-        : view("global-room", { total: 91, capacity: 100, bytes: 91, bytes_capacity: 100 });
+        ? view("none", { rooms: [], total: 0, capacity: 10, bytes: 0, bytes_capacity: 100, whole_store })
+        : view("global-room", { total: 2, capacity: 10, bytes: 2, bytes_capacity: 100, whole_store });
     await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(payload) });
   });
   await capacityPage.goto(`${BASE}/humans`, { waitUntil: "domcontentloaded" });
-  const globalUse = "91 of 100 global room cap";
-  const warning = "near capacity — 91% full";
-  await capacityPage.locator("#stats", { hasText: "1 discussion" }).waitFor();
-  check("discussion view keeps its category count", (await capacityPage.locator("#stats").innerText()).includes("1 discussion"));
-  check("discussion view uses global capacity and warns",
+  const globalUse = "10 of 10 global room cap";
+  const globalBytes = "95B of 100B globally stored";
+  const warning = "near capacity — 100% full";
+  await capacityPage.locator("#stats", { hasText: "2 discussions" }).waitFor();
+  check("discussion view keeps its listed category count", (await capacityPage.locator("#stats").innerText()).includes("2 discussions"));
+  check("discussion view uses whole-store capacity and warns",
         (await capacityPage.locator("#stats").innerText()).includes(globalUse)
+        && (await capacityPage.locator("#stats").innerText()).includes(globalBytes)
         && (await capacityPage.locator("#stats .badge.err").innerText()) === warning);
   await capacityPage.selectOption("#kind", "mailbox");
-  await capacityPage.locator("#stats", { hasText: "90 public mailboxes" }).waitFor();
-  check("mailbox view keeps its category count", (await capacityPage.locator("#stats").innerText()).includes("90 public mailboxes"));
+  await capacityPage.locator("#stats", { hasText: "0 public mailboxes" }).waitFor();
+  check("mailbox view keeps its listed category count", (await capacityPage.locator("#stats").innerText()).includes("0 public mailboxes"));
   check("mailbox view keeps the same global warning",
         (await capacityPage.locator("#stats").innerText()).includes(globalUse)
+        && (await capacityPage.locator("#stats").innerText()).includes(globalBytes)
         && (await capacityPage.locator("#stats .badge.err").innerText()) === warning);
   await capacityPage.selectOption("#kind", "all");
-  await capacityPage.locator("#stats", { hasText: "91 public rooms" }).waitFor();
-  check("all view names its public-room total", (await capacityPage.locator("#stats").innerText()).includes("91 public rooms"));
+  await capacityPage.locator("#stats", { hasText: "2 public rooms" }).waitFor();
+  check("all view names only its listed-room total", (await capacityPage.locator("#stats").innerText()).includes("2 public rooms"));
   check("all view keeps the same global warning",
         (await capacityPage.locator("#stats").innerText()).includes(globalUse)
+        && (await capacityPage.locator("#stats").innerText()).includes(globalBytes)
         && (await capacityPage.locator("#stats .badge.err").innerText()) === warning);
   await capacityPage.close();
   await context.close();

--- a/tests/humans_ui_probe.mjs
+++ b/tests/humans_ui_probe.mjs
@@ -124,6 +124,7 @@ const browser = await chromium.launch({
   await page.waitForTimeout(800);
 
   console.log("desktop 900px");
+  check("starts with discussions", (await page.inputValue("#kind")) === "discussion");
   const heads = await page.locator("#rooms thead th:visible").allInnerTexts();
   check("column headers", heads.length === 5, heads.join(" / "));
 
@@ -159,6 +160,16 @@ const browser = await chromium.launch({
   await page.waitForTimeout(6000); // outlast one 5s auto-refresh
   check("filter survives the refresh", (await page.inputValue("#filter")) === "lobby");
   check("and stays applied", (await page.locator("#rooms tbody tr").count()) === 1);
+
+  await page.fill("#filter", "");
+  await page.selectOption("#kind", "mailbox");
+  await page.waitForTimeout(800);
+  check("empty mailbox view explains itself",
+        (await page.locator("#rooms tbody").innerText()).includes("No public mailboxes"));
+  await page.selectOption("#kind", "all");
+  await page.waitForTimeout(800);
+  check("all-room view restores the seeded rooms",
+        (await page.locator("#rooms tbody tr").count()) >= 3);
 
   console.log("navigation");
   await page.fill("#filter", "");
@@ -459,7 +470,7 @@ const browser = await chromium.launch({
     logBottom: Math.round(document.getElementById("log").getBoundingClientRect().bottom),
     composer: Math.round(document.getElementById("composer").getBoundingClientRect().bottom),
     rooms: Math.round([...document.querySelectorAll("h2")]
-      .find((h) => h.textContent === "All rooms").getBoundingClientRect().top),
+      .find((h) => h.textContent === "Rooms").getBoundingClientRect().top),
     fold: innerHeight,
   }));
   check("live: the log is above the fold", box.logBottom < box.fold, JSON.stringify(box));

--- a/tests/humans_ui_probe.mjs
+++ b/tests/humans_ui_probe.mjs
@@ -25,13 +25,14 @@
  * Exits non-zero on the first failed check, so it is usable by hand before pushing as well
  * as by the workflow.
  *
- * Checked 2026-09-09, 154 checks, all passing — expected shape:
+ * Checked 2026-09-10, 156 checks, all passing — expected shape:
  *   desktop 900px   5 columns, copy icon is an <svg> with an accessible name
  *   copy            writes the #r/<room> permalink, swaps glyph + label, restores after 1.2s
  *   filter          narrows rows, counts against LOADED rooms, survives the 5s refresh
  *   category        removes stale room targets while the next category request is pending
  *                   and rejects older same-kind responses after category ABA or overlapping polls
- *   capacity        category counts stay scoped; global occupancy and warnings do not change views
+ *   capacity        category counts stay scoped; count warnings do not change views, and
+ *                   last-reap bytes are labelled as a snapshot rather than live headroom
  *   open a room     scrolls the Room heading into view
  *   Enter in filter opens the top match
  *   mobile 390px    4 columns (byte column dropped), no horizontal scroll at 320-1280px
@@ -205,7 +206,7 @@ const browser = await chromium.launch({
     capacity: 5120,
     bytes: 100,
     bytes_capacity: 5368709120,
-    whole_store: { total: 1, capacity: 5120, bytes: 100, bytes_capacity: 5368709120 },
+    whole_store: { total: 1, capacity: 5120, bytes_at_last_reap: 100, bytes_capacity: 5368709120 },
     engagement: {
       window_cap: 200,
       windowed_messages: 1,
@@ -330,7 +331,7 @@ const browser = await chromium.launch({
   capacityPage.setDefaultTimeout(5000);
   await capacityPage.route("**/rooms?*", async (route) => {
     const kind = new URL(route.request().url()).searchParams.get("kind");
-    const whole_store = { total: 10, capacity: 10, bytes: 95, bytes_capacity: 100 };
+    const whole_store = { total: 10, capacity: 10, bytes_at_last_reap: 95, bytes_capacity: 100 };
     const payload = kind === "discussion"
       ? view("only-discussion", { total: 2, capacity: 10, bytes: 2, bytes_capacity: 100, whole_store })
       : kind === "mailbox"
@@ -340,8 +341,8 @@ const browser = await chromium.launch({
   });
   await capacityPage.goto(`${BASE}/humans`, { waitUntil: "domcontentloaded" });
   const globalUse = "10 of 10 global room cap";
-  const globalBytes = "95B of 100B globally stored";
-  const warning = "near capacity — 100% full";
+  const globalBytes = "95B room bytes at last reap (100B budget; current byte use is not sampled here)";
+  const warning = "near room-count capacity — 100% full";
   await capacityPage.locator("#stats", { hasText: "2 discussions" }).waitFor();
   check("discussion view keeps its listed category count", (await capacityPage.locator("#stats").innerText()).includes("2 discussions"));
   check("discussion view uses whole-store capacity and warns",
@@ -363,6 +364,21 @@ const browser = await chromium.launch({
         && (await capacityPage.locator("#stats").innerText()).includes(globalBytes)
         && (await capacityPage.locator("#stats .badge.err").innerText()) === warning);
   await capacityPage.close();
+
+  const staleBytesPage = await context.newPage();
+  staleBytesPage.setDefaultTimeout(5000);
+  await staleBytesPage.route("**/rooms?*", async (route) => {
+    const whole_store = { total: 1, capacity: 10, bytes_at_last_reap: 95, bytes_capacity: 100 };
+    const payload = view("growing-room", { whole_store });
+    await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(payload) });
+  });
+  await staleBytesPage.goto(`${BASE}/humans`, { waitUntil: "domcontentloaded" });
+  await staleBytesPage.locator("#stats", { hasText: "room bytes at last reap" }).waitFor();
+  check("last-reap bytes are explicitly labelled as a non-current snapshot",
+        (await staleBytesPage.locator("#stats").innerText()).includes(globalBytes));
+  check("a stale byte snapshot does not drive a real-time capacity warning",
+        (await staleBytesPage.locator("#stats .badge.err").count()) === 0);
+  await staleBytesPage.close();
   await context.close();
 }
 

--- a/tests/unit/test_memo_caches.py
+++ b/tests/unit/test_memo_caches.py
@@ -164,7 +164,7 @@ def test_the_rooms_cache_answers_every_worker_while_it_is_evicting(monkeypatch):
     slow."""
     app._rooms_walk.cache_clear()
     bound = app.MAX_ROOMS_CACHE
-    gate = _Gated(lambda limit: {"limit": limit})
+    gate = _Gated(lambda limit, kind="all": {"limit": limit, "kind": kind})
     monkeypatch.setattr(app, "_rooms_payload", gate)
     for n in range(bound):
         app._rooms_walk(n, STAMP, 0)
@@ -172,7 +172,7 @@ def test_the_rooms_cache_answers_every_worker_while_it_is_evicting(monkeypatch):
 
     def work() -> None:
         for n in range(bound + WORKERS * 4):
-            assert app._rooms_walk(n, STAMP, 0) == {"limit": n}
+            assert app._rooms_walk(n, STAMP, 0) == {"limit": n, "kind": "all"}
 
     _in_parallel(work)
     assert app._rooms_walk.cache_info().currsize == bound


### PR DESCRIPTION
## What

Adds `kind=discussion|mailbox|all` to `/rooms`, filtering before `limit` while preserving the default `all` behavior. `/humans` now starts with discussions and can switch to public mailboxes or all public rooms; composed private rooms remain unlisted.

## Why

Public `mb-*` rooms require signed writes but remain publicly readable. Mailbox-heavy activity can displace useful discussions from the bounded recent-room view, with no semantic way to request discussions first.

Closes #768.

## Checks

- [ ] `uv run coverage run -m pytest tests -q && uv run coverage report` — attempted on Windows: 736 passed; 36 existing POSIX `fcntl`, filesystem-semantics, or child-import failures
- [ ] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — ruff/format pass; Linux-target ty pass
- [x] Docs that would now be wrong are updated
- [x] New surface on a world-writable service: nothing new; this only filters public discovery responses

Relevant pytest: 188 passed, 1 skipped, 1 deselected. Size baseline passes with no core growth. Chromium humans UI probe passes.