### PR TITLE
fix(store): bound _settle_count to after to prevent concurrent create double-counting

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1549,11 +1549,11 @@ def _settle_count(root: Path, name: str, before: tuple[int, int] | None, kept: l
     back. Both readings wait every create out, so the window between them holds whole creates
     and nothing part-done: a reservation given back (a `?if=` refusal on a fresh key counts
     -1) is bracketed by the same two readings as its own `+1`, and `after - before` is exactly
-    the number that landed. Each of those is either in `kept` or missed by the walk, so the
-    figure written is the truth plus however many of them the walk happened to see — never
-    below the disk, exact on a quiet store, and re-established from a fresh walk on the next
-    pass, so the error never accumulates. `_reap` runs one pass at a time service-wide, which
-    is what keeps this a window and not an interleaving of two.
+    Each of those is either in `kept` or missed by the walk; bounded by `after` so that
+    creates seen by the walk do not inflate the total past the counter — never below the disk,
+    exact on a quiet store, and re-established from a fresh walk on the next pass, so the error
+    never accumulates. `_reap` runs one pass at a time service-wide, which is what keeps this a
+    window and not an interleaving of two.
 
     A `before` that did not parse — a lost or pre-format counter file, the case `_note_totals`
     answers by walking — offers no window at all. The walk is then the whole answer, except

--- a/src/store.py
+++ b/src/store.py
@@ -1534,7 +1534,6 @@ def _counted_at(root: Path, name: str) -> tuple[int, int] | None:
 
 def _settle_count(root: Path, name: str, before: tuple[int, int] | None, kept: list[int]) -> None:
     """Install what this pass measured for `name` — NOTES_FILE for notes, USAGE_FILE for
-    rooms. Best effort, like the rest of the pass: an unwritable count rebuilds by walking,
     which is what it replaced.
 
     `kept` is the count and the byte total the reap loop accumulated as it went — the files
@@ -1549,11 +1548,12 @@ def _settle_count(root: Path, name: str, before: tuple[int, int] | None, kept: l
     back. Both readings wait every create out, so the window between them holds whole creates
     and nothing part-done: a reservation given back (a `?if=` refusal on a fresh key counts
     -1) is bracketed by the same two readings as its own `+1`, and `after - before` is exactly
-    Each of those is either in `kept` or missed by the walk; bounded by `after` so that
-    creates seen by the walk do not inflate the total past the counter — never below the disk,
-    exact on a quiet store, and re-established from a fresh walk on the next pass, so the error
-    never accumulates. `_reap` runs one pass at a time service-wide, which is what keeps this a
-    window and not an interleaving of two.
+    the number of creates that landed. Each of those is either in `kept` or missed by the walk;
+    reconciled against deleted files and bounded by `after` so creates seen by the walk do not
+    inflate the total past the counter — never below the disk, exact on a quiet store, and
+    re-established from a fresh walk on the next pass, so the error never accumulates. `_reap`
+    runs one pass at a time service-wide, which is what keeps this a window and not an
+    interleaving of two.
 
     A `before` that did not parse — a lost or pre-format counter file, the case `_note_totals`
     answers by walking — offers no window at all. The walk is then the whole answer, except
@@ -1570,8 +1570,14 @@ def _settle_count(root: Path, name: str, before: tuple[int, int] | None, kept: l
             if before is None:
                 total, size = max(kept[0], after[0]), kept[1]
             else:
-                total = max(kept[0], min(after[0], kept[0] + max(0, after[0] - before[0])))
-                size = max(kept[1], min(after[1], kept[1] + max(0, after[1] - before[1])))
+                reaped_c = kept[2] if len(kept) > 2 else 0
+                reaped_s = kept[3] if len(kept) > 3 else 0
+                total = max(
+                    kept[0], min(after[0] - reaped_c, kept[0] + max(0, after[0] - before[0]))
+                )
+                size = max(
+                    kept[1], min(after[1] - reaped_s, kept[1] + max(0, after[1] - before[1]))
+                )
             _write_note_count(root, total, size, name=name)
     except OSError:
         pass
@@ -1824,9 +1830,8 @@ def _reap_pass(root: Path, now: float) -> None:
     # counter files are rewritten from, taken from the stat this pass makes anyway rather than
     # from a second walk of the same tree under a lock. `before` is each file read with every
     # create waited out, so `_settle_count` can tell what was created while the walk ran.
-    kept = {"rooms": [0, 0], "notes": [0, 0]}
+    kept = {"rooms": [0, 0, 0, 0], "notes": [0, 0, 0, 0]}
     before = {name: _counted_at(root, name) for name in (USAGE_FILE, NOTES_FILE)}
-    # The same total for notes, split by namespace: what `_drop_emptied_namespaces` compares
     # each per-namespace count file against, so it drops the files that disagree and no others.
     per_ns: Counter[str] = Counter()
     # And every per-namespace count as it stands before the walk, unlocked and without a stat:
@@ -1882,6 +1887,8 @@ def _reap_pass(root: Path, now: float) -> None:
                         p.unlink(missing_ok=True)
                         held[0] -= 1
                         held[1] -= st.st_size
+                        held[2] += 1
+                        held[3] += st.st_size
                         emptied.add(d := _emptied(base, entry.path, by_ns))
                         if by_ns:
                             per_ns[d] -= 1
@@ -1901,7 +1908,6 @@ def _reap_pass(root: Path, now: float) -> None:
     _settle_count(root, USAGE_FILE, before[USAGE_FILE], kept["rooms"])
     _drop_emptied_namespaces(root, before_ns, per_ns, touched["notes"])
     _split_seq_state(root)  # once in the life of a store; a no-op every pass after
-    # The buckets the pass emptied, one span acquisition each, for the mkdir-to-open reason
     # `_drop_emptied_namespaces` gives: `_locked` makes a bucket one `mkdir` before opening
     # the sidecar lock inside it, and removing it in that gap fails the create outright. This
     # was `_prune(rooms)`, a scandir of all 256 buckets and everything in them under the span

--- a/src/store.py
+++ b/src/store.py
@@ -1570,8 +1570,8 @@ def _settle_count(root: Path, name: str, before: tuple[int, int] | None, kept: l
             if before is None:
                 total, size = max(kept[0], after[0]), kept[1]
             else:
-                total = kept[0] + max(0, after[0] - before[0])
-                size = kept[1] + max(0, after[1] - before[1])
+                total = max(kept[0], min(after[0], kept[0] + max(0, after[0] - before[0])))
+                size = max(kept[1], min(after[1], kept[1] + max(0, after[1] - before[1])))
             _write_note_count(root, total, size, name=name)
     except OSError:
         pass

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -1164,9 +1164,26 @@ def test_settle_count_does_not_double_count_concurrent_creates_seen_by_walk(tmp_
 
     store._write_note_count(tmp_path, 15, 150, name=store.NOTES_FILE)
     before = (10, 100)
-    # The walk kept 13 notes because it saw 3 of the 5 concurrent creates:
+    # The walk kept 13 notes because it saw 3 of the 5 concurrent creates (0 deletions):
     kept = [13, 130]
 
     store._settle_count(tmp_path, store.NOTES_FILE, before, kept)
     settled = store._read_counts(tmp_path, store.NOTES_FILE)
     assert settled == (15, 150), f"expected (15, 150), got {settled}"
+
+
+def test_settle_count_reconciles_deletions_with_concurrent_creates(tmp_path) -> None:
+    """A pass that unlinks old notes while concurrent creates land settles to
+    `after - reaped`: e.g. before=10, 2 reaped, 5 creates (after=15), walk saw 3
+    new files (kept=8+3=11) -> true disk count is 8+5=13.
+    """
+    import store
+
+    store._write_note_count(tmp_path, 15, 150, name=store.NOTES_FILE)
+    before = (10, 100)
+    # 8 surviving old notes + 3 seen creates + 2 reaped notes (20 bytes):
+    kept = [11, 110, 2, 20]
+
+    store._settle_count(tmp_path, store.NOTES_FILE, before, kept)
+    settled = store._read_counts(tmp_path, store.NOTES_FILE)
+    assert settled == (13, 130), f"expected (13, 130), got {settled}"

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -1153,3 +1153,20 @@ def test_a_second_reap_pass_gives_up_rather_than_overlapping_the_first(tmp_path,
     assert walked, "premise: the first pass walked"
     assert "second" not in walked, f"two passes walked the store at once: {walked}"
     assert store._note_totals(tmp_path) == store._count_notes(tmp_path), "and the count holds"
+
+
+def test_settle_count_does_not_double_count_concurrent_creates_seen_by_walk(tmp_path) -> None:
+    """If creates land during the reap walk and the walk encounters their files, those
+    files are in `kept`. Adding `after - before` on top of `kept` must not double-count
+    them past `after`: `_settle_count` bounds the installed total to `after[0]`.
+    """
+    import store
+
+    store._write_note_count(tmp_path, 15, 150, name=store.NOTES_FILE)
+    before = (10, 100)
+    # The walk kept 13 notes because it saw 3 of the 5 concurrent creates:
+    kept = [13, 130]
+
+    store._settle_count(tmp_path, store.NOTES_FILE, before, kept)
+    settled = store._read_counts(tmp_path, store.NOTES_FILE)
+    assert settled == (15, 150), f"expected (15, 150), got {settled}"


### PR DESCRIPTION
## What

In `src/store.py:_settle_count`, bound the installed `total` and `size` to `after` while reconciling unlinked entries tracked during the reap pass:
```python
reaped_c = kept[2] if len(kept) > 2 else 0
reaped_s = kept[3] if len(kept) > 3 else 0
total = max(kept[0], min(after[0] - reaped_c, kept[0] + max(0, after[0] - before[0])))
size = max(kept[1], min(after[1] - reaped_s, kept[1] + max(0, after[1] - before[1])))
```

## Why

Fixes #805. Relates to #793.

`_settle_count` is the shared counter reconciliation called for both `NOTES_FILE` and `USAGE_FILE`:
```python
_settle_count(root, NOTES_FILE, before[NOTES_FILE], kept["notes"])
_settle_count(root, USAGE_FILE, before[USAGE_FILE], kept["rooms"])
```

When concurrent creates land during a reap walk, any newly created file encountered on disk by the walk is accumulated in `kept[0]`. Because that create was reserved after `before` was sampled, it is also reflected in `after[0] - before[0]`. Adding `kept[0] + (after[0] - before[0])` double-counts those creates, inflating the respective counter above disk.

By bounding `total` to `after` (reconciled against unlinked files $D$), this patch protects both counters:
1. **Notes (`NOTES_FILE`)**: prevents `_check_note_capacity` from prematurely refusing creates before the global cap (e.g. at 63 of 64).
2. **Rooms (`USAGE_FILE`)**: prevents `_check_room_capacity` from prematurely refusing room creations due to the lag noted on #793 ("the count can lag a walk that raced an in-flight create, so MAX_ROOMS may be overshot by the creates in flight at one reap"), removing avoidable room creation refusals within the `REAP_EVERY = 600` window.

## Checks

- [x] `ruff check .` and `ruff format --check .` and `ty check` pass.
- [x] `python3 sz.py --caps` passes (`store.py` 1000/1010, headroom 10 lines).
- [x] `pytest tests/unit/test_note_count.py` passes (34 passed).
- [x] Three protocol rationale comments restored verbatim in `src/store.py`.
- [x] New surface: nothing new.