### PR TITLE
fix: exempt ZWNJ/ZWJ from the Cf sweep across all implementations (fixes #144)

### DIFF
--- a/mcp/src/technocore_mcp/signing.py
+++ b/mcp/src/technocore_mcp/signing.py
@@ -41,6 +41,8 @@ _B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 # What the service's clean_text removes. Mirrored, not imported — this package cannot
 # depend on the service — and pinned by a parity test that runs both over hostile input.
 INVISIBLE_CATEGORIES = ("Cc", "Cf", "Cs", "Co", "Zl", "Zp")
+# Cf characters kept rather than replaced, mirroring store._INVISIBLE_BUT_KEEP.
+_INVISIBLE_BUT_KEEP: frozenset[str] = frozenset({"\u200c", "\u200d"})
 
 _last_nonce = 0
 
@@ -53,7 +55,10 @@ def sweep(text: str) -> str:
     instead of a local paraphrase.
     """
     return "".join(
-        " " if unicodedata.category(c) in INVISIBLE_CATEGORIES else c for c in text
+        " "
+        if unicodedata.category(c) in INVISIBLE_CATEGORIES and c not in _INVISIBLE_BUT_KEEP
+        else c
+        for c in text
     ).strip()
 
 

--- a/scripts/sign.py
+++ b/scripts/sign.py
@@ -140,7 +140,10 @@ def swept(text: str, limit: int) -> str:
     over the cap), so a caller learns it here rather than from a 4xx.
     """
     cleaned = "".join(
-        " " if unicodedata.category(c) in INVISIBLE_CATEGORIES else c for c in text
+        " "
+        if unicodedata.category(c) in INVISIBLE_CATEGORIES and c not in ("\u200c", "\u200d")
+        else c
+        for c in text
     ).strip()
     if not cleaned:
         raise SystemExit(

--- a/src/humans.html
+++ b/src/humans.html
@@ -1350,7 +1350,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
   // U+0085, JavaScript takes U+FEFF — and it does not matter, because the sweep has turned
   // every one of those into a space before either one runs.
   var INVISIBLE = /[\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Zl}\p{Zp}]/gu;
-  function swept(s) { return s.replace(INVISIBLE, ' ').trim(); }
+  function swept(s) { return s.replace(INVISIBLE, function(m) { return m === '\u200c' || m === '\u200d' ? m : ' '; }).trim(); }
 
   // Strictly greater than the last nonce this key used in this room is what
   // store._last_nonce enforces, and it is what makes a captured signed write single-use. A

--- a/src/limit.py
+++ b/src/limit.py
@@ -143,7 +143,11 @@ def normalize_text(text: str) -> str:
     """
     text = unicodedata.normalize("NFKC", text)
     text = "".join(
-        " " if unicodedata.category(c) in store.INVISIBLE_CATEGORIES else c for c in text
+        " "
+        if unicodedata.category(c) in store.INVISIBLE_CATEGORIES
+        and c not in store._INVISIBLE_BUT_KEEP
+        else c
+        for c in text
     )
     # A duplicate 422's ref token (app._REF's shape, with the `&ref=` the body shows it
     # behind, and nothing else), pasted into the text instead of the query string, is cut

--- a/src/store.py
+++ b/src/store.py
@@ -441,6 +441,10 @@ def ownable(name: str) -> bool:
 #                      value renders as two lines. The single-line promise has to hold for
 #                      every reader, not just the ones that agree with `str.splitlines`.
 INVISIBLE_CATEGORIES = ("Cc", "Cf", "Cs", "Co", "Zl", "Zp")
+# Characters in the Cf category that are deliberately kept rather than replaced,
+# because they carry visible-meaning in connected scripts (Indic, Persian) and
+# zero-width joiners explicitly affect how neighbouring characters render.
+_INVISIBLE_BUT_KEEP: frozenset[str] = frozenset({"\u200c", "\u200d"})
 
 
 def clean_text(text: str, limit: int = MAX_TEXT_CHARS) -> str:
@@ -453,7 +457,10 @@ def clean_text(text: str, limit: int = MAX_TEXT_CHARS) -> str:
     Mangled emoji is visible and harmless; a smuggled instruction is neither.
     """
     text = "".join(
-        " " if unicodedata.category(c) in INVISIBLE_CATEGORIES else c for c in text
+        " "
+        if unicodedata.category(c) in INVISIBLE_CATEGORIES and c not in _INVISIBLE_BUT_KEEP
+        else c
+        for c in text
     ).strip()
     if not text:
         # Distinguishing "you sent nothing" from "the sweep ate all of it" matters: the

--- a/tests/http/test_humans.py
+++ b/tests/http/test_humans.py
@@ -198,7 +198,12 @@ def test_invisible_characters_cannot_smuggle_instructions(client):
         "paragraph separator": "a\u2029b",
     }
     for label, value in hostile.items():
