### PR TITLE
fix: reject boolean signed nonces

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -2523,7 +2523,7 @@ def _write_record(
         rec = {"seq": 0, "ts": _now(), "from": valid_name(nick), "text": clean_text(text)}
     else:
         didkey.public_key(did)
-        if not isinstance(nonce, int) or nonce < 0:
+        if not isinstance(nonce, int) or isinstance(nonce, bool) or nonce < 0:
             raise StoreError(
                 f"signed writes need a non-negative integer nonce, got {nonce!r} — 1-19 "
                 "digits, greater than the last one this key used in this room. A counter "

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -1337,3 +1337,26 @@ def test_the_append_path_can_size_the_file_it_just_wrote(tmp_path):
 
     texts = [m["text"] for m in store.read_messages(tmp_path, "torncalc")["messages"]]
     assert texts == ["first", "second"], "the healed record and the new one both survive"
+
+
+@pytest.mark.parametrize(("nonce", "shown"), [(True, "True"), (False, "False")])
+def test_a_signed_write_refuses_a_bool_nonce(tmp_path, nonce, shown):
+    """A bool is an int subclass, but it cannot be a signed nonce (#810)."""
+    import store
+
+    did, _ = _keypair()
+    with pytest.raises(store.StoreError, match="non-negative integer nonce") as refused:
+        store.append(tmp_path, "lobby", "", "hello", did=did, nonce=nonce)
+    assert f"got {shown}" in str(refused.value)
+
+
+def test_a_refused_bool_nonce_does_not_burn_the_counter(tmp_path):
+    """A rejected boolean must not consume nonce 0 or 1."""
+    import store
+
+    did, _ = _keypair()
+    with pytest.raises(store.StoreError):
+        store.append(tmp_path, "lobby", "", "hello", did=did, nonce=True)
+    rec = store.append(tmp_path, "lobby", "", "hello", did=did, nonce=0, sig="x" * 86)
+    assert rec["nonce"] == 0
+    assert isinstance(rec["nonce"], int) and not isinstance(rec["nonce"], bool)


### PR DESCRIPTION
## What

Reject `True` and `False` in the store-level signed nonce guard.

## Why

Python treats `bool` as an `int` subclass. HTTP routes accept only 1–19 ASCII digits, but an in-process caller could otherwise serialize a JSON boolean that violates the published nonce contract.

Fixes #810.

## Checks

- [x] `git diff --check`
- [x] `python -m py_compile src/store.py tests/unit/test_store.py`
- [ ] Full `uv` suite: dependency setup was blocked by this environment's local runtime/DNS constraints
- [x] No new public surface or abusive caller capability

## Technocore identity

`did:key:z6MkqhfrtgwW2TwJp5PE3tKfdfjnMqVkmuHSWLRmzH4o6aKR`

Public contributor context only; not authentication, authorization, affiliation, or a reward/airdrop claim.