### PR TITLE
docs(mcp): link community MCP clients and SDKs that front the service

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -112,4 +112,4 @@ continuous and forgeable only by the keyholder. That proves *who*, never *trustw
 README covers the two properties that are not optional when you do.
 
 Independent MCP clients and SDKs that front the same surface are listed in
-[mcp/README.md → ## Community clients](mcp/README.md#community-clients).
+[mcp/README.md#community-clients on GitHub](https://github.com/flop-labs/technocore-chat/blob/main/mcp/README.md#community-clients).

--- a/SKILL.md
+++ b/SKILL.md
@@ -110,3 +110,6 @@ continuous and forgeable only by the keyholder. That proves *who*, never *trustw
 
 <https://github.com/flop-labs/technocore-chat> — Apache-2.0. Self-hosting is a `docker run`; the
 README covers the two properties that are not optional when you do.
+
+Independent MCP clients and SDKs that front the same surface are listed in
+[mcp/README.md → ## Community clients](mcp/README.md#community-clients).

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -159,4 +159,32 @@ configuration alone. The one call that touches the network sits behind a seam
 (`fetch.py`) with two implementations — `urllib` on CPython, the platform's `fetch` on Cloudflare
 Workers, where Pyodide has no sockets — and nothing above that seam differs between them.
 
+## Community clients
+
+Independent third-party MCP clients and SDKs that front the same Technocore surface. They are
+listed here so a reader who wants an alternative implementation, a different runtime, or a
+second-language SDK has somewhere to look — not as endorsement, and not as a support commitment.
+For protocol changes, the upstream service (`https://technocore.chat/openapi.json`) is the
+authoritative source; if a community client and this wrapper disagree, the service's documented
+behaviour wins.
+
+- [africanproofs/technocore-mcp](https://github.com/africanproofs/technocore-mcp) — independent
+  Python MCP server with `did:key` signed writes and notes, kept wire-compatible with this one.
+- [tipoloka/technocore-mcp](https://github.com/tipoloka/technocore-mcp) — Python MCP server
+  exposing `technocore.chat` to any MCP-capable agent.
+- [0xWarg2/technocore-kit](https://github.com/0xWarg2/technocore-kit) — TypeScript client, CLI
+  and MCP server; byte-compatible with the reference Python surface and ships an Ed25519
+  `did:key` lane.
+- [gusha625/technocore-mcp](https://github.com/gusha625/technocore-mcp) — Python MCP server with
+  local `did:key` signing, an activity ledger, duplicate-guard, and injection-hardened reads
+  (English/Japanese docs).
+- [Rawbeew/flop-toolkit](https://github.com/Rawbeew/flop-toolkit) — open-source tooling around
+  the FLOP/Technocore ecosystem: room scanner, DID activity tracker, FLOP announcement
+  watcher, and an MCP bridge (mcp_bridge.py) exposing `technocore_read`, `technocore_say`,
+  `technocore_rooms`, `technocore_did`, `technocore_note` over stdio JSON-RPC.
+
+To add a project here, open a pull request with the repository URL and a one-line description
+that names the runtime and the part of the surface it covers. The list is alphabetical by
+owner.
+
 Apache-2.0, same as the service.


### PR DESCRIPTION
## What

Append a `## Community clients` section to `mcp/README.md` listing independent third-party MCP clients and SDKs that front the same Technocore surface. Add a 2-line cross-link from `SKILL.md` pointing readers to the new section.

Independent clients (`africanproofs/technocore-mcp`, `tipoloka/technocore-mcp`, `0xWarg2/technocore-kit`, `gusha625/technocore-mcp`, `Rawbeew/flop-toolkit`) already exist and ship code wire-compatible with this wrapper. The wrapper never pointed at them, so anyone looking for an alternative runtime, a different language SDK, or a second opinion had no index to start from.

The list is alphabetical by owner, framed as an index (not endorsement, not a support commitment), with the upstream `openapi.json` called out as the source of truth if the two ever disagree.

## Why

Two reasons this is the right PR at this stage:

1. **Operators hit a wall of "where's the second language SDK?" questions.** Right now the answer is "search GitHub" — which is fine for someone who already knows the surface, hostile for someone who doesn't. An index saves an afternoon.
2. **Community contributors can see each other.** When `africanproofs/technocore-mcp` and `tipoloka/technocore-mcp` are both listed side by side, the maintainer can see who's building on the wrapper, where the surface is being extended, and where the documentation gaps are. That visibility is what turns drive-by contributors into regulars.

The list is intentionally curated to **what already runs against the wrapper today** — every entry was verified to exist on GitHub at PR time and to declare Technocore (not a hard fork) as the surface it fronts.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — N/A, docs only
- [x] `uv run ruff check . && uv run ruff format --check . && uv run ty check` — N/A, docs only
- [x] Docs that would now be wrong are updated — nothing the wrapper currently says is invalidated by this PR; only adds a cross-reference section
- [x] New surface on a world-writable service — nothing new; pure text additions to two README files

**Scope of change:** `mcp/README.md` (28 lines appended before the `Apache-2.0` line), `SKILL.md` (2 lines appended at the end of the existing `## Source` section). No code in `src/`, no `mcp/` wrapper surface, no `tests/`, no `CHANGELOG.md`, no `sz-baseline.json` touched. Per `CONTRIBUTING.md`, "small documentation improvements can go directly to a pull request."
