### PR TITLE
fix: validate CHAT_CLIENT_IP_HEADER as HTTP field-name at boot (fixes #745)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -115,7 +115,10 @@ FSYNC = os.environ.get("CHAT_FSYNC", "1") != "0"
 # is the right answer for a bug in the software rather than in a deployment — an operator
 # who wants reports about their instance sets this to their own address.
 SECURITY_CONTACT = os.environ.get("CHAT_SECURITY_CONTACT", "security@flop.finance").strip()
-CLIENT_IP_HEADER = os.environ.get("CHAT_CLIENT_IP_HEADER", "").strip().lower()
+_raw_h = os.environ.get("CHAT_CLIENT_IP_HEADER", "").strip().lower()
+if _raw_h and _raw_h != _raw_h.encode("latin-1", errors="replace").decode("latin-1"):
+    raise SystemExit(f"FATAL: CHAT_CLIENT_IP_HEADER={_raw_h!r} contains non-ASCII. HTTP field names are ASCII-only.")
+CLIENT_IP_HEADER = _raw_h
 # The origin to print in /openapi.json and /.well-known/agent.json. Unset is fine — those
 # documents then derive it from the request, or fall back to relative URLs when the Host
 # header is not a plausible hostname (see manifest.public_base). Set it when the service

--- a/src/config.py
+++ b/src/config.py
@@ -115,10 +115,17 @@ FSYNC = os.environ.get("CHAT_FSYNC", "1") != "0"
 # is the right answer for a bug in the software rather than in a deployment — an operator
 # who wants reports about their instance sets this to their own address.
 SECURITY_CONTACT = os.environ.get("CHAT_SECURITY_CONTACT", "security@flop.finance").strip()
-_raw_h = os.environ.get("CHAT_CLIENT_IP_HEADER", "").strip().lower()
-if _raw_h and _raw_h != _raw_h.encode("latin-1", errors="replace").decode("latin-1"):
-    raise SystemExit(f"FATAL: CHAT_CLIENT_IP_HEADER={_raw_h!r} contains non-ASCII. HTTP field names are ASCII-only.")
-CLIENT_IP_HEADER = _raw_h
+_raw_h = os.environ.get("CHAT_CLIENT_IP_HEADER", "").strip()
+if _raw_h:
+    # RFC 9110 §5.1: field-name is a token — ASCII alphanumeric + !#$%&'*+-.^_`|~
+    # We store the lowercased form for case-insensitive lookup.
+    _valid = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~")
+    if not all(c in _valid for c in _raw_h):
+        raise SystemExit(
+            f"FATAL: CHAT_CLIENT_IP_HEADER={_raw_h!r} is not a valid HTTP field-name. "
+            "Must be ASCII alphanumeric or one of: !#$%&'*+-.^_`|~"
+        )
+CLIENT_IP_HEADER = _raw_h.lower()
 # The origin to print in /openapi.json and /.well-known/agent.json. Unset is fine — those
 # documents then derive it from the request, or fall back to relative URLs when the Host
 # header is not a plausible hostname (see manifest.public_base). Set it when the service

--- a/tests/unit/test_config_knobs.py
+++ b/tests/unit/test_config_knobs.py
@@ -313,3 +313,60 @@ def test_junk_in_the_poll_interval_refuses_to_boot() -> None:
             env={**clean, "CHAT_WAIT_POLL": raw},
         )
         assert run.returncode != 0, f"CHAT_WAIT_POLL={raw!r} booted"
+
+
+# ---------------------------------------------------------------------------
+# CHAT_CLIENT_IP_HEADER validation (PR #752 / issue #745)
+# ---------------------------------------------------------------------------
+
+
+def _boot_fails(env_name: str, value: str, marker: str = "FATAL") -> bool:
+    """Return True if the app refuses to boot with env set to value."""
+    clean = {k: v for k, v in os.environ.items() if not k.startswith("CHAT_")}
+    run = subprocess.run(
+        [sys.executable, "-c", PROBE],
+        capture_output=True,
+        text=True,
+        env={**clean, env_name: value},
+    )
+    return run.returncode != 0 and marker in (run.stderr + run.stdout)
+
+
+def test_client_ip_header_non_ascii_refuses_to_boot() -> None:
+    """Non-ASCII values like é (U+00E9, Latin-1) must fail at boot."""
+    assert _boot_fails("CHAT_CLIENT_IP_HEADER", "é")
+    assert _boot_fails("CHAT_CLIENT_IP_HEADER", "☃")
+    assert _boot_fails("CHAT_CLIENT_IP_HEADER", "café")
+
+
+def test_client_ip_header_colon_refuses_to_boot() -> None:
+    """A colon is not a valid HTTP field-name token character."""
+    assert _boot_fails("CHAT_CLIENT_IP_HEADER", "x-forwarded-for:8080")
+
+
+def test_client_ip_header_space_refuses_to_boot() -> None:
+    """Space is not a valid HTTP field-name token character."""
+    assert _boot_fails("CHAT_CLIENT_IP_HEADER", "x forward")
+
+
+def test_client_ip_header_comma_refuses_to_boot() -> None:
+    """Comma is not a valid HTTP field-name token character."""
+    assert _boot_fails("CHAT_CLIENT_IP_HEADER", "x,forwarded")
+
+
+def test_client_ip_header_valid_ascii_header_boots() -> None:
+    """A real HTTP header like cf-connecting-ip must boot and be lowercased."""
+    clean = {k: v for k, v in os.environ.items() if not k.startswith("CHAT_")}
+    run = subprocess.run(
+        [sys.executable, "-c", PROBE],
+        capture_output=True,
+        text=True,
+        env={**clean, "CHAT_CLIENT_IP_HEADER": "CF-Connecting-IP"},
+    )
+    assert run.returncode == 0, f"valid header failed: {run.stderr}"
+
+
+def test_client_ip_header_empty_is_opt_out() -> None:
+    """Empty string is the documented opt-out and must boot."""
+    assert boot(CHAT_CLIENT_IP_HEADER="")["config.WORKERS"] == 1
+    assert boot(CHAT_CLIENT_IP_HEADER="  ")["config.WORKERS"] == 1  # stripped to empty


### PR DESCRIPTION
CHAT_CLIENT_IP_HEADER was lowercased but not validated as an HTTP field-name token (RFC 9110 §5.1). A non-ASCII value like '☃' or 'é' booted successfully then crashed every rate-limited route with UnicodeEncodeError at Latin-1 header lookup.

Changes:
- **src/config.py**: validate non-empty value against the RFC 9110 HTTP token grammar (ASCII alphanumeric + `!#$%&'*+-.^_`|~`)
- Empty/whitespace-only values remain the documented opt-out
- Lowercasing preserved for case-insensitive lookup
- **Tests**: regression coverage for non-ASCII, colon, space, comma, valid header (cf-connecting-ip), and empty opt-out

All 776 tests pass, 1 skipped.\n\nFixes #745