### PR TITLE
fix: recipe_names fallback regex misses default-valued just recipes

### DIFF
--- a/tests/unit/test_contributing_recipes.py
+++ b/tests/unit/test_contributing_recipes.py
@@ -105,7 +105,14 @@ def recipe_names(justfile: Path) -> set[str]:
             check=True,
         )
         return set(listed.stdout.split())
-    header = re.compile(r"^([A-Za-z][A-Za-z0-9_-]*)[^:=]*:(?!=)")
+    # `[^:]*`, not `[^:=]*`: a parameter with a default (`serve port="8080":`, `mutate
+    # children="4":`) puts an `=` before the header's colon, and excluding it stopped the
+    # match before that colon — every default-valued recipe went uncounted, so a
+    # contributor running bare `pytest` (no `just` on PATH) saw `serve`/`mutate` reported
+    # as undefined even though the justfile defines them. The `:=` lookahead below is what
+    # keeps a `set name := value` line from matching; the parameter list itself may
+    # contain `=` freely.
+    header = re.compile(r"^([A-Za-z][A-Za-z0-9_-]*)[^:]*:(?!=)")
     names = set()
     for line in justfile.read_text(encoding="utf-8").splitlines():
         if line[:1].strip() and not line.startswith(("#", "set ", "export ")):


### PR DESCRIPTION
  ## What
  Fixes the `just`-less fallback in `recipe_names()` (tests/unit/test_contributing_recipes.py)
  so it recognizes recipes with default-valued parameters.

  ## Why
  `test_contributing_names_only_things_that_exist` fails whenever `just` isn't on PATH
  (e.g. a bare `pytest` run outside `uv run`), reporting `just serve` and `just mutate`
  as undefined recipes even though the justfile defines both. The fallback regex excluded
  `=` from the segment before the header's colon, so it never got past `port="8080"` /
  `children="4"` to find the real terminating `:`.

  ## Fix
  Drop `=` from the excluded character class (`[^:=]*` → `[^:]*`). The existing `(?!=)`
  lookahead already keeps this from matching a `set name := value` assignment line, so
  nothing else changes.

  ## Verification
  - Confirmed `just_recipe_names(justfile.parent)`'s fallback path is hit when `just`
    is absent from PATH (my sandbox had no `just` binary).
  - Before: `test_contributing_names_only_things_that_exist` failed with the exact
    "just serve/mutate is not a recipe" complaint.
  - After: `pytest tests/unit/test_contributing_recipes.py -q` → 5 passed.
  - Ran the broader suite (excluding the tests that require the mcp SDK, which my
    sandbox doesn't have installed): 645 passed, 1 skipped.
  - `ruff check` and `ruff format --check` on the changed file: clean.