### PR TITLE
fix(manifest): /config states the staleness its header allows, not an hour

### DIFF
--- a/src/manifest.py
+++ b/src/manifest.py
@@ -1686,13 +1686,22 @@ def config_document(version: str) -> dict:
             "static_cache_seconds": "s-maxage on the documents; 0 means no-store",
         },
         "withheld": _WITHHELD,
+        # The staleness is named as the knob rather than as a period, because that is the
+        # one form that cannot go stale itself: this document is served through
+        # app._static_cacheable, so what a shared cache may hold is `static_cache_seconds`
+        # above plus its stale-while-revalidate, and nothing at all at 0. It said "up to an
+        # hour" — the private `max-age=3600` these documents carried until 0.11.0 moved
+        # them onto the knob — for as long as that had stopped being true, in the one
+        # document whose whole claim is that it reports what this process enforces.
         "note": (
             "Every key in `settings` is the environment variable of the same name, "
             "uppercased and prefixed with `env_prefix` — `rate_read` is CHAT_RATE_READ. "
             "The values are what THIS process enforces, read from the same bindings the "
             "handlers read, so they cannot disagree with the service's behaviour; they can "
             "differ between deployments and change on restart, and a shared cache may hold "
-            "this document for up to an hour. `withheld` names every remaining knob and why "
+            "this document for the `static_cache_seconds` window above plus its "
+            "stale-while-revalidate, never for a fixed period — at 0 nothing shared holds it "
+            "at all. `withheld` names every remaining knob and why "
             "it is not here — the list is complete, not a selection. The rate limits also "
             "appear in /.well-known/agent.json, which is the document registries read; this "
             "one is for a client tuning itself and for an operator reading back what they "

--- a/tests/http/test_config.py
+++ b/tests/http/test_config.py
@@ -159,6 +159,38 @@ def test_it_is_never_rate_limited_and_stays_indexable(client):
     )
 
 
+def test_the_note_states_the_staleness_this_deployment_actually_allows(client):
+    """The one paragraph in this document that named a period rather than a binding.
+
+    `/config` promises its readers that its values "cannot disagree with the service's
+    behaviour", and the note beside them said a shared cache may hold the document "for up
+    to an hour" — the private `max-age=3600` these JSON documents carried until 0.11.0 put
+    them on `_static_cacheable`. Since then the header has been the knob: 360s at the
+    default (`s-maxage=300` plus a 60s stale-while-revalidate), whatever the operator sets,
+    and `no-store` at 0 — so the document overstated its own staleness by 10x while
+    publishing the number that contradicted it two keys higher up, and told an operator who
+    had switched shared caching *off* that the copy in front of them might be an hour old.
+    """
+    import config
+
+    doc = client.get("/config").json()
+    assert "an hour" not in doc["note"], "the pre-0.11.0 max-age=3600 window, still promised"
+    assert "static_cache_seconds" in doc["note"], "the note has to name the binding it means"
+
+    # The knob is what the note now points at, so it has to move the header with it.
+    with config.override(STATIC_CACHE_SECONDS=30):
+        moved = client.get("/config")
+        assert moved.headers["cache-control"] == (
+            "public, max-age=0, s-maxage=30, stale-while-revalidate=60"
+        )
+        assert moved.json()["settings"]["static_cache_seconds"] == 30
+    # And 0 really is "no shared cache holds it", which is the half an hour cannot describe.
+    with config.override(STATIC_CACHE_SECONDS=0):
+        off = client.get("/config")
+        assert off.headers["cache-control"] == "no-store"
+        assert off.json()["settings"]["static_cache_seconds"] == 0
+
+
 def test_a_published_setting_is_a_number_json_can_carry(client):
     """Publishing a knob makes its finiteness a contract.
 


### PR DESCRIPTION
## The bug

`/config` tells its readers, in the `note` beside the settings, that

> The values are what THIS process enforces, read from the same bindings the handlers read, **so they cannot disagree with the service's behaviour**; they can differ between deployments and change on restart, and **a shared cache may hold this document for up to an hour.**

That last clause is the private `max-age=3600` these JSON documents carried until 0.11.0 put them on `_static_cacheable`. It has not been true since. The header is the knob now, and the document publishes the knob itself two keys higher up.

### Reproduction on `origin/main` (20a4457)

```
Cache-Control: public, max-age=0, s-maxage=300, stale-while-revalidate=60
settings.static_cache_seconds: 300
units.static_cache_seconds: s-maxage on the documents; 0 means no-store

note tail: change on restart, and a shared cache may hold this document for up to an hour. `withheld` names every remaining knob and why it is not here ...

with CHAT_STATIC_CACHE_SECONDS=0 -> Cache-Control: no-store
  note still claims: True
with CHAT_STATIC_CACHE_SECONDS=30 -> Cache-Control: public, max-age=0, s-maxage=30, stale-while-revalidate=60
  settings says: 30
  note still claims: True
```

Three ways wrong, all in the one document that promises it cannot be:

1. **10x at the default.** `s-maxage=300` plus a 60s `stale-while-revalidate` is 360 seconds of shared staleness. The note says 3600.
2. **It contradicts the document's own field.** `settings.static_cache_seconds` is right there, and moves with `CHAT_STATIC_CACHE_SECONDS`; the note does not move with anything.
3. **At 0 it is backwards, not merely stale.** `CHAT_STATIC_CACHE_SECONDS=0` answers `no-store` — no shared cache holds the document at all — while the note still tells the operator who set it that the copy in front of them may be an hour old. `units` already states this correctly: *"0 means no-store"*.

### What it contradicts, verbatim

`src/manifest.py`, `config_document`'s own claim, three sentences before the offending one:

> "The values are what THIS process enforces, read from the same bindings the handlers read, so they cannot disagree with the service's behaviour"

`README.md`, the `CHAT_STATIC_CACHE_SECONDS` row, which records exactly the change that stranded this sentence:

> "The JSON set carried a private `max-age=3600` until 0.11.0, which ignored this knob and told the *client* to hold a copy for an hour; they follow the same policy as the prose now."

`tests/http/test_config.py::test_it_is_never_rate_limited_and_stays_indexable`, whose comment already says the hour is gone:

> "`/config` is static per *deploy* rather than per release, which is exactly the case `max-age=0` serves — a caller revalidates and sees the new settings, instead of holding the previous deploy's for an hour."

And `src/app.py::_document`, which describes the removal:

> "This used to be its own hardcoded `public, max-age=3600` ... an agent that read /.well-known/mcp/server-card.json held it for an hour"

## The fix

One sentence in `src/manifest.py::config_document`. It now names the **binding** rather than a period, which is the one form that cannot go stale again — the number is already published in the same document, so a second copy here would only be something else to drift:

```diff
-            "this document for up to an hour. `withheld` names every remaining knob and why "
+            "this document for the `static_cache_seconds` window above plus its "
+            "stale-while-revalidate, never for a fixed period — at 0 nothing shared holds it "
+            "at all. `withheld` names every remaining knob and why "
```

Plus a comment above it recording why it is phrased that way and what it used to say. No behaviour change, no core file touched, no `sz.py` cap moved (`manifest.py` is `extra/`, uncapped; core headroom unchanged).

## RED on main / GREEN with the fix

The new test is `tests/http/test_config.py::test_the_note_states_the_staleness_this_deployment_actually_allows`.

**RED** — with `git show origin/main:src/manifest.py` swapped in, the new test alone:

```
$ git show origin/main:src/manifest.py > src/manifest.py
$ uv run python -m pytest tests/http/test_config.py::test_the_note_states_the_staleness_this_deployment_actually_allows -q
E       AssertionError: the pre-0.11.0 max-age=3600 window, still promised
E       assert 'an hour' not in 'Every key i...ey deployed.'
E         'an hour' is contained here:
E           for up to an hour. `withheld` names every remaining knob and why it is not here ...
1 failed in 3.90s
```

**GREEN** — with the fix restored:

```
$ uv run python -m pytest tests/http/test_config.py -q
1 failed, 9 passed in 0.88s        # the 1 is the Windows-only subprocess boot probe, see below
```

The test also pins the two directions the note now points at: `STATIC_CACHE_SECONDS=30` must produce `s-maxage=30` and publish `30`, and `STATIC_CACHE_SECONDS=0` must produce `no-store`.

## Full gate

```
$ uv run ruff check src/ tests/          All checks passed!
$ uv run ruff format --check src/ tests/ 60 files already formatted
$ uv run ty check src/app.py src/limit.py src/manifest.py
                                         All checks passed!
$ uv run python sz.py --caps
file                       code    cap  headroom
core/app.py                1020   1030        10
core/config.py               63     73        10
core/didkey.py               59     67         8
core/limit.py               183    193        10
core/store.py               992   1010        18
extra/manifest.py          1578      -
core total (code)          2317   3010       693      # unchanged: no core file touched

$ uv run python -m pytest tests/http -q
2 failed, 298 passed in 41.39s

$ uv run python -m pytest tests/test_contract.py tests/test_input_doctrine.py -q
38 passed in 41.43s
```

The two `tests/http` failures are pre-existing on `origin/main` in this Windows environment and are identical before and after the change (baseline: `2 failed, 297 passed`): `test_config.py::test_a_published_setting_is_a_number_json_can_carry` (spawns a subprocess; `OSError: [WinError 10106]` on `_overlapped`) and `test_docs.py::test_skill_md_is_the_installable_skill_and_is_never_rate_limited` (CRLF/encoding on the checked-out `SKILL.md`). `tests/unit` was run before and after as well — the same fcntl/multiprocess set fails either way (7 on main, 8 with the change, with `test_export_snapshot` and `test_note_count::test_the_global_cap_binds_exactly` swapping between runs, i.e. flaky rather than regressed).

## Not a duplicate

Checked by full listing (`gh issue list --state all --limit 500`, `gh pr list --state all --limit 2000`), not by search:

- **#317** (open, `docs(config): scope static_cache_seconds to text documents`) predates #591 and argues the opposite: it wants `units.static_cache_seconds` narrowed because "JSON discovery documents keep their separate fixed one-hour browser cache". #591 removed that hour. This PR touches `note`, not `units`, and fixes the sentence that #591 left behind.
- **#188 / #191** (open) are about `stale-while-revalidate` on `CHAT_EDGE_CACHE_SECONDS` — the *room read* window, a different knob, a different document, no `/config` note involved.
- **#737** (open, `docs: fix stale idle/CSP/humans/budget claims`) touches README / manual / SKILL.md / `agent.json`'s `limits.note` for the budget-footer stride. It does not touch `config_document`'s `note` or anything about cache staleness.
- **#591** (merged) is what made this sentence wrong; nothing filed since names it.
- Nothing in the issue list mentions the `/config` note, `max-age=3600`, or an hour.

---

Signed off: `did:key:z6MkmDkcrgAGa2DZ9qxfmMjNpwaKBXkDt3owfUPKyUxRQAtx`
