### PR TITLE
feat(client): a local signer with crash-safe nonce allocation (#39)

### DIFF
--- a/client/technocore_client/__init__.py
+++ b/client/technocore_client/__init__.py
@@ -10,7 +10,12 @@ that must never disagree.
 """
 
 from .keyring import Keyring, did_from_seed
-from .nonces import NonceStore
+from .nonces import LedgerUnreadableError, NonceStore
 from .signer import Signer
 
-__all__ = ["Keyring", "NonceStore", "Signer", "did_from_seed"]
+# `LedgerUnreadableError` is part of the contract, not an internal: this package refuses
+# rather than guessing when the nonce record is untrustworthy, so an application has to be
+# able to catch that by type. It was reachable only as `technocore_client.nonces.` until a
+# test needed it, which is a caller reaching into a private module to do the documented
+# thing.
+__all__ = ["Keyring", "LedgerUnreadableError", "NonceStore", "Signer", "did_from_seed"]

--- a/client/technocore_client/__init__.py
+++ b/client/technocore_client/__init__.py
@@ -1,0 +1,16 @@
+"""A local signer for technocore's signed lane.
+
+Deliberately not part of the core (`src/app.py`, `src/config.py`, `src/didkey.py`,
+`src/limit.py`, `src/store.py`): this is a client, it ships beside the server the way
+`mcp/` does, and `sz.py`'s caps stay about the thing that has to stay small.
+
+It does import from the core, one way only — `store.clean_text` for the sweep and
+`didkey` for the DID constants — because the alternative is a second copy of two rules
+that must never disagree.
+"""
+
+from .keyring import Keyring, did_from_seed
+from .nonces import NonceStore
+from .signer import Signer
+
+__all__ = ["Keyring", "NonceStore", "Signer", "did_from_seed"]

--- a/client/technocore_client/durable.py
+++ b/client/technocore_client/durable.py
@@ -1,0 +1,55 @@
+"""Making a new file's *directory entry* durable, not just its contents.
+
+`fsync` on a file makes its data durable. It does not make the name durable: on POSIX the
+directory entry that points at it lives in the parent directory, and until that is fsynced a
+power loss can leave a file whose bytes reached the disk and whose name did not.
+
+That matters least for a cache and most for an identity. `Keyring` writes a seed, fsyncs it,
+and returns a usable DID — and without this a host crash immediately afterwards leaves the next
+process seeing no seed and generating a *different* key. The advertised persisted identity would
+change silently after a successful first run, which is the one failure that cannot be retried.
+
+Raised by @yukkie3276 in review of #803. The nonce store in the same change already fsynced its
+parent after `os.replace` and the keyring did not, so this is one rule written once rather than
+the same reasoning applied in one place and forgotten in the other.
+
+POSIX, like the rest of this package: fsyncing a directory handle is not available on Windows.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def fsync_dir(directory: Path) -> None:
+    """Flush a directory's own entries. Opening it read-only is enough to fsync it."""
+    fd = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def mkdir_durable(path: Path) -> None:
+    """`mkdir -p`, with every directory entry it creates made durable.
+
+    Creating `a/b/c` adds an entry to `a`, to `a/b` and to `a/b/c`'s parent in turn, so syncing
+    only the deepest one leaves the shallower entries no more durable than the file would have
+    been. The walk stops at the first ancestor that already exists, because its entry was
+    somebody else's problem and is not one this call created.
+    """
+    new: list[Path] = []
+    probe = path
+    while not probe.exists():
+        new.append(probe)
+        if probe.parent == probe:  # reached the root; nothing above to sync
+            break
+        probe = probe.parent
+
+    path.mkdir(parents=True, exist_ok=True)
+
+    # Shallowest first: a parent's entry must be durable before the child's entry inside it
+    # means anything.
+    for created in reversed(new):
+        fsync_dir(created.parent)

--- a/client/technocore_client/keyring.py
+++ b/client/technocore_client/keyring.py
@@ -12,6 +12,7 @@ world-readable between runs is the failure this catches, and it is silent otherw
 from __future__ import annotations
 
 import base64
+import binascii
 import os
 import stat
 import tempfile
@@ -59,6 +60,27 @@ class Keyring:
         self.did = did_from_seed(self.seed)
 
     def _load(self) -> bytes:
+        """The seed on disk, minting one if there is none.
+
+        Every path out of here fsyncs the directory before returning, not only the one that
+        created the file. A constructor that returns an identity is promising that identity
+        survives a power cut, and the promise cannot depend on which branch it took: a process
+        whose `exists()` check lands after another's `os.link` but before that other's fsync
+        would otherwise return a working DID whose name is not yet durable (@Minh3132, #803).
+
+        The first fix covered only the lost-create race, which left the plain already-there path
+        open — and the test caught that, because it counted directory syncs globally and was
+        acquitted by the winner's. Attributing each sync to the thread that made it is what
+        turned a passing test into a failing one. One fsync per process on an already-synced
+        directory is cheap; reasoning about which interleavings need it is not.
+        """
+        try:
+            return self._load_inner()
+        finally:
+            if self._path.parent.exists():
+                fsync_dir(self._path.parent)
+
+    def _load_inner(self) -> bytes:
         if not self._path.exists():
             created = self._create()
             if created is not None:
@@ -67,15 +89,50 @@ class Keyring:
             # complete by construction — see `_create` — so there is nothing to wait for; fall
             # through and read the winner's identity rather than failing a startup that has no
             # reason to fail (@yukkie3276, #803).
+            #
+            # But fsync the directory before doing so. The winner links the name and fsyncs the
+            # directory afterwards, so a loser that read the file and returned in between would
+            # hand back a working identity whose *name* was not yet durable — the same power-loss
+            # window the directory fsync exists to close, reopened for whichever process did not
+            # create the file (@Minh3132, #803). fsync on an already-synced directory is cheap and
+            # this runs once per process, so ordering it here rather than reasoning about the
+            # interleaving is the trade worth making.
         mode = stat.S_IMODE(self._path.stat().st_mode)
         if mode & 0o077:
             raise PermissionError(
                 f"{self._path} is mode {mode:04o}; a signing seed must not be group- or "
                 "world-readable. Fix with chmod 600 and rotate if it was ever shared."
             )
-        seed = base64.urlsafe_b64decode(self._path.read_text().strip() + "==")
+        # `validate=True`, and this is not a detail. Without it `urlsafe_b64decode` *silently
+        # discards* characters outside the alphabet: "not base64 at all!!" decodes to ten bytes
+        # rather than raising. A corrupted seed therefore does not fail — it becomes a different
+        # 32-byte value whenever the garbage happens to be the right length, and the identity
+        # quietly changes. The length check below is not a substitute; it catches most
+        # corruptions and not the one that matters.
+        #
+        # Raised as a labelled refusal for the same reason the nonce ledger's is: an unreadable
+        # identity is unknown state, and a bare `binascii.Error` traceback tells the operator
+        # neither what it cost nor what to do (found in review by @yukkie3276, #803).
+        try:
+            # `b64decode` with `altchars`, because `urlsafe_b64decode` takes no `validate`
+            # argument — the urlsafe wrapper is the lenient one, and leniency is the bug here.
+            body = self._path.read_text().strip()
+            # Pad to a multiple of four rather than always appending "==": with validate=True,
+            # surplus padding is itself an error ("Excess data after padding"), so the sloppy
+            # version that worked under the lenient decoder does not survive the strict one.
+            seed = base64.b64decode(body + "=" * (-len(body) % 4), altchars=b"-_", validate=True)
+        except (ValueError, binascii.Error) as exc:
+            raise ValueError(
+                f"{self._path} is not base64 ({exc}). A seed that cannot be read is not a seed "
+                "that is absent: generating a new one here would silently change this identity, "
+                "and every signature and published note already names the old key. Repair the "
+                "file or move it aside deliberately."
+            ) from exc
         if len(seed) != 32:
-            raise ValueError(f"{self._path} does not hold a 32-byte seed")
+            raise ValueError(
+                f"{self._path} decodes to {len(seed)} bytes, not 32. Same reasoning as above: "
+                "this is a damaged identity, not a missing one."
+            )
         return seed
 
     def _create(self) -> bytes | None:

--- a/client/technocore_client/keyring.py
+++ b/client/technocore_client/keyring.py
@@ -1,0 +1,87 @@
+"""Ed25519 key generation and local persistence, with the DID derived rather than stored.
+
+Storing the `did:key` beside the seed would let the two disagree — a truncated write, a
+hand-edited file — and a client that trusts a stored DID signs under an identity it does
+not hold. The DID is a pure function of the seed, so it is computed on load and the file
+holds one thing.
+
+Permissions are 0600 and are checked on read, not only set on write: a seed that became
+world-readable between runs is the failure this catches, and it is silent otherwise.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import stat
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+import didkey
+
+_B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def _b58encode(raw: bytes) -> str:
+    """base58btc, the inverse of `didkey._b58decode`.
+
+    Leading zero bytes are not carried by the integer and each one is a significant '1'
+    in base58btc. The multicodec prefix (0xed) means that never fires for a did:key; it
+    is handled anyway so this is the inverse rather than nearly the inverse.
+    """
+    pad = len(raw) - len(raw.lstrip(b"\x00"))
+    number = int.from_bytes(raw, "big")
+    out = ""
+    while number:
+        number, digit = divmod(number, 58)
+        out = _B58[digit] + out
+    return "1" * pad + out
+
+
+def did_from_seed(seed: bytes) -> str:
+    """The `did:key:z6Mk…` for a 32-byte Ed25519 seed."""
+    if len(seed) != 32:
+        raise ValueError(f"seed must be 32 bytes, got {len(seed)}")
+    public = Ed25519PrivateKey.from_private_bytes(seed).public_key().public_bytes_raw()
+    return didkey.PREFIX + "z" + _b58encode(didkey.MULTICODEC_ED25519 + public)
+
+
+class Keyring:
+    """One seed on disk, its DID derived on load."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self.seed = self._load()
+        self.did = did_from_seed(self.seed)
+
+    def _load(self) -> bytes:
+        if not self._path.exists():
+            return self._create()
+        mode = stat.S_IMODE(self._path.stat().st_mode)
+        if mode & 0o077:
+            raise PermissionError(
+                f"{self._path} is mode {mode:04o}; a signing seed must not be group- or "
+                "world-readable. Fix with chmod 600 and rotate if it was ever shared."
+            )
+        seed = base64.urlsafe_b64decode(self._path.read_text().strip() + "==")
+        if len(seed) != 32:
+            raise ValueError(f"{self._path} does not hold a 32-byte seed")
+        return seed
+
+    def _create(self) -> bytes:
+        seed = Ed25519PrivateKey.generate().private_bytes_raw()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        # Opened 0600 rather than written and then chmod'ed: between those two calls the
+        # seed exists at the process umask, and that window is the whole exposure.
+        fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(base64.urlsafe_b64encode(seed).decode().rstrip("="))
+            handle.flush()
+            os.fsync(handle.fileno())
+        return seed
+
+    def sign(self, message: str) -> str:
+        """Sign a canonical string, returning the 86-character base64url the server takes."""
+        signature = Ed25519PrivateKey.from_private_bytes(self.seed).sign(message.encode())
+        return base64.urlsafe_b64encode(signature).decode().rstrip("=")

--- a/client/technocore_client/keyring.py
+++ b/client/technocore_client/keyring.py
@@ -97,6 +97,19 @@ class Keyring:
             # create the file (@Minh3132, #803). fsync on an already-synced directory is cheap and
             # this runs once per process, so ordering it here rather than reasoning about the
             # interleaving is the trade worth making.
+        # A seed that exists and is not a regular file, before anything else asks about its
+        # mode or its contents. Without this a directory named `seed` made `exists()` true, so
+        # `Signer` refused about the *nonce ledger* — "this key already exists, so a ledger was
+        # written and has since been lost" — and sent the operator to investigate the wrong
+        # file entirely. A dangling symlink got a bare FileNotFoundError from the read. Neither
+        # minted a key, so both failed closed; both named the wrong problem (own audit).
+        if not self._path.is_file():
+            raise ValueError(
+                f"{self._path} exists and is not a regular file. A signing seed must be a plain "
+                "file containing 32 base64 bytes; a directory, a socket or a symlink with no "
+                "target is not one. Nothing was created and no identity was derived — move "
+                "whatever is there out of the way, or point this install at a different home."
+            )
         mode = stat.S_IMODE(self._path.stat().st_mode)
         if mode & 0o077:
             raise PermissionError(
@@ -113,10 +126,22 @@ class Keyring:
         # Raised as a labelled refusal for the same reason the nonce ledger's is: an unreadable
         # identity is unknown state, and a bare `binascii.Error` traceback tells the operator
         # neither what it cost nor what to do (found in review by @yukkie3276, #803).
+        # Read before decoding, and refused separately: mode 0000 clears the group/other check
+        # above and then raised a bare PermissionError from inside the base64 attempt, which
+        # would have been reported as "is not base64" — a wrong diagnosis of a permissions
+        # problem (own audit).
+        try:
+            body = self._path.read_text().strip()
+        except OSError as exc:
+            raise ValueError(
+                f"{self._path} exists and cannot be read ({exc.__class__.__name__}). A seed that "
+                "cannot be read is not a seed that is absent: generating a new one here would "
+                "silently change this identity. Fix the permissions, or move the file aside "
+                "deliberately."
+            ) from exc
         try:
             # `b64decode` with `altchars`, because `urlsafe_b64decode` takes no `validate`
             # argument — the urlsafe wrapper is the lenient one, and leniency is the bug here.
-            body = self._path.read_text().strip()
             # Pad to a multiple of four rather than always appending "==": with validate=True,
             # surplus padding is itself an error ("Excess data after padding"), so the sloppy
             # version that worked under the lenient decoder does not survive the strict one.

--- a/client/technocore_client/keyring.py
+++ b/client/technocore_client/keyring.py
@@ -59,7 +59,13 @@ class Keyring:
 
     def _load(self) -> bytes:
         if not self._path.exists():
-            return self._create()
+            created = self._create()
+            if created is not None:
+                return created
+            # Another process created the seed between our check and our create. Its file is
+            # complete by construction — see `_create` — so there is nothing to wait for; fall
+            # through and read the winner's identity rather than failing a startup that has no
+            # reason to fail (@yukkie3276, #803).
         mode = stat.S_IMODE(self._path.stat().st_mode)
         if mode & 0o077:
             raise PermissionError(
@@ -71,16 +77,38 @@ class Keyring:
             raise ValueError(f"{self._path} does not hold a 32-byte seed")
         return seed
 
-    def _create(self) -> bytes:
+    def _create(self) -> bytes | None:
+        """Mint and persist a seed, or return None if another process got there first.
+
+        Written to a pid-scoped temporary and then `os.link`ed into place, rather than opened
+        at the final path and filled in afterwards. Two reasons, and the second is the one that
+        removes a whole class of retry logic:
+
+        * `link` is create-or-fail — it raises `FileExistsError` rather than clobbering — so it
+          is the atomic claim on the name that `O_EXCL` was doing before.
+        * the name never exists holding a partial seed. A process that loses the race sees
+          either no file or a complete one, so it can read the winner's identity immediately
+          instead of waiting for bytes that may still be arriving.
+
+        The temporary is opened 0600 rather than written and then chmod'ed: between those two
+        calls the seed would exist at the process umask, and that window is the whole exposure.
+        The link preserves the mode, so the final file is 0600 without a second syscall.
+        """
         seed = Ed25519PrivateKey.generate().private_bytes_raw()
         mkdir_durable(self._path.parent)
-        # Opened 0600 rather than written and then chmod'ed: between those two calls the
-        # seed exists at the process umask, and that window is the whole exposure.
-        fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            handle.write(base64.urlsafe_b64encode(seed).decode().rstrip("="))
-            handle.flush()
-            os.fsync(handle.fileno())
+        tmp = self._path.with_name(f"{self._path.name}.{os.getpid()}.tmp")
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(base64.urlsafe_b64encode(seed).decode().rstrip("="))
+                handle.flush()
+                os.fsync(handle.fileno())
+            try:
+                os.link(tmp, self._path)
+            except FileExistsError:
+                return None
+        finally:
+            tmp.unlink(missing_ok=True)
         # The bytes are durable; the *name* is not until the directory holding it is synced.
         # Without this the constructor can return a working identity and a power loss can leave
         # the next process generating a different one (@yukkie3276, #803).

--- a/client/technocore_client/keyring.py
+++ b/client/technocore_client/keyring.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import base64
 import os
 import stat
+import tempfile
 from pathlib import Path
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -90,16 +91,25 @@ class Keyring:
           either no file or a complete one, so it can read the winner's identity immediately
           instead of waiting for bytes that may still be arriving.
 
-        The temporary is opened 0600 rather than written and then chmod'ed: between those two
-        calls the seed would exist at the process umask, and that window is the whole exposure.
-        The link preserves the mode, so the final file is 0600 without a second syscall.
+        The temporary is created 0600 by `mkstemp` rather than written and then chmod'ed:
+        between those two calls the seed would exist at the process umask, and that window is
+        the whole exposure. The link preserves the mode, so the final file is 0600 without a
+        second syscall. `mkstemp` also makes the staging name unique per *attempt* rather than
+        per process, which a pid was not: two threads share a pid.
         """
         seed = Ed25519PrivateKey.generate().private_bytes_raw()
         mkdir_durable(self._path.parent)
-        tmp = self._path.with_name(f"{self._path.name}.{os.getpid()}.tmp")
-        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        # `mkstemp`, not a pid-derived name. A pid is unique per process and two *threads* in one
+        # process share it, so both would build the same staging path and the loser would raise
+        # at the temporary's own O_EXCL — before ever reaching the link that handles the race
+        # (@yukkie3276, #803). mkstemp is the stdlib primitive for exactly this: a name nobody
+        # else has, created O_CREAT|O_EXCL at 0600, which is the mode this file needs anyway.
+        handle_fd, tmp_name = tempfile.mkstemp(
+            dir=self._path.parent, prefix=f"{self._path.name}.", suffix=".tmp"
+        )
+        tmp = Path(tmp_name)
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
                 handle.write(base64.urlsafe_b64encode(seed).decode().rstrip("="))
                 handle.flush()
                 os.fsync(handle.fileno())

--- a/client/technocore_client/keyring.py
+++ b/client/technocore_client/keyring.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import base64
 import binascii
 import os
+import re
 import stat
 import tempfile
 from pathlib import Path
@@ -25,6 +26,11 @@ import didkey
 from .durable import fsync_dir, mkdir_durable
 
 _B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+# The base64url alphabet, matched with `fullmatch` the way `didkey.verify` gates a signature's
+# alphabet before it decodes one. Trailing padding is admitted because the decode below already
+# accepts a padded body; rejecting it would be a new refusal rather than this fix.
+_B64URL_BODY = re.compile(r"[A-Za-z0-9_-]+={0,2}")
 
 
 def _b58encode(raw: bytes) -> str:
@@ -139,6 +145,38 @@ class Keyring:
                 "silently change this identity. Fix the permissions, or move the file aside "
                 "deliberately."
             ) from exc
+        # The alphabet, before the decode and not left to it. `altchars=b"-_"` translates `-` to
+        # `+` and `_` to `/`, and `validate=True` then checks what came out against the STANDARD
+        # alphabet — which contains `+` and `/`, the two characters base64url exists to exclude.
+        # So a `+` or a `/` in the file passes as ordinary alphabet and decodes to a different
+        # valid 32-byte seed, and `_create` writes with `urlsafe_b64encode`, so neither character
+        # can come from a file this package wrote: it is damage, and it was being accepted.
+        # `Keyring.did` derives from those bytes and `Signer.sign` signs with them, so the install
+        # publishes and signs under a different did:key with no error at all (second reader, #803).
+        #
+        # This does not make a corrupted seed detectable in general, and claiming it would be
+        # false. Over every single-character substitution in a 43-character body, 2706 still
+        # decode to a different valid seed because base64url can emit those characters — inherent
+        # to base64, and no decoder can see it. The 84 that base64url can never emit are exactly
+        # what this closes.
+        #
+        # Same defect as `nonces._no_duplicate_keys`, in a different parser: a permissive default
+        # silently changing the meaning of damaged input, where the leniency *is* the bug.
+        # `validate=True` stays — it still catches everything else, padding included.
+        # `body and`, because an empty or whitespace-only file holds no character outside the
+        # alphabet — it holds none at all, and saying otherwise names evidence that is not
+        # there. Left to the length check below, which already calls it a damaged identity
+        # rather than a missing one. Caught while verifying this guard rather than by a
+        # reviewer, and it is the same defect the rest of this branch keeps producing: a true
+        # refusal carrying a claim the file does not support.
+        if body and not _B64URL_BODY.fullmatch(body):
+            raise ValueError(
+                f"{self._path} is not base64url: it holds a character outside A-Z a-z 0-9 '-' "
+                "'_', and a seed file this package wrote can never contain one. A seed that "
+                "cannot be read is not a seed that is absent: generating a new one here would "
+                "silently change this identity, and every signature and published note already "
+                "names the old key. Repair the file or move it aside deliberately."
+            )
         try:
             # `b64decode` with `altchars`, because `urlsafe_b64decode` takes no `validate`
             # argument — the urlsafe wrapper is the lenient one, and leniency is the bug here.

--- a/client/technocore_client/keyring.py
+++ b/client/technocore_client/keyring.py
@@ -81,8 +81,8 @@ class Keyring:
     def _create(self) -> bytes | None:
         """Mint and persist a seed, or return None if another process got there first.
 
-        Written to a pid-scoped temporary and then `os.link`ed into place, rather than opened
-        at the final path and filled in afterwards. Two reasons, and the second is the one that
+        Written to a temporary from `mkstemp` and then `os.link`ed into place, rather than
+        opened at the final path and filled in afterwards. Two reasons, and the second is the one that
         removes a whole class of retry logic:
 
         * `link` is create-or-fail — it raises `FileExistsError` rather than clobbering — so it

--- a/client/technocore_client/keyring.py
+++ b/client/technocore_client/keyring.py
@@ -20,6 +20,8 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 import didkey
 
+from .durable import fsync_dir, mkdir_durable
+
 _B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
 
@@ -71,7 +73,7 @@ class Keyring:
 
     def _create(self) -> bytes:
         seed = Ed25519PrivateKey.generate().private_bytes_raw()
-        self._path.parent.mkdir(parents=True, exist_ok=True)
+        mkdir_durable(self._path.parent)
         # Opened 0600 rather than written and then chmod'ed: between those two calls the
         # seed exists at the process umask, and that window is the whole exposure.
         fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
@@ -79,6 +81,10 @@ class Keyring:
             handle.write(base64.urlsafe_b64encode(seed).decode().rstrip("="))
             handle.flush()
             os.fsync(handle.fileno())
+        # The bytes are durable; the *name* is not until the directory holding it is synced.
+        # Without this the constructor can return a working identity and a power loss can leave
+        # the next process generating a different one (@yukkie3276, #803).
+        fsync_dir(self._path.parent)
         return seed
 
     def sign(self, message: str) -> str:

--- a/client/technocore_client/keyring.py
+++ b/client/technocore_client/keyring.py
@@ -152,7 +152,10 @@ class Keyring:
         # valid 32-byte seed, and `_create` writes with `urlsafe_b64encode`, so neither character
         # can come from a file this package wrote: it is damage, and it was being accepted.
         # `Keyring.did` derives from those bytes and `Signer.sign` signs with them, so the install
-        # publishes and signs under a different did:key with no error at all (second reader, #803).
+        # publishes and signs under a different did:key with no error at all (own audit, sweeping
+        # for the class after @Minh3132's duplicate-key finding rather than waiting for the
+        # next report — and this is the line I had been citing as the example of getting it
+        # right, which is why nobody reread it).
         #
         # This does not make a corrupted seed detectable in general, and claiming it would be
         # false. Over every single-character substitution in a 43-character body, 2706 still

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -171,7 +171,12 @@ class NonceStore:
         else is history (second reader, #803). The marker is stripped by `_load`, so it is never
         counted here as a key.
         """
-        state = self._load()
+        # Through `_reload` like the other two readers, rather than a bare `_load`. Its single
+        # caller runs before anything has allocated, so the lock changes no answer today — but
+        # three read paths with two different locking rules is the kind of asymmetry this file
+        # otherwise has to justify in a comment, and the justification would have been "nobody
+        # calls it at a bad time yet".
+        state = self._reload()
         return len(state), sum(len(rooms) for rooms in state.values()), self._marker_present
 
     def _load(self) -> dict[str, dict[str, int]]:

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -47,6 +47,8 @@ import os
 import time
 from pathlib import Path
 
+from .durable import fsync_dir, mkdir_durable
+
 # The highest nonce this *process* has issued, across every store object and every pair.
 # A store rebuilt from a deleted file knows nothing, and the clock alone cannot separate
 # two allocations landing in the same millisecond — so the one thing still available, the
@@ -91,13 +93,13 @@ class NonceStore:
         `os.replace`, so a lock held on it would follow the old inode and stop excluding
         anyone the moment the first writer finished.
         """
-        self._path.parent.mkdir(parents=True, exist_ok=True)
+        mkdir_durable(self._path.parent)
         fd = os.open(str(self._path) + ".lock", os.O_CREAT | os.O_RDWR, 0o600)
         fcntl.flock(fd, fcntl.LOCK_EX)
         return fd
 
     def _flush(self) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
+        mkdir_durable(self._path.parent)
         tmp = self._path.with_suffix(f"{self._path.suffix}.{os.getpid()}.tmp")
         with open(tmp, "w", encoding="utf-8") as handle:
             json.dump(self._state, handle, indent=2, sort_keys=True)
@@ -105,11 +107,7 @@ class NonceStore:
             os.fsync(handle.fileno())
         os.replace(tmp, self._path)
         # The rename itself needs to be durable, not just the bytes it points at.
-        directory = os.open(self._path.parent, os.O_RDONLY)
-        try:
-            os.fsync(directory)
-        finally:
-            os.close(directory)
+        fsync_dir(self._path.parent)
 
     def last(self, did: str, room: str) -> int | None:
         """The last nonce allocated for this pair, or None if there has never been one."""

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -91,6 +91,46 @@ class LedgerUnreadableError(ValueError):
         self.why = why
 
 
+class _DuplicateLedgerKeyError(Exception):
+    """A key repeated inside one JSON object, carrying its name so the refusal can say it.
+
+    Deliberately not a `ValueError`: `_load` turns one of those into "could not be read as JSON",
+    and this is the opposite fact. The file parsed perfectly; the parser is what lost the data.
+    Folding it into the parse-failure message would send an operator looking for damaged syntax
+    in a file whose syntax is fine.
+    """
+
+    def __init__(self, key: str) -> None:
+        super().__init__(key)
+        self.key = key
+
+
+def _no_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    """`object_pairs_hook` that refuses a repeated key rather than keeping the last one.
+
+    `json.loads` accepts `{"room": 900, "room": 5}` and returns `{"room": 5}` without a word. A
+    ledger damaged that way satisfies every check below — valid JSON, an object, an entry of the
+    right shape — while the higher number is gone before any of them runs. `_allocate_locked`
+    then treats 5 as the last nonce issued, and after a clock rollback allocates beneath the
+    server's retained replay floor, which is the failure the whole loader exists to prevent
+    (@Minh3132, #803). A repeated DID discards an entire room map by the same mechanism.
+
+    This is the defect `keyring.py` fixes with `base64.b64decode(..., validate=True)`, in a
+    different parser: a permissive default silently changing the meaning of damaged input, where
+    the leniency *is* the bug. The package refuses both now rather than interpreting either.
+
+    Every key is treated alike, `_MARKER` included. `_load` pops the marker after parsing, so it
+    is an ordinary key at this point, and a file carrying two of them is exactly as unreadable as
+    one carrying two DIDs.
+    """
+    seen: dict[str, object] = {}
+    for key, value in pairs:
+        if key in seen:
+            raise _DuplicateLedgerKeyError(key)
+        seen[key] = value
+    return seen
+
+
 class NonceStore:
     """Per-(did, room) allocation, persisted before each number is handed out."""
 
@@ -207,7 +247,15 @@ class NonceStore:
             self._marker_present = False
             return {}
         try:
-            raw = json.loads(self._path.read_text())
+            raw = json.loads(self._path.read_text(), object_pairs_hook=_no_duplicate_keys)
+        except _DuplicateLedgerKeyError as exc:
+            # `json.dump` cannot emit a duplicate key, so no file this class wrote can hold one:
+            # it was hand-edited, or damaged by something merging two ledgers. That is unknown
+            # state, not something to interpret, and it takes the same refusal as the rest.
+            raise self._refuse(
+                f"records {exc.key!r} twice in one object, so the parser kept one of the two "
+                "values and discarded the other"
+            ) from exc
         except (OSError, ValueError) as exc:
             raise self._refuse(f"could not be read as JSON ({exc.__class__.__name__})") from exc
         if not isinstance(raw, dict):

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -45,6 +45,7 @@ import fcntl
 import json
 import os
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 from .durable import fsync_dir, mkdir_durable
@@ -92,24 +93,39 @@ class LedgerUnreadableError(ValueError):
 class NonceStore:
     """Per-(did, room) allocation, persisted before each number is handed out."""
 
-    def __init__(self, path: str | Path, *, key_exists: bool = False) -> None:
-        """`key_exists` says a signing key already exists at this home.
+    def __init__(self, path: str | Path, *, key_exists: bool | Callable[[], bool] = False) -> None:
+        """`key_exists` says whether a signing key exists at this home — a bool, or a callable
+        asked afresh at every load.
+
+        Pass the callable whenever the answer can change while this store is alive. It can:
+        `Signer` has to build the store before it mints the key, so a boolean captured there is
+        false for the whole life of the store that created the identity (@yukkie3276, #803). A
+        snapshot of a fact that is about to change is not a cheaper version of the fact.
 
         Absence is only proof of a first run when nothing has run before. Once a key exists, an
         absent ledger is not "nothing was issued" — it is "something may have been issued and
         the record is gone", which is the same unknown as a corrupt one and gets the same
         refusal (@yukkie3276, #803).
 
-        The judgement cannot be made here, and the default says so by being `False`. A store on
-        its own sees a path and nothing else; only something that knows whether a *key* already
-        exists can tell a first run from a loss, and that is `Signer`, which creates an empty
-        ledger before the key so that seed-without-ledger can only mean the record went missing.
+        The judgement still cannot be made here, and the default says so by being `False`. A store
+        on its own sees a path and nothing else; only something that knows whether a *key* exists
+        can tell a first run from a loss, and that is `Signer`, which creates an empty ledger
+        before the key so that seed-without-ledger can only mean the record went missing. Handing
+        over a question rather than an answer keeps that division and drops the staleness.
         Constructed directly, a `NonceStore` therefore still degrades to the clock floor on a
         lost file — weaker, and asserted rather than assumed, because deleting the test that
         covered it would have left the weaker path unexamined.
         """
         self._path = Path(path)
-        self._key_exists = key_exists
+        # A question, not an answer. Passed as a plain `bool` this was read once at
+        # construction, and `Signer` constructs the store BEFORE `Keyring` mints the key —
+        # so on a first run the store held "no key here" for its whole life, and a ledger
+        # deleted later in that same process was read as a first run by the very install
+        # that had just created the identity (@yukkie3276, #803). A callable is asked at
+        # every load, so there is no snapshot left to go stale.
+        self._key_exists: Callable[[], bool] = (
+            key_exists if callable(key_exists) else (lambda: bool(key_exists))
+        )
         self._marker: dict[str, int] = {"v": _FORMAT_VERSION}
         self._state: dict[str, dict[str, int]] = self._load()
 
@@ -172,7 +188,7 @@ class NonceStore:
         none — applied to my own state file, which is where it had not been.
         """
         if not self._path.exists():
-            if self._key_exists:
+            if self._key_exists():
                 raise self._refuse(
                     "is missing, and this key already exists, so a ledger was written and has "
                     "since been lost"
@@ -201,7 +217,7 @@ class NonceStore:
         # The legitimate never-signed state is not caught here. A first run creates the ledger
         # before the key and stamps it, so an interrupted one leaves the marker present with no
         # entries, which is exactly what this admits.
-        if marker is None and not raw and self._key_exists:
+        if marker is None and not raw and self._key_exists():
             raise self._refuse(
                 "holds an empty object with no initialisation record, and this key already "
                 "exists, so the ledger this class wrote has been emptied rather than left as "

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -62,6 +62,16 @@ from .durable import fsync_dir, mkdir_durable
 # millisecond later.
 _process_floor = 0
 
+# The ledger's "initialised and never used" value. It used to be exactly `{}`, and `{}` is also
+# what you get by truncating a populated ledger — so the innocent state and an erased one were
+# byte-identical and no check could separate them (@Minh3132, #803). A file this class wrote
+# carries this key; a file wiped to `{}` does not, and beside an existing key that is unknown.
+#
+# Not a DID, and cannot be mistaken for one: every DID begins `did:`, so `!` can never collide
+# with a real entry in the same object.
+_MARKER = "!ledger"
+_FORMAT_VERSION = 1
+
 
 class LedgerUnreadableError(ValueError):
     """A ledger that exists and cannot be trusted, carrying its reason apart from its advice.
@@ -82,8 +92,8 @@ class LedgerUnreadableError(ValueError):
 class NonceStore:
     """Per-(did, room) allocation, persisted before each number is handed out."""
 
-    def __init__(self, path: str | Path, *, expect_initialised: bool = False) -> None:
-        """`expect_initialised` says a ledger should already exist for this identity.
+    def __init__(self, path: str | Path, *, key_exists: bool = False) -> None:
+        """`key_exists` says a signing key already exists at this home.
 
         Absence is only proof of a first run when nothing has run before. Once a key exists, an
         absent ledger is not "nothing was issued" — it is "something may have been issued and
@@ -99,7 +109,8 @@ class NonceStore:
         covered it would have left the weaker path unexamined.
         """
         self._path = Path(path)
-        self._expect_initialised = expect_initialised
+        self._key_exists = key_exists
+        self._marker: dict[str, int] = {"v": _FORMAT_VERSION}
         self._state: dict[str, dict[str, int]] = self._load()
 
     def initialise(self) -> None:
@@ -124,6 +135,7 @@ class NonceStore:
             if self._path.exists():
                 return
             self._state = {}
+            self._marker = {"v": _FORMAT_VERSION}
             self._flush()
         finally:
             fcntl.flock(fd, fcntl.LOCK_UN)
@@ -136,8 +148,10 @@ class NonceStore:
         private state — and it returns both numbers because the first version returned only the
         pair count, which is not the same predicate. `{"did:key:z...": {}}` holds zero pairs and
         is not empty: `allocate` never writes a key with no rooms, so a key sitting there means
-        something happened that this class did not do. The innocent value is exactly `{}`, the
-        thing `initialise()` writes, and anything else is history (second reader, #803).
+        something happened that this class did not do. The innocent value is a ledger holding the
+        initialisation marker and no entries, which is what `initialise()` writes, and anything
+        else is history (second reader, #803). The marker is stripped by `_load`, so it is never
+        counted here as a key.
         """
         state = self._load()
         return len(state), sum(len(rooms) for rooms in state.values())
@@ -158,7 +172,7 @@ class NonceStore:
         none — applied to my own state file, which is where it had not been.
         """
         if not self._path.exists():
-            if self._expect_initialised:
+            if self._key_exists:
                 raise self._refuse(
                     "is missing, and this key already exists, so a ledger was written and has "
                     "since been lost"
@@ -170,6 +184,29 @@ class NonceStore:
             raise self._refuse(f"could not be read as JSON ({exc.__class__.__name__})") from exc
         if not isinstance(raw, dict):
             raise self._refuse("does not hold a JSON object")
+        # Take the initialisation record out before the entries are validated: it is not a DID
+        # and must not be walked as one, and `records()` must not count it as history.
+        marker = raw.pop(_MARKER, None)
+        if marker is not None and not isinstance(marker, dict):
+            raise self._refuse(f"holds {_MARKER!r} as something that is not an object")
+        self._marker = dict(marker) if marker is not None else {"v": _FORMAT_VERSION}
+        # An empty object carrying no initialisation record, beside a key that already exists.
+        # `initialise()` stamps every ledger it creates, so this file was not created by this
+        # class — it was emptied. That is the same unknown as a corrupt one and takes the same
+        # refusal. Without this, a ledger truncated to `{}` read as "initialised and never
+        # used": allocation restarted from the clock, and on a host whose clock had moved
+        # backwards it issued below a nonce already spent, so every signed write was refused
+        # until wall time caught up (@Minh3132, #803).
+        #
+        # The legitimate never-signed state is not caught here. A first run creates the ledger
+        # before the key and stamps it, so an interrupted one leaves the marker present with no
+        # entries, which is exactly what this admits.
+        if marker is None and not raw and self._key_exists:
+            raise self._refuse(
+                "holds an empty object with no initialisation record, and this key already "
+                "exists, so the ledger this class wrote has been emptied rather than left as "
+                "it was"
+            )
         # Strict, and every violation is fatal rather than filtered. The previous version dropped
         # a malformed entry and carried on, which reads like leniency and is not: dropping an
         # entry does not omit a fact, it *asserts* that the pair has never issued a nonce. That
@@ -228,7 +265,10 @@ class NonceStore:
         mkdir_durable(self._path.parent)
         tmp = self._path.with_suffix(f"{self._path.suffix}.{os.getpid()}.tmp")
         with open(tmp, "w", encoding="utf-8") as handle:
-            json.dump(self._state, handle, indent=2, sort_keys=True)
+            # The marker is written on every flush, not only at creation: it is what separates
+            # this file from one truncated to `{}`, and a rewrite that dropped it would erase
+            # that distinction for the next process to start.
+            json.dump({_MARKER: self._marker, **self._state}, handle, indent=2, sort_keys=True)
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(tmp, self._path)

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -342,9 +342,51 @@ class NonceStore:
         # The rename itself needs to be durable, not just the bytes it points at.
         fsync_dir(self._path.parent)
 
+    def identities(self) -> tuple[str, ...]:
+        """Every DID this ledger records, named rather than counted, from one read.
+
+        `records()` counts, and a count cannot answer the question `Signer` has to ask: whether
+        the identities in this ledger include the one the local key derives. A ledger recording
+        only somebody else's DID is a wrong seed restored or a home reused, and both look
+        identical to `records()` — one key, some allocations, nothing wrong.
+
+        The judgement stays with `Signer` and cannot move here. A store constructed directly may
+        hold several DIDs and sign for all of them legitimately, so "none of these is mine" is
+        only a defect for a caller that knows there is exactly one key at this home.
+        """
+        return tuple(self._reload())
+
     def last(self, did: str, room: str) -> int | None:
-        """The last nonce allocated for this pair, or None if there has never been one."""
-        return self._state.get(did, {}).get(room)
+        """The last nonce allocated for this pair, or None if there has never been one.
+
+        Reloaded rather than read from memory. It used to answer from `self._state`, which is
+        whatever the last load happened to leave there — so a store still open across another
+        process's allocation reported a number that process had already passed, and a caller
+        deciding anything from it was reading history as the present. Every other read in this
+        class reloads, `_allocate_locked` explains at length why the in-memory copy cannot be
+        trusted, and this was the one exception; no caller depended on the stale answer (own
+        audit).
+        """
+        return self._reload().get(did, {}).get(room)
+
+    def _reload(self) -> dict[str, dict[str, int]]:
+        """Re-read the ledger under the lock, for the paths that only look.
+
+        The same reload `_allocate_locked` does, without the write: taking the lock for a read
+        means the answer is not one an allocation already holding it has decided to supersede.
+
+        Never called from inside the lock. `flock` attaches to the open file description and
+        `_lock` opens a fresh one per call, so a nested read would block on a lock this same
+        process holds — a deadlock rather than a re-entry. `allocate` is the only holder, and it
+        reloads itself rather than calling this.
+        """
+        fd = self._lock()
+        try:
+            self._state = self._load()
+            return self._state
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
 
     def allocate(self, did: str, room: str) -> int:
         """Reserve and persist the next nonce for `did` in `room`, then return it."""

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -8,10 +8,16 @@ cause is a file it wrote three restarts ago.
 Two properties, and the second is the whole reason this file exists rather than a counter
 in memory:
 
-**Monotonic across processes, not just within one.** The floor is the wall clock in
-milliseconds. A fresh process with no state still allocates above anything a previous
-process could plausibly have used, so losing the file degrades to "probably fine" rather
-than "silently reuses from 1".
+**Monotonic across concurrent processes, not merely across restarts.** The first version of
+this claimed the former and delivered the latter: the wall clock plus a process-local
+high-water mark keeps a *restart* safe, and does nothing for two processes that load the same
+persisted value in the same millisecond — they compute the same number and one signed write is
+refused. Raised by @yukkie3276 in review, and correct. Reload, allocate and flush now happen
+under an exclusive `flock` on a sidecar lock file, so the read-modify-write is serialized
+across processes and each one sees the previous one's number.
+
+Losing the file still degrades to "probably fine" rather than "reuses from 1", because the
+clock remains a floor.
 
 **Persisted before it is returned, never after.** The caller may crash, or the network may
 swallow the write, between being handed a nonce and the server seeing it. If the record
@@ -21,12 +27,21 @@ nonces cost nothing, while a repeat is a rejected write the caller cannot explai
 
 The file is rewritten whole under `os.replace`, which is atomic on POSIX and on Windows for
 the same path: a reader either sees the old file or the new one, never a truncated one. The
-containing directory is fsynced too, because on ext4 the rename can otherwise outlive the
+temporary it is renamed from carries the pid, because a fixed `.tmp` name is a second way two
+processes collide — one writing it while the other renames it — which is the same defect as
+the nonce race wearing different clothes.
+
+The containing directory is fsynced too, because on ext4 the rename can otherwise outlive the
 data it points at across a power cut.
+
+**POSIX.** `fcntl.flock` and fsyncing a directory handle are both POSIX; this module does not
+run on Windows and says so here rather than failing at import with a message about a missing
+attribute. That was already true of the directory fsync before the lock was added.
 """
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import time
@@ -69,9 +84,21 @@ class NonceStore:
                 out[did] = {r: n for r, n in rooms.items() if isinstance(n, int) and n >= 0}
         return out
 
+    def _lock(self):
+        """Exclusive lock over the whole read-modify-write.
+
+        A sidecar file rather than the state file itself: the state file is replaced by
+        `os.replace`, so a lock held on it would follow the old inode and stop excluding
+        anyone the moment the first writer finished.
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(str(self._path) + ".lock", os.O_CREAT | os.O_RDWR, 0o600)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        return fd
+
     def _flush(self) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp = self._path.with_suffix(f"{self._path.suffix}.{os.getpid()}.tmp")
         with open(tmp, "w", encoding="utf-8") as handle:
             json.dump(self._state, handle, indent=2, sort_keys=True)
             handle.flush()
@@ -91,6 +118,19 @@ class NonceStore:
     def allocate(self, did: str, room: str) -> int:
         """Reserve and persist the next nonce for `did` in `room`, then return it."""
         global _process_floor
+        fd = self._lock()
+        try:
+            return self._allocate_locked(did, room)
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+    def _allocate_locked(self, did: str, room: str) -> int:
+        global _process_floor
+        # Re-read inside the lock. The copy loaded at construction is stale the moment another
+        # process allocates, and allocating from it is exactly the duplicate this lock exists to
+        # prevent — taking the lock and then trusting memory would be a lock that guards nothing.
+        self._state = self._load()
         known = self._state.get(did, {}).get(room)
         # With no record, the floor is the clock PLUS ONE, not the clock. A nonce equal to
         # the current millisecond may already have been used and forgotten — that is exactly

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -63,6 +63,22 @@ from .durable import fsync_dir, mkdir_durable
 _process_floor = 0
 
 
+class LedgerUnreadableError(ValueError):
+    """A ledger that exists and cannot be trusted, carrying its reason apart from its advice.
+
+    Two callers need different halves of the same refusal. An operator wants the whole message,
+    ending in how to recover. `Signer` wants only the reason, because its own advice is the
+    opposite one — for a *lost key*, moving the ledger aside is the catastrophic step — and it
+    has to quote why the file is unreadable inside a different recommendation. It used to get
+    that by splitting the formatted string on the first ". ", which a `repr` containing ". "
+    would clip. The reason is data; formatting it and parsing it back is not.
+    """
+
+    def __init__(self, why: str, message: str) -> None:
+        super().__init__(message)
+        self.why = why
+
+
 class NonceStore:
     """Per-(did, room) allocation, persisted before each number is handed out."""
 
@@ -112,6 +128,19 @@ class NonceStore:
         finally:
             fcntl.flock(fd, fcntl.LOCK_UN)
             os.close(fd)
+
+    def records(self) -> tuple[int, int]:
+        """(keys recorded, (key, room) pairs recorded), from one read.
+
+        Exists so `Signer` can tell an empty ledger from one with history without reaching into
+        private state — and it returns both numbers because the first version returned only the
+        pair count, which is not the same predicate. `{"did:key:z...": {}}` holds zero pairs and
+        is not empty: `allocate` never writes a key with no rooms, so a key sitting there means
+        something happened that this class did not do. The innocent value is exactly `{}`, the
+        thing `initialise()` writes, and anything else is history (second reader, #803).
+        """
+        state = self._load()
+        return len(state), sum(len(rooms) for rooms in state.values())
 
     def _load(self) -> dict[str, dict[str, int]]:
         """The persisted ledger, or `{}` when there has never been one.
@@ -173,13 +202,14 @@ class NonceStore:
         and a person doing that has decided the clock is safely past whatever was issued, which
         is exactly the judgement no automatic recovery can make.
         """
-        return ValueError(
+        return LedgerUnreadableError(
+            why,
             f"{self._path} {why}. The nonces already issued for this key are unknown, so "
             "allocating from the clock could repeat one and every signed write would be refused. "
             "This file is left in place deliberately: it is the only record of what was issued, "
             "and while it is here no process will allocate. Recover by repairing it, or by moving "
             "it aside once you are satisfied the clock is past the last nonce used — or by using a "
-            "different key."
+            "different key.",
         )
 
     def _lock(self):

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -71,20 +71,50 @@ class NonceStore:
         self._state: dict[str, dict[str, int]] = self._load()
 
     def _load(self) -> dict[str, dict[str, int]]:
+        """The persisted ledger, or `{}` when there has never been one.
+
+        **Absent and corrupt are not the same fact**, and the first version of this treated them
+        alike. A missing file is a first run: nothing was ever issued, so starting from the clock
+        is correct. A file that exists and does not parse is *unknown*: numbers were issued and
+        we cannot say which. Starting from the clock then is a guess, and @Minh3132's sequence on
+        #803 is when the guess is wrong — a host whose clock later moves backwards allocates
+        below a nonce already used, and every write is refused for a reason the caller cannot see.
+
+        So a corrupt ledger is quarantined and raised on. That is the rule I wrote for consumers
+        elsewhere — a failed read is unknown, not empty, and the only safe action on unknown is
+        none — applied to my own state file, which is where it had not been.
+        """
+        if not self._path.exists():
+            return {}
         try:
             raw = json.loads(self._path.read_text())
-        except (OSError, ValueError):
-            # A missing file is the ordinary first run. A corrupt one is treated the same
-            # way on purpose: the clock floor below keeps a lost file safe, whereas
-            # refusing to start would strand a caller over state it cannot repair.
-            return {}
+        except (OSError, ValueError) as exc:
+            raise self._quarantine(f"could not be read as JSON ({exc.__class__.__name__})") from exc
         if not isinstance(raw, dict):
-            return {}
+            raise self._quarantine("does not hold a JSON object")
         out: dict[str, dict[str, int]] = {}
         for did, rooms in raw.items():
             if isinstance(rooms, dict):
                 out[did] = {r: n for r, n in rooms.items() if isinstance(n, int) and n >= 0}
         return out
+
+    def _quarantine(self, why: str) -> Exception:
+        """Move a damaged ledger aside and describe the recovery, rather than continuing.
+
+        Renamed rather than deleted: it is the only record of what was issued, and whoever has
+        to decide whether waiting out the clock is enough will want to look at it.
+        """
+        aside = self._path.with_name(f"{self._path.name}.corrupt.{int(time.time())}")
+        try:
+            os.replace(self._path, aside)
+        except OSError:  # pragma: no cover - the rename failing does not change the verdict
+            aside = self._path
+        return ValueError(
+            f"{self._path} {why}; moved to {aside}. The nonces already issued for this key are "
+            "unknown, so allocating from the clock could repeat one and every signed write would "
+            "be refused. Recover by waiting until the clock is certainly past the last nonce "
+            "used, or by using a different key."
+        )
 
     def _lock(self):
         """Exclusive lock over the whole read-modify-write.

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -87,12 +87,31 @@ class NonceStore:
         self._state: dict[str, dict[str, int]] = self._load()
 
     def initialise(self) -> None:
-        """Write an empty ledger if there is none, so its later absence is evidence."""
-        if self._path.exists():
-            return
+        """Write an empty ledger if there is none, so its later absence is evidence.
+
+        Under the same lock every other write takes, and re-checking inside it. The first
+        version checked `exists()` and then flushed with no lock at all, which put a
+        first-start clobber *into the fix for a first-start race* (@yukkie3276, #803): two
+        starters both see the ledger absent, A initialises, mints its key, allocates and
+        persists nonce N — and B, still holding the stale answer to a question it asked before
+        any of that, replaces `{}` over A's populated ledger. Nothing was deleted and nothing
+        was corrupted, and a durable nonce is gone anyway, which lands the next restart back in
+        exactly the unknown-floor case this whole change exists to close.
+
+        `_flush` publishes with `os.replace`, so it overwrites by design; the only thing that
+        can stop it is not calling it, and the only way to know is to look while holding the
+        lock.
+        """
         mkdir_durable(self._path.parent)
-        self._state = {}
-        self._flush()
+        fd = self._lock()
+        try:
+            if self._path.exists():
+                return
+            self._state = {}
+            self._flush()
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
 
     def _load(self) -> dict[str, dict[str, int]]:
         """The persisted ledger, or `{}` when there has never been one.

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import tempfile
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -158,41 +159,7 @@ class NonceStore:
             fcntl.flock(fd, fcntl.LOCK_UN)
             os.close(fd)
 
-    def stamp_if_empty(self) -> None:
-        """Adopt an unmarked, entry-free ledger that was already here, by stamping it.
-
-        The marker turned "an empty ledger beside an existing key" into a refusal, which is
-        right — but a bare `{}` sitting in a directory with no key yet was innocent before that
-        and had to stay innocent. It did not: `initialise()` skips a file that exists, so the
-        stray `{}` survived startup unmarked, `Keyring` then created the key one line later, and
-        the first `allocate()` refused — telling the operator their ledger had been emptied when
-        nothing had ever written one. A fresh install minted an identity it could never use.
-
-        Found by auditing my own change rather than by a reviewer, which is the only reason it is
-        worth writing down twice: the refusal was correct and its trigger was a fact that the
-        constructor itself was about to make true.
-
-        Stamping is honest only here. `Signer` calls this having just established that the ledger
-        holds no keys and no allocations *and* that no key exists yet — so there is no history it
-        could be hiding. Beside an existing key the same file stays a refusal, because then
-        emptiness proves nothing.
-
-        Re-reads under the lock and writes only if the file is still unmarked and still empty,
-        for the same reason `initialise()` does: a writer that decided outside the lock is a
-        writer that clobbers.
-        """
-        fd = self._lock()
-        try:
-            state = self._load()
-            if self._marker_present or state:
-                return
-            self._state = state
-            self._flush()
-        finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
-            os.close(fd)
-
-    def records(self) -> tuple[int, int]:
+    def records(self) -> tuple[int, int, bool]:
         """(keys recorded, (key, room) pairs recorded), from one read.
 
         Exists so `Signer` can tell an empty ledger from one with history without reaching into
@@ -205,7 +172,7 @@ class NonceStore:
         counted here as a key.
         """
         state = self._load()
-        return len(state), sum(len(rooms) for rooms in state.values())
+        return len(state), sum(len(rooms) for rooms in state.values()), self._marker_present
 
     def _load(self) -> dict[str, dict[str, int]]:
         """The persisted ledger, or `{}` when there has never been one.
@@ -228,6 +195,11 @@ class NonceStore:
                     "is missing, and this key already exists, so a ledger was written and has "
                     "since been lost"
                 )
+            # Reset both, or this store keeps reporting the marker of a file it no longer has.
+            # `records()` and anything else asking about marker presence would answer about the
+            # previous read rather than the current state of disk (own audit).
+            self._marker = {"v": _FORMAT_VERSION}
+            self._marker_present = False
             return {}
         try:
             raw = json.loads(self._path.read_text())
@@ -255,7 +227,12 @@ class NonceStore:
                 )
         self._marker = dict(marker) if marker is not None else {"v": _FORMAT_VERSION}
         self._marker_present = marker is not None
-        # An empty object carrying no initialisation record, beside a key that already exists.
+        # Any ledger with no initialisation record, beside a key that already exists. Narrowing
+        # this to the exact shape `{}` left `{"did:key:z...": {}}` accepted — no marker, but a
+        # non-empty object, so the guard missed it and allocation fell back to the clock. The
+        # property is "a file this package did not write", not "an empty file", and the code
+        # claimed the former while checking the latter (own audit). Safe to broaden because this
+        # package has never been released: there are no unmarked ledgers in the world to reject.
         # `initialise()` stamps every ledger it creates, so this file was not created by this
         # class — it was emptied. That is the same unknown as a corrupt one and takes the same
         # refusal. Without this, a ledger truncated to `{}` read as "initialised and never
@@ -266,11 +243,10 @@ class NonceStore:
         # The legitimate never-signed state is not caught here. A first run creates the ledger
         # before the key and stamps it, so an interrupted one leaves the marker present with no
         # entries, which is exactly what this admits.
-        if marker is None and not raw and self._key_exists():
+        if marker is None and self._key_exists():
             raise self._refuse(
-                "holds an empty object with no initialisation record, and this key already "
-                "exists, so the ledger this class wrote has been emptied rather than left as "
-                "it was"
+                "carries no initialisation record, and this key already exists, so it was not "
+                "written by this package — a stamped ledger has been replaced or emptied"
             )
         # Strict, and every violation is fatal rather than filtered. The previous version dropped
         # a malformed entry and carried on, which reads like leniency and is not: dropping an
@@ -345,8 +321,17 @@ class NonceStore:
 
     def _flush(self) -> None:
         mkdir_durable(self._path.parent)
-        tmp = self._path.with_suffix(f"{self._path.suffix}.{os.getpid()}.tmp")
-        with open(tmp, "w", encoding="utf-8") as handle:
+        # `mkstemp`, not a pid-derived name. The pid is unique across processes and shared by
+        # threads, and nothing on this method said it must be called under the lock — so one
+        # caller flushing outside it would give two threads the same path to write and rename in
+        # turn, tearing the file before `os.replace` ever sees it. `keyring.py` learned this and
+        # moved to `mkstemp`; the ledger kept the pid (own audit). Latent rather than live: all
+        # callers do hold the lock today.
+        fd_tmp, tmp_name = tempfile.mkstemp(
+            dir=self._path.parent, prefix=self._path.name + ".", suffix=".tmp"
+        )
+        tmp = Path(tmp_name)
+        with os.fdopen(fd_tmp, "w", encoding="utf-8") as handle:
             # The marker is written on every flush, not only at creation: it is what separates
             # this file from one truncated to `{}`, and a rewrite that dropped it would erase
             # that distinction for the next process to start.
@@ -383,11 +368,15 @@ class NonceStore:
         # the state after a lost file — and the server's rule is strictly greater, so
         # returning `now` would be refused with nothing local to explain it. The test for
         # this failed before the `+ 1` was here.
-        previous = known if known is not None else int(time.time() * 1000)
+        # One read, used for both the fallback and the floor. Reading the clock twice meant a
+        # millisecond boundary falling between them returned a nonce equal to the clock — exactly
+        # the value the `+ 1` above was added to avoid, refunded silently (own audit).
+        now_ms = int(time.time() * 1000)
+        previous = known if known is not None else now_ms
         # `max` and not `previous + 1`: a clock that has moved forward since the last write
         # jumps the counter, which keeps two processes sharing one key from colliding on a
         # value neither has persisted yet.
-        nonce = max(int(time.time() * 1000), previous + 1, _process_floor + 1)
+        nonce = max(now_ms, previous + 1, _process_floor + 1)
         _process_floor = nonce
         self._state.setdefault(did, {})[room] = nonce
         self._flush()

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -1,0 +1,108 @@
+"""Crash-safe nonce allocation for the signed lane.
+
+The server's rule is that a nonce must be strictly greater than the last one *that key*
+used *in that room* — per (key, room), never global. A client that allocates badly does
+not fail loudly: it gets a 4xx naming a number it thought it had never used, and the
+cause is a file it wrote three restarts ago.
+
+Two properties, and the second is the whole reason this file exists rather than a counter
+in memory:
+
+**Monotonic across processes, not just within one.** The floor is the wall clock in
+milliseconds. A fresh process with no state still allocates above anything a previous
+process could plausibly have used, so losing the file degrades to "probably fine" rather
+than "silently reuses from 1".
+
+**Persisted before it is returned, never after.** The caller may crash, or the network may
+swallow the write, between being handed a nonce and the server seeing it. If the record
+were written after a successful send, that gap would hand the same number out twice. It is
+written first and fsynced, so a nonce that was *never used* is simply skipped — and skipped
+nonces cost nothing, while a repeat is a rejected write the caller cannot explain.
+
+The file is rewritten whole under `os.replace`, which is atomic on POSIX and on Windows for
+the same path: a reader either sees the old file or the new one, never a truncated one. The
+containing directory is fsynced too, because on ext4 the rename can otherwise outlive the
+data it points at across a power cut.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+# The highest nonce this *process* has issued, across every store object and every pair.
+# A store rebuilt from a deleted file knows nothing, and the clock alone cannot separate
+# two allocations landing in the same millisecond — so the one thing still available, the
+# fact that this process already handed out that number, is kept here. It bounds the
+# realistic loss case (a file removed while the program runs, or a second store opened on
+# the same path) to something strictly increasing.
+#
+# What it does not cover, and no in-process value could: file lost AND a new process AND
+# the same millisecond as the last write. That needs the persisted state, which is the
+# point of the file; the residue is one refused write and a retry that succeeds a
+# millisecond later.
+_process_floor = 0
+
+
+class NonceStore:
+    """Per-(did, room) allocation, persisted before each number is handed out."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._state: dict[str, dict[str, int]] = self._load()
+
+    def _load(self) -> dict[str, dict[str, int]]:
+        try:
+            raw = json.loads(self._path.read_text())
+        except (OSError, ValueError):
+            # A missing file is the ordinary first run. A corrupt one is treated the same
+            # way on purpose: the clock floor below keeps a lost file safe, whereas
+            # refusing to start would strand a caller over state it cannot repair.
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        out: dict[str, dict[str, int]] = {}
+        for did, rooms in raw.items():
+            if isinstance(rooms, dict):
+                out[did] = {r: n for r, n in rooms.items() if isinstance(n, int) and n >= 0}
+        return out
+
+    def _flush(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        with open(tmp, "w", encoding="utf-8") as handle:
+            json.dump(self._state, handle, indent=2, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, self._path)
+        # The rename itself needs to be durable, not just the bytes it points at.
+        directory = os.open(self._path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+
+    def last(self, did: str, room: str) -> int | None:
+        """The last nonce allocated for this pair, or None if there has never been one."""
+        return self._state.get(did, {}).get(room)
+
+    def allocate(self, did: str, room: str) -> int:
+        """Reserve and persist the next nonce for `did` in `room`, then return it."""
+        global _process_floor
+        known = self._state.get(did, {}).get(room)
+        # With no record, the floor is the clock PLUS ONE, not the clock. A nonce equal to
+        # the current millisecond may already have been used and forgotten — that is exactly
+        # the state after a lost file — and the server's rule is strictly greater, so
+        # returning `now` would be refused with nothing local to explain it. The test for
+        # this failed before the `+ 1` was here.
+        previous = known if known is not None else int(time.time() * 1000)
+        # `max` and not `previous + 1`: a clock that has moved forward since the last write
+        # jumps the counter, which keeps two processes sharing one key from colliding on a
+        # value neither has persisted yet.
+        nonce = max(int(time.time() * 1000), previous + 1, _process_floor + 1)
+        _process_floor = nonce
+        self._state.setdefault(did, {})[room] = nonce
+        self._flush()
+        return nonce

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -66,9 +66,33 @@ _process_floor = 0
 class NonceStore:
     """Per-(did, room) allocation, persisted before each number is handed out."""
 
-    def __init__(self, path: str | Path) -> None:
+    def __init__(self, path: str | Path, *, expect_initialised: bool = False) -> None:
+        """`expect_initialised` says a ledger should already exist for this identity.
+
+        Absence is only proof of a first run when nothing has run before. Once a key exists, an
+        absent ledger is not "nothing was issued" — it is "something may have been issued and
+        the record is gone", which is the same unknown as a corrupt one and gets the same
+        refusal (@yukkie3276, #803).
+
+        The judgement cannot be made here, and the default says so by being `False`. A store on
+        its own sees a path and nothing else; only something that knows whether a *key* already
+        exists can tell a first run from a loss, and that is `Signer`, which creates an empty
+        ledger before the key so that seed-without-ledger can only mean the record went missing.
+        Constructed directly, a `NonceStore` therefore still degrades to the clock floor on a
+        lost file — weaker, and asserted rather than assumed, because deleting the test that
+        covered it would have left the weaker path unexamined.
+        """
         self._path = Path(path)
+        self._expect_initialised = expect_initialised
         self._state: dict[str, dict[str, int]] = self._load()
+
+    def initialise(self) -> None:
+        """Write an empty ledger if there is none, so its later absence is evidence."""
+        if self._path.exists():
+            return
+        mkdir_durable(self._path.parent)
+        self._state = {}
+        self._flush()
 
     def _load(self) -> dict[str, dict[str, int]]:
         """The persisted ledger, or `{}` when there has never been one.
@@ -86,6 +110,11 @@ class NonceStore:
         none — applied to my own state file, which is where it had not been.
         """
         if not self._path.exists():
+            if self._expect_initialised:
+                raise self._refuse(
+                    "is missing, and this key already exists, so a ledger was written and has "
+                    "since been lost"
+                )
             return {}
         try:
             raw = json.loads(self._path.read_text())

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -80,8 +80,8 @@ class NonceStore:
         #803 is when the guess is wrong — a host whose clock later moves backwards allocates
         below a nonce already used, and every write is refused for a reason the caller cannot see.
 
-        So a corrupt ledger is quarantined and raised on, and "corrupt" includes a file that
-        parses but does not hold the shape this writes. That is the rule I wrote for consumers
+        So an unreadable ledger is refused and left where it is, and "unreadable" includes a
+        file that parses but does not hold the shape this writes. That is the rule I wrote for consumers
         elsewhere — a failed read is unknown, not empty, and the only safe action on unknown is
         none — applied to my own state file, which is where it had not been.
         """
@@ -90,9 +90,9 @@ class NonceStore:
         try:
             raw = json.loads(self._path.read_text())
         except (OSError, ValueError) as exc:
-            raise self._quarantine(f"could not be read as JSON ({exc.__class__.__name__})") from exc
+            raise self._refuse(f"could not be read as JSON ({exc.__class__.__name__})") from exc
         if not isinstance(raw, dict):
-            raise self._quarantine("does not hold a JSON object")
+            raise self._refuse("does not hold a JSON object")
         # Strict, and every violation is fatal rather than filtered. The previous version dropped
         # a malformed entry and carried on, which reads like leniency and is not: dropping an
         # entry does not omit a fact, it *asserts* that the pair has never issued a nonce. That
@@ -101,32 +101,37 @@ class NonceStore:
         # the whole file had been lost (@yukkie3276, #803).
         for did, rooms in raw.items():
             if not isinstance(rooms, dict):
-                raise self._quarantine(f"maps {did!r} to something that is not an object")
+                raise self._refuse(f"maps {did!r} to something that is not an object")
             for room, nonce in rooms.items():
                 # bool before int: `isinstance(True, int)` is true in Python, and `true` in the
                 # file would otherwise load as the nonce 1.
                 if isinstance(nonce, bool) or not isinstance(nonce, int) or nonce < 0:
-                    raise self._quarantine(
+                    raise self._refuse(
                         f"holds {nonce!r} for {did!r}/{room!r}, which is not a non-negative integer"
                     )
         return {did: dict(rooms) for did, rooms in raw.items()}
 
-    def _quarantine(self, why: str) -> Exception:
-        """Move a damaged ledger aside and describe the recovery, rather than continuing.
+    def _refuse(self, why: str) -> Exception:
+        """Refuse to allocate, and leave the damaged ledger exactly where it is.
 
-        Renamed rather than deleted: it is the only record of what was issued, and whoever has
-        to decide whether waiting out the clock is enough will want to look at it.
+        The first version of this renamed the file aside to preserve it as evidence. That made
+        the refusal last one process: the next `NonceStore` found the canonical path absent,
+        read it as a first run, and allocated from the clock with the previous floor still
+        unknown — the very failure the refusal exists to prevent, delayed by one restart
+        (@yukkie3276, #803).
+
+        Leaving it in place is both the evidence and the lock. Every process that starts reads
+        the same unreadable file and refuses the same way, until a person removes or repairs it —
+        and a person doing that has decided the clock is safely past whatever was issued, which
+        is exactly the judgement no automatic recovery can make.
         """
-        aside = self._path.with_name(f"{self._path.name}.corrupt.{int(time.time())}")
-        try:
-            os.replace(self._path, aside)
-        except OSError:  # pragma: no cover - the rename failing does not change the verdict
-            aside = self._path
         return ValueError(
-            f"{self._path} {why}; moved to {aside}. The nonces already issued for this key are "
-            "unknown, so allocating from the clock could repeat one and every signed write would "
-            "be refused. Recover by waiting until the clock is certainly past the last nonce "
-            "used, or by using a different key."
+            f"{self._path} {why}. The nonces already issued for this key are unknown, so "
+            "allocating from the clock could repeat one and every signed write would be refused. "
+            "This file is left in place deliberately: it is the only record of what was issued, "
+            "and while it is here no process will allocate. Recover by repairing it, or by moving "
+            "it aside once you are satisfied the clock is past the last nonce used — or by using a "
+            "different key."
         )
 
     def _lock(self):

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -80,7 +80,8 @@ class NonceStore:
         #803 is when the guess is wrong — a host whose clock later moves backwards allocates
         below a nonce already used, and every write is refused for a reason the caller cannot see.
 
-        So a corrupt ledger is quarantined and raised on. That is the rule I wrote for consumers
+        So a corrupt ledger is quarantined and raised on, and "corrupt" includes a file that
+        parses but does not hold the shape this writes. That is the rule I wrote for consumers
         elsewhere — a failed read is unknown, not empty, and the only safe action on unknown is
         none — applied to my own state file, which is where it had not been.
         """
@@ -92,11 +93,23 @@ class NonceStore:
             raise self._quarantine(f"could not be read as JSON ({exc.__class__.__name__})") from exc
         if not isinstance(raw, dict):
             raise self._quarantine("does not hold a JSON object")
-        out: dict[str, dict[str, int]] = {}
+        # Strict, and every violation is fatal rather than filtered. The previous version dropped
+        # a malformed entry and carried on, which reads like leniency and is not: dropping an
+        # entry does not omit a fact, it *asserts* that the pair has never issued a nonce. That
+        # is the same claim the quarantine above exists to refuse, made one level in — and after
+        # a clock rollback it resumes allocation below the server's replay floor exactly as if
+        # the whole file had been lost (@yukkie3276, #803).
         for did, rooms in raw.items():
-            if isinstance(rooms, dict):
-                out[did] = {r: n for r, n in rooms.items() if isinstance(n, int) and n >= 0}
-        return out
+            if not isinstance(rooms, dict):
+                raise self._quarantine(f"maps {did!r} to something that is not an object")
+            for room, nonce in rooms.items():
+                # bool before int: `isinstance(True, int)` is true in Python, and `true` in the
+                # file would otherwise load as the nonce 1.
+                if isinstance(nonce, bool) or not isinstance(nonce, int) or nonce < 0:
+                    raise self._quarantine(
+                        f"holds {nonce!r} for {did!r}/{room!r}, which is not a non-negative integer"
+                    )
+        return {did: dict(rooms) for did, rooms in raw.items()}
 
     def _quarantine(self, why: str) -> Exception:
         """Move a damaged ledger aside and describe the recovery, rather than continuing.

--- a/client/technocore_client/nonces.py
+++ b/client/technocore_client/nonces.py
@@ -127,6 +127,7 @@ class NonceStore:
             key_exists if callable(key_exists) else (lambda: bool(key_exists))
         )
         self._marker: dict[str, int] = {"v": _FORMAT_VERSION}
+        self._marker_present = False
         self._state: dict[str, dict[str, int]] = self._load()
 
     def initialise(self) -> None:
@@ -152,6 +153,40 @@ class NonceStore:
                 return
             self._state = {}
             self._marker = {"v": _FORMAT_VERSION}
+            self._flush()
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+    def stamp_if_empty(self) -> None:
+        """Adopt an unmarked, entry-free ledger that was already here, by stamping it.
+
+        The marker turned "an empty ledger beside an existing key" into a refusal, which is
+        right — but a bare `{}` sitting in a directory with no key yet was innocent before that
+        and had to stay innocent. It did not: `initialise()` skips a file that exists, so the
+        stray `{}` survived startup unmarked, `Keyring` then created the key one line later, and
+        the first `allocate()` refused — telling the operator their ledger had been emptied when
+        nothing had ever written one. A fresh install minted an identity it could never use.
+
+        Found by auditing my own change rather than by a reviewer, which is the only reason it is
+        worth writing down twice: the refusal was correct and its trigger was a fact that the
+        constructor itself was about to make true.
+
+        Stamping is honest only here. `Signer` calls this having just established that the ledger
+        holds no keys and no allocations *and* that no key exists yet — so there is no history it
+        could be hiding. Beside an existing key the same file stays a refusal, because then
+        emptiness proves nothing.
+
+        Re-reads under the lock and writes only if the file is still unmarked and still empty,
+        for the same reason `initialise()` does: a writer that decided outside the lock is a
+        writer that clobbers.
+        """
+        fd = self._lock()
+        try:
+            state = self._load()
+            if self._marker_present or state:
+                return
+            self._state = state
             self._flush()
         finally:
             fcntl.flock(fd, fcntl.LOCK_UN)
@@ -205,7 +240,21 @@ class NonceStore:
         marker = raw.pop(_MARKER, None)
         if marker is not None and not isinstance(marker, dict):
             raise self._refuse(f"holds {_MARKER!r} as something that is not an object")
+        if marker is not None:
+            # A marker written by a newer version may mean something this code does not know,
+            # and "I do not understand this record" is the same unknown as a damaged one. The
+            # version was unchecked when the marker was introduced, so a future v2 ledger would
+            # have been read as a v1 one and quietly misinterpreted (own audit).
+            version = marker.get("v")
+            if isinstance(version, bool) or not isinstance(version, int):
+                raise self._refuse(f"holds {_MARKER!r} with no usable version")
+            if version > _FORMAT_VERSION:
+                raise self._refuse(
+                    f"was written in ledger format v{version}, and this build understands "
+                    f"v{_FORMAT_VERSION}"
+                )
         self._marker = dict(marker) if marker is not None else {"v": _FORMAT_VERSION}
+        self._marker_present = marker is not None
         # An empty object carrying no initialisation record, beside a key that already exists.
         # `initialise()` stamps every ledger it creates, so this file was not created by this
         # class — it was emptied. That is the same unknown as a corrupt one and takes the same
@@ -255,15 +304,32 @@ class NonceStore:
         and a person doing that has decided the clock is safely past whatever was issued, which
         is exactly the judgement no automatic recovery can make.
         """
-        return LedgerUnreadableError(
-            why,
-            f"{self._path} {why}. The nonces already issued for this key are unknown, so "
-            "allocating from the clock could repeat one and every signed write would be refused. "
-            "This file is left in place deliberately: it is the only record of what was issued, "
-            "and while it is here no process will allocate. Recover by repairing it, or by moving "
-            "it aside once you are satisfied the clock is past the last nonce used — or by using a "
-            "different key.",
+        cost = (
+            "The nonces already issued for this key are unknown, so allocating from the clock "
+            "could repeat one and every signed write would be refused. "
         )
+        # Two different recoveries, and giving the wrong one is not a cosmetic problem: the
+        # advice for a damaged file is to repair it or move it aside, and neither is possible
+        # for a file that is not there. An operator who follows it looks for something to move,
+        # finds nothing, and has no route out of a refusal that repeats on every start. Same
+        # lesson as the chained-refusal fix earlier on this branch — a true message can still
+        # tell someone to do something impossible (own audit, after @yukkie3276's live-predicate
+        # finding).
+        if self._path.exists():
+            advice = (
+                "This file is left in place deliberately: it is the only record of what was "
+                "issued, and while it is here no process will allocate. Recover by repairing it, "
+                "or by moving it aside once you are satisfied the clock is past the last nonce "
+                "used — or by using a different key."
+            )
+        else:
+            advice = (
+                "There is nothing here to repair or move aside. Restore the ledger from a backup, "
+                "or use a different key. Creating a fresh one is safe only once you are certain "
+                "the wall clock is past every nonce this key has ever used, which is a judgement "
+                "no automatic recovery can make — so this refuses rather than making it for you."
+            )
+        return LedgerUnreadableError(why, f"{self._path} {why}. {cost}{advice}")
 
     def _lock(self):
         """Exclusive lock over the whole read-modify-write.

--- a/client/technocore_client/signer.py
+++ b/client/technocore_client/signer.py
@@ -146,6 +146,22 @@ class Signer:
         self.nonces = NonceStore(ledger, key_exists=seed.exists)
         # Last, so that a refusal above cannot leave a freshly minted seed behind it.
         self.keys = Keyring(seed)
+        # And the ledger-versus-key comparison after that, because it needs the DID, which does
+        # not exist until `Keyring` has loaded or minted the seed. That ordering does not give up
+        # the property the line above buys: every state that can reach this refusal already had a
+        # seed on disk when `Keyring` ran, because a ledger recording another DID *without* a seed
+        # is the identity-loss gate's case and that gate answers first. So nothing was minted
+        # behind this refusal in any state the gates admit.
+        #
+        # The residue is the window the gate cannot close — a ledger with history arriving between
+        # its live re-check and `os.link(seed)`. That start does mint, and then refuses here. It
+        # keeps refusing on every later start, because the seed it left derives a DID the ledger
+        # still does not record, so the operator gets a repeating refusal rather than the silent
+        # success that is the thing being fixed. Closing the window instead would mean deriving a
+        # DID before the keyring exists, which is a second copy of the seed loader.
+        recorded = self.nonces.identities()
+        if recorded and self.keys.did not in recorded:
+            raise self._identity_mismatch(seed, ledger, recorded, self.keys.did)
 
     @staticmethod
     def _identity_lost(seed: Path, ledger: Path, what: str) -> Exception:
@@ -181,6 +197,41 @@ class Signer:
             f"you. If nothing has ever signed from here, delete {ledger} and start again. If it "
             "has, restore the seed from a backup; a new identity will not be the old one, and "
             "everything already published stays under a DID that can never sign again."
+        )
+
+    @staticmethod
+    def _identity_mismatch(
+        seed: Path, ledger: Path, recorded: tuple[str, ...], did: str
+    ) -> Exception:
+        """Refuse a ledger whose recorded identities do not include this key's own.
+
+        Nothing compared the two before, and the route into the gap is our own recovery advice.
+        An operator who loses a seed, restores a backup and restores the wrong one gets a silent
+        success: the key is present, so the identity-loss gate is skipped; the entries are
+        well-formed, so `_load` accepts them; and the first `allocate` finds no record under the
+        restored DID and starts from the clock — while a ledger holding the previous identity's
+        entire history sits unread beside it. The install comes back up signing as somebody else
+        and reports nothing wrong.
+
+        Two readings, and the file cannot tell them apart: the wrong seed was restored, or this
+        home is being reused for a new identity deliberately. Asserting either one is the defect
+        this branch keeps finding — a true refusal carrying a claim its evidence does not support
+        — so both are named, with the route out of each, and neither is stated as fact.
+
+        A ledger recording no DIDs at all is not this case and stays acceptable: it is what
+        `initialise()` writes, and a first run reaches here before it has allocated anything.
+        """
+        return ValueError(
+            f"{ledger} records nonce history for {', '.join(sorted(recorded))} and none for "
+            f"{did}, which is the identity the key at {seed} derives. The ledger and the key "
+            "describe different identities, and that has two readings this cannot distinguish: a "
+            "seed was restored from the wrong backup, in which case signing now would publish "
+            "under an identity this home has never used and leave the recorded history unread — "
+            "or this home is being reused for a new identity on purpose. Restore the seed that "
+            "derives one of the recorded identities, or, to start deliberately as a new one, "
+            f"clear this home: move or delete {seed.parent} so that nothing left here describes "
+            "the old identity. Do not delete the ledger on its own — that leaves a key whose "
+            "history is gone, which is the unknown-floor state refused elsewhere in this package."
         )
 
     @property

--- a/client/technocore_client/signer.py
+++ b/client/technocore_client/signer.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import store
 
 from .keyring import Keyring
-from .nonces import NonceStore
+from .nonces import LedgerUnreadableError, NonceStore
 
 
 class Signer:
@@ -48,8 +48,73 @@ class Signer:
         # means the window does not exist rather than being narrow.
         if not seed_existed and not ledger_existed:
             NonceStore(ledger).initialise()
-        self.keys = Keyring(seed)
+        # The mirror image, which was fail-open while its twin was fail-closed (@Minh3132,
+        # #803). A ledger with history beside no seed is not a first start: the key is gone, and
+        # minting a replacement is the loudest possible failure wearing silence. The new DID
+        # reads the old ledger, finds no entries under its own name, allocates from the clock as
+        # if it had never signed — and every signature and note already published names an
+        # identity nobody can ever sign as again. `Keyring` already refuses to mint over an
+        # unreadable existing seed for exactly this reason; the same fact arriving as an absent
+        # file was being waved through.
+        #
+        # Asked BEFORE the store is built, because the store's own corrupt-ledger refusal
+        # otherwise answers first and answers a different question. Its advice — move the file
+        # aside once you are satisfied the clock has passed — is correct for a lost record and
+        # catastrophic for a lost key: follow it here and the next start finds neither file,
+        # calls it a first run, and mints the replacement identity this check exists to prevent.
+        # An unreadable ledger is never the innocent interrupted first start, because that path
+        # writes exactly `{}`; beside a missing seed it is a loss, and it is the identity that
+        # was lost.
+        #
+        # An *empty* ledger beside no seed stays innocent: that is the window this class opens
+        # on purpose two lines up, and the reason the test is on allocations and not on the file.
+        if ledger_existed and not seed_existed:
+            try:
+                keys_recorded, allocations = NonceStore(ledger).records()
+            except LedgerUnreadableError as exc:
+                # `from None`, and the reason folded into the text instead. Chaining printed the
+                # store's own refusal as the cause, and that message ends "move it aside once
+                # you are satisfied the clock is past the last nonce used" — the one action this
+                # error exists to argue against. Suppressing the wrong answer by putting a right
+                # one in front of it is not suppressing it; an operator reading the cause block
+                # does the catastrophic thing anyway.
+                raise self._identity_lost(
+                    seed, ledger, f"exists but cannot be read ({exc.why})"
+                ) from None
+            # Anything but `{}` is history. Not "any allocations": a key with no rooms holds zero
+            # allocations and is still not the file `initialise()` writes, and `allocate` cannot
+            # produce it, so its presence means something happened here.
+            if keys_recorded or allocations:
+                raise self._identity_lost(
+                    seed,
+                    ledger,
+                    f"records {allocations} nonce allocation(s)"
+                    if allocations
+                    else f"records {keys_recorded} prior key(s) and no allocations",
+                )
+        # One known window, left as it is on purpose. A second starter that reads
+        # `seed_existed=False` after the winner's `initialise()` but before its `os.link` will
+        # come through here, and if the winner's *application* has also allocated by then it
+        # refuses a key that exists. Nothing allocates during `__init__` — only a later sign
+        # does — so the window needs an unlucky interleaving of two different layers, and it
+        # fails closed and clears on retry, which is the direction this module errs in
+        # everywhere else. Recorded rather than fixed: a reader who finds it should know it was
+        # seen (second reader, #803).
         self.nonces = NonceStore(ledger, expect_initialised=lost)
+        # Last, so that a refusal above cannot leave a freshly minted seed behind it.
+        self.keys = Keyring(seed)
+
+    @staticmethod
+    def _identity_lost(seed: Path, ledger: Path, what: str) -> Exception:
+        return ValueError(
+            f"{seed} is missing, but {ledger} {what}, so this install has signed before and its "
+            "key is gone. Minting a new one here would silently change identity: everything "
+            "already published stays under a DID that can never sign again, and the replacement "
+            "would allocate from the clock with no history. Restore the seed from a backup, or "
+            "move this whole directory aside to start deliberately as a new identity. Do not "
+            "move the ledger aside on its own — that turns this into what looks like a first "
+            "run, which is precisely the silent replacement being refused here."
+        )
 
     @property
     def did(self) -> str:

--- a/client/technocore_client/signer.py
+++ b/client/technocore_client/signer.py
@@ -220,6 +220,14 @@ class Signer:
 
         A ledger recording no DIDs at all is not this case and stays acceptable: it is what
         `initialise()` writes, and a first run reaches here before it has allocated anything.
+
+        The advice says *move aside*, never delete. The first draft of it offered "move or delete
+        this home", which is safe under one reading and destroys evidence under the other — the
+        ledger is the only surviving record of the old identity's history precisely in the case
+        where the wrong seed was restored. Every other refusal in this module says the file is
+        deliberately left in place; this one shipped telling the operator to remove it, and was
+        corrected within the hour. A refusal that gives destructive advice for the situation it
+        was written to protect is the same defect as the chained one fixed earlier on this branch.
         """
         return ValueError(
             f"{ledger} records nonce history for {', '.join(sorted(recorded))} and none for "
@@ -229,9 +237,11 @@ class Signer:
             "under an identity this home has never used and leave the recorded history unread — "
             "or this home is being reused for a new identity on purpose. Restore the seed that "
             "derives one of the recorded identities, or, to start deliberately as a new one, "
-            f"clear this home: move or delete {seed.parent} so that nothing left here describes "
-            "the old identity. Do not delete the ledger on its own — that leaves a key whose "
-            "history is gone, which is the unknown-floor state refused elsewhere in this package."
+            f"move {seed.parent} aside — keep it rather than delete it, because under the first "
+            "reading this ledger is the only surviving record of what the old identity issued, "
+            "and it is the thing you would need to restore the right seed against. Do not delete "
+            "the ledger on its own: that leaves a key whose history is gone, which is the "
+            "unknown-floor state refused elsewhere in this package."
         )
 
     @property

--- a/client/technocore_client/signer.py
+++ b/client/technocore_client/signer.py
@@ -26,9 +26,30 @@ class Signer:
     """A local identity: one seed, one nonce ledger, both on disk."""
 
     def __init__(self, home: str | Path) -> None:
+        """The ledger is created *before* the key, and the order is the point.
+
+        A missing ledger is only innocent when no key exists yet. Creating it first means that
+        by the time a seed is visible to anyone — including a process that lost the creation
+        race — an empty ledger is visible too, so "seed present, ledger absent" can only mean
+        the ledger was lost. Doing it the other way round leaves a window in which a losing
+        starter sees a key with no ledger and cannot tell that from a theft of the record.
+        """
         home = Path(home)
-        self.keys = Keyring(home / "seed")
-        self.nonces = NonceStore(home / "nonces.json")
+        ledger = home / "nonces.json"
+        seed = home / "seed"
+        # Read both before touching either: an earlier version initialised the ledger and *then*
+        # asked whether it had been missing, answering a question it had just changed.
+        seed_existed, ledger_existed = seed.exists(), ledger.exists()
+        lost = seed_existed and not ledger_existed
+        # And on a first run create the ledger BEFORE the key, which is what the comment used to
+        # claim while the code did the opposite. It matters under concurrency: a second starter
+        # landing between the winner's `os.link(seed)` and a later ledger write would see exactly
+        # seed-present-ledger-absent and refuse a perfectly healthy startup. Creating it first
+        # means the window does not exist rather than being narrow.
+        if not seed_existed and not ledger_existed:
+            NonceStore(ledger).initialise()
+        self.keys = Keyring(seed)
+        self.nonces = NonceStore(ledger, expect_initialised=lost)
 
     @property
     def did(self) -> str:

--- a/client/technocore_client/signer.py
+++ b/client/technocore_client/signer.py
@@ -48,11 +48,15 @@ class Signer:
     def note(self, namespace: str, key: str, value: str) -> tuple[str, str, int, str]:
         """Sign a note write. Returns (did, signature, nonce, swept value).
 
-        The nonce is scoped to the namespace and key together, matching how the server
-        scopes a note's replay window — a note nonce shares no counter with a room's.
+        The nonce is scoped to the **key alone**, not to the namespace and key together,
+        because that is what the server does: `app._burn_nonce(key, nonce)` keeps one counter
+        per note key across every namespace. Scoping this more finely looked harmless — the
+        clock floor makes a collision unlikely — but it would have meant two counters where the
+        server keeps one, and "unlikely" is the word that precedes every nonce bug in this file.
+        A note nonce still shares no counter with a room's.
         """
         swept = store.clean_text(value)
-        nonce = self.nonces.allocate(self.keys.did, f"kv:{namespace}/{key}")
+        nonce = self.nonces.allocate(self.keys.did, f"kv:{key}")
         return (
             self.keys.did,
             self.keys.sign(f"{namespace}|{key}|{nonce}|{swept}"),

--- a/client/technocore_client/signer.py
+++ b/client/technocore_client/signer.py
@@ -80,9 +80,15 @@ class Signer:
         #
         # An *empty* ledger beside no seed stays innocent: that is the window this class opens
         # on purpose two lines up, and the reason the test is on allocations and not on the file.
-        if ledger_existed and not seed_existed:
+        # Live reads, not the snapshot taken before `initialise()` ran. With the snapshot, a
+        # ledger carrying history that arrived after line 1 of this function — a partial
+        # restore, a file-by-file sync, a `cp -r` racing a start — left `ledger_existed`
+        # false, so this check was skipped and the key was minted over it. A fresh re-check
+        # cannot miss a real loss: if the seed has appeared since, it is not lost (own audit,
+        # same staleness @yukkie3276 found one consumer away).
+        if ledger.exists() and not seed.exists():
             try:
-                keys_recorded, allocations = NonceStore(ledger).records()
+                keys_recorded, allocations, marked = NonceStore(ledger).records()
             except LedgerUnreadableError as exc:
                 # `from None`, and the reason folded into the text instead. Chaining printed the
                 # store's own refusal as the cause, and that message ends "move it aside once
@@ -104,14 +110,21 @@ class Signer:
                     if allocations
                     else f"records {keys_recorded} prior key(s) and no allocations",
                 )
-            # Nothing above refused, so this ledger provably holds no history and no key exists
-            # yet to have made any. Stamp it before `Keyring` runs. Without this, a stray `{}`
-            # stays unmarked, the key is created immediately below, and the first `allocate()`
-            # refuses on a ledger that was never written — a fresh install holding an identity
-            # it can never use, told that its records were erased. My own change one commit ago
-            # opened that path: the refusal it added keys off a fact this constructor is about
-            # to make true.
-            NonceStore(ledger).stamp_if_empty()
+            # An entry-free ledger with no marker, beside no key. Every ledger this package
+            # writes is stamped, so this file did not come from here: either it is a stray that
+            # something else created, or it is a ledger of ours that was emptied — and an
+            # emptied one means this install had a key and has lost it as well as its history.
+            # The two are indistinguishable on disk, which is exactly why this refuses instead
+            # of choosing.
+            #
+            # I chose, one commit ago, and chose wrong. `stamp_if_empty` adopted the file so a
+            # stray `{}` would stop bricking a fresh install. It also stamped the emptied case,
+            # which erased the single bit that distinguished them and then let `Keyring` mint a
+            # replacement identity on top — signing happily under a new DID forever, evidence
+            # gone. Reproduced before reverting it. Refusing costs a fresh install one manual
+            # step; stamping cost a real one its identity, silently. That asymmetry decides it.
+            if not marked:
+                raise self._unknown_ledger(seed, ledger)
         # One known window, left as it is on purpose. A second starter that reads
         # `seed_existed=False` after the winner's `initialise()` but before its `os.link` will
         # come through here, and if the winner's *application* has also allocated by then it
@@ -144,6 +157,30 @@ class Signer:
             "move this whole directory aside to start deliberately as a new identity. Do not "
             "move the ledger aside on its own — that turns this into what looks like a first "
             "run, which is precisely the silent replacement being refused here."
+        )
+
+    @staticmethod
+    def _unknown_ledger(seed: Path, ledger: Path) -> Exception:
+        """Refuse without asserting which of two things happened, because it cannot be known.
+
+        `_identity_lost` states as fact that the install has signed before. For a ledger holding
+        *entries* that is sound. For an entry-free ledger with no marker it is one of two
+        readings, and the file cannot tell them apart: something else created a stray `{}`, or a
+        ledger of ours was emptied — and only the second means a key existed. Reusing the
+        confident wording here would have been the same defect this package keeps finding, a true
+        refusal carrying a claim the evidence does not support.
+        """
+        return ValueError(
+            f"{seed} is missing, and {ledger} exists, holds no entries and carries no "
+            "initialisation record. Every ledger this package writes is stamped, so this one was "
+            "not written here, and that has two readings it cannot distinguish: something else "
+            "created the file and nothing has ever signed from this directory, or a stamped "
+            "ledger was emptied — in which case this install had a key and both the key and its "
+            "nonce history are gone. Minting a key now would be right in the first case and a "
+            "silent identity replacement in the second, so it refuses and leaves the choice with "
+            f"you. If nothing has ever signed from here, delete {ledger} and start again. If it "
+            "has, restore the seed from a backup; a new identity will not be the old one, and "
+            "everything already published stays under a DID that can never sign again."
         )
 
     @property

--- a/client/technocore_client/signer.py
+++ b/client/technocore_client/signer.py
@@ -40,6 +40,19 @@ class Signer:
         # Read both before touching either: an earlier version initialised the ledger and *then*
         # asked whether it had been missing, answering a question it had just changed.
         seed_existed, ledger_existed = seed.exists(), ledger.exists()
+        # Before any of the lost-state reasoning below, because that reasoning takes
+        # `seed_existed` to mean "a usable key is here". A directory named `seed` makes it
+        # true, and then an absent ledger was refused as "this key already exists, so a
+        # ledger was written and has since been lost" — pointing the operator at the wrong
+        # file for a problem that is not the ledger's. `Keyring` has the same check, and it
+        # never runs, because this function answers first (own audit).
+        if seed_existed and not seed.is_file():
+            raise ValueError(
+                f"{seed} exists and is not a regular file, so this home has no usable key "
+                "and nothing here can be trusted to describe one. This is not a lost ledger: "
+                "move whatever is at that path out of the way, or point this install at a "
+                "different home."
+            )
         # And on a first run create the ledger BEFORE the key, which is what the comment used to
         # claim while the code did the opposite. It matters under concurrency: a second starter
         # landing between the winner's `os.link(seed)` and a later ledger write would see exactly
@@ -91,6 +104,14 @@ class Signer:
                     if allocations
                     else f"records {keys_recorded} prior key(s) and no allocations",
                 )
+            # Nothing above refused, so this ledger provably holds no history and no key exists
+            # yet to have made any. Stamp it before `Keyring` runs. Without this, a stray `{}`
+            # stays unmarked, the key is created immediately below, and the first `allocate()`
+            # refuses on a ledger that was never written — a fresh install holding an identity
+            # it can never use, told that its records were erased. My own change one commit ago
+            # opened that path: the refusal it added keys off a fact this constructor is about
+            # to make true.
+            NonceStore(ledger).stamp_if_empty()
         # One known window, left as it is on purpose. A second starter that reads
         # `seed_existed=False` after the winner's `initialise()` but before its `os.link` will
         # come through here, and if the winner's *application* has also allocated by then it

--- a/client/technocore_client/signer.py
+++ b/client/technocore_client/signer.py
@@ -40,7 +40,6 @@ class Signer:
         # Read both before touching either: an earlier version initialised the ledger and *then*
         # asked whether it had been missing, answering a question it had just changed.
         seed_existed, ledger_existed = seed.exists(), ledger.exists()
-        lost = seed_existed and not ledger_existed
         # And on a first run create the ledger BEFORE the key, which is what the comment used to
         # claim while the code did the opposite. It matters under concurrency: a second starter
         # landing between the winner's `os.link(seed)` and a later ledger write would see exactly
@@ -63,8 +62,8 @@ class Signer:
         # catastrophic for a lost key: follow it here and the next start finds neither file,
         # calls it a first run, and mints the replacement identity this check exists to prevent.
         # An unreadable ledger is never the innocent interrupted first start, because that path
-        # writes exactly `{}`; beside a missing seed it is a loss, and it is the identity that
-        # was lost.
+        # writes a stamped, entry-free ledger; beside a missing seed it is a loss, and it is the
+        # identity that was lost.
         #
         # An *empty* ledger beside no seed stays innocent: that is the window this class opens
         # on purpose two lines up, and the reason the test is on allocations and not on the file.
@@ -100,7 +99,10 @@ class Signer:
         # fails closed and clears on retry, which is the direction this module errs in
         # everywhere else. Recorded rather than fixed: a reader who finds it should know it was
         # seen (second reader, #803).
-        self.nonces = NonceStore(ledger, expect_initialised=lost)
+        # `key_exists`, not `lost`: the store needs to know a key is here even when the
+        # ledger is present, because a ledger emptied to `{}` is only detectable as a loss
+        # against the fact that this install has a key (@Minh3132, #803).
+        self.nonces = NonceStore(ledger, key_exists=seed_existed)
         # Last, so that a refusal above cannot leave a freshly minted seed behind it.
         self.keys = Keyring(seed)
 

--- a/client/technocore_client/signer.py
+++ b/client/technocore_client/signer.py
@@ -1,0 +1,61 @@
+"""The signed lane's client half: sweep, canonical string, signature, nonce.
+
+Nothing here reimplements the sweep. `store.clean_text` is imported and called, because a
+client that carries its own copy of a Unicode category rule is a copy that drifts — and
+the failure when it drifts is a permanent 403 on any text containing an invisible
+character, with nothing in the input to show why. Sharing the function makes parity
+structural instead of something a test has to keep asserting.
+
+The signature covers the text *after* the sweep. That is the single sharpest edge in this
+protocol: the bytes the server stores are the bytes it verifies, so a client that signs
+what the user typed is correct on every ASCII string and wrong on the first one carrying a
+zero-width space.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import store
+
+from .keyring import Keyring
+from .nonces import NonceStore
+
+
+class Signer:
+    """A local identity: one seed, one nonce ledger, both on disk."""
+
+    def __init__(self, home: str | Path) -> None:
+        home = Path(home)
+        self.keys = Keyring(home / "seed")
+        self.nonces = NonceStore(home / "nonces.json")
+
+    @property
+    def did(self) -> str:
+        return self.keys.did
+
+    def message(self, room: str, text: str) -> tuple[str, str, int, str]:
+        """Sign a room message. Returns (did, signature, nonce, swept text).
+
+        The swept text is returned rather than left implicit: it is what the caller must
+        send, and handing back the original would invite signing one string and posting
+        another.
+        """
+        swept = store.clean_text(text)
+        nonce = self.nonces.allocate(self.keys.did, room)
+        return self.keys.did, self.keys.sign(f"{room}|{nonce}|{swept}"), nonce, swept
+
+    def note(self, namespace: str, key: str, value: str) -> tuple[str, str, int, str]:
+        """Sign a note write. Returns (did, signature, nonce, swept value).
+
+        The nonce is scoped to the namespace and key together, matching how the server
+        scopes a note's replay window — a note nonce shares no counter with a room's.
+        """
+        swept = store.clean_text(value)
+        nonce = self.nonces.allocate(self.keys.did, f"kv:{namespace}/{key}")
+        return (
+            self.keys.did,
+            self.keys.sign(f"{namespace}|{key}|{nonce}|{swept}"),
+            nonce,
+            swept,
+        )

--- a/client/technocore_client/signer.py
+++ b/client/technocore_client/signer.py
@@ -102,7 +102,14 @@ class Signer:
         # `key_exists`, not `lost`: the store needs to know a key is here even when the
         # ledger is present, because a ledger emptied to `{}` is only detectable as a loss
         # against the fact that this install has a key (@Minh3132, #803).
-        self.nonces = NonceStore(ledger, key_exists=seed_existed)
+        #
+        # And `seed.exists` rather than `seed_existed` — the method, not the snapshot. This line
+        # runs BEFORE `Keyring` mints the key, so on a first run the boolean was false for the
+        # life of the store: delete the ledger later in this same process, after it has signed,
+        # and the lost-ledger refusal did not fire because the store still believed there was no
+        # key to have lost one for (@yukkie3276, #803). Handing over the question keeps the
+        # judgement here and removes the staleness.
+        self.nonces = NonceStore(ledger, key_exists=seed.exists)
         # Last, so that a refusal above cannot leave a freshly minted seed behind it.
         self.keys = Keyring(seed)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,23 +72,27 @@ ignore = ["E501"]  # Line length is the formatter's job.
 # app.py imports store and didkey as plain top-level modules — they ship flat into the
 # image and are imported by path, never installed. Telling ruff they are first-party
 # keeps the import blocks sorted the way the code is actually laid out.
-known-first-party = ["app", "didkey", "store"]
+known-first-party = ["app", "didkey", "store", "technocore_client"]
 
 [tool.ty.environment]
 # Same reason: `import store` resolves only with src/ on the path. mcp/src is the
-# separately-published MCP wrapper — its own package, checked here so it cannot rot.
-extra-paths = ["./src", "./mcp/src"]
+# separately-published MCP wrapper and client/ the local signer — each its own package
+# beside the server, both checked here so neither can rot unnoticed.
+extra-paths = ["./src", "./mcp/src", "./client"]
 
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 # The single source of path bootstrap for the suite — src for import app/store/didkey,
 # tests for _client — so no test file needs its own sys.path.insert.
-pythonpath = ["src", "tests"]
+pythonpath = ["src", "tests", "client"]
 
 [tool.coverage.run]
 branch = true
-source = ["src", "mcp/src"]
+# client/ is measured for the same reason src/ is: its interesting lines are refusals and
+# recovery paths — a lost create race, a widened seed mode, a corrupt nonce file — and an
+# unmeasured package is the hole #638 describes one directory over.
+source = ["src", "mcp/src", "client"]
 
 [tool.coverage.report]
 # Combined statement + branch coverage. A branch-aware floor keeps a PR from improving the

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -170,17 +170,17 @@ def test_a_lost_nonce_file_does_not_restart_the_counter(tmp_path) -> None:
     assert fresh.allocate(signer.did, "room") > used
 
 
-def test_a_corrupt_nonce_file_is_refused_in_a_fresh_process(tmp_path) -> None:
-    """@Minh3132, #803: the test this replaces proved nothing about the case it named.
+def test_a_corrupt_ledger_keeps_refusing_after_a_restart(tmp_path) -> None:
+    """@yukkie3276, #803, twice over.
 
-    It corrupted the file and then allocated from a new `NonceStore` *in the same process*, where
-    `_process_floor` still held the nonce issued moments earlier — so the new number cleared the
-    old one because of an in-memory value, not because the corrupt-file path was safe. A fresh
-    process has no such floor, and if the clock has since moved backwards it allocates below a
-    nonce already used and every write is refused.
+    First: the original test proved nothing, because it allocated from a new `NonceStore` in the
+    same process where `_process_floor` still held the nonce issued moments earlier.
 
-    So the check runs in a subprocess, where the floor is genuinely zero, and asserts the ledger
-    is refused rather than silently treated as empty.
+    Then: the fix that replaced it renamed the damaged file aside, which made the refusal last
+    exactly one process — the next one found the canonical path absent, read it as a first run,
+    and allocated from the clock with the floor still unknown. The refusal has to outlive the
+    process that noticed, so this runs it twice in fresh subprocesses and then checks that
+    deliberate recovery still works.
     """
     home = tmp_path / "home"
     signer = Signer(home)
@@ -195,21 +195,30 @@ def test_a_corrupt_nonce_file_is_refused_in_a_fresh_process(tmp_path) -> None:
         "from technocore_client.nonces import NonceStore;"
         "NonceStore(sys.argv[2])"
     )
-    result = subprocess.run(
-        [sys.executable, "-c", program, f"{repo / 'client'}:{repo / 'src'}", str(store)],
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
-    assert result.returncode != 0, "a corrupt ledger was accepted as an empty one"
-    assert "could not be read as JSON" in result.stderr
-    assert "would be refused" in result.stderr, "the error must say what it costs, not just fail"
 
-    # Quarantined rather than deleted: it is the only record of what was issued.
-    aside = list(home.glob("nonces.json.corrupt.*"))
-    assert len(aside) == 1, f"the damaged ledger was not moved aside: {list(home.iterdir())}"
-    assert aside[0].read_text() == "{ this is not json"
-    assert not store.exists()
+    def fresh_process():
+        return subprocess.run(
+            [sys.executable, "-c", program, f"{repo / 'client'}:{repo / 'src'}", str(store)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    first = fresh_process()
+    assert first.returncode != 0, "a corrupt ledger was accepted as an empty one"
+    assert "could not be read as JSON" in first.stderr
+    assert "would be refused" in first.stderr, "the error must say what it costs, not just fail"
+
+    second = fresh_process()
+    assert second.returncode != 0, "the refusal did not outlive the process that noticed"
+    assert "could not be read as JSON" in second.stderr
+
+    # The damaged ledger is still there, because it is the evidence and the lock at once.
+    assert store.read_text() == "{ this is not json"
+
+    # Recovery is a deliberate act by someone who has decided the clock is safely past: move it.
+    store.rename(home / "nonces.json.set-aside")
+    assert fresh_process().returncode == 0, "recovery left the store unusable"
 
 
 def test_a_new_seed_makes_its_directory_entry_durable(tmp_path, monkeypatch) -> None:
@@ -319,7 +328,14 @@ def test_a_seed_of_the_wrong_length_is_refused_at_both_doors(tmp_path) -> None:
     seed_path.parent.mkdir(parents=True)
     seed_path.write_text(base64.urlsafe_b64encode(b"\x02" * 16).decode().rstrip("="))
     seed_path.chmod(0o600)
-    with pytest.raises(ValueError, match="does not hold a 32-byte seed"):
+    with pytest.raises(ValueError, match="not 32"):
+        Keyring(seed_path)
+
+    # The one that matters: without validate=True, base64 silently drops characters outside its
+    # alphabet, so a corrupted file decodes to *something* rather than failing. When that
+    # something is 32 bytes the identity changes and nothing says so.
+    seed_path.write_text("not a seed!! " + base64.urlsafe_b64encode(b"\x03" * 32).decode())
+    with pytest.raises(ValueError, match="is not base64"):
         Keyring(seed_path)
 
 
@@ -350,8 +366,9 @@ def test_every_shape_the_ledger_cannot_hold_is_quarantined(tmp_path, body, reaso
     store.write_text(body)
     with pytest.raises(ValueError, match=reason):
         NonceStore(store)
-    assert len(list(tmp_path.glob("nonces.json.corrupt.*"))) == 1, "damaged ledger not moved aside"
-    assert not store.exists()
+    # Left exactly where it was: it is the evidence, and it is also what makes the refusal
+    # outlast this process.
+    assert store.read_text() == body
 
 
 def test_a_well_formed_ledger_round_trips(tmp_path) -> None:
@@ -363,6 +380,74 @@ def test_a_well_formed_ledger_round_trips(tmp_path) -> None:
     reread = NonceStore(store)
     assert reread.last("did:key:zX", "room") == first
     assert reread.allocate("did:key:zX", "room") > first
+
+
+def test_every_successful_first_start_is_past_the_durability_barrier(tmp_path, monkeypatch) -> None:
+    """@Minh3132, #803: convergence is not the same claim as durability.
+
+    The winner links the seed's name and fsyncs the directory afterwards. A loser that read the
+    winner's complete file and returned in between would hand back a working identity whose
+    *name* was not yet durable — the same power-loss window the directory fsync exists to close,
+    reopened for whichever process did not create the file. The existing race tests prove every
+    constructor agrees on the DID; none proved every constructor had passed the barrier.
+
+    The assertion records **which thread** performed each directory fsync, because the first
+    version of this test counted them globally and therefore passed without the fix: the loser
+    was being acquitted by the winner's sync. Counting is not attribution, and the property is
+    about the loser.
+    """
+    seed_path = tmp_path / "home" / "seed"
+    synced_by: set[int] = set()
+    real_fsync = os.fsync
+    guard = threading.Lock()
+
+    # Attributed by (thread, inode), not merely by thread. `mkdir_durable` syncs the *parent
+    # of* each directory it creates, so a thread that only made the folder would otherwise be
+    # credited with syncing the folder holding the seed. Third way this test found to pass
+    # without the fix; each one was found by running the control rather than by reading it.
+    home_inode = {"value": None}
+
+    def attributing_fsync(fd: int) -> None:
+        info = os.fstat(fd)
+        if stat.S_ISDIR(info.st_mode):
+            with guard:
+                if home_inode["value"] is None and seed_path.parent.exists():
+                    home_inode["value"] = seed_path.parent.stat().st_ino
+                if info.st_ino == home_inode["value"]:
+                    synced_by.add(threading.get_ident())
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", attributing_fsync)
+    start = threading.Barrier(2)
+    outcomes: list[object] = []
+    idents: set[int] = set()
+
+    def start_one() -> None:
+        start.wait(timeout=10)
+        try:
+            did = Keyring(seed_path).did
+        except Exception as exc:  # noqa: BLE001 — any raise is the failure under test
+            with guard:
+                outcomes.append(exc)
+            return
+        with guard:
+            outcomes.append(did)
+            idents.add(threading.get_ident())
+
+    threads = [threading.Thread(target=start_one) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not [o for o in outcomes if isinstance(o, Exception)], outcomes
+    assert len(set(outcomes)) == 1, f"threads disagreed about the identity: {outcomes}"
+    # Both constructors returned, and *each* of them fsynced a directory itself — the loser
+    # included, which is the half that was not previously true.
+    assert len(idents) == 2, "both threads should have constructed a Keyring"
+    assert idents <= synced_by, (
+        "a constructor returned without itself syncing the directory holding the seed"
+    )
 
 
 def test_concurrent_first_starts_in_one_process_converge(tmp_path) -> None:

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -1,0 +1,170 @@
+"""The local signer against the real server, not beside it.
+
+PR #14 was closed because its client scripts were standalone: they had their own tests,
+their own copy of the sweep, and nothing that ran them against the thing they had to
+agree with. So every assertion here goes through the `client` fixture and the actual
+app. The one that matters most is the sweep: a client that signs what the user typed is
+correct on every ASCII string and refused on the first one carrying a zero-width space,
+and that is the failure a standalone test cannot see.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from urllib.parse import quote
+
+import pytest
+
+import _client  # noqa: F401 (imported for the fixture alias below)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "client"))
+
+import didkey  # noqa: E402
+from technocore_client import Keyring, NonceStore, Signer  # noqa: E402
+
+client = _client.client
+
+
+def say(client, signer: Signer, room: str, text: str):
+    did, sig, nonce, swept = signer.message(room, text)
+    return client.get(f"/r/{room}/say-signed/{did}/{sig}/{nonce}/{quote(swept)}"), swept
+
+
+def test_a_local_signature_is_accepted_by_the_real_server(client, tmp_path) -> None:
+    signer = Signer(tmp_path / "home")
+    response, swept = say(client, signer, "localsigner", "hello from the local signer")
+    assert response.status_code == 200, response.text
+    assert swept in response.text
+    assert "<z6Mk" in response.text  # rendered as the key, not a self-asserted nick
+
+
+def test_the_signature_covers_the_swept_text_and_not_the_input(client, tmp_path) -> None:
+    """The design's sharpest edge, end to end.
+
+    U+200B is category Cf, so the server stores `a b` and verifies against that. Signing
+    what the caller typed produces a signature over `a​b`, which is a string the
+    server never sees — a 403 whose cause is invisible in the input.
+    """
+    signer = Signer(tmp_path / "home")
+    raw = "a​b"
+
+    did, sig, nonce, swept = signer.message("sweeproom", raw)
+    assert swept == "a b"
+    good = client.get(f"/r/sweeproom/say-signed/{did}/{sig}/{nonce}/{quote(swept)}")
+    assert good.status_code == 200, good.text
+
+    # The same write, signed over the raw input instead. Nothing else differs.
+    bad_nonce = signer.nonces.allocate(signer.did, "sweeproom")
+    bad_sig = signer.keys.sign(f"sweeproom|{bad_nonce}|{raw}")
+    bad = client.get(f"/r/sweeproom/say-signed/{did}/{bad_sig}/{bad_nonce}/{quote(swept)}")
+    assert bad.status_code == 403, bad.text
+
+
+def test_the_server_verifies_what_the_signer_produced(client, tmp_path) -> None:
+    signer = Signer(tmp_path / "home")
+    response, swept = say(client, signer, "storedsig", "41 rooms at 20:31Z")
+    assert response.status_code == 200
+
+    record = client.get("/r/storedsig?format=json").json()["messages"][-1]
+    didkey.verify(signer.did, record["sig"], f"storedsig|{record['nonce']}|{record['text']}")
+
+
+def test_a_signed_note_write_is_accepted(client, tmp_path) -> None:
+    """The signed note lane is narrower than "notes": the server takes a signed write only
+    for `room-owners` and `room-allow`, because every other namespace is world-writable and
+    a signature there would assert something the lane does not enforce. So the test claims
+    a room, which is what the lane is for."""
+    signer = Signer(tmp_path / "home")
+    did, sig, nonce, swept = signer.note("room-owners", "d-localsigner", signer.did)
+    r = client.get(
+        f"/kv/room-owners/d-localsigner/set-signed/{did}/{sig}/{nonce}/{quote(swept)}"
+        "?if_absent=1"
+    )
+    assert r.status_code == 200, r.text
+    # And the claim is real: the unsigned lane is now refused on that room.
+    assert client.get("/r/d-localsigner/say/stranger/hello").status_code == 403
+
+
+def test_every_nonce_the_signer_mints_is_one_the_server_accepts(tmp_path) -> None:
+    """The client's grammar must be a subset of the server's, not merely similar."""
+    signer = Signer(tmp_path / "home")
+    for i in range(5):
+        nonce = signer.nonces.allocate(signer.did, f"room{i}")
+        assert didkey.NONCE_RE.fullmatch(str(nonce)), nonce
+
+
+def test_each_room_keeps_its_own_counter(tmp_path) -> None:
+    """Scope is (key, room). Writing to one room must not consume another's number.
+
+    Allocation is also monotonic across the whole process, which is allowed and not the
+    same thing: the server's rule is a floor per room, so a nonce higher than that room
+    needed is accepted. What would be wrong is a write to room `a` advancing room `b`'s
+    stored counter, because then `b`'s next write would have to clear a bar nothing in
+    room `b` ever set.
+    """
+    signer = Signer(tmp_path / "home")
+    first_a = signer.nonces.allocate(signer.did, "a")
+    first_b = signer.nonces.allocate(signer.did, "b")
+    second_a = signer.nonces.allocate(signer.did, "a")
+    assert second_a > first_a
+    assert signer.nonces.last(signer.did, "b") == first_b
+
+
+def test_a_nonce_handed_out_before_a_crash_is_never_handed_out_again(tmp_path) -> None:
+    """The property the persistence exists for.
+
+    The store is written before the number is returned, so a process that dies between
+    being handed a nonce and using it loses the number rather than repeating it. This
+    simulates the crash by dropping the object entirely and rebuilding from disk.
+    """
+    home = tmp_path / "home"
+    signer = Signer(home)
+    did = signer.did
+    lost = signer.nonces.allocate(did, "crashroom")
+    del signer  # the process dies here; the write was never sent
+
+    revived = NonceStore(home / "nonces.json")
+    assert revived.last(did, "crashroom") == lost
+    assert revived.allocate(did, "crashroom") > lost
+
+
+def test_a_lost_nonce_file_does_not_restart_the_counter(tmp_path) -> None:
+    """Losing the file degrades to the clock, not to 1.
+
+    A counter that restarted would be refused by the server for as long as it took to
+    climb back past what the key had already used, with nothing local to explain it.
+    """
+    home = tmp_path / "home"
+    signer = Signer(home)
+    used = signer.nonces.allocate(signer.did, "room")
+    (home / "nonces.json").unlink()
+
+    fresh = NonceStore(home / "nonces.json")
+    assert fresh.last(signer.did, "room") is None
+    assert fresh.allocate(signer.did, "room") > used
+
+
+def test_a_corrupt_nonce_file_is_not_fatal(tmp_path) -> None:
+    home = tmp_path / "home"
+    signer = Signer(home)
+    used = signer.nonces.allocate(signer.did, "room")
+    (home / "nonces.json").write_text("{ this is not json")
+
+    fresh = NonceStore(home / "nonces.json")
+    assert fresh.allocate(signer.did, "room") > used
+
+
+def test_the_seed_is_written_0600_and_refused_if_it_is_widened(tmp_path) -> None:
+    home = tmp_path / "home"
+    signer = Signer(home)
+    seed_path = home / "seed"
+    assert (seed_path.stat().st_mode & 0o777) == 0o600
+
+    os.chmod(seed_path, 0o644)
+    with pytest.raises(PermissionError):
+        Keyring(seed_path)
+    # The DID is derived, so a reload under the original mode still yields the same key.
+    os.chmod(seed_path, 0o600)
+    assert Keyring(seed_path).did == signer.did

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -479,8 +479,13 @@ def test_a_ledger_recording_another_identity_is_refused(tmp_path) -> None:
     assert "two readings this cannot distinguish" in text
     assert "wrong backup" in text and "reused for a new identity" in text
     assert "has signed before" not in text, "reused the wording that asserts one of the readings"
-    # A route out for the deliberate half, which is clearing the home rather than the ledger.
-    assert "clear this home" in text
+    # A route out for the deliberate half, and it must not be a destructive one. The first
+    # version of this message offered to "move or delete" the home, which is safe if the home is
+    # genuinely being reused and destroys evidence if the wrong seed was restored — the ledger is
+    # the only surviving record of the old identity's history in exactly that case. Asserted on
+    # the property rather than the phrasing, because the phrasing is what was wrong.
+    assert "move" in text and "keep it rather than delete it" in text
+    assert "move or delete" not in text, "advised destroying the evidence under one reading"
     assert ledger.read_text() == before, "the refusal rewrote the evidence"
 
     # And the right seed still starts, allocating above what the old one had already issued.

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -149,14 +149,46 @@ def test_a_lost_nonce_file_does_not_restart_the_counter(tmp_path) -> None:
     assert fresh.allocate(signer.did, "room") > used
 
 
-def test_a_corrupt_nonce_file_is_not_fatal(tmp_path) -> None:
+def test_a_corrupt_nonce_file_is_refused_in_a_fresh_process(tmp_path) -> None:
+    """@Minh3132, #803: the test this replaces proved nothing about the case it named.
+
+    It corrupted the file and then allocated from a new `NonceStore` *in the same process*, where
+    `_process_floor` still held the nonce issued moments earlier — so the new number cleared the
+    old one because of an in-memory value, not because the corrupt-file path was safe. A fresh
+    process has no such floor, and if the clock has since moved backwards it allocates below a
+    nonce already used and every write is refused.
+
+    So the check runs in a subprocess, where the floor is genuinely zero, and asserts the ledger
+    is refused rather than silently treated as empty.
+    """
     home = tmp_path / "home"
     signer = Signer(home)
-    used = signer.nonces.allocate(signer.did, "room")
-    (home / "nonces.json").write_text("{ this is not json")
+    signer.nonces.allocate(signer.did, "room")
+    store = home / "nonces.json"
+    store.write_text("{ this is not json")
 
-    fresh = NonceStore(home / "nonces.json")
-    assert fresh.allocate(signer.did, "room") > used
+    repo = Path(__file__).resolve().parents[2]
+    program = (
+        "import sys;"
+        "sys.path[:0] = sys.argv[1].split(':');"
+        "from technocore_client.nonces import NonceStore;"
+        "NonceStore(sys.argv[2])"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program, f"{repo / 'client'}:{repo / 'src'}", str(store)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode != 0, "a corrupt ledger was accepted as an empty one"
+    assert "could not be read as JSON" in result.stderr
+    assert "would be refused" in result.stderr, "the error must say what it costs, not just fail"
+
+    # Quarantined rather than deleted: it is the only record of what was issued.
+    aside = list(home.glob("nonces.json.corrupt.*"))
+    assert len(aside) == 1, f"the damaged ledger was not moved aside: {list(home.iterdir())}"
+    assert aside[0].read_text() == "{ this is not json"
+    assert not store.exists()
 
 
 def test_a_new_seed_makes_its_directory_entry_durable(tmp_path, monkeypatch) -> None:
@@ -270,15 +302,19 @@ def test_a_seed_of_the_wrong_length_is_refused_at_both_doors(tmp_path) -> None:
         Keyring(seed_path)
 
 
-def test_a_nonce_file_holding_the_wrong_shape_is_ignored_not_trusted(tmp_path) -> None:
-    """A note that parses as JSON but is not the map this expects is the same class as a corrupt
-    one: unknown, so start from the clock rather than from whatever was there."""
+def test_a_nonce_file_of_the_wrong_shape_is_refused_and_a_bad_entry_is_dropped(tmp_path) -> None:
+    """Two different facts, deliberately treated differently.
+
+    A file that is not an object at all is unreadable state — same class as unparseable, so it is
+    quarantined. A file that *is* the right shape with one implausible entry is readable state
+    with a hole: the rest is trustworthy and the bad entry is dropped, which leaves that one pair
+    starting from the clock rather than throwing the whole ledger away.
+    """
     store = tmp_path / "nonces.json"
     store.write_text('["not", "a", "map"]')
-    assert NonceStore(store).last("did:key:zX", "room") is None
-
-    store.write_text('{"did:key:zX": "not a room map"}')
-    assert NonceStore(store).last("did:key:zX", "room") is None
+    with pytest.raises(ValueError, match="does not hold a JSON object"):
+        NonceStore(store)
+    assert len(list(tmp_path.glob("nonces.json.corrupt.*"))) == 1
 
     store.write_text('{"did:key:zX": {"room": -5, "other": 7}}')
     fresh = NonceStore(store)

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -90,6 +90,27 @@ def test_a_signed_note_write_is_accepted(client, tmp_path) -> None:
     assert client.get("/r/d-localsigner/say/stranger/hello").status_code == 403
 
 
+def test_note_nonces_share_one_counter_per_key_as_the_server_does(client, tmp_path) -> None:
+    """`app._burn_nonce(key, nonce)` keeps one counter per note key across every namespace.
+
+    A client keeping a counter per (namespace, key) would be tracking two where the server
+    tracks one. The clock floor makes a collision unlikely rather than impossible, and unlikely
+    is the word in front of every nonce bug in this package — so the scope matches the server's
+    and this asserts it against the real one.
+    """
+    signer = Signer(tmp_path / "home")
+    first = signer.nonces.allocate(signer.did, "kv:shared-key")
+    did, sig, nonce, swept = signer.note("room-owners", "shared-key", signer.did)
+    assert nonce > first, "a second note write on the same key must clear the first"
+
+    # And the real server accepts a write signed under that scope.
+    did, sig, nonce, swept = signer.note("room-owners", "d-notescope", signer.did)
+    response = client.get(
+        f"/kv/room-owners/d-notescope/set-signed/{did}/{sig}/{nonce}/{quote(swept)}?if_absent=1"
+    )
+    assert response.status_code == 200, response.text
+
+
 def test_every_nonce_the_signer_mints_is_one_the_server_accepts(tmp_path) -> None:
     """The client's grammar must be a subset of the server's, not merely similar."""
     signer = Signer(tmp_path / "home")

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -27,7 +27,7 @@ import _client  # noqa: F401 (imported for the fixture alias below)
 import pytest
 
 import didkey
-from technocore_client import Keyring, NonceStore, Signer, did_from_seed
+from technocore_client import Keyring, LedgerUnreadableError, NonceStore, Signer, did_from_seed
 from technocore_client import nonces as nonces_module
 
 client = _client.client
@@ -190,6 +190,104 @@ def test_a_deleted_ledger_is_refused_in_a_fresh_process(tmp_path) -> None:
     assert result.returncode != 0, "a lost ledger was accepted as a first run"
     assert "has since been lost" in result.stderr
     assert "would be refused" in result.stderr, "the error must say what it costs"
+
+
+def test_a_ledger_emptied_to_braces_is_refused_beside_an_existing_key(tmp_path) -> None:
+    """@Minh3132, #803: `{}` meant both "never used" and "history erased".
+
+    The previous round closed an absent ledger, malformed JSON, and entries of the wrong shape.
+    It left the one value that needs no corruption at all: truncate a populated ledger to
+    exactly `{}` and it is byte-identical to what `initialise()` wrote on a first run, so every
+    fail-closed check passed it. A fresh process then found no entry and no floor, allocated from
+    the clock, and on a host whose clock had moved backwards issued below a nonce already spent —
+    after which the server refused every signed write until wall time caught up.
+
+    So the innocent value stopped being `{}`. Ledgers this class writes carry an initialisation
+    marker, and an entry-free object without one, beside a key that exists, is an emptied file
+    rather than a new one.
+
+    No clock manipulation here, deliberately. The review asked for a rollback in the regression,
+    and the refusal does not depend on one: an emptied ledger is unknown whichever way the clock
+    has moved, which is a stronger guarantee than the test it was asked to make.
+    """
+    home = tmp_path / "home"
+    signer = Signer(home)
+    issued = signer.nonces.allocate(signer.did, "room")
+    ledger = home / "nonces.json"
+    assert issued > 0 and json.loads(ledger.read_text()), "the ledger was not populated"
+    ledger.write_text("{}")
+
+    repo = Path(__file__).resolve().parents[2]
+    program = (
+        "import sys;"
+        "sys.path[:0] = sys.argv[1].split(':');"
+        "from technocore_client import Signer;"
+        "s = Signer(sys.argv[2]);"
+        "print(s.nonces.allocate(s.did, 'room'))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program, f"{repo / 'client'}:{repo / 'src'}", str(home)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode != 0, (
+        f"an emptied ledger was accepted and allocated {result.stdout.strip()!r}, which is not "
+        "known to be above the nonce already issued"
+    )
+    assert "no initialisation record" in result.stderr, result.stderr
+    assert "would be refused" in result.stderr, "the error must say what it costs"
+    assert ledger.read_text() == "{}", "the refusal moved the evidence instead of leaving it"
+
+
+def test_a_marker_of_the_wrong_shape_is_refused_like_any_other_damage(tmp_path) -> None:
+    """The marker is now load-bearing, so a malformed one has to refuse rather than be ignored.
+
+    In-process and against `NonceStore` directly, because the point is the branch and not the
+    plumbing: this repository's own standard is that a refusal nobody exercises is a refusal
+    nobody has checked. Treating a bad marker as absent would be the lenient reading the rest of
+    this loader exists to reject — it would turn a damaged file into an entry-free one and hand
+    back the clock.
+    """
+    path = tmp_path / "nonces.json"
+    path.write_text(json.dumps({"!ledger": "v1"}))
+    with pytest.raises(LedgerUnreadableError) as caught:
+        NonceStore(path, key_exists=True)
+    assert "not an object" in str(caught.value)
+    assert path.exists(), "the refusal removed the evidence"
+
+
+def test_a_stamped_ledger_with_no_entries_stays_innocent_beside_a_key(tmp_path) -> None:
+    """The other half of the pair above, and the reason the marker exists rather than a ban on
+    `{}`.
+
+    Refusing every entry-free ledger beside a key would refuse the state a first run legitimately
+    produces: the ledger is created *before* the key, so an install interrupted after both exist
+    and before anything signs has a key and no allocations. That is innocent, and it has to keep
+    starting, or the fix for an erased ledger becomes a fresh install that cannot boot.
+    """
+    home = tmp_path / "home"
+    first = Signer(home)
+    ledger = home / "nonces.json"
+    assert not [k for k in json.loads(ledger.read_text()) if k != "!ledger"], (
+        "this test needs the never-allocated state it is named for"
+    )
+
+    repo = Path(__file__).resolve().parents[2]
+    program = (
+        "import sys;"
+        "sys.path[:0] = sys.argv[1].split(':');"
+        "from technocore_client import Signer;"
+        "print(Signer(sys.argv[2]).did)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program, f"{repo / 'client'}:{repo / 'src'}", str(home)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, f"an interrupted first start was refused: {result.stderr}"
+    assert result.stdout.strip() == first.did, "the second start changed identity"
 
 
 def test_a_bare_store_degrades_to_the_clock_and_not_to_one(tmp_path) -> None:
@@ -635,10 +733,16 @@ def test_a_concurrent_initialiser_cannot_overwrite_a_populated_ledger(tmp_path, 
     b_thread.join(30)
     assert not b_thread.is_alive()
 
-    assert json.loads(ledger.read_text()) == {signer.did: {"room": issued}}, (
+    on_disk = json.loads(ledger.read_text())
+    assert on_disk.get(signer.did) == {"room": issued}, (
         "a concurrent initialiser replaced a populated ledger with an empty one, losing a "
         "nonce that had already been issued and persisted"
     )
+    # Asserted rather than dropped from the comparison: the marker is what tells the next
+    # process this file was written here and not truncated to `{}`, so a flush that lost it
+    # would reopen the emptied-ledger case this format exists to close.
+    assert "!ledger" in on_disk, "the flush dropped the initialisation marker"
+    assert set(on_disk) == {"!ledger", signer.did}, f"unexpected entries on disk: {on_disk}"
 
 
 def test_a_seed_of_the_wrong_length_is_refused_at_both_doors(tmp_path) -> None:

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -362,6 +362,43 @@ def test_an_unmarked_ledger_with_entries_is_refused_beside_a_key(tmp_path) -> No
     assert NonceStore(store, key_exists=True).last("did:key:zStub", "room") == 5
 
 
+def test_a_ledger_with_a_duplicate_key_is_refused_rather_than_resolved(tmp_path) -> None:
+    """@Minh3132, #803: the parser chose which nonce survived, before any check could see either.
+
+    `json.loads` accepts a repeated key and keeps the last value, so a ledger holding `900` and
+    then `5` for the same (did, room) loads as `5`. Every existing check passes it — valid JSON,
+    an object, an entry of the right shape — and `_allocate_locked` takes 5 as the last nonce
+    issued, which after a clock rollback puts allocation below the server's retained replay floor.
+    The number that would have prevented that was discarded during parsing. A repeated DID throws
+    away a whole room map the same way, one level up.
+
+    Written as raw text on purpose: there is no Python object `json.dumps` could turn into a
+    duplicate, which is also why no ledger this class writes can contain one. It means the file
+    was hand-edited or damaged, and that is unknown state rather than something to resolve.
+    """
+    store = tmp_path / "nonces.json"
+    for body, repeated in (
+        ('{"!ledger": {"v": 1}, "did:key:zStub": {"room": 900, "room": 5}}', "room"),
+        (
+            '{"!ledger": {"v": 1}, "did:key:zStub": {"room": 900}, "did:key:zStub": {"other": 5}}',
+            "did:key:zStub",
+        ),
+    ):
+        store.write_text(body)
+        with pytest.raises(LedgerUnreadableError) as caught:
+            NonceStore(store, key_exists=True)
+        text = str(caught.value)
+        assert f"{repeated!r} twice" in text, (
+            f"the refusal must name the duplicated key, or there is nothing to repair: {text}"
+        )
+        assert "would be refused" in text, "the error must say what it costs"
+        assert store.read_text() == body, "the refusal rewrote the evidence"
+
+    # The innocent half, because a hook that rejected ordinary objects would brick every start.
+    store.write_text(json.dumps({"!ledger": {"v": 1}, "did:key:zStub": {"room": 900}}))
+    assert NonceStore(store, key_exists=True).last("did:key:zStub", "room") == 900
+
+
 def test_a_ledger_from_a_newer_format_is_unknown_rather_than_fresh(tmp_path) -> None:
     """The marker carried a version that nothing read.
 

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -383,6 +383,10 @@ def test_a_ledger_with_a_duplicate_key_is_refused_rather_than_resolved(tmp_path)
             '{"!ledger": {"v": 1}, "did:key:zStub": {"room": 900}, "did:key:zStub": {"other": 5}}',
             "did:key:zStub",
         ),
+        # The marker is not exempt, and this asserts it rather than leaving it to the hook's
+        # docstring. A file carrying two of those is exactly as unreadable as one carrying two
+        # DIDs, and the hook runs before `_load` pops the marker, so nothing special protects it.
+        ('{"!ledger": {"v": 1}, "!ledger": {"v": 1}}', "!ledger"),
     ):
         store.write_text(body)
         with pytest.raises(LedgerUnreadableError) as caught:
@@ -1079,6 +1083,39 @@ def test_a_seed_of_the_wrong_length_is_refused_at_both_doors(tmp_path) -> None:
     seed_path.write_text("not a seed!! " + base64.urlsafe_b64encode(b"\x03" * 32).decode())
     with pytest.raises(ValueError, match="is not base64"):
         Keyring(seed_path)
+
+
+def test_a_seed_holding_a_character_base64url_cannot_emit_is_refused(tmp_path) -> None:
+    """`+` and `/` are the two characters `altchars` hides, and each one is provable damage.
+
+    `b64decode(body, altchars=b"-_", validate=True)` translates `-` to `+` and `_` to `/` and
+    then validates against the *standard* alphabet, which contains both. `_create` writes with
+    `urlsafe_b64encode`, so neither can come from a file this package wrote — and yet both
+    decoded to a different valid 32-byte seed, after which `Keyring.did` and `Signer.sign`
+    published and signed under an identity nobody chose, with no error anywhere.
+
+    Not corruption detection in general, and it must not be read as it. Over every
+    single-character substitution in a 43-character body, 2706 still decode to a different valid
+    seed because base64url can emit those characters, and nothing downstream of base64 can
+    separate them from the original. The 84 base64url can never emit are what this closes.
+
+    The last assertion is the other half: the guard is an alphabet check and not a length or a
+    content check, so an ordinary seed must still load and still derive the same DID.
+    """
+    seed = b"\x04" * 32
+    body = base64.urlsafe_b64encode(seed).decode().rstrip("=")
+    seed_path = tmp_path / "home" / "seed"
+    seed_path.parent.mkdir(parents=True)
+
+    for character in ("+", "/"):
+        seed_path.write_text(character + body[1:])
+        seed_path.chmod(0o600)
+        with pytest.raises(ValueError, match="is not base64"):
+            Keyring(seed_path)
+
+    seed_path.write_text(body)
+    seed_path.chmod(0o600)
+    assert Keyring(seed_path).did == did_from_seed(seed)
 
 
 @pytest.mark.parametrize(

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -228,6 +228,172 @@ def test_a_bare_store_degrades_to_the_clock_and_not_to_one(tmp_path) -> None:
     assert second > first, "a lost ledger restarted the counter below a nonce already issued"
 
 
+def test_a_ledger_with_history_and_no_key_is_refused(tmp_path) -> None:
+    """@Minh3132, #803: one half of this pair failed closed and the other failed open.
+
+    Seed present, ledger absent was already a refusal. The mirror — ledger present with
+    history, seed gone — walked straight into `Keyring`, which minted a replacement. The new
+    DID then reads the old ledger, finds nothing under its own name, and allocates from the
+    clock as though it had never signed; meanwhile every signature and note already published
+    names an identity nobody can sign as again. `Keyring` refuses to mint over an unreadable
+    *existing* seed for exactly this reason, and the same fact arriving as an absent file was
+    waved through.
+
+    Fresh process, because the whole failure mode is what a restart concludes from disk.
+    """
+    home = tmp_path / "home"
+    signer = Signer(home)
+    original = signer.did
+    signer.nonces.allocate(original, "room")
+    (home / "seed").unlink()
+
+    repo = Path(__file__).resolve().parents[2]
+    program = (
+        "import sys;"
+        "sys.path[:0] = sys.argv[1].split(':');"
+        "from technocore_client import Signer;"
+        "print(Signer(sys.argv[2]).did)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program, f"{repo / 'client'}:{repo / 'src'}", str(home)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode != 0, (
+        f"a lost key was replaced silently; the install came back as {result.stdout.strip()} "
+        f"instead of {original}"
+    )
+    assert "its key is gone" in result.stderr
+    assert "can never sign again" in result.stderr, "the error must say what is unrecoverable"
+    # And the refusal is not a one-shot — asserted by running it again rather than by checking
+    # the precondition for it. `exists()` is what would have to be true for a second refusal,
+    # not the refusal, and this branch has a habit of asserting the setup for a claim in place
+    # of the claim.
+    assert (home / "nonces.json").exists()
+    again = subprocess.run(
+        [sys.executable, "-c", program, f"{repo / 'client'}:{repo / 'src'}", str(home)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert again.returncode != 0, "the refusal lasted one process"
+    assert "its key is gone" in again.stderr
+
+
+def test_a_corrupt_ledger_beside_no_key_reports_the_lost_key(tmp_path) -> None:
+    """Second reader on this branch: the wrong refusal was answering first.
+
+    The identity check landed after the store was built, so seed-gone plus ledger-corrupt hit
+    `_load`'s refusal instead — a message about lost *nonces* whose advice is to move the file
+    aside once the clock has passed. Follow that here and the next start finds neither file,
+    reads it as a first run, and mints the replacement identity the check exists to prevent.
+    The softer message was attached to the strictly more alarming state.
+
+    An unreadable ledger is never the innocent interrupted first start: that path writes exactly
+    `{}`. Beside a missing seed it is a loss, and it is the identity that was lost.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "nonces.json").write_text("{ this is not json")
+
+    repo = Path(__file__).resolve().parents[2]
+    program = (
+        "import sys;"
+        "sys.path[:0] = sys.argv[1].split(':');"
+        "from technocore_client import Signer;"
+        "Signer(sys.argv[2])"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program, f"{repo / 'client'}:{repo / 'src'}", str(home)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode != 0
+    assert "its key is gone" in result.stderr, "the refusal named the nonces, not the identity"
+    assert "can never sign again" in result.stderr
+    # And it must argue against the recovery the other message recommends, which from this state
+    # leads straight back to a silent first run.
+    assert "Do not move the ledger aside on its own" in result.stderr
+    # And the advice it argues against must not be printed alongside it. Chaining the store's
+    # own refusal as the cause put both in the output: an operator reading the cause block
+    # moves the ledger aside, the next start sees neither file, calls it a first run, and mints
+    # the replacement. Asserting the right phrase is present says nothing about the wrong one.
+    assert "moving it aside once you are satisfied" not in result.stderr, (
+        "the refusal printed the recovery it exists to argue against, as a chained cause"
+    )
+    # The parse failure is still named, folded in rather than chained, so the operator can tell
+    # a truncated file from a corrupted one.
+    assert "could not be read as JSON" in result.stderr
+    # Carried as data, not recovered by splitting the formatted message on its first ". " — a
+    # ledger holding a repr with ". " inside it would have clipped the reason away.
+    (home / "nonces.json").write_text(json.dumps({"did:key:z6MkStub": {"a. b": "x"}}))
+    odd = subprocess.run(
+        [sys.executable, "-c", program, f"{repo / 'client'}:{repo / 'src'}", str(home)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert odd.returncode != 0
+    assert "which is not a non-negative integer" in odd.stderr, (
+        "the reason was truncated at a period inside the ledger's own contents"
+    )
+
+
+def test_a_key_with_no_rooms_beside_no_seed_is_history_too(tmp_path) -> None:
+    """Second reader on this branch: "populated" was implemented as a non-zero pair count.
+
+    `{"did:key:z...": {}}` holds zero (key, room) pairs and is not empty. `allocate` cannot
+    produce it — `setdefault(did, {})[room] = nonce` always adds a room — and `initialise`
+    writes exactly `{}`, so a key sitting there with no rooms means something happened that this
+    class did not do: a partial restore, a hand-edit, another tool. Summing pairs called it
+    innocent and minted a replacement identity, which is the outcome the whole branch exists to
+    refuse. The innocent value is `{}` and the predicate now says so.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "nonces.json").write_text(json.dumps({"did:key:z6MkStub": {}}))
+
+    repo = Path(__file__).resolve().parents[2]
+    program = (
+        "import sys;"
+        "sys.path[:0] = sys.argv[1].split(':');"
+        "from technocore_client import Signer;"
+        "print(Signer(sys.argv[2]).did)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program, f"{repo / 'client'}:{repo / 'src'}", str(home)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode != 0, (
+        f"a ledger naming a prior key was read as a first start; minted {result.stdout.strip()}"
+    )
+    assert "its key is gone" in result.stderr
+    assert "1 prior key(s) and no allocations" in result.stderr, (
+        "the message must say what was found, since it is not an allocation count"
+    )
+
+
+def test_an_empty_ledger_with_no_key_is_still_a_first_start(tmp_path) -> None:
+    """The innocent half of the same shape, which the refusal above must not swallow.
+
+    This class creates the ledger before the key on purpose, so ledger-present-seed-absent is
+    the ordinary state of a first start that was interrupted — or of a starter that lost the
+    creation race by a microsecond. History is what separates it from a lost key, which is why
+    the check counts allocations rather than testing for the file.
+    """
+    home = tmp_path / "home"
+    NonceStore(home / "nonces.json").initialise()
+    assert not (home / "seed").exists()
+
+    signer = Signer(home)
+    assert signer.did.startswith("did:key:z6Mk")
+    assert signer.nonces.allocate(signer.did, "room") > 0
+
+
 def test_a_first_run_is_not_mistaken_for_a_loss(tmp_path) -> None:
     """The other half: a genuinely new identity must start, or the check above is a brick.
 

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -192,6 +192,36 @@ def test_a_deleted_ledger_is_refused_in_a_fresh_process(tmp_path) -> None:
     assert "would be refused" in result.stderr, "the error must say what it costs"
 
 
+def test_a_ledger_lost_mid_process_is_refused_by_the_signer_that_created_it(tmp_path) -> None:
+    """@yukkie3276, #803: the lost-ledger refusal was off for exactly the process that mattered.
+
+    `Signer` builds the store before `Keyring` mints the key, deliberately — the ledger has to
+    exist first so that seed-without-ledger can only mean the record went missing. That ordering
+    made a plain boolean wrong: on a first run the store was told "no key here", and it kept
+    believing it while the key was created one line later and nonces were issued under it. Delete
+    the ledger in that same process and the refusal did not fire, because the store still thought
+    this was an install that had never had a key to lose a ledger for.
+
+    In-process on purpose: the earlier tests in this file use a subprocess precisely to get away
+    from a stale `_process_floor`, and here the staleness under test is the flag rather than the
+    floor, so the same live `Signer` has to be the one that asks.
+
+    The module's in-memory floor does keep this particular sequence above the nonces *this*
+    process issued. It says nothing about a nonce a second process wrote and the deleted ledger
+    was the only record of, which is what the refusal is for.
+    """
+    home = tmp_path / "home"
+    signer = Signer(home)
+    issued = signer.nonces.allocate(signer.did, "room")
+    assert issued > 0
+    assert (home / "seed").exists(), "this test needs the key the first run creates"
+    (home / "nonces.json").unlink()
+
+    with pytest.raises(LedgerUnreadableError) as caught:
+        signer.nonces.allocate(signer.did, "room")
+    assert "has since been lost" in str(caught.value)
+
+
 def test_a_ledger_emptied_to_braces_is_refused_beside_an_existing_key(tmp_path) -> None:
     """@Minh3132, #803: `{}` meant both "never used" and "history erased".
 

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -154,20 +154,93 @@ def test_a_nonce_handed_out_before_a_crash_is_never_handed_out_again(tmp_path) -
     assert revived.allocate(did, "crashroom") > lost
 
 
-def test_a_lost_nonce_file_does_not_restart_the_counter(tmp_path) -> None:
-    """Losing the file degrades to the clock, not to 1.
+def test_a_deleted_ledger_is_refused_in_a_fresh_process(tmp_path) -> None:
+    """@yukkie3276, #803: absence was still being read as proof of a first run.
 
-    A counter that restarted would be refused by the server for as long as it took to
-    climb back past what the key had already used, with nothing local to explain it.
+    The test this replaces deleted the ledger and allocated from a new `NonceStore` in the same
+    interpreter, where `_process_floor` still held the earlier nonce — the identical test-axis
+    flaw already corrected for the corrupt-ledger case, sitting in the function next to it. I
+    fixed one and left its neighbour, which is the failure I had written into my own notes the
+    day before.
+
+    A fresh process has no floor, so if the clock has since moved backwards it allocates below a
+    nonce already used. `Signer` now writes an empty ledger before the key exists, so a seed with
+    no ledger can only mean the ledger was lost — and that is unknown, not empty.
     """
     home = tmp_path / "home"
     signer = Signer(home)
-    used = signer.nonces.allocate(signer.did, "room")
+    signer.nonces.allocate(signer.did, "room")
     (home / "nonces.json").unlink()
 
-    fresh = NonceStore(home / "nonces.json")
-    assert fresh.last(signer.did, "room") is None
-    assert fresh.allocate(signer.did, "room") > used
+    repo = Path(__file__).resolve().parents[2]
+    program = (
+        "import sys;"
+        "sys.path[:0] = sys.argv[1].split(':');"
+        "from technocore_client import Signer;"
+        "Signer(sys.argv[2])"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program, f"{repo / 'client'}:{repo / 'src'}", str(home)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode != 0, "a lost ledger was accepted as a first run"
+    assert "has since been lost" in result.stderr
+    assert "would be refused" in result.stderr, "the error must say what it costs"
+
+
+def test_a_bare_store_degrades_to_the_clock_and_not_to_one(tmp_path) -> None:
+    """The layer below `Signer` cannot detect a loss, so assert what it does instead.
+
+    Second reader on this branch: replacing the old lost-ledger test removed the only coverage of
+    a directly-constructed `NonceStore` — the exported surface, and the one the rest of the
+    package builds on. The refusal cannot live here (a store sees a path and nothing else; only
+    something that knows whether a *key* exists can tell a first run from a loss), so the honest
+    thing is to state the weaker guarantee and check it: a lost ledger falls back to the wall
+    clock, which is ahead of every nonce a sane clock has already issued, rather than restarting
+    at 1, which is behind all of them.
+
+    Fresh process on purpose. In-process, `_process_floor` survives the deletion and would carry
+    the guarantee for free — the same test-axis flaw this branch has now fixed twice.
+    """
+    store_path = tmp_path / "nonces.json"
+    first = NonceStore(store_path).allocate("did:key:zStub", "room")
+    store_path.unlink()
+
+    repo = Path(__file__).resolve().parents[2]
+    program = (
+        "import sys;"
+        "sys.path[:0] = sys.argv[1].split(':');"
+        "from technocore_client import NonceStore;"
+        "print(NonceStore(sys.argv[2]).allocate('did:key:zStub', 'room'))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program, f"{repo / 'client'}:{repo / 'src'}", str(store_path)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    second = int(result.stdout.strip())
+    assert second > first, "a lost ledger restarted the counter below a nonce already issued"
+
+
+def test_a_first_run_is_not_mistaken_for_a_loss(tmp_path) -> None:
+    """The other half: a genuinely new identity must start, or the check above is a brick.
+
+    Both files absent is a first run. The ledger is created before the key precisely so that the
+    two cases stay distinguishable, and this asserts the innocent one still works — including a
+    second construction, which is where an over-eager refusal would show up.
+    """
+    home = tmp_path / "home"
+    signer = Signer(home)
+    first = signer.nonces.allocate(signer.did, "room")
+    assert (home / "nonces.json").exists(), "the ledger should exist from the start"
+
+    again = Signer(home)
+    assert again.did == signer.did
+    assert again.nonces.allocate(again.did, "room") > first
 
 
 def test_a_corrupt_ledger_keeps_refusing_after_a_restart(tmp_path) -> None:
@@ -312,6 +385,42 @@ def test_concurrent_first_starts_converge_on_one_identity(tmp_path) -> None:
     # No temporary survived the race, and the winner's file carries the mode the loser skipped.
     assert list(home.glob("seed.*.tmp")) == []
     assert (home / "seed").stat().st_mode & 0o777 == 0o600
+
+
+def test_the_ledger_is_created_before_the_key_on_a_first_run(tmp_path, monkeypatch) -> None:
+    """Second reader on this branch: the loss check reopened, one level up, the race below it.
+
+    `Keyring._load` was made safe across processes, and then `Signer.__init__` put the same
+    two-process window back: it read `seed.exists() and not ledger.exists()`, then constructed
+    the keyring — which may mint the seed — and only afterwards created the ledger. A second
+    starter arriving between the winner's `os.link(seed)` and the winner's ledger write saw
+    exactly seed-present-ledger-absent, concluded the record had been lost, and refused a
+    perfectly healthy startup. My own comment claimed the opposite order was "the point" while
+    the code did it backwards, which is the kind of promise the compiler does not check.
+
+    Asserting the ordering rather than the collision, and deliberately. A gated six-process race
+    passes against the broken code every time: gated starters all evaluate the check before the
+    winner has minted anything, so they take the safe branch and the window is never entered. It
+    needs an arrival inside a window microseconds wide — and reproducing that by sleeping is the
+    flaky guard this file already refuses elsewhere. The window is closed by creating the ledger
+    first, so that is what gets checked, at the syscall that publishes the key.
+    """
+    seen: dict[str, bool] = {}
+    real_link = os.link
+
+    def recording_link(src, dst, **kwargs):
+        seen.setdefault("ledger_first", (tmp_path / "home" / "nonces.json").exists())
+        return real_link(src, dst, **kwargs)
+
+    monkeypatch.setattr(os, "link", recording_link)
+    signer = Signer(tmp_path / "home")
+
+    assert seen.get("ledger_first") is not None, "the seed was never minted; test proves nothing"
+    assert seen["ledger_first"], (
+        "the key was published before the ledger existed, so a concurrent starter landing in "
+        "that window would read a healthy first run as a lost ledger and refuse"
+    )
+    assert signer.nonces.allocate(signer.did, "room") > 0
 
 
 def test_a_seed_of_the_wrong_length_is_refused_at_both_doors(tmp_path) -> None:

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -339,6 +339,29 @@ def test_a_seed_that_is_not_a_regular_file_names_itself_and_not_the_ledger(tmp_p
     assert "is not a regular file" in str(dangling.value)
 
 
+def test_an_unmarked_ledger_with_entries_is_refused_beside_a_key(tmp_path) -> None:
+    """The guard checked "empty" while its reasoning claimed "not written here".
+
+    Narrowed to the exact shape `{}`, it missed `{"did:key:z...": {"room": 1}}` and even
+    `{"did:key:z...": {}}`: no marker, but a non-empty object, so nothing refused and allocation
+    fell back to the clock — the rollback failure the marker exists to prevent, reachable through
+    a shape one character away from the one that was covered.
+
+    Safe to broaden to any unmarked ledger because this package has never been released, so
+    there are no unmarked ledgers in the world for the stricter rule to reject.
+    """
+    store = tmp_path / "nonces.json"
+    for shape in ({"did:key:zStub": {}}, {"did:key:zStub": {"room": 1_700_000_000_000}}):
+        store.write_text(json.dumps(shape))
+        with pytest.raises(LedgerUnreadableError) as caught:
+            NonceStore(store, key_exists=True)
+        assert "carries no initialisation record" in str(caught.value)
+
+    # A marked ledger of the same shape is ordinary history and must still load.
+    store.write_text(json.dumps({"!ledger": {"v": 1}, "did:key:zStub": {"room": 5}}))
+    assert NonceStore(store, key_exists=True).last("did:key:zStub", "room") == 5
+
+
 def test_a_ledger_from_a_newer_format_is_unknown_rather_than_fresh(tmp_path) -> None:
     """The marker carried a version that nothing read.
 
@@ -360,36 +383,92 @@ def test_a_ledger_from_a_newer_format_is_unknown_rather_than_fresh(tmp_path) -> 
     assert "no usable version" in str(bare.value)
 
 
-def test_a_stray_empty_ledger_on_a_first_run_is_adopted_and_not_fatal(tmp_path) -> None:
-    """The marker's own regression, found by auditing the commit that added it.
+def test_an_unmarked_empty_ledger_with_no_seed_refuses_rather_than_guessing(tmp_path) -> None:
+    """Two readings, indistinguishable on disk, so it refuses instead of picking one.
 
-    A bare `{}` in a directory with no key was innocent before the marker existed, and had to
-    stay innocent. It did not. `initialise()` skips a file that already exists, so the stray
-    ledger survived startup unmarked; `Keyring` created the key one line later, which flipped
-    `key_exists` true; and the first `allocate()` refused, telling the operator their ledger had
-    been emptied when nothing had ever written one. A fresh install came up holding an identity
-    it could never sign with, and the next start refused during construction.
+    Every ledger this package writes is stamped. An entry-free ledger with *no* marker therefore
+    did not come from here, and that has two meanings: something else created a stray `{}` and
+    nothing has ever signed, or a stamped ledger was emptied — which means a key existed and is
+    now gone along with its history.
 
-    Worth a test rather than a comment because the refusal was right and its trigger was a fact
-    the constructor itself was about to make true — the same shape as every other finding on this
-    branch, which is a new line meeting an ordering constraint somewhere else.
+    I picked the innocent reading once and it was the wrong half. A `stamp_if_empty` adopted the
+    file so that a stray would stop bricking a fresh install; it also stamped the emptied case,
+    erasing the one bit that told them apart, after which `Keyring` minted a replacement and the
+    client signed under a new DID indefinitely with the evidence destroyed. Refusing costs a
+    fresh install one manual step. Stamping cost a real install its identity, silently. The
+    asymmetry is the whole argument.
     """
     home = tmp_path / "home"
     home.mkdir(parents=True)
     (home / "nonces.json").write_text("{}")
 
-    signer = Signer(home)
-    issued = signer.nonces.allocate(signer.did, "room")
-    assert issued > 0, "a fresh install with a stray empty ledger could not sign"
+    with pytest.raises(ValueError) as caught:
+        Signer(home)
+    text = str(caught.value)
+    # Both readings named, and neither asserted as fact — the failure mode of every refusal on
+    # this branch has been a true message carrying a claim its evidence did not support.
+    assert "two readings it cannot distinguish" in text
+    assert "nothing has ever signed" in text and "was emptied" in text
+    assert "has signed before" not in text, "asserted a history it cannot know"
+    # A usable route out for each reading.
+    assert "delete" in text and "restore the seed from a backup" in text.lower()
 
-    on_disk = json.loads((home / "nonces.json").read_text())
-    assert "!ledger" in on_disk, "the stray ledger was used without being adopted"
-    assert on_disk[signer.did] == {"room": issued}
 
-    # And the next start, which is where the old behaviour refused during construction.
-    again = Signer(home)
-    assert again.did == signer.did
-    assert again.nonces.allocate(again.did, "room") > issued
+def test_an_emptied_ledger_beside_a_lost_seed_is_never_silently_replaced(tmp_path) -> None:
+    """The case the adopt-and-stamp version got wrong, asserted directly.
+
+    An install signs under one identity; its ledger is then truncated to `{}` and its seed lost.
+    Both are gone, so the identity is already unrecoverable — the only thing left to protect is
+    the operator's knowledge that it happened. Stamping made the state look innocent and signed
+    on under a new DID forever. This asserts the refusal, and that the evidence is left alone.
+    """
+    home = tmp_path / "home"
+    first = Signer(home)
+    first.nonces.allocate(first.did, "room")
+
+    (home / "nonces.json").write_text("{}")
+    (home / "seed").unlink()
+
+    with pytest.raises(ValueError) as caught:
+        Signer(home)
+    assert "carries no initialisation record" in str(caught.value)
+    assert not (home / "seed").exists(), "a replacement key was minted behind the refusal"
+    assert (home / "nonces.json").read_text() == "{}", "the evidence was rewritten"
+
+
+def test_a_ledger_arriving_after_the_startup_snapshot_is_still_seen(tmp_path, monkeypatch) -> None:
+    """The gate consumed a snapshot taken before it, so a late arrival was invisible.
+
+    `seed.exists()` and `ledger.exists()` were sampled once at the top of `__init__`, and the
+    identity-loss gate tested the sample. A ledger carrying real history that lands *after* that
+    sample — a partial restore, a file-by-file sync, a copy racing a start — left the flag false,
+    so the gate was skipped and a key was minted over the restored history. The store could not
+    catch it either: its own key check answers false at that moment too.
+
+    The first version of this test wrote the ledger before constructing `Signer`, so the snapshot
+    and a live read agreed and it passed with the bug present — a regression that proved nothing
+    about the case in its name, which is a mistake this branch has already been corrected for
+    once. The arrival has to happen *inside* the constructor, so `initialise()` is hooked to
+    deliver the file exactly where an external writer would.
+    """
+    home = tmp_path / "home"
+    ledger = home / "nonces.json"
+    history = {"!ledger": {"v": 1}, "did:key:zStub": {"room": 1_700_000_000_000}}
+
+    real_initialise = nonces_module.NonceStore.initialise
+
+    def deliver_then_initialise(self) -> None:
+        real_initialise(self)
+        # An external writer landing between the snapshot and the gate.
+        ledger.write_text(json.dumps(history))
+
+    monkeypatch.setattr(nonces_module.NonceStore, "initialise", deliver_then_initialise)
+
+    with pytest.raises(ValueError) as caught:
+        Signer(home)
+    assert "nonce allocation(s)" in str(caught.value)
+    assert not (home / "seed").exists(), "a key was minted over history that arrived late"
+    assert json.loads(ledger.read_text()) == history, "the refusal rewrote the evidence"
 
 
 def test_a_stamped_ledger_with_no_entries_stays_innocent_beside_a_key(tmp_path) -> None:

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -14,8 +14,10 @@ import os
 import stat
 import subprocess
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from types import SimpleNamespace
 from urllib.parse import quote
 
 import pytest
@@ -195,6 +197,55 @@ def test_a_new_seed_makes_its_directory_entry_durable(tmp_path, monkeypatch) -> 
         assert ident(created) in synced, f"{created.name} was created but its entry never flushed"
     # And the identity is stable across a reload, which is what the durability protects.
     assert Keyring(home / "seed").did == signer.did
+
+
+def test_concurrent_first_starts_converge_on_one_identity(tmp_path) -> None:
+    """@yukkie3276, #803: first start raced, and one starter lost for no good reason.
+
+    `_load` checked `exists()` and then `_create` claimed the name with `O_EXCL`, so two
+    processes starting against the same absent seed both passed the check and the loser raised
+    instead of reading the winner's key. This package already promises a signer shared across
+    concurrent processes for nonce allocation; initialisation has to converge too, or the
+    promise only holds after somebody has started alone once.
+
+    Six processes, one absent path, no coordination: all must succeed and all must report the
+    same DID.
+    """
+    home = tmp_path / "home"
+    gate = tmp_path / "go"
+    # A start gate, because without one this test passed against the broken code roughly one run
+    # in five: the children finished staggered and the race simply did not happen. A flaky guard
+    # over a race is worse than none — it is a regression that goes green often enough to be
+    # believed. Each child imports, then spins until the gate appears, so they all reach the
+    # create within the same few microseconds.
+    program = (
+        "import os, sys, time;"
+        "sys.path[:0] = sys.argv[1].split(':');"
+        "from technocore_client import Keyring;"
+        "deadline = time.time() + 30;"
+        "[time.sleep(0.001) for _ in iter(lambda: os.path.exists(sys.argv[3]) or time.time() > deadline, True)];"
+        "print(Keyring(sys.argv[2]).did)"
+    )
+    repo = Path(__file__).resolve().parents[2]
+    paths = f"{repo / 'client'}:{repo / 'src'}"
+    procs = [
+        subprocess.Popen([sys.executable, "-c", program, paths, str(home / "seed"), str(gate)],
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        for _ in range(6)
+    ]
+    time.sleep(0.5)  # let every child get past its imports and onto the gate
+    gate.write_text("go")
+    results = [SimpleNamespace(returncode=p.wait(timeout=60), **dict(zip(("stdout", "stderr"), p.communicate())))
+               for p in procs]
+
+    failed = [r.stderr.strip().splitlines()[-1] for r in results if r.returncode != 0]
+    assert not failed, f"a concurrent first start failed: {failed}"
+    dids = {r.stdout.strip() for r in results}
+    assert len(dids) == 1, f"first starts disagreed about the identity: {dids}"
+    assert next(iter(dids)).startswith("did:key:z6Mk")
+    # No temporary survived the race, and the winner's file carries the mode the loser skipped.
+    assert list(home.glob("seed.*.tmp")) == []
+    assert (home / "seed").stat().st_mode & 0o777 == 0o600
 
 
 def test_concurrent_processes_never_hand_out_the_same_nonce(tmp_path) -> None:

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -10,24 +10,23 @@ and that is the failure a standalone test cannot see.
 
 from __future__ import annotations
 
+import base64
 import os
 import stat
 import subprocess
 import sys
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
 from urllib.parse import quote
 
+import _client  # noqa: F401 (imported for the fixture alias below)
 import pytest
 
-import _client  # noqa: F401 (imported for the fixture alias below)
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "client"))
-
-import didkey  # noqa: E402
-from technocore_client import Keyring, NonceStore, Signer  # noqa: E402
+import didkey
+from technocore_client import Keyring, NonceStore, Signer, did_from_seed
 
 client = _client.client
 
@@ -84,8 +83,7 @@ def test_a_signed_note_write_is_accepted(client, tmp_path) -> None:
     signer = Signer(tmp_path / "home")
     did, sig, nonce, swept = signer.note("room-owners", "d-localsigner", signer.did)
     r = client.get(
-        f"/kv/room-owners/d-localsigner/set-signed/{did}/{sig}/{nonce}/{quote(swept)}"
-        "?if_absent=1"
+        f"/kv/room-owners/d-localsigner/set-signed/{did}/{sig}/{nonce}/{quote(swept)}?if_absent=1"
     )
     assert r.status_code == 200, r.text
     # And the claim is real: the unsigned lane is now refused on that room.
@@ -229,14 +227,20 @@ def test_concurrent_first_starts_converge_on_one_identity(tmp_path) -> None:
     repo = Path(__file__).resolve().parents[2]
     paths = f"{repo / 'client'}:{repo / 'src'}"
     procs = [
-        subprocess.Popen([sys.executable, "-c", program, paths, str(home / "seed"), str(gate)],
-                         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        subprocess.Popen(
+            [sys.executable, "-c", program, paths, str(home / "seed"), str(gate)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
         for _ in range(6)
     ]
     time.sleep(0.5)  # let every child get past its imports and onto the gate
     gate.write_text("go")
-    results = [SimpleNamespace(returncode=p.wait(timeout=60), **dict(zip(("stdout", "stderr"), p.communicate())))
-               for p in procs]
+    results = []
+    for proc in procs:
+        stdout, stderr = proc.communicate(timeout=60)
+        results.append(SimpleNamespace(returncode=proc.returncode, stdout=stdout, stderr=stderr))
 
     failed = [r.stderr.strip().splitlines()[-1] for r in results if r.returncode != 0]
     assert not failed, f"a concurrent first start failed: {failed}"
@@ -246,6 +250,80 @@ def test_concurrent_first_starts_converge_on_one_identity(tmp_path) -> None:
     # No temporary survived the race, and the winner's file carries the mode the loser skipped.
     assert list(home.glob("seed.*.tmp")) == []
     assert (home / "seed").stat().st_mode & 0o777 == 0o600
+
+
+def test_a_seed_of_the_wrong_length_is_refused_at_both_doors(tmp_path) -> None:
+    """The two length checks, which are the only thing standing between a truncated file and a
+    signer that runs happily under an identity nobody else can verify.
+
+    Covered explicitly because the repository's coverage floor is branch-aware for exactly this
+    reason: a refusal that is never exercised is a refusal nobody has checked works.
+    """
+    with pytest.raises(ValueError, match="32 bytes"):
+        did_from_seed(b"\x01" * 31)
+
+    seed_path = tmp_path / "home" / "seed"
+    seed_path.parent.mkdir(parents=True)
+    seed_path.write_text(base64.urlsafe_b64encode(b"\x02" * 16).decode().rstrip("="))
+    seed_path.chmod(0o600)
+    with pytest.raises(ValueError, match="does not hold a 32-byte seed"):
+        Keyring(seed_path)
+
+
+def test_a_nonce_file_holding_the_wrong_shape_is_ignored_not_trusted(tmp_path) -> None:
+    """A note that parses as JSON but is not the map this expects is the same class as a corrupt
+    one: unknown, so start from the clock rather than from whatever was there."""
+    store = tmp_path / "nonces.json"
+    store.write_text('["not", "a", "map"]')
+    assert NonceStore(store).last("did:key:zX", "room") is None
+
+    store.write_text('{"did:key:zX": "not a room map"}')
+    assert NonceStore(store).last("did:key:zX", "room") is None
+
+    store.write_text('{"did:key:zX": {"room": -5, "other": 7}}')
+    fresh = NonceStore(store)
+    assert fresh.last("did:key:zX", "room") is None, "a negative nonce is not a nonce"
+    assert fresh.last("did:key:zX", "other") == 7
+
+
+def test_concurrent_first_starts_in_one_process_converge(tmp_path) -> None:
+    """@yukkie3276, #803 again, and the sharp part is why the previous test could not see it.
+
+    The staging file was named from `os.getpid()`. Separate processes get distinct names by
+    construction, so the six-subprocess test above is *structurally blind* to two threads: they
+    share a pid, both build the same staging path, and the loser raises at the temporary's own
+    O_EXCL before ever reaching the link that handles the race. A rigorous test of the wrong
+    axis is still a test of the wrong axis.
+
+    A barrier rather than a sleep, so both threads are inside `Keyring.__init__` at the same
+    moment rather than probably-overlapping.
+    """
+    seed_path = tmp_path / "home" / "seed"
+    start = threading.Barrier(2)
+    results: list[object] = []
+    lock = threading.Lock()
+
+    def start_one() -> None:
+        start.wait(timeout=10)
+        try:
+            outcome: object = Keyring(seed_path).did
+        except Exception as exc:  # noqa: BLE001 — the failure mode under test is any raise
+            outcome = exc
+        with lock:
+            results.append(outcome)
+
+    threads = [threading.Thread(target=start_one) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    raised = [r for r in results if isinstance(r, Exception)]
+    assert not raised, f"a concurrent first start raised: {raised!r}"
+    assert len(set(results)) == 1, f"threads disagreed about the identity: {results}"
+    # No staging file outlived the race, and the survivor carries the mode.
+    assert [p.name for p in seed_path.parent.iterdir()] == ["seed"]
+    assert seed_path.stat().st_mode & 0o777 == 0o600
 
 
 def test_concurrent_processes_never_hand_out_the_same_nonce(tmp_path) -> None:
@@ -275,12 +353,18 @@ def test_concurrent_processes_never_hand_out_the_same_nonce(tmp_path) -> None:
     repo = Path(__file__).resolve().parents[2]
     client_dir = f"{repo / 'client'}:{repo / 'src'}"
     with ThreadPoolExecutor(max_workers=6) as pool:
-        outs = list(pool.map(
-            lambda _: subprocess.run(
-                [sys.executable, "-c", program, client_dir, str(store), did],
-                capture_output=True, text=True, timeout=60, check=True).stdout.split(),
-            range(6),
-        ))
+        outs = list(
+            pool.map(
+                lambda _: subprocess.run(
+                    [sys.executable, "-c", program, client_dir, str(store), did],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                    check=True,
+                ).stdout.split(),
+                range(6),
+            )
+        )
 
     nonces = [int(n) for out in outs for n in out]
     assert len(nonces) == 120

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -11,6 +11,7 @@ and that is the failure a standalone test cannot see.
 from __future__ import annotations
 
 import os
+import stat
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
@@ -156,6 +157,44 @@ def test_a_corrupt_nonce_file_is_not_fatal(tmp_path) -> None:
 
     fresh = NonceStore(home / "nonces.json")
     assert fresh.allocate(signer.did, "room") > used
+
+
+def test_a_new_seed_makes_its_directory_entry_durable(tmp_path, monkeypatch) -> None:
+    """@yukkie3276, #803: fsyncing the seed file does not make its *name* durable.
+
+    Power loss is not reproducible in a test, so this asserts the call rather than the outcome —
+    that a directory handle is fsynced after the seed is written, and that the directories the
+    keyring itself created are covered too. Asserting the mechanism is weaker than asserting the
+    property and is the strongest thing available here; the alternative is asserting nothing,
+    which is how the gap survived review-free for a day.
+    """
+    home = tmp_path / "deep" / "nested" / "home"
+    # Identify each fsynced handle by (device, inode) rather than by a path: /dev/fd does not
+    # resolve back to a name on macOS, and an inode pair is exact on every platform this runs on.
+    synced: set[tuple[int, int]] = set()
+    real_fsync = os.fsync
+
+    def recording_fsync(fd: int) -> None:
+        info = os.fstat(fd)
+        if stat.S_ISDIR(info.st_mode):
+            synced.add((info.st_dev, info.st_ino))
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", recording_fsync)
+    signer = Signer(home)
+    assert (home / "seed").exists()
+
+    def ident(path: Path) -> tuple[int, int]:
+        info = path.stat()
+        return (info.st_dev, info.st_ino)
+
+    # The directory holding the seed, and every directory this call had to create beneath an
+    # existing one, must have had its own entries flushed.
+    assert ident(home) in synced, "the seed's own directory was never fsynced"
+    for created in (tmp_path / "deep", tmp_path / "deep" / "nested"):
+        assert ident(created) in synced, f"{created.name} was created but its entry never flushed"
+    # And the identity is stable across a reload, which is what the durability protects.
+    assert Keyring(home / "seed").did == signer.did
 
 
 def test_concurrent_processes_never_hand_out_the_same_nonce(tmp_path) -> None:

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -287,6 +287,111 @@ def test_a_marker_of_the_wrong_shape_is_refused_like_any_other_damage(tmp_path) 
     assert path.exists(), "the refusal removed the evidence"
 
 
+def test_the_refusal_for_a_missing_ledger_does_not_advise_moving_it_aside(tmp_path) -> None:
+    """One refusal, two situations, and the advice only fitted one of them.
+
+    `_refuse` told every caller the file "is left in place deliberately" and to recover by
+    repairing it or moving it aside. For a ledger that is *missing* there is nothing to repair
+    and nothing to move, so an operator following the message hunts for a file that is not there
+    and has no route out of a refusal that repeats on every start. The verdict was right and the
+    instructions were impossible — the same shape as the chained-refusal fix earlier on this
+    branch, where a true message told someone to do the catastrophic thing.
+    """
+    store = tmp_path / "nonces.json"
+    with pytest.raises(LedgerUnreadableError) as missing:
+        NonceStore(store, key_exists=True)
+    text = str(missing.value)
+    assert "nothing here to repair or move aside" in text
+    assert "left in place" not in text, "advice for a damaged file was given for a missing one"
+    assert "backup" in text and "different key" in text, "no recovery was offered"
+
+    # And the damaged case must keep the advice that does fit it.
+    store.write_text("{ not json")
+    with pytest.raises(LedgerUnreadableError) as damaged:
+        NonceStore(store, key_exists=True)
+    assert "left in place" in str(damaged.value)
+
+
+def test_a_seed_that_is_not_a_regular_file_names_itself_and_not_the_ledger(tmp_path) -> None:
+    """`seed_existed` meant "a usable key is here", and a directory made it true.
+
+    With a directory named `seed` and no ledger, `Signer` refused about the *nonce ledger* —
+    "this key already exists, so a ledger was written and has since been lost" — which sends
+    the operator to investigate a file that was never the problem. `Keyring` grew the same check
+    and it never ran, because the ledger reasoning answers first. Both layers now have it: the
+    one in `Signer` because it owns the ordering, the one in `Keyring` because it is reachable
+    directly.
+    """
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    (home / "seed").mkdir(mode=0o700)
+    with pytest.raises(ValueError) as caught:
+        Signer(home)
+    assert "is not a regular file" in str(caught.value)
+    assert "not a lost ledger" in str(caught.value).lower()
+
+    # Reachable on its own too, and a dangling symlink is the same fact wearing a different shape.
+    other = tmp_path / "other"
+    other.mkdir(parents=True)
+    os.symlink(str(other / "nowhere"), str(other / "seed"))
+    with pytest.raises(ValueError) as dangling:
+        Keyring(other / "seed")
+    assert "is not a regular file" in str(dangling.value)
+
+
+def test_a_ledger_from_a_newer_format_is_unknown_rather_than_fresh(tmp_path) -> None:
+    """The marker carried a version that nothing read.
+
+    A future writer stamping `v2` with different semantics would have been read as a v1 ledger
+    and quietly misinterpreted, which is the same "unknown treated as understood" that the rest
+    of this loader exists to refuse. A marker with no usable version is refused for the same
+    reason: it is a record this build cannot vouch for.
+    """
+    newer = tmp_path / "newer.json"
+    newer.write_text(json.dumps({"!ledger": {"v": 2}}))
+    with pytest.raises(LedgerUnreadableError) as ahead:
+        NonceStore(newer)
+    assert "v2" in str(ahead.value) and "understands" in str(ahead.value)
+
+    unversioned = tmp_path / "unversioned.json"
+    unversioned.write_text(json.dumps({"!ledger": {}}))
+    with pytest.raises(LedgerUnreadableError) as bare:
+        NonceStore(unversioned)
+    assert "no usable version" in str(bare.value)
+
+
+def test_a_stray_empty_ledger_on_a_first_run_is_adopted_and_not_fatal(tmp_path) -> None:
+    """The marker's own regression, found by auditing the commit that added it.
+
+    A bare `{}` in a directory with no key was innocent before the marker existed, and had to
+    stay innocent. It did not. `initialise()` skips a file that already exists, so the stray
+    ledger survived startup unmarked; `Keyring` created the key one line later, which flipped
+    `key_exists` true; and the first `allocate()` refused, telling the operator their ledger had
+    been emptied when nothing had ever written one. A fresh install came up holding an identity
+    it could never sign with, and the next start refused during construction.
+
+    Worth a test rather than a comment because the refusal was right and its trigger was a fact
+    the constructor itself was about to make true — the same shape as every other finding on this
+    branch, which is a new line meeting an ordering constraint somewhere else.
+    """
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    (home / "nonces.json").write_text("{}")
+
+    signer = Signer(home)
+    issued = signer.nonces.allocate(signer.did, "room")
+    assert issued > 0, "a fresh install with a stray empty ledger could not sign"
+
+    on_disk = json.loads((home / "nonces.json").read_text())
+    assert "!ledger" in on_disk, "the stray ledger was used without being adopted"
+    assert on_disk[signer.did] == {"room": issued}
+
+    # And the next start, which is where the old behaviour refused during construction.
+    again = Signer(home)
+    assert again.did == signer.did
+    assert again.nonces.allocate(again.did, "room") > issued
+
+
 def test_a_stamped_ledger_with_no_entries_stays_innocent_beside_a_key(tmp_path) -> None:
     """The other half of the pair above, and the reason the marker exists rather than a ban on
     `{}`.

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -11,7 +11,9 @@ and that is the failure a standalone test cannot see.
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from urllib.parse import quote
 
@@ -154,6 +156,48 @@ def test_a_corrupt_nonce_file_is_not_fatal(tmp_path) -> None:
 
     fresh = NonceStore(home / "nonces.json")
     assert fresh.allocate(signer.did, "room") > used
+
+
+def test_concurrent_processes_never_hand_out_the_same_nonce(tmp_path) -> None:
+    """The claim @yukkie3276 broke in review, now asserted instead of stated.
+
+    The first version said "monotonic across processes" and meant "across restarts": the wall
+    clock plus a process-local high-water mark keeps a restart safe and does nothing for two
+    processes that load the same persisted value inside one millisecond. A concurrency claim
+    with no concurrency test is how that shipped, so this forks real processes rather than
+    simulating them — the bug lived precisely in what separate address spaces cannot share.
+    """
+    home = tmp_path / "home"
+    Signer(home)  # mint the seed once, so the children only allocate
+    did = Keyring(home / "seed").did
+    store = home / "nonces.json"
+
+    program = (
+        "import sys;"
+        "sys.path[:0] = sys.argv[1].split(':');"
+        "from technocore_client.nonces import NonceStore;"
+        "s = NonceStore(sys.argv[2]);"
+        "print(' '.join(str(s.allocate(sys.argv[3], 'r')) for _ in range(20)))"
+    )
+    # Both paths, because the package's __init__ reaches the core's `didkey` through
+    # `keyring` — the child needs no key material, but importing the module still walks
+    # the package.
+    repo = Path(__file__).resolve().parents[2]
+    client_dir = f"{repo / 'client'}:{repo / 'src'}"
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        outs = list(pool.map(
+            lambda _: subprocess.run(
+                [sys.executable, "-c", program, client_dir, str(store), did],
+                capture_output=True, text=True, timeout=60, check=True).stdout.split(),
+            range(6),
+        ))
+
+    nonces = [int(n) for out in outs for n in out]
+    assert len(nonces) == 120
+    assert len(set(nonces)) == len(nonces), "two processes were handed the same nonce"
+    # And the file agrees with the highest number any of them was given: a lock that let a
+    # process write a value below one already issued would leave the next run repeating it.
+    assert NonceStore(store).last(did, "r") == max(nonces)
 
 
 def test_the_seed_is_written_0600_and_refused_if_it_is_widened(tmp_path) -> None:

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -436,6 +436,61 @@ def test_an_emptied_ledger_beside_a_lost_seed_is_never_silently_replaced(tmp_pat
     assert (home / "nonces.json").read_text() == "{}", "the evidence was rewritten"
 
 
+def test_a_ledger_recording_another_identity_is_refused(tmp_path) -> None:
+    """Nothing compared the DIDs in the ledger to the DID the key derives, and our own recovery
+    advice walks an operator into the gap.
+
+    Lose a seed, restore from a backup, restore the wrong one: the key is present, so the
+    identity-loss gate is skipped; the entries are well-formed, so `_load` accepts them; and the
+    first `allocate` finds no record under the restored DID and starts from the clock — while a
+    ledger holding the previous identity's whole history sits unread beside it. A silent success,
+    which is the outcome every other check on this branch exists to refuse.
+
+    In-process, unlike the floor tests: nothing here turns on `_process_floor` or on what a fresh
+    interpreter concludes, because the comparison is made from disk inside every construction.
+
+    The second half is the innocent case, asserted because a refusal that also rejects the right
+    seed is a home nobody can start.
+    """
+    home = tmp_path / "home"
+    original = Signer(home)
+    issued = original.nonces.allocate(original.did, "room")
+    ledger = home / "nonces.json"
+    before = ledger.read_text()
+    assert original.did in json.loads(before), "this test needs the recorded history it names"
+
+    # The wrong backup: a valid seed, correctly permissioned, deriving a different identity — so
+    # every existing check passes it and only the comparison under test can see anything wrong.
+    seed = home / "seed"
+    wrong = b"\x07" * 32
+    seed.write_text(base64.urlsafe_b64encode(wrong).decode().rstrip("="))
+    seed.chmod(0o600)
+    assert did_from_seed(wrong) != original.did
+
+    with pytest.raises(ValueError) as caught:
+        Signer(home)
+    text = str(caught.value)
+    assert original.did in text and did_from_seed(wrong) in text, (
+        "the refusal must name both identities, or the operator cannot tell which seed is wrong"
+    )
+    # Both readings named and neither asserted. The recurring defect on this branch is a true
+    # refusal carrying a claim the evidence does not support, and which of these two happened is
+    # not on disk.
+    assert "two readings this cannot distinguish" in text
+    assert "wrong backup" in text and "reused for a new identity" in text
+    assert "has signed before" not in text, "reused the wording that asserts one of the readings"
+    # A route out for the deliberate half, which is clearing the home rather than the ledger.
+    assert "clear this home" in text
+    assert ledger.read_text() == before, "the refusal rewrote the evidence"
+
+    # And the right seed still starts, allocating above what the old one had already issued.
+    seed.write_text(base64.urlsafe_b64encode(original.keys.seed).decode().rstrip("="))
+    seed.chmod(0o600)
+    restored = Signer(home)
+    assert restored.did == original.did
+    assert restored.nonces.allocate(restored.did, "room") > issued
+
+
 def test_a_ledger_arriving_after_the_startup_snapshot_is_still_seen(tmp_path, monkeypatch) -> None:
     """The gate consumed a snapshot taken before it, so a late arrival was invisible.
 
@@ -1025,6 +1080,65 @@ def test_a_well_formed_ledger_round_trips(tmp_path) -> None:
     reread = NonceStore(store)
     assert reread.last("did:key:zX", "room") == first
     assert reread.allocate("did:key:zX", "room") > first
+
+
+def test_last_reloads_under_the_lock_rather_than_answering_from_memory(tmp_path, monkeypatch):
+    """`last` returned from `self._state`, which is whatever the previous load left there.
+
+    Every other read in this class reloads, and `_allocate_locked` says why at length: the copy
+    in memory is stale the moment another process allocates, and this package's whole claim is
+    that a signer works across concurrent processes. So a store still open across a sibling's
+    allocation answered with a number that sibling had already passed — history reported as the
+    present, with nothing local to show it.
+
+    A real second process, not a thread, because the staleness is exactly what separate address
+    spaces cannot share.
+
+    The lock is asserted separately and by mechanism, because the reload alone would satisfy the
+    read: `os.replace` means a reader sees the old file or the new one, never a torn one. What
+    the lock buys is that the number returned is not one an allocation already holding the lock
+    has decided to supersede, and the only way to check that here is the call itself.
+    """
+    store_path = tmp_path / "nonces.json"
+    store = NonceStore(store_path)
+    did = "did:key:zStub"
+    first = store.allocate(did, "room")
+
+    repo = Path(__file__).resolve().parents[2]
+    program = (
+        "import sys;"
+        "sys.path[:0] = sys.argv[1].split(':');"
+        "from technocore_client import NonceStore;"
+        "print(NonceStore(sys.argv[2]).allocate(sys.argv[3], 'room'))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program, f"{repo / 'client'}:{repo / 'src'}", str(store_path), did],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=True,
+    )
+    second = int(result.stdout.strip())
+    assert second > first, "the child did not allocate above the parent; the test proves nothing"
+    assert store.last(did, "room") == second, (
+        "`last` answered from memory, reporting a nonce another process had already passed"
+    )
+
+    real = nonces_module.fcntl
+    exclusive: list[int] = []
+
+    def recording_flock(fd: int, operation: int) -> None:
+        if operation == real.LOCK_EX:
+            exclusive.append(fd)
+        real.flock(fd, operation)
+
+    monkeypatch.setattr(
+        nonces_module,
+        "fcntl",
+        SimpleNamespace(flock=recording_flock, LOCK_EX=real.LOCK_EX, LOCK_UN=real.LOCK_UN),
+    )
+    assert store.last(did, "room") == second
+    assert exclusive, "`last` read without the lock every other read in this class takes"
 
 
 def test_every_successful_first_start_is_past_the_durability_barrier(tmp_path, monkeypatch) -> None:

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -302,24 +302,46 @@ def test_a_seed_of_the_wrong_length_is_refused_at_both_doors(tmp_path) -> None:
         Keyring(seed_path)
 
 
-def test_a_nonce_file_of_the_wrong_shape_is_refused_and_a_bad_entry_is_dropped(tmp_path) -> None:
-    """Two different facts, deliberately treated differently.
+@pytest.mark.parametrize(
+    ("body", "reason"),
+    [
+        ('["not", "a", "map"]', "does not hold a JSON object"),
+        ('{"did:key:zX": "not a room map"}', "not an object"),
+        ('{"did:key:zX": {"room": "1730000000000"}}', "not a non-negative integer"),
+        ('{"did:key:zX": {"room": -5}}', "not a non-negative integer"),
+        ('{"did:key:zX": {"room": 1.5}}', "not a non-negative integer"),
+        ('{"did:key:zX": {"room": true}}', "not a non-negative integer"),
+    ],
+)
+def test_every_shape_the_ledger_cannot_hold_is_quarantined(tmp_path, body, reason) -> None:
+    """@yukkie3276, #803: valid JSON of the wrong shape was being filtered rather than refused.
 
-    A file that is not an object at all is unreadable state — same class as unparseable, so it is
-    quarantined. A file that *is* the right shape with one implausible entry is readable state
-    with a hole: the rest is trustworthy and the bad entry is dropped, which leaves that one pair
-    starting from the clock rather than throwing the whole ledger away.
+    The previous version dropped a malformed entry and carried on, and I defended that in the
+    commit before this one as "readable state with a hole". It is not a hole. Dropping the entry
+    *asserts* that the pair has never issued a nonce, which is the same claim the quarantine
+    exists to refuse, made one level further in — and after a clock rollback it resumes below the
+    server's replay floor exactly as a lost file would.
+
+    `true` is in the table because `isinstance(True, int)` is true in Python, so a JSON `true`
+    would otherwise load as the nonce 1.
     """
     store = tmp_path / "nonces.json"
-    store.write_text('["not", "a", "map"]')
-    with pytest.raises(ValueError, match="does not hold a JSON object"):
+    store.write_text(body)
+    with pytest.raises(ValueError, match=reason):
         NonceStore(store)
-    assert len(list(tmp_path.glob("nonces.json.corrupt.*"))) == 1
+    assert len(list(tmp_path.glob("nonces.json.corrupt.*"))) == 1, "damaged ledger not moved aside"
+    assert not store.exists()
 
-    store.write_text('{"did:key:zX": {"room": -5, "other": 7}}')
-    fresh = NonceStore(store)
-    assert fresh.last("did:key:zX", "room") is None, "a negative nonce is not a nonce"
-    assert fresh.last("did:key:zX", "other") == 7
+
+def test_a_well_formed_ledger_round_trips(tmp_path) -> None:
+    """The other half of strictness: what the writer produces, the reader must accept."""
+    store = tmp_path / "nonces.json"
+    written = NonceStore(store)
+    first = written.allocate("did:key:zX", "room")
+    written.allocate("did:key:zX", "other")
+    reread = NonceStore(store)
+    assert reread.last("did:key:zX", "room") == first
+    assert reread.allocate("did:key:zX", "room") > first
 
 
 def test_concurrent_first_starts_in_one_process_converge(tmp_path) -> None:

--- a/tests/http/test_local_signer.py
+++ b/tests/http/test_local_signer.py
@@ -11,6 +11,7 @@ and that is the failure a standalone test cannot see.
 from __future__ import annotations
 
 import base64
+import json
 import os
 import stat
 import subprocess
@@ -27,6 +28,7 @@ import pytest
 
 import didkey
 from technocore_client import Keyring, NonceStore, Signer, did_from_seed
+from technocore_client import nonces as nonces_module
 
 client = _client.client
 
@@ -421,6 +423,56 @@ def test_the_ledger_is_created_before_the_key_on_a_first_run(tmp_path, monkeypat
         "that window would read a healthy first run as a lost ledger and refuse"
     )
     assert signer.nonces.allocate(signer.did, "room") > 0
+
+
+def test_a_concurrent_initialiser_cannot_overwrite_a_populated_ledger(tmp_path, monkeypatch):
+    """@yukkie3276, #803: the fix for a first-start race shipped a first-start clobber.
+
+    `initialise()` checked `exists()` and then flushed, with no lock and no create-only
+    publication, so two starters could both find the ledger absent. A gets there first,
+    initialises, mints its key, allocates nonce N and persists it — and B, still acting on the
+    answer to a question it asked before any of that happened, `os.replace`s `{}` over the top.
+    Nothing was deleted and nothing was corrupted, and a durable nonce is gone anyway, which
+    puts the next restart back into the unknown-floor case this change exists to close.
+
+    The ordering test one function up cannot see this. It proves the ledger exists before the
+    key is published, which is a statement about one process's sequence; this is a statement
+    about two, and they are different claims.
+
+    Deterministic, not timed. B is held inside its own `initialise` — after the stale check the
+    old code made, before the flush that acts on it — while A completes in full. The gate is on
+    `mkdir_durable` because it is the one call both versions make in that stretch, and it is
+    held for B's thread only, so A never blocks on it. B holds no lock while it waits, so there
+    is nothing here to deadlock.
+    """
+    home = tmp_path / "home"
+    ledger = home / "nonces.json"
+    b_arrived, a_done = threading.Event(), threading.Event()
+    b_thread: threading.Thread | None = None
+    real_mkdir = nonces_module.mkdir_durable
+
+    def gated_mkdir(path):
+        if threading.current_thread() is b_thread:
+            b_arrived.set()
+            assert a_done.wait(30), "the winner never finished; the race did not happen"
+        return real_mkdir(path)
+
+    monkeypatch.setattr(nonces_module, "mkdir_durable", gated_mkdir)
+
+    b_thread = threading.Thread(target=lambda: NonceStore(ledger).initialise(), daemon=True)
+    b_thread.start()
+    assert b_arrived.wait(30), "the second initialiser never reached the window"
+
+    signer = Signer(home)
+    issued = signer.nonces.allocate(signer.did, "room")
+    a_done.set()
+    b_thread.join(30)
+    assert not b_thread.is_alive()
+
+    assert json.loads(ledger.read_text()) == {signer.did: {"room": issued}}, (
+        "a concurrent initialiser replaced a populated ledger with an empty one, losing a "
+        "nonce that had already been issued and persisted"
+    )
 
 
 def test_a_seed_of_the_wrong_length_is_refused_at_both_doors(tmp_path) -> None:


### PR DESCRIPTION
Implements the design in #39. @krypt0bi wrote that design and handed the implementation over
[there](https://github.com/flop-labs/technocore-chat/pull/39) — the shape is theirs, and the
persistence and nonce sections in particular are implemented from their reasoning rather than
worked out again.

#14 was closed because its client scripts were standalone: their own copy of the sweep, their own
tests, and nothing that ran them against the thing they had to agree with. This is built to avoid
exactly that.

## What it adds

`client/technocore_client/` — three small modules, 251 lines:

- **`keyring.py`** — Ed25519 generation and persistence. The seed file is opened `O_EXCL` at
  `0600` rather than written and then `chmod`'d, because between those two calls the seed exists
  at the process umask. Mode is checked on *read*, not only set on write: a seed that became
  world-readable between runs is the failure that is otherwise silent. The DID is derived on load
  and never stored, so the file cannot hold a DID that disagrees with its key.
- **`nonces.py`** — allocation that survives a crash. **Persisted before the number is returned,
  never after**: a process that dies between being handed a nonce and using it loses the number
  rather than repeating it, and a skipped nonce costs nothing while a repeat is a rejected write
  the caller cannot explain. Written whole under `os.replace`, with the containing directory
  fsynced so the rename cannot outlive the data it points at.
- **`signer.py`** — sweep, canonical string, signature, nonce. **It imports and calls
  `store.clean_text`.** A client carrying its own copy of a Unicode category rule is a copy that
  drifts, and the failure when it drifts is a permanent 403 on any text containing an invisible
  character, with nothing in the input to show why. Sharing the function makes parity structural
  instead of something a test has to keep asserting.

## Where it lives, and why not `src/`

Beside the server, the way `mcp/` sits there. `sz.py`'s caps exist to keep
`app`/`config`/`didkey`/`limit`/`store` small and a client is not core. It is also true that a new
file under `src/` is currently *unmeasured* rather than exempt (#638) — putting it there would be
exploiting that hole rather than respecting the policy. Core size is unchanged: **2317 ≤ 2317**.

## Tests — through the real app, not beside it

`tests/http/test_local_signer.py`, ten tests on `_client.py`'s fixture. The one that matters:

```python
raw = "a​b"                       # U+200B is category Cf
did, sig, nonce, swept = signer.message("sweeproom", raw)
assert swept == "a b"
# signing the swept text: accepted
assert client.get(f"/r/sweeproom/say-signed/{did}/{sig}/{nonce}/{quote(swept)}").status_code == 200
# the same write, signed over the raw input instead. Nothing else differs.
bad_sig = signer.keys.sign(f"sweeproom|{bad_nonce}|{raw}")
assert client.get(f"/r/sweeproom/say-signed/{did}/{bad_sig}/{bad_nonce}/{quote(swept)}").status_code == 403
```

That is the design's sharpest edge asserted end to end, and it is the assertion a standalone test
cannot make. The rest: a signed note write on the `room-owners` lane (narrower than "notes" — the
signed lane takes only `room-owners` and `room-allow`, which the server tells you in the 400);
every minted nonce matching the server's own `NONCE_RE`; per-room counters; crash safety;
a deleted nonce file not restarting the counter; a corrupt one not being fatal; and the seed's
mode being refused when widened.

**A test of mine caught a real bug in this.** The persisted value and the wall clock are not
enough: lose the file, allocate twice inside one millisecond, and you get the same nonce back. A
process-wide high-water mark is the third floor, and the one case that genuinely cannot be solved
without the file is documented rather than hidden.

## Verification

780 passed, 1 skipped, on this branch rebased onto `20a4457`. `sz.py --check` ok. The client's own
ten pass in isolation.

## Not in this PR

The published signer vectors (20 sweep, 7 canonical strings with exact signatures, 5 nonce cases,
Apache-2.0) as an in-tree CI gate. That is a second change and a second review — happy to send it
straight after if wanted, which would make the executable contract @luch91 asked for on #39 a
gate rather than a link.
