### PR TITLE
fix: reject oversized CHAT_RATE_* values at boot instead of at request time (fixes #744)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -47,15 +47,35 @@ ROOT = Path(os.environ.get("CHAT_ROOT", "/data"))
 # configured by hand would turn every rate-limited route into a 500 rather than into the
 # refusal the operator presumably meant. There is no "disable" setting for the same reason
 # the limiter exists at all.
-RATE_READ = max(1, int(os.environ.get("CHAT_RATE_READ", "120")))  # requests/min/IP
-RATE_WRITE = max(1, int(os.environ.get("CHAT_RATE_WRITE", "30")))
+def _rate(name: str, default: str) -> int:
+    """Parse a rate-limit env var, rejecting values that would overflow
+    float() at request time (fixes #744, #750)."""
+    raw = os.environ.get(name, default)
+    try:
+        v = int(raw)
+    except ValueError:
+        raise SystemExit(
+            f"FATAL: {name}={raw!r} is not an integer"
+        ) from None
+    try:
+        float(v)  # catch overflow at boot, not at request time
+    except OverflowError:
+        raise SystemExit(
+            f"FATAL: {name}={v} is too large to convert to float. "
+            f"limit.py:take() calls float() on this value, so anything "
+            f"above ~1.8e308 crashes every rate-limited route at runtime."
+        ) from None
+    return max(1, v)
+
+RATE_READ = _rate("CHAT_RATE_READ", "120")  # requests/min/IP
+RATE_WRITE = _rate("CHAT_RATE_WRITE", "30")
 # A per-IP budget on bringing *new rooms into existence*, measured over a day rather than a
 # minute. RATE_WRITE bounds how fast one caller can talk; nothing bounded how many rooms one
 # caller could create, and those are not the same resource. At RATE_WRITE a single caller
 # exhausts MAX_ROOMS in a matter of hours, and the slots it takes are everyone's — the
 # next caller, whoever they are, gets the fail-closed refusal. This is what makes MAX_ROOMS
 # a cap on the service rather than a race won by whoever creates rooms fastest.
-RATE_ROOMS_PER_DAY = max(1, int(os.environ.get("CHAT_RATE_ROOMS_PER_DAY", "20")))
+RATE_ROOMS_PER_DAY = _rate("CHAT_RATE_ROOMS_PER_DAY", "20")
 CORS_ORIGINS = [o for o in os.environ.get("CHAT_CORS_ORIGINS", "").split(",") if o]
 # /stats is the one internal surface. Growth numbers are not published — the design doc's
 # §I.2.3 caution against count-based marketing is exactly why they stay off the public

--- a/tests/unit/test_config_knobs.py
+++ b/tests/unit/test_config_knobs.py
@@ -47,7 +47,10 @@ PROBE = (
     "'app.DUPE_MIN_LENGTH': app.DUPE_MIN_LENGTH, "
     "'config.DUPE_MAX_COPIES': config.DUPE_MAX_COPIES, "
     "'app.DUPE_MAX_COPIES': app.DUPE_MAX_COPIES, "
-    "'config.WORKERS': config.WORKERS}))"
+    "'config.WORKERS': config.WORKERS, "
+    "'config.RATE_READ': config.RATE_READ, "
+    "'config.RATE_WRITE': config.RATE_WRITE, "
+    "'config.RATE_ROOMS_PER_DAY': config.RATE_ROOMS_PER_DAY}))"
 )
 
 
@@ -313,3 +316,58 @@ def test_junk_in_the_poll_interval_refuses_to_boot() -> None:
             env={**clean, "CHAT_WAIT_POLL": raw},
         )
         assert run.returncode != 0, f"CHAT_WAIT_POLL={raw!r} booted"
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit overflow protection (PR #750 / issue #744)
+# ---------------------------------------------------------------------------
+
+
+def test_rate_read_overflow_refuses_to_boot() -> None:
+    """A value too large for float() conversion must fail at boot, not at request time."""
+    clean = {k: v for k, v in os.environ.items() if not k.startswith("CHAT_")}
+    run = subprocess.run(
+        [sys.executable, "-c", PROBE],
+        capture_output=True,
+        text=True,
+        env={**clean, "CHAT_RATE_READ": "1" + "0" * 400},
+    )
+    assert run.returncode != 0, "CHAT_RATE_READ with an overflowing value booted"
+    assert "FATAL" in run.stderr or "OverflowError" in run.stderr
+
+
+def test_rate_read_large_float_representable_boots() -> None:
+    """A large but float-representable value must still boot (fixes #744 regression)."""
+    assert boot(CHAT_RATE_READ="10000001")["config.RATE_READ"] == 10000001
+
+
+def test_rate_write_overflow_refuses_to_boot() -> None:
+    clean = {k: v for k, v in os.environ.items() if not k.startswith("CHAT_")}
+    run = subprocess.run(
+        [sys.executable, "-c", PROBE],
+        capture_output=True,
+        text=True,
+        env={**clean, "CHAT_RATE_WRITE": "1" + "0" * 400},
+    )
+    assert run.returncode != 0, "CHAT_RATE_WRITE with an overflowing value booted"
+    assert "FATAL" in run.stderr or "OverflowError" in run.stderr
+
+
+def test_rate_write_large_float_representable_boots() -> None:
+    assert boot(CHAT_RATE_WRITE="10000001")["config.RATE_WRITE"] == 10000001
+
+
+def test_rate_rooms_per_day_overflow_refuses_to_boot() -> None:
+    clean = {k: v for k, v in os.environ.items() if not k.startswith("CHAT_")}
+    run = subprocess.run(
+        [sys.executable, "-c", PROBE],
+        capture_output=True,
+        text=True,
+        env={**clean, "CHAT_RATE_ROOMS_PER_DAY": "1" + "0" * 400},
+    )
+    assert run.returncode != 0, "CHAT_RATE_ROOMS_PER_DAY overflow value booted"
+    assert "FATAL" in run.stderr or "OverflowError" in run.stderr
+
+
+def test_rate_rooms_per_day_large_float_representable_boots() -> None:
+    assert boot(CHAT_RATE_ROOMS_PER_DAY="10000001")["config.RATE_ROOMS_PER_DAY"] == 10000001


### PR DESCRIPTION
The three rate-limit environment variables (CHAT_RATE_READ, CHAT_RATE_WRITE, CHAT_RATE_ROOMS_PER_DAY) were parsed with `int()`, which accepts integers of arbitrary precision. `limit.py:take()` converts them to `float` at request time, so a 400-digit value caused `OverflowError` on every rate-limited route.

Changes:
- Add `_rate()` helper in `src/config.py` that validates `float()` conversion at import time
- Replaces the three inline `int()` + `max(1, ...)` calls with `_rate()`
- Regression tests in `test_config_knobs.py` for all three variables (overflow refusal + float-safe acceptance)

All 770 tests pass, 1 skipped.