### PR TITLE
fix(store): reap the flat room the walk found instead of migrating it

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -1101,9 +1101,12 @@ def _tail_seq(path: Path) -> int:
     it leaves behind, which moved the very file the branch had just decided to unlink into
     its bucket, and the unlink that followed found nothing. The room then outlived its
     retention by a whole REAP_EVERY while the pass counted it reaped and subtracted it from
-    the room count — a count below the disk, which is the direction `_settle_count` fails
-    closed against. `_migrate` says the reaper "only ever unlinks"; this is what makes that
-    true rather than nearly true.
+    the room count, leaving the settled figure one below the disk for an interval —
+    creates admitted past MAX_ROOMS. `_settle_count` cannot correct that: its fail-closed
+    term is `max(0, after - before)`, which covers creates that landed *while the walk
+    ran*, and this corrupts `kept` itself, which nothing downstream can recover.
+    `_migrate` says the reaper "only ever unlinks"; this is what makes that true rather
+    than nearly true.
 
     chunk_size 4 KiB, not the 64 KiB default: this runs under the room lock on every append
     and wants exactly one record — the newest. A typical record is ~120 B, so 4 KiB holds

--- a/src/store.py
+++ b/src/store.py
@@ -1092,21 +1092,37 @@ def _set_seq_entry(root: Path, room: str, floor: int | None) -> None:
         pass
 
 
+def _tail_seq(path: Path) -> int:
+    """The newest record's `seq` in the file AT `path`, or 0 if it holds none.
+
+    Takes the path and never a name, so a caller that already has one does not resolve it
+    again. `_resolve` *migrates* a pre-sharding file as the side effect of answering, so
+    asking by name is a write: the reaper's reap branch did that to read the high-water mark
+    it leaves behind, which moved the very file the branch had just decided to unlink into
+    its bucket, and the unlink that followed found nothing. The room then outlived its
+    retention by a whole REAP_EVERY while the pass counted it reaped and subtracted it from
+    the room count — a count below the disk, which is the direction `_settle_count` fails
+    closed against. `_migrate` says the reaper "only ever unlinks"; this is what makes that
+    true rather than nearly true.
+
+    chunk_size 4 KiB, not the 64 KiB default: this runs under the room lock on every append
+    and wants exactly one record — the newest. A typical record is ~120 B, so 4 KiB holds
+    ~34 of them and the first read almost always answers. reverse_lines loops until it has a
+    complete line, so a room of long records simply reads again; nothing is lost, and the
+    common case stops reading 60 KiB it only ever split and threw away.
+    """
+    with path.open("rb") as f:
+        for raw in reverse_lines(f, chunk_size=4096, max_bytes=65536):
+            rec = _parse(raw)
+            if rec is not None:
+                return rec["seq"]
+    return 0
+
+
 def last_seq(root: Path, room: str) -> int:
     path = room_path(root, room)
     if path.exists():
-        with path.open("rb") as f:
-            # chunk_size 4 KiB, not the 64 KiB default: this runs under the room lock on
-            # every append and wants exactly one record — the newest. A typical record is
-            # ~120 B, so 4 KiB holds ~34 of them and the first read almost always answers.
-            # reverse_lines loops until it has a complete line, so a room of long records
-            # simply reads again; nothing is lost, and the common case stops reading 60 KiB
-            # it only ever split and threw away.
-            for raw in reverse_lines(f, chunk_size=4096, max_bytes=65536):
-                rec = _parse(raw)
-                if rec is not None:
-                    return rec["seq"]
-        return 0
+        return _tail_seq(path)
     # The room file is gone (reaped). A recreated room carries the previous generation's
     # high-water mark in a root-level floor map so cursors from the old generation keep
     # seeing new messages instead of starving on a restarted sequence (#139 dir #2): a
@@ -1877,8 +1893,11 @@ def _reap_pass(root: Path, now: float) -> None:
                             # (#139 dir #3): a silently-repaired cursor is fine for a stateless
                             # reader, but a stateful one needs to know the conversation changed.
                             # (Rooms only: notes are not sequenced, so they carry no floor/gen.)
+                            # Read from `p`, the path this pass locked, and never by name:
+                            # resolving a name migrates a pre-sharding file, which would move
+                            # the file out from under the unlink below (see `_tail_seq`).
                             room = p.name[: -len(".jsonl")]
-                            _set_seq_entry(root, room, max(0, last_seq(root, room)))
+                            _set_seq_entry(root, room, max(0, _tail_seq(p)))
                         p.unlink(missing_ok=True)
                         held[0] -= 1
                         held[1] -= st.st_size

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -447,3 +447,52 @@ def test_pruning_keeps_the_bucket_of_a_room_that_survived(tmp_path, monkeypatch)
     assert not doomed_bucket.exists(), "the emptied bucket was not pruned"
     assert store.room_path(tmp_path, "keeper").exists(), "…and the live room went with it"
     assert store.read_messages(tmp_path, "keeper", limit=5)["messages"][0]["text"] == "hi"
+
+
+def test_the_reaper_unlinks_the_flat_room_it_found_rather_than_migrating_it(tmp_path, monkeypatch):
+    """The reap branch must act on the path its walk locked, never on one it re-resolved.
+
+    Resolving a name MIGRATES a pre-sharding file, so reading the high-water mark by name
+    inside the branch moved the very file the branch had just decided to unlink into its
+    bucket. `p.unlink(missing_ok=True)` then found nothing: the room outlived the retention
+    it had already exceeded, and the pass still reported it reaped and subtracted it from
+    the room count. And the only flat files left on a live store are the ones nobody has
+    read or written since the migration — which is exactly the set the reaper is here for.
+
+    The count is asserted against a walk of the disk rather than against a literal: a cached
+    figure BELOW what is on disk admits creates past MAX_ROOMS, which is the one direction
+    `_settle_count` is written to fail closed in.
+    """
+    import store
+
+    legacy = _legacy_room(tmp_path, "old", _record(1, "one"), _record(2, "two"))
+    old = time.time() - store.IDLE_SECONDS - 60
+    os.utime(legacy, (old, old))
+    monkeypatch.setattr(store, "REAP_EVERY", 0)
+
+    store._reap(tmp_path)
+
+    left = sorted(str(p) for p in (tmp_path / "rooms").rglob("*.jsonl"))
+    assert left == [], f"an idle room past its retention is still on disk: {left}"
+    assert store._read_counts(tmp_path, store.USAGE_FILE) == store._count_rooms(tmp_path), (
+        "the cached room count no longer describes the disk"
+    )
+    assert store.last_seq(tmp_path, "old") == 2, "the floor outlived the room it came from"
+
+
+def test_a_reaped_flat_room_is_counted_once_and_not_once_per_pass(tmp_path, monkeypatch):
+    """The digest half of the same bug. A room the pass did not actually delete is found
+    again by the next pass and counted again, so `reaped_idle` — a lifetime counter whose
+    whole contract is that it only ever goes up by real events — over-reports every flat
+    room by one."""
+    import store
+
+    legacy = _legacy_room(tmp_path, "old", _record(1, "one"))
+    old = time.time() - store.IDLE_SECONDS - 60
+    os.utime(legacy, (old, old))
+    monkeypatch.setattr(store, "REAP_EVERY", 0)
+
+    store._reap(tmp_path)
+    store._reap(tmp_path)
+
+    assert store.counters(tmp_path)["reaped_idle"] == 1, "one room, one reap"

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -460,8 +460,10 @@ def test_the_reaper_unlinks_the_flat_room_it_found_rather_than_migrating_it(tmp_
     read or written since the migration — which is exactly the set the reaper is here for.
 
     The count is asserted against a walk of the disk rather than against a literal: a cached
-    figure BELOW what is on disk admits creates past MAX_ROOMS, which is the one direction
-    `_settle_count` is written to fail closed in.
+    figure BELOW what is on disk admits creates past MAX_ROOMS. `_settle_count` does not
+    defend against this one — its fail-closed term, `max(0, after - before)`, covers creates
+    that landed while the walk ran, and here the corruption is in `kept` itself, which no
+    later correction can recover.
     """
     import store
 


### PR DESCRIPTION
## The bug

`_reap_pass` decides a room is reapable from the path its walk found, locks that path, re-stats it under the lock — and then reads the room's high-water mark with `last_seq(root, room)`, **by name**.

Resolving a name is not a read. `_resolve` *migrates* a pre-sharding file as the side effect of answering:

```python
if (legacy := d / filename).exists():
    _migrate(legacy, sharded)          # os.replace(legacy, sharded)
```

So on a store that still holds flat `rooms/<name>.jsonl` files, the reap branch moves the very file it has just decided to unlink into its bucket, and the `p.unlink(missing_ok=True)` on the next line finds nothing:

```python
with _locked(p):
    reason = _reapable(p, now, stillborn_rule)
    if reason:
        if stillborn_rule:
            room = p.name[: -len(".jsonl")]
            _set_seq_entry(root, room, max(0, last_seq(root, room)))   # <- migrates p away
        p.unlink(missing_ok=True)                                      # <- no-op
        held[0] -= 1
        held[1] -= st.st_size
```

This contradicts `_migrate`'s own docstring, which is where the safety argument for leaving sidecar locks behind is written:

> The reaper is the one caller that can hold a legacy lock, because it locks what its walk found rather than what a resolver returned. **It only ever unlinks**, and it re-stats by path under the lock, so a file migrated out from under it fails that stat and is skipped rather than deleted.

It does not only ever unlink. It resolves — and it migrates the file out from under *itself*, after the stat, so the file is neither skipped nor deleted, yet the pass books it as both.

## Why it matters

Three consequences, all on `origin/main` at `20a4457`:

1. **The room outlives its retention by a whole `REAP_EVERY` (10 minutes).** `IDLE_SECONDS` / `STILLBORN_SECONDS` are the promise the manual and both capacity refusals publish; the pass that was supposed to honour it deletes nothing.
2. **`reaped_idle` / `reaped_stillborn` double-count.** The counters are documented as the one monotonic thing in the store ("These four only ever go up" — `COUNTERS_FILE`) and they back the digest. The pass that migrated counts the room; the next pass, which actually deletes it, counts it again.
3. **`_settle_count` writes a room count *below* the disk.** `held[0]` / `held[1]` are decremented for a file that is still there, so `.usage` under-reports. That is the direction `_settle_count` is explicitly written to fail closed in:

   > A walk cannot see a create that has reserved but not yet written, and **a figure below the disk admits a write the cap should refuse** — so this fails closed rather than aiming to be exact.

   `_check_room_capacity` reads that figure, so `MAX_ROOMS` and `MAX_TOTAL_ROOM_BYTES` fail *open* for one interval, and `_ring_limit` reads the byte half.

And the reachable set is not a corner. On a live store the flat files still left are precisely the ones nobody has read or written since #298 — because any read or write migrates them. That is exactly the set the reaper is there for, so this hits every one of them.

## Reproduction on `origin/main`

```python
legacy = root / "rooms" / "oldroom.jsonl"        # a pre-sharding room, 2 records
os.utime(legacy, (time.time() - 8 * 86400,) * 2) # 8 days idle: past IDLE_SECONDS
store._reap_pass(root, time.time())
```

```
before: legacy exists: True
before: counters: {'messages': 0, 'rooms_created': 0, 'reaped_idle': 0, ...}
after: legacy exists: False
after: sharded exists: True
after: counters: {..., 'reaped_idle': 1, ...}
after: .usage: 0 0
after: real room count on disk: (1, 136)
after: seqstate floor: 2 gen: 0
after: read_messages: 2
```

The room is still there and still readable; `.usage` says the store holds 0 rooms and 0 bytes while `_count_rooms` walks up `(1, 136)`; and `reaped_idle` says one room was reaped.

Two passes, to show the double count:

```
pass1: sharded exists: True  mtime age days: 8.0
pass1: counters reaped_idle: 1
pass2: sharded exists: False
pass2: counters reaped_idle: 2
pass2: .usage: 0 0
```

One room, reaped once, counted twice.

## The fix

`_tail_seq(path)` — the tail read `last_seq` already did, taking the path and never a name, so a caller that already holds one does not resolve it again. The reaper reads the file it locked; `last_seq` keeps its behaviour exactly (`path.exists()`, then the same bounded backwards read with the same `chunk_size=4096` and `max_bytes=65536`, and the same `0` when nothing parses) and now calls it too.

If the file *is* migrated out from under the reaper concurrently — by another worker's resolver, which is the race `_migrate` describes — `_tail_seq` raises `FileNotFoundError` into the loop's existing `except OSError: continue`, which is the "skipped rather than deleted" behaviour that docstring promises.

No public surface changed (`_tail_seq` is private), so `docs/store.md` regenerates byte-identical: `uv run python scripts/gen_store_doc.py` leaves the working tree with only `src/store.py` and `tests/unit/test_sharding.py` modified.

+2 code lines in `src/store.py` (992 -> 994 against a cap of 1010).

## Test evidence — RED on main, GREEN with the fix

Two tests in `tests/unit/test_sharding.py`, the file that already owns the lazy migration.

**RED — `src/store.py` swapped for `git show origin/main:src/store.py`, tests unchanged:**

```
$ git show origin/main:src/store.py > src/store.py
$ python -m pytest tests/unit/test_sharding.py -q -k "flat_room_it_found or counted_once_and_not"

>       assert left == [], f"an idle room past its retention is still on disk: {left}"
E       AssertionError: an idle room past its retention is still on disk: ['...\rooms\5b\old.jsonl']
E       assert ['...\5b\old.jsonl'] == []

>       assert store.counters(tmp_path)["reaped_idle"] == 1, "one room, one reap"
E       AssertionError: one room, one reap
E       assert 2 == 1

FAILED tests/unit/test_sharding.py::test_the_reaper_unlinks_the_flat_room_it_found_rather_than_migrating_it
FAILED tests/unit/test_sharding.py::test_a_reaped_flat_room_is_counted_once_and_not_once_per_pass
2 failed, 21 deselected in 0.42s
```

**GREEN — with the fix restored:**

```
$ python -m pytest tests/unit/test_sharding.py -q
.......................                                                  [100%]
23 passed in 3.67s
```

## Full local gate

```
$ uv run ruff check src/ tests/
All checks passed!
$ uv run ruff format --check src/ tests/
60 files already formatted

$ uv run ty check src/store.py
      2 error[unresolved-attribute]: Module `fcntl` has no member `flock`
      1 error[unresolved-attribute]: Module `fcntl` has no member `LOCK_EX`
      1 error[unresolved-attribute]: Module `fcntl` has no member `LOCK_NB`
      1 error[unresolved-attribute]: Module `fcntl` has no member `LOCK_SH`
      1 error[unresolved-attribute]: Module `fcntl` has no member `LOCK_UN`
      1 error[unresolved-attribute]: Module `os` has no member `fchmod`
```

POSIX-only attributes, unrelated to this change and identical on `origin/main` (this checkout is Windows).

```
$ uv run python sz.py --caps
file                       code    cap  headroom
core/app.py                1020   1030        10
core/config.py               63     73        10
core/didkey.py               59     67         8
core/limit.py               183    193        10
core/store.py               994   1010        16
extra/manifest.py          1576      -
core total (code)          2319   3010       691
```

Every file has headroom >= 0.

```
$ python -m pytest tests -q
9 failed, 763 passed, 1 skipped, 18 warnings in 282.92s
```

The 9 are environmental on this Windows checkout and fail identically on `origin/main` with the same command — the `fcntl` / `os.fchmod` shim (`test_note_cap_holds_under_concurrent_creates`, `test_concurrent_appends_never_duplicate_a_seq`, `test_listings_never_echo_a_name_the_validator_would_reject`, `test_the_per_namespace_cap_holds_under_concurrent_creates`, `test_a_reap_cannot_remove_a_namespace_a_create_is_entering`, `test_creates_of_distinct_rooms_run_at_the_same_time`, `test_a_compaction_mid_export_keeps_reading_the_opened_inode`), CRLF (`test_skill_md_is_the_installable_skill_and_is_never_rate_limited`), and a subprocess boot (`test_a_published_setting_is_a_number_json_can_carry`). On the store-adjacent subset, main is `6 failed, 234 passed` and this branch is `6 failed, 236 passed` — the same six, plus the two new tests.

The Hypothesis state machines that drive append, compaction and the signed lane (`tests/test_store_stateful.py`, `tests/test_signed_lane_stateful.py`) pass.

## Not a duplicate

Listed every issue and PR (`gh issue list --state all --limit 500`, `gh pr list --state all --limit 700`) and read every store / reap / migration entry. Nothing covers the reaper resolving a name inside the reap branch:

- **#805 / PR #806** — `_settle_count` double-counts *concurrent creates* the walk saw. A different mechanism (the create window between the two `_counted_at` readings) and the opposite drift direction: that one runs the count high, this one runs it low against a file the pass did not delete.
- **#302 / PR #311** — `_sweep_orphan_locks`' grace period for idle-reaped rooms. About the sidecar lock left behind, not about the data file surviving.
- **#516 / PR #518** — guard notes outliving a stillborn-reaped room. Notes, and about `_guards_a_live_room`'s idle window.
- **#489 / PR #497, #708, and #652** — `.seqstate` growth, expiry of retired entries, and generation across a mixed-version split. All about the seq-state file's contents; none about the room file the reap branch fails to unlink.
- **#233** — reaped writes inside capacity gates (a write recreating something a reap just deleted). The reverse ordering, and a note-path concern.
- **#330** — a malformed guard filename aborting the pass. Also a resolver call inside `_reap_pass`, but in `_guards_a_live_room`, and the failure is a raised `StoreError`, not a migrated room.
- **#298** (merged) introduced the lazy migration; **#722** (merged) reshaped the reaper's lock spans and left this call as it was. Neither addresses it.
- **#273** / `test_bug_compact_drops_oversized_newest_record.py` is the other `last_seq` regression and is already fixed; unrelated.

Keyword search over both listings for `migrat`, `legacy`, `shard`, `reap`, `unlink` and `last_seq` returns nothing on this.

---

did:key:z6MkmDkcrgAGa2DZ9qxfmMjNpwaKBXkDt3owfUPKyUxRQAtx
