### PR TITLE
fix(config): fail boot on a CHAT_RATE_* too large for float()

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -43,19 +43,30 @@ def _finite_env(name: str, default: str) -> float:
 
 ROOT = Path(os.environ.get("CHAT_ROOT", "/data"))
 
+
+def _rate_env(name: str, default: str) -> int:
+    """A rate knob, floored at 1. take()/refund() convert this to float() on every call —
+    which raises OverflowError past ~1.8e308, where int() does not — so an oversized value
+    must fail here, at boot, instead of 500ing the first rate-limited request that needs it.
+    """
+    value = max(1, int(os.environ.get(name, default)))
+    float(value)
+    return value
+
+
 # Floored at 1: the bucket arithmetic divides by this, so a zero or negative value
 # configured by hand would turn every rate-limited route into a 500 rather than into the
 # refusal the operator presumably meant. There is no "disable" setting for the same reason
 # the limiter exists at all.
-RATE_READ = max(1, int(os.environ.get("CHAT_RATE_READ", "120")))  # requests/min/IP
-RATE_WRITE = max(1, int(os.environ.get("CHAT_RATE_WRITE", "30")))
+RATE_READ = _rate_env("CHAT_RATE_READ", "120")  # requests/min/IP
+RATE_WRITE = _rate_env("CHAT_RATE_WRITE", "30")
 # A per-IP budget on bringing *new rooms into existence*, measured over a day rather than a
 # minute. RATE_WRITE bounds how fast one caller can talk; nothing bounded how many rooms one
 # caller could create, and those are not the same resource. At RATE_WRITE a single caller
 # exhausts MAX_ROOMS in a matter of hours, and the slots it takes are everyone's — the
 # next caller, whoever they are, gets the fail-closed refusal. This is what makes MAX_ROOMS
 # a cap on the service rather than a race won by whoever creates rooms fastest.
-RATE_ROOMS_PER_DAY = max(1, int(os.environ.get("CHAT_RATE_ROOMS_PER_DAY", "20")))
+RATE_ROOMS_PER_DAY = _rate_env("CHAT_RATE_ROOMS_PER_DAY", "20")
 CORS_ORIGINS = [o for o in os.environ.get("CHAT_CORS_ORIGINS", "").split(",") if o]
 # /stats is the one internal surface. Growth numbers are not published — the design doc's
 # §I.2.3 caution against count-based marketing is exactly why they stay off the public

--- a/tests/unit/test_config_knobs.py
+++ b/tests/unit/test_config_knobs.py
@@ -16,6 +16,8 @@ import json
 import os
 import subprocess
 import sys
+
+import pytest
 from pathlib import Path
 
 SRC = str(Path(__file__).resolve().parents[2] / "src")
@@ -254,18 +256,21 @@ def test_junk_refuses_to_boot() -> None:
     assert "ValueError" in run.stderr
 
 
-def test_oversized_rate_knob_refuses_to_boot() -> None:
+@pytest.mark.parametrize("knob", ["CHAT_RATE_READ", "CHAT_RATE_WRITE", "CHAT_RATE_ROOMS_PER_DAY"])
+def test_oversized_rate_knob_refuses_to_boot(knob: str) -> None:
     """`int()` accepts arbitrary-size integers, but `take()`/`refund()` later convert the
     knob to `float()`, which raises OverflowError past ~1.8e308. Without this check that
-    boots cleanly and only 500s the first rate-limited request that reaches it (#744)."""
+    boots cleanly and only 500s the first rate-limited request that reaches it (#744).
+    All three rate knobs are covered so that moving one of them back to a bare `int()`
+    parse fails this test, not just a change to the shared helper."""
     clean = {k: v for k, v in os.environ.items() if not k.startswith("CHAT_")}
     run = subprocess.run(
         [sys.executable, "-c", PROBE],
         capture_output=True,
         text=True,
-        env={**clean, "CHAT_RATE_READ": "9" * 400},
+        env={**clean, knob: "9" * 400},
     )
-    assert run.returncode != 0, "app booted with a CHAT_RATE_READ too large for float()"
+    assert run.returncode != 0, f"app booted with a {knob} too large for float()"
     assert "OverflowError" in run.stderr
 
 

--- a/tests/unit/test_config_knobs.py
+++ b/tests/unit/test_config_knobs.py
@@ -254,6 +254,21 @@ def test_junk_refuses_to_boot() -> None:
     assert "ValueError" in run.stderr
 
 
+def test_oversized_rate_knob_refuses_to_boot() -> None:
+    """`int()` accepts arbitrary-size integers, but `take()`/`refund()` later convert the
+    knob to `float()`, which raises OverflowError past ~1.8e308. Without this check that
+    boots cleanly and only 500s the first rate-limited request that reaches it (#744)."""
+    clean = {k: v for k, v in os.environ.items() if not k.startswith("CHAT_")}
+    run = subprocess.run(
+        [sys.executable, "-c", PROBE],
+        capture_output=True,
+        text=True,
+        env={**clean, "CHAT_RATE_READ": "9" * 400},
+    )
+    assert run.returncode != 0, "app booted with a CHAT_RATE_READ too large for float()"
+    assert "OverflowError" in run.stderr
+
+
 def test_the_poll_interval_is_a_knob_and_defaults_where_it_was_hardcoded() -> None:
     """CHAT_WAIT_POLL was the literal 0.5 in app.py. It reaches `app`, which is the module
     the wait loop sleeps on — a knob that stopped at `config` would parse and change

--- a/tests/unit/test_config_knobs.py
+++ b/tests/unit/test_config_knobs.py
@@ -16,9 +16,9 @@ import json
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
-from pathlib import Path
 
 SRC = str(Path(__file__).resolve().parents[2] / "src")
 


### PR DESCRIPTION
## What

`CHAT_RATE_READ`, `CHAT_RATE_WRITE` and `CHAT_RATE_ROOMS_PER_DAY` now refuse to boot when their value can't survive `float()`. Previously the service booted cleanly and the first rate-limited request hit `OverflowError` inside `limit.take()`/`refund()` and returned 500.

## Why

Fixes #744. `int()` accepts arbitrarily large integers, but the limiter converts the configured cap to `float()` on every call, which raises `OverflowError` past ~1.8e308. That's the same class of problem `_finite_env` already solves for the cache-window knobs ("the loudest possible way to report bad configuration") — this applies the same eager-validation idea to the three rate knobs, via a small `_rate_env` helper.

Verified against `20a4457`.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 771 passed, 1 skipped
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check` — all pass
- [x] Docs that would now be wrong are updated: none, this doesn't change any documented default or contract
- [x] New surface on a world-writable service: none, this only makes an already-invalid operator config fail earlier

🤖 Generated with [Claude Code](https://claude.com/claude-code)