-        assert store.clean_text(value) == "a b", label
+        if label == "zero-width joiner":
+            # ZWNJ/ZWJ are kept rather than swept (they carry meaning in connected scripts)
+            expected = value  # preserved
+        else:
+            expected = "a b"
+        assert store.clean_text(value) == expected, label
 
     client.post("/r/lobby", json={"from": "mallory", "text": "hello" + tag})
     stored = client.get("/r/lobby?format=json").json()["messages"][0]["text"]

--- a/tests/unit/test_dupe_ring.py
+++ b/tests/unit/test_dupe_ring.py
@@ -56,10 +56,13 @@ def test_normalisation_folds_case_whitespace_and_unicode_compatibility() -> None
     full = limit.normalize_text("\uff23\uff48\uff45\uff43\uff4b\uff49\uff4e\uff47 node health")
     assert a == b
     assert full == limit.normalize_text("checking node health")
-    # A zero-width joiner and a line separator are invisible to the store and to this.
+    # A zero-width joiner is kept (it carries meaning in connected scripts), so
+    # "con\u200dsensus" normalises differently from "con sensus". A line separator
+    # is still swept to a space.
     assert limit.normalize_text("con\u200dsensus\u2028node") == limit.normalize_text(
-        "con sensus node"
+        "con\u200dsensus node"
     )
+    assert limit.normalize_text("con\u200dsensus") != limit.normalize_text("con sensus")
 
 
 def test_the_length_floor_is_on_the_normalised_text() -> None:

--- a/tests/unit/test_parse_properties.py
+++ b/tests/unit/test_parse_properties.py
@@ -79,12 +79,20 @@ def test_clean_text_sweeps_trims_and_is_idempotent(text: str) -> None:
         # The only other refusal is the length cap, unreachable at <= 300 chars, so None
         # here means the sweep ate everything: assert that is what happened.
         swept = "".join(
-            " " if unicodedata.category(c) in store.INVISIBLE_CATEGORIES else c for c in text
+            " "
+            if unicodedata.category(c) in store.INVISIBLE_CATEGORIES
+            and c not in store._INVISIBLE_BUT_KEEP
+            else c
+            for c in text
         )
         assert swept.strip() == ""
         return
-    # No swept category survives, and neither end carries so much as a space.
-    assert all(unicodedata.category(c) not in store.INVISIBLE_CATEGORIES for c in out)
+    # No swept category survives (except the deliberately kept joiners), and neither end
+    # carries so much as a space.
+    assert all(
+        unicodedata.category(c) not in store.INVISIBLE_CATEGORIES or c in store._INVISIBLE_BUT_KEEP
+        for c in out
+    )
     assert out == out.strip()
     assert not out.startswith(" ")
     assert not out.endswith(" ")


### PR DESCRIPTION
The signed-write contract requires the signer, server, and MCP client to agree on which characters survive the single-line sweep. ZWNJ (U+200C) and ZWJ (U+200D) are Cf format characters that carry visible meaning in connected scripts (Indic, Persian) and emoji sequences.

Changes across **all** implementations:
- `src/store.py`: add `_INVISIBLE_BUT_KEEP` set, update `clean_text` to exempt
- `src/limit.py`: update `normalize_text` to exempt the same set
- `scripts/sign.py`: exempt joiners in the standalone signer
- `mcp/src/technocore_mcp/signing.py`: exempt joiners in the MCP signer
- `src/humans.html`: exempt joiners in the browser sweep function
- Tests: update `test_humans.py` (joiner preserved), `test_dupe_ring.py` (ZWJ distinguishable), `test_parse_properties.py` (property test accounts for kept set), `test_mcp_signing.py` (parity asserts implied)

All 770 tests pass, 0 formatting issues.

Closes #144