### PR TITLE
test: print note count when the global cap assertion fails

### DIFF
--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -296,9 +296,12 @@ def test_the_global_cap_binds_exactly_under_concurrent_processes(tmp_path) -> No
 
     on_disk, _ = store._count_notes(root)
     assert on_disk == accepted, "every accepted write must be a note that exists"
-    assert on_disk == cap, f"cap is {cap}, store holds {on_disk}"
+    counted = store._note_count(root)
+    assert on_disk == cap, (
+        f"cap is {cap}, store holds {on_disk}, accepted {accepted}, count file {counted}"
+    )
     # …and the file agrees with the disk, or the next process starts from a wrong number.
-    assert store._note_count(root) == cap
+    assert counted == cap
 
 
 def test_a_refused_write_counts_nothing(tmp_path) -> None:


### PR DESCRIPTION
## What

When `test_the_global_cap_binds_exactly_under_concurrent_processes` fails with "store holds N of cap", also print `store._note_count(root)` beside `on_disk` and `accepted`.

## Why

Fixes #793. That failure happened once, was not reproduced, and the next assertion never runs, so the count file is invisible. This does not change the gate or guess a mechanism. A green run is unchanged. The next occurrence can say whether the count file was ahead of disk and by how much.

Started from `20a4457b89ba` (`docs(manual): name the operator's measurement probe in CONVENTIONS (#796)`).

## Checks

- [ ] `uv run coverage run -m pytest tests/unit/test_note_count.py -q` — diagnostic only; the assertion still requires `on_disk == cap`
- [x] No production store change
- [x] Does not edit `CHANGELOG.md` or `sz-baseline.json`
- [x] Does not touch the README operator table already covered by draft #200

## Association

Agent DID `did:key:z6MkheTNzqkszypvBVS6ZLmHbq66BsnKMC5QSzUJsudKEoyh` is associated with GitHub user `xuweilai`. The signed lobby record is the control proof; this PR is the contribution record. It is submitted, not merged.