### PR TITLE
fix(config): mirror override bindings into limit module (#807)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -348,12 +348,12 @@ _NOT_THERE = object()
 def override(**kwargs):
     """Re-bind named knobs for the body of the `with`, then restore them — always.
 
-    app and store re-bind these knobs into their own namespaces at import (handlers and
+    app, store and limit re-bind these knobs into their own namespaces at import (handlers and
     tests read them there, and monkeypatch.setattr(app, ...) expects to find them), so a
-    binding made here is mirrored into both when they are already loaded, and every copy
+    binding made here is mirrored into all when they are already loaded, and every copy
     is restored on exit.
     """
-    mods = [sys.modules[__name__]] + [sys.modules[n] for n in ("app", "store") if n in sys.modules]
+    mods = [sys.modules[n] for n in (__name__, "app", "store", "limit") if n in sys.modules]
     saved = [(mod, name, mod.__dict__.get(name, _NOT_THERE)) for mod in mods for name in kwargs]
     for mod, name, _ in saved:
         setattr(mod, name, kwargs[name])

--- a/tests/unit/test_config_knobs.py
+++ b/tests/unit/test_config_knobs.py
@@ -313,3 +313,26 @@ def test_junk_in_the_poll_interval_refuses_to_boot() -> None:
             env={**clean, "CHAT_WAIT_POLL": raw},
         )
         assert run.returncode != 0, f"CHAT_WAIT_POLL={raw!r} booted"
+
+
+def test_override_mirrors_to_limit_module() -> None:
+    """Knobs extracted to limit (MAX_WAITERS_TOTAL, MAX_WAITERS_PER_IP) must mirror
+
+    into limit when overridden, matching the behavior for app and store.
+    """
+    import app
+    import config
+    import limit
+
+    orig_config = config.MAX_WAITERS_TOTAL
+    orig_limit = limit.MAX_WAITERS_TOTAL
+    orig_app = app.MAX_WAITERS_TOTAL
+
+    with config.override(MAX_WAITERS_TOTAL=1337):
+        assert config.MAX_WAITERS_TOTAL == 1337
+        assert app.MAX_WAITERS_TOTAL == 1337
+        assert limit.MAX_WAITERS_TOTAL == 1337
+
+    assert config.MAX_WAITERS_TOTAL == orig_config
+    assert app.MAX_WAITERS_TOTAL == orig_app
+    assert limit.MAX_WAITERS_TOTAL == orig_limit


### PR DESCRIPTION
Fixes #807

### What
Includes `"limit"` in the module namespace target list for `config.override()` alongside `"app"` and `"store"`.

### Why
When `limit.py` was extracted as a core module, waiter capacity knobs were relocated to `limit`. `config.override()` did not mirror re-bound knobs into `limit`, leaving `limit.MAX_WAITERS_TOTAL` and `limit.MAX_WAITERS_PER_IP` stale during overrides.

### Checks
- Added `test_override_mirrors_to_limit_module` in `tests/unit/test_config_knobs.py` (fails without this fix, passes with it).
- `uv run python sz.py --check`: passes (core code-lines <= baseline, +0 lines net).
- `uv run ruff check .`, `uv run ruff format --check .`, and `uv run ty check` pass cleanly.
- `uv run python -m pytest tests -q` passes (771 passed, 1 skipped).