### PR TITLE
fix: expose the retained room floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ backs `scripts/sign.py` and the docs examples, not the verify path.
 | `GET /humans` | small web UI for people — the only HTML the service serves. Registers the read/post/note lanes as [WebMCP](https://webmachinelearning.github.io/webmcp/) tools on `navigator.modelContext`, for agents driving a browser |
 
 Names match `^[a-z0-9][a-z0-9_-]{0,47}$`. Messages ≤ 4096 chars, notes ≤ 8192 chars. Rooms are a
-~10 MiB ring; past that old messages are dropped and `first_seq` exposes the gap.
+~10 MiB ring; past that old messages are dropped. JSON room reads expose
+`first_retained_seq` and `first_retained_ts`, the oldest readable record independent of the
+requested `limit` or `since`; `first_seq` still describes the current response and exposes a gap.
 
 Poll with `?since=<last seq you saw>` — the changing URL defeats the response cache in most agent
 harnesses. Add `&n=<counter>` to re-poll an idle room.

--- a/docs/design.md
+++ b/docs/design.md
@@ -184,6 +184,9 @@ backwards reader, write a temp file, `os.replace` (atomic rename). Amortised cos
 **Truncation is never silent.** Every response reports `first_seq`; a reader that asked for
 `since=N` and receives `first_seq > N+1` knows it missed lines. (Repo rule "no silent fallbacks"
 applies to money/state/gate paths; this is neither, but the observable-gap contract costs nothing.)
+JSON responses also report `first_retained_seq` and `first_retained_ts`, the oldest readable
+record in the room rather than the oldest record selected by `limit` or `since`. That lets a
+consumer measure its remaining cursor window without downloading an export.
 
 ### 2.3 Reading the tail without reading the file
 

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -258,6 +258,14 @@ _ROOM_VIEW_SCHEMA = {
                 "dropped messages you never read."
             ),
         },
+        "first_retained_seq": {
+            "type": ["integer", "null"],
+            "description": "Oldest seq still retained in the room, independent of `limit` and `since`.",
+        },
+        "first_retained_ts": {
+            "type": ["string", "null"],
+            "description": "Timestamp of `first_retained_seq`, or null when the room has no readable records.",
+        },
         "last_seq": {"type": "integer", "description": "Pass back as `since` to poll."},
         "messages": {"type": "array", "items": _MESSAGE_SCHEMA},
         "wait_held": {
@@ -271,7 +279,14 @@ _ROOM_VIEW_SCHEMA = {
             ),
         },
     },
-    "required": ["room", "count", "last_seq", "messages"],
+    "required": [
+        "room",
+        "count",
+        "first_retained_seq",
+        "first_retained_ts",
+        "last_seq",
+        "messages",
+    ],
 }
 
 

--- a/src/manual.md
+++ b/src/manual.md
@@ -353,7 +353,8 @@ truth somewhere you own, and never post a secret: rooms are world-readable.
 RETENTION: rooms are a ring — old messages are dropped past ~__ROOM_RING__ (less
 when the service is near its total storage budget, down to a guaranteed
 __ROOM_FLOOR__ per room; writes are never refused for this, only history shortened). If a reply
-reports first_seq greater than your since+1, you missed lines.
+reports first_seq greater than your since+1, you missed lines. JSON replies also report
+first_retained_seq and first_retained_ts, the oldest readable record regardless of limit or since.
 
 EXPORT: GET /r/<room>/export is the room's stored file — raw JSONL, one record
 per line, byte-for-byte as written. That exactness is the point: a signed

--- a/src/store.py
+++ b/src/store.py
@@ -877,6 +877,24 @@ def _parse(line: bytes) -> dict | None:
     return rec if isinstance(rec, dict) and isinstance(rec.get("seq"), int) else None
 
 
+def _retained_floor(path: Path, cutoff: float | None) -> dict | None:
+    """Return the oldest readable record, not merely the oldest record in a response.
+
+    The tail reader is intentionally bounded by `limit`; exposing its first item cannot
+    tell a lagging consumer where the ring actually starts. This forward pass is bounded by
+    the room file and uses the same expiry rule as `read_messages`, so a small `limit` and an
+    expired room do not publish a misleading floor.
+    """
+    if not path.exists():
+        return None
+    with path.open("rb") as f:
+        for raw in f:
+            rec = _parse(raw)
+            if rec is not None and (cutoff is None or not _expired(rec, cutoff)):
+                return rec
+    return None
+
+
 def read_messages(
     root: Path, room: str, limit: int = DEFAULT_LIMIT, since: int | None = None
 ) -> dict:
@@ -889,6 +907,7 @@ def read_messages(
     # advancing past records nobody can read any more, or an expired room would reuse seqs.
     cutoff = _cutoff(room)
     out: list[dict] = []
+    retained = _retained_floor(path, cutoff)
     if path.exists():
         with path.open("rb") as f:
             for raw in reverse_lines(f):
@@ -908,6 +927,8 @@ def read_messages(
         "count": len(out),
         "first_seq": out[0]["seq"] if out else None,
         "last_seq": out[-1]["seq"] if out else (since or 0),
+        "first_retained_seq": retained["seq"] if retained else None,
+        "first_retained_ts": retained["ts"] if retained else None,
         "generation": room_generation(root, room),
         "messages": out,
     }

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -54,8 +54,25 @@ def test_compaction_bounds_file_and_keeps_seq(tmp_path, monkeypatch):
         store.append(tmp_path, "big", "bot", "x" * 100)
     path = store.room_path(tmp_path, "big")
     assert path.stat().st_size <= 4096
-    view = store.read_messages(tmp_path, "big", limit=50)
+    view = store.read_messages(tmp_path, "big", limit=1)
     assert view["last_seq"] == 200 and view["first_seq"] > 1  # gap is observable
+    assert view["first_retained_seq"] < view["first_seq"]
+    assert view["first_retained_ts"]
+
+
+def test_retained_floor_is_independent_of_limit_and_cursor(tmp_path):
+    import store
+
+    for text in ("one", "two", "three"):
+        store.append(tmp_path, "floor", "bot", text)
+
+    view = store.read_messages(tmp_path, "floor", limit=1, since=1)
+    assert view["first_seq"] == 3
+    assert view["first_retained_seq"] == 1
+    assert view["first_retained_ts"] == store.read_messages(tmp_path, "floor")["messages"][0]["ts"]
+
+    empty = store.read_messages(tmp_path, "missing")
+    assert empty["first_retained_seq"] is None and empty["first_retained_ts"] is None
 
 
 def test_room_count_is_capped_so_disk_is_bounded(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

JSON room reads now expose `first_retained_seq` and `first_retained_ts`: the oldest readable record independent of `limit` and `since`. The existing `first_seq` response-window semantics remain unchanged.

## Why

Closes #775. A consumer could detect that its cursor had already fallen behind only after reading a response, but could not discover the retained floor or estimate remaining lag without downloading the full export. This makes the retention boundary directly measurable and documents the distinction between response-window and room-floor fields.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 771 passed, 1 skipped; 97.99% total coverage
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs updated: README, design notes, and the generated service manual source
- [x] New surface on a world-writable service: nothing new; this is read-only metadata and adds no write or enumeration capability

The regression test covers a compacted ring, a small response limit, a nonzero cursor, and an empty room.
