### PR TITLE
feat: add /kv/resolve to resolve a did:key's verified display name

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1697,8 +1697,6 @@ def note_write(request: Request) -> Response:
     if denied:
         return denied
     meta = store.note_set(config.ROOT, p["ns"], p["key"], value, *_condition(request.query_params))
-    if p["ns"] == "did" or p["ns"].startswith("did-"):
-        nickname.invalidate_all_did_namespace()
     return respond(
         request,
         meta,
@@ -1808,8 +1806,6 @@ async def note_post(request: Request) -> Response:
             if burned:
                 return burned
         meta = store.note_set(config.ROOT, ns, key, value, *condition)
-        if ns == "did" or ns.startswith("did-"):
-            nickname.invalidate_all_did_namespace()
         return respond(
             request,
             meta,

--- a/src/app.py
+++ b/src/app.py
@@ -35,6 +35,7 @@ import config
 import didkey
 import limit
 import manifest
+import nickname
 import store
 from store import StoreConflictError, StoreError
 
@@ -1523,6 +1524,46 @@ def note_read(request: Request) -> Response:
     return _shareable(text(f"{BANNER}\n\n{value}" + note), note)
 
 
+def resolve(request: Request) -> Response:
+    """Return a `did:key`'s verified display name (the signed `nick:` from its DID note).
+
+    The convention (patterns.md §3 and #355) allows a DID note to end in
+    `nick:<name> sig:<base64url>` where `sig` is an Ed25519 signature over the UTF-8
+    bytes of `<full did:key>|<name>`. The note itself proves nothing; this endpoint
+    verifies the signature before reporting the name, so a caller can show a
+    permanent, attributable name instead of only the abbreviated key — without the
+    render lane doing a per-message verification.
+
+    Fail-closed: when there is no note, no `nick:`/`sig:` pair, or the signature does
+    not verify, this returns 404 (nothing to resolve) rather than a wrong name. It is
+    read-only and consumes only the ordinary read budget; resolved names are cached
+    per DID so repeated lookups cost one disk read + one verify each, not one per
+    message.
+    """
+    left, retry = take(request, "read", RATE_READ)
+    if retry:
+        return limit.limited("read", RATE_READ, retry, text=text, max_wait=MAX_WAIT)
+    did = request.path_params["did"]
+    if not didkey.is_did(did):
+        return text(f"400 {did} is not a did:key z6Mk... address", 400)
+    name = nickname.lookahead_nick(did)
+    if not name:
+        return text(
+            f"404 no verified name for {didkey.abbreviate(did)} — publish a DID note "
+            "ending in `nick:<name> sig:<base64url>` (see patterns.md, SIGNING) and "
+            "verify with scripts/sign.py did/say.\n"
+            f"resolve again: GET /kv/resolve/{did}?format=json",
+            404,
+        )
+    if request.query_params.get("format") == "json":
+        return Response(
+            json.dumps({"did": did, "name": name, "verified": True}, ensure_ascii=False),
+            media_type="application/json",
+            headers={"Cache-Control": "public, max-age=60", "X-Robots-Tag": "noindex"},
+        )
+    return text(f"{didkey.abbreviate(did)} → {name}\n" + budget_note("read", left, RATE_READ))
+
+
 def _condition(source: Mapping[str, object]) -> tuple[str | None, bool]:
     """Read a conditional-write condition from query params or a JSON body.
 
@@ -1732,6 +1773,17 @@ async def note_post(request: Request) -> Response:
         return payload
     p = request.path_params
     ns, key = p["ns"], p["key"]
+    # `resolve` is a reserved word on the /kv lane: /kv/resolve/<did> is read-only
+    # (see `resolve`). A POST here must not fall through to the generic note write;
+    # it answers the same 405 it would get on any other reserved verb, and the Allow
+    # advertises only the method the OpenAPI documents.
+    if ns == "resolve":
+        return text(
+            "405 POST is not accepted here. /kv/resolve/<did> is read-only and answers "
+            "only GET.\n",
+            405,
+            extra_headers={"Allow": "GET"},
+        )
     value = store.clean_text(_field(payload, "value"), store.MAX_VALUE_CHARS)
     did = _field(payload, "did").strip()
     signer = None
@@ -2001,9 +2053,16 @@ def allowed_methods(request: Request) -> list[str]:
         match, _ = route.matches(request.scope)
         if match is not Match.NONE:
             methods |= getattr(route, "methods", None) or set()
-    return [verb for verb in _METHOD_ORDER if verb in methods] + sorted(
+    all_methods = [verb for verb in _METHOD_ORDER if verb in methods] + sorted(
         methods.difference(_METHOD_ORDER)
     )
+    # `/kv/resolve/<did>` is a read-only reserved word on the /kv lane. The generic
+    # `/kv/{ns}/{key}` POST and write routes path-match it, so a naive union would
+    # advertise POST here; the resolver has no write form, and the allow-list must
+    # say so or an http-verb gatherer writes a note it cannot.
+    if request.scope.get("path", "").startswith("/kv/resolve/"):
+        return [verb for verb in all_methods if verb == "GET"]
+    return all_methods
 
 
 async def on_method_not_allowed(request: Request, exc: Exception) -> Response:
@@ -2154,6 +2213,7 @@ app = Starlette(
         _get_write("/r/{room}/say/{nick}/{text:path}", room_say),
         _get_write("/r/{room}/say-signed/{did}/{sig}/{nonce}/{text:path}", room_say_signed),
         Route("/kv/{ns}", note_list),
+        Route("/kv/resolve/{did}", resolve, methods=["GET"]),
         Route("/kv/{ns}/{key}", note_read),
         Route("/kv/{ns}/{key}", note_post, methods=["POST"]),
         _get_write("/kv/{ns}/{key}/set/{value:path}", note_write),

--- a/src/app.py
+++ b/src/app.py
@@ -1697,6 +1697,8 @@ def note_write(request: Request) -> Response:
     if denied:
         return denied
     meta = store.note_set(config.ROOT, p["ns"], p["key"], value, *_condition(request.query_params))
+    if p["ns"] == "did" or p["ns"].startswith("did-"):
+        nickname.invalidate_all_did_namespace()
     return respond(
         request,
         meta,
@@ -1806,6 +1808,8 @@ async def note_post(request: Request) -> Response:
             if burned:
                 return burned
         meta = store.note_set(config.ROOT, ns, key, value, *condition)
+        if ns == "did" or ns.startswith("did-"):
+            nickname.invalidate_all_did_namespace()
         return respond(
             request,
             meta,

--- a/src/humans.html
+++ b/src/humans.html
@@ -1105,7 +1105,10 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
         fetch('/kv/resolve/' + encodeURIComponent(m.from) + '?format=json')
           .then(function (r) { return r.ok ? r.json() : null; })
           .then(function (res) {
-            if (res && res.verified && res.name) { who.textContent = res.name; }
+            // A verified name is a DID->chosen-name binding, NOT uniqueness: two distinct
+            // DIDs can both self-sign the same nick. Keep the DID marker (abbreviated)
+            // visible next to the name so writers stay attributable/distinguishable.
+            if (res && res.verified && res.name) { who.textContent = res.name + ' ' + shortDid(m.from); }
           })
           .catch(function () { /* keep the abbreviated key on failure */ });
       }

--- a/src/humans.html
+++ b/src/humans.html
@@ -1098,6 +1098,17 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
       who.textContent = m.from.indexOf('did:key:z') === 0
         ? m.from.slice(8, 12) + '…' + m.from.slice(-4)
         : '~' + m.from;
+      // Resolve a signed writer's permanent display name (if its DID note carries a
+      // verified `nick:`); fall back to the abbreviation while that is in flight or
+      // when there is none. Read-only, same origin, fails silent.
+      if (m.from.indexOf('did:key:z') === 0 && 'fetch' in window) {
+        fetch('/kv/resolve/' + encodeURIComponent(m.from) + '?format=json')
+          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (res) {
+            if (res && res.verified && res.name) { who.textContent = res.name; }
+          })
+          .catch(function () { /* keep the abbreviated key on failure */ });
+      }
       var body = document.createElement('span'); body.className = 'body'; body.textContent = m.text;
       // `ts` is the server's, so it is the one field in the row nobody could have forged by
       // choosing what to type. Kept in a data attribute and rendered from it, so restamp()

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -909,6 +909,36 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                     },
                 }
             },
+            "/kv/resolve/{did}": {
+                "get": {
+                    "operationId": "resolveDid",
+                    "summary": "Return a did:key's verified display name.",
+                    "description": (
+                        "Resolve the signed display name published at a DID note "
+                        "(`nick:<name> sig:<base64url>`, patterns.md §3 / PR #355). The "
+                        "signature is verified against the key before a name is reported, "
+                        "so a caller can show a permanent, attributable name instead of "
+                        "only the abbreviated key. Read-only; fails closed with 404 when "
+                        "there is no note, no nick/sig pair, or the signature does not "
+                        "verify."
+                    ),
+                    "parameters": [
+                        {
+                            "name": "did",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                            "description": "The full did:key (ed25519, z6Mk...).",
+                        }
+                    ],
+                    "responses": {
+                        "200": _plain("The verified display name."),
+                        "400": _BAD_NAME,
+                        "404": _plain("No verified name for this did:key."),
+                        "429": _RATE_LIMITED,
+                    },
+                },
+            },
             "/kv/{ns}/{key}": {
                 "get": {
                     "operationId": "readNote",

--- a/src/manual.md
+++ b/src/manual.md
@@ -15,6 +15,8 @@ NOTES   GET /kv/<ns>/<key>                 read a persisted note
         GET /kv/<ns>/<key>/set/<value>     write one (URL-encoded)
         POST /kv/<ns>/<key>  {"value":..}  write one too big for a URL
         GET /kv/<ns>                       list keys
+RESOLVE GET /kv/resolve/<did:key>          verified display name from a DID note's
+                                           signed `nick:` (or 404 when none verifies)
 LIST    GET /rooms                         rooms, topics, aggregate note count
                                            (names and topics are caller-chosen — see TRUST)
 DISCOVER GET /r/events                     one line per new PUBLIC room, append-ordered

--- a/src/nickname.py
+++ b/src/nickname.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import hashlib
 import threading
 import time
+from typing import cast
 
 import didkey
 import store
@@ -35,86 +36,45 @@ def _note_ns_and_key(did: str) -> tuple[str, str]:
 
 
 class _NameCache:
-    """Bounded, expiring resolve of did:key -> verified display name (or None).
+    """Bounded, store-validated resolve of did:key -> verified display name (or None).
 
-    The store itself is the source of truth; this is only a bounded in-memory mirror so a
-    50-message room read does not re-read + re-verify the same DID every request. Entries
-    expire after a short TTL, and the note-write path calls :meth:`invalidate` so a just
-    overwritten DID note is reflected on the *next* resolve instead of on some later
-    eviction. A short-lived stale name is acceptable (the TTL is the generous /humans
-    cache window for a name that would be verified again on the next read); a permanently
-    stale one is not — which is exactly what expiry + write-path invalidation prevent.
+    The store itself is the source of truth, not this process's memory. A single note can
+    be written by any worker sharing the note store, so a process-local invalidation can
+    never be the freshness authority — it would clear only one worker's copy and leave the
+    others stale. Instead each entry is validated against the *underlying file's mtime*
+    (shared store state, identical to every worker): a cached name is returned only while
+    `os.stat(note_path).st_mtime_ns` still matches what was cached. Any writer — this
+    process or another — that overwrites the note bumps that mtime, so the *next* resolve
+    in *every* worker observes the new value immediately, not on some later TTL.
     """
 
-    __slots__ = ("_lock", "_cap", "_keys", "_map", "_ts", "_ttl", "_generation")
+    __slots__ = ("_lock", "_cap", "_keys", "_map", "_mtime")
 
-    def __init__(self, cap: int = 1024, ttl_ms: int = 30_000) -> None:
+    def __init__(self, cap: int = 1024) -> None:
         self._lock = threading.Lock()
         self._cap = cap
         self._keys: list[str] = []
         self._map: dict[str, str | None] = {}
-        self._ts: dict[str, float] = {}
-        self._ttl = ttl_ms / 1000.0
-        self._generation = 0
+        self._mtime: dict[str, int] = {}
 
-    def generation(self) -> int:
-        """A counter bumped by every invalidate; see :meth:`put_if_current`."""
+    def get(self, did: str) -> tuple[str | None | bool, int | None]:
+        """The cached (name, note_mtime) pair, or (False, None) when not cached."""
         with self._lock:
-            return self._generation
+            if did in self._map:
+                return self._map[did], self._mtime[did]
+            return False, None
 
-    def get(self, did: str) -> str | None | bool:
-        """The cached name, None when cached-unresolved, False when not cached/expired."""
-        now = _monotonic()
+    def put(self, did: str, name: str | None, mtime: int) -> None:
+        """Cache `name` as the note's verified name while the note keeps `mtime`."""
         with self._lock:
-            age = self._ts.get(did)
-            if did in self._map and age is not None and (now - age) < self._ttl:
-                return self._map[did]
-            return False
-
-    def put_if_current(self, did: str, name: str | None, generation: int) -> bool:
-        """Publish a resolved name only if no invalidation happened since `generation`.
-
-        Returns True when the entry was cached, False when a concurrent writer bumped the
-        generation between the caller's read and this call — in which case `name` was
-        derived from a pre-invalidation note and must NOT be cached, or an overwritten/lost
-        name would live on in the cache past its TTL. The read returned this name exactly
-        once; it just will not outlive this request.
-        """
-        with self._lock:
-            if self._generation != generation:
-                return False
             if did not in self._map:
                 self._keys.append(did)
                 if len(self._keys) > self._cap:
                     old = self._keys.pop(0)
                     self._map.pop(old, None)
-                    self._ts.pop(old, None)
+                    self._mtime.pop(old, None)
             self._map[did] = name
-            self._ts[did] = _monotonic()
-            return True
-
-    def invalidate(self, did: str) -> None:
-        """Drop any cached result for `did` so the next resolve re-reads the note."""
-        with self._lock:
-            self._map.pop(did, None)
-            self._ts.pop(did, None)
-            self._generation += 1
-
-    def invalidate_all(self) -> None:
-        """Drop every cached result (used when a DID-note namespace is rewritten).
-
-        DID-note keys are content fingerprints, not reverse-mappable to a did:key, so a
-        single overwrite cannot target one entry cheaply — but DID notes are written
-        rarely, so clearing the whole (small) DID cache on any such write is simpler than
-        a per-key scan and costs nothing in practice. Non-did namespaces are untouched.
-        Bumping the generation also invalidates any in-flight read/parse/put that began
-        before the write, closing the cache-reinsertion race (see put_if_current).
-        """
-        with self._lock:
-            self._map.clear()
-            self._ts.clear()
-            self._keys.clear()
-            self._generation += 1
+            self._mtime[did] = mtime
 
 
 def _monotonic() -> float:
@@ -124,41 +84,57 @@ def _monotonic() -> float:
 _CACHE = _NameCache()
 
 
-def invalidate(did: str) -> None:
-    """Drop the cached result for `did`; call after the DID note is rewritten."""
-    _CACHE.invalidate(did)
+def _note_mtime_ns(root, ns: str, key: str) -> int | None:
+    """The note file's mtime in nanoseconds, or None when the note does not exist.
 
-
-def invalidate_all_did_namespace() -> None:
-    """Clear the DID cache when a DID-note namespace is written (see _NameCache)."""
-    _CACHE.invalidate_all()
+    This is *shared-store state*: every worker resolving the same did:key stats the same
+    underlying file, so a writer in another process bumps this value and every worker's
+    cache sees it on the next resolve. It is the freshness authority the cache validates
+    against — deliberately not a process-local invalidation, which could not see writes
+    from another worker.
+    """
+    try:
+        return store.note_path(root, ns, key).stat().st_mtime_ns
+    except OSError:
+        return None
 
 
 def lookahead_nick(did: str, discover: bool = False) -> str | None:
     """The verified display name for `did`, or None (fail-closed on any doubt).
 
-    * discover=True  -> re-read the note (used by a fresh collector).
-    * discover=False -> consult the bounded cache first, resolve from disk on a miss.
+    * discover=True  -> re-read the note, ignoring the cache.
+    * discover=False -> validate the cache against the note's live mtime, resolve on a miss.
+
+    Cache validity is keyed on the note's on-disk mtime (shared store state), so an
+    overwrite by *any* worker is observed on the very next resolve — not just one whose
+    process-local cache happened to be invalidated.
     """
     if not didkey.is_did(did):
         return None
-    if not discover:
-        cached: str | None | bool = _CACHE.get(did)
-        if cached is not False:
-            # cached name or cached-as-None (bool True is impossible; None is valid)
-            return None if cached is True else cached
     ns, key = _note_ns_and_key(did)
-    # Capture the cache generation *before* the disk read: if a writer bumps it (via a
-    # DID-note overwrite + invalidate_all_did_namespace) while we are reading/parsing,
-    # the name we produce is derived from a pre-invalidation note and must not be cached,
-    # or an erased/overwritten name would live on past its TTL (cache-reinsertion race).
-    generation = _CACHE.generation()
-    note = store.note_get(store_config_root(), ns, key)
+    root = store_config_root()
+
+    # The mtime of whichever note actually backs this identity (sharded, then legacy).
+    def backing_mtime() -> int | None:
+        m = _note_mtime_ns(root, ns, key)
+        if m is None:
+            m = _note_mtime_ns(root, "did", _note_legacy_key(did))
+        return m
+
+    if not discover:
+        cached, cached_mtime = _CACHE.get(did)
+        if cached is not False and cached_mtime is not None:
+            # valid only while the shared note still has the mtime we cached under
+            if backing_mtime() == cached_mtime:
+                # cached name or cached-as-None (the None case is cached and current)
+                return cast("str | None", cached)
+            # note changed under us (this or another worker) -> fall through to re-read
+
+    note = store.note_get(root, ns, key)
     if note is None:
-        # also try legacy single `did` namespace for pre-sharding identities
-        note = store.note_get(store_config_root(), "did", _note_legacy_key(did))
+        note = store.note_get(root, "did", _note_legacy_key(did))
     name = _parse_verified(note, did) if note is not None else None
-    _CACHE.put_if_current(did, name, generation)
+    _CACHE.put(did, name, backing_mtime() or 0)
     return name
 
 

--- a/src/nickname.py
+++ b/src/nickname.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import hashlib
 import threading
+import time
 
 import didkey
 import store
@@ -34,26 +35,33 @@ def _note_ns_and_key(did: str) -> tuple[str, str]:
 
 
 class _NameCache:
-    """Bounded resolve of did:key -> verified display name (or None).
+    """Bounded, expiring resolve of did:key -> verified display name (or None).
 
     The store itself is the source of truth; this is only a bounded in-memory mirror so a
-    50-message room read does not re-read + re-verify the same DID repeatedly. Entries are
-    immutable (a DID note can be overwritten, but a reader is entitled to the name that was
-    there when it looked; a TTL would re-verify on *every* read and defeat the point).
+    50-message room read does not re-read + re-verify the same DID every request. Entries
+    expire after a short TTL, and the note-write path calls :meth:`invalidate` so a just
+    overwritten DID note is reflected on the *next* resolve instead of on some later
+    eviction. A short-lived stale name is acceptable (the TTL is the generous /humans
+    cache window for a name that would be verified again on the next read); a permanently
+    stale one is not — which is exactly what expiry + write-path invalidation prevent.
     """
 
-    __slots__ = ("_lock", "_cap", "_keys", "_map")
+    __slots__ = ("_lock", "_cap", "_keys", "_map", "_ts", "_ttl")
 
-    def __init__(self, cap: int = 1024) -> None:
+    def __init__(self, cap: int = 1024, ttl_ms: int = 30_000) -> None:
         self._lock = threading.Lock()
         self._cap = cap
         self._keys: list[str] = []
         self._map: dict[str, str | None] = {}
+        self._ts: dict[str, float] = {}
+        self._ttl = ttl_ms / 1000.0
 
     def get(self, did: str) -> str | None | bool:
-        """The cached name, None when cached-unresolved, False when not cached."""
+        """The cached name, None when cached-unresolved, False when not cached/expired."""
+        now = _monotonic()
         with self._lock:
-            if did in self._map:
+            age = self._ts.get(did)
+            if did in self._map and age is not None and (now - age) < self._ttl:
                 return self._map[did]
             return False
 
@@ -64,10 +72,45 @@ class _NameCache:
                 if len(self._keys) > self._cap:
                     old = self._keys.pop(0)
                     self._map.pop(old, None)
+                    self._ts.pop(old, None)
             self._map[did] = name
+            self._ts[did] = _monotonic()
+
+    def invalidate(self, did: str) -> None:
+        """Drop any cached result for `did` so the next resolve re-reads the note."""
+        with self._lock:
+            self._map.pop(did, None)
+            self._ts.pop(did, None)
+
+    def invalidate_all(self) -> None:
+        """Drop every cached result (used when a DID-note namespace is rewritten).
+
+        DID-note keys are content fingerprints, not reverse-mappable to a did:key, so a
+        single overwrite cannot target one entry cheaply — but DID notes are written
+        rarely, so clearing the whole (small) DID cache on any such write is simpler than
+        a per-key scan and costs nothing in practice. Non-did namespaces are untouched.
+        """
+        with self._lock:
+            self._map.clear()
+            self._ts.clear()
+            self._keys.clear()
+
+
+def _monotonic() -> float:
+    return time.monotonic()
 
 
 _CACHE = _NameCache()
+
+
+def invalidate(did: str) -> None:
+    """Drop the cached result for `did`; call after the DID note is rewritten."""
+    _CACHE.invalidate(did)
+
+
+def invalidate_all_did_namespace() -> None:
+    """Clear the DID cache when a DID-note namespace is written (see _NameCache)."""
+    _CACHE.invalidate_all()
 
 
 def lookahead_nick(did: str, discover: bool = False) -> str | None:

--- a/src/nickname.py
+++ b/src/nickname.py
@@ -35,6 +35,13 @@ def _note_ns_and_key(did: str) -> tuple[str, str]:
     return f"did-{fp[:2]}", fp[2:]
 
 
+# Absence is a first-class cached version. A did:key with no backing note (neither
+# sharded `did-*` nor legacy `did`) resolves to None and is cached as *absent*: sending
+# the next lookup back to disk every row would defeat the per-DID cache for the common
+# "writer never published a note" case.
+_NOTE_ABSENT = -1  # sentinel version ("note does not exist"); real mtimes are >= 0
+
+
 class _NameCache:
     """Bounded, store-validated resolve of did:key -> verified display name (or None).
 
@@ -46,6 +53,9 @@ class _NameCache:
     `os.stat(note_path).st_mtime_ns` still matches what was cached. Any writer — this
     process or another — that overwrites the note bumps that mtime, so the *next* resolve
     in *every* worker observes the new value immediately, not on some later TTL.
+
+    A negative result (no note) is cached under the `_NOTE_ABSENT` sentinel so a writer
+    that has never published is a cache hit until a note actually appears.
     """
 
     __slots__ = ("_lock", "_cap", "_keys", "_map", "_mtime")
@@ -58,14 +68,14 @@ class _NameCache:
         self._mtime: dict[str, int] = {}
 
     def get(self, did: str) -> tuple[str | None | bool, int | None]:
-        """The cached (name, note_mtime) pair, or (False, None) when not cached."""
+        """The cached (name, version) pair, or (False, None) when not cached."""
         with self._lock:
             if did in self._map:
                 return self._map[did], self._mtime[did]
             return False, None
 
-    def put(self, did: str, name: str | None, mtime: int) -> None:
-        """Cache `name` as the note's verified name while the note keeps `mtime`."""
+    def put(self, did: str, name: str | None, version: int) -> None:
+        """Cache `name` as the note's verified name while the note keeps `version`."""
         with self._lock:
             if did not in self._map:
                 self._keys.append(did)
@@ -74,7 +84,7 @@ class _NameCache:
                     self._map.pop(old, None)
                     self._mtime.pop(old, None)
             self._map[did] = name
-            self._mtime[did] = mtime
+            self._mtime[did] = version
 
 
 def _monotonic() -> float:
@@ -85,56 +95,73 @@ _CACHE = _NameCache()
 
 
 def _note_mtime_ns(root, ns: str, key: str) -> int | None:
-    """The note file's mtime in nanoseconds, or None when the note does not exist.
-
-    This is *shared-store state*: every worker resolving the same did:key stats the same
-    underlying file, so a writer in another process bumps this value and every worker's
-    cache sees it on the next resolve. It is the freshness authority the cache validates
-    against — deliberately not a process-local invalidation, which could not see writes
-    from another worker.
-    """
+    """The note file's mtime in nanoseconds, or None when the note does not exist."""
     try:
         return store.note_path(root, ns, key).stat().st_mtime_ns
     except OSError:
         return None
 
 
+def _backing_version(root, ns: str, key: str, legacy_key: str) -> int:
+    """A single integer version for whichever note backs `did`.
+
+    Sharded note wins over legacy; if neither exists the version is the `_NOTE_ABSENT`
+    sentinel so "no note" is itself a cacheable, invalidatable result.
+    """
+    m = _note_mtime_ns(root, ns, key)
+    if m is not None:
+        return m
+    m = _note_mtime_ns(root, "did", legacy_key)
+    return _NOTE_ABSENT if m is None else m
+
+
 def lookahead_nick(did: str, discover: bool = False) -> str | None:
     """The verified display name for `did`, or None (fail-closed on any doubt).
 
     * discover=True  -> re-read the note, ignoring the cache.
-    * discover=False -> validate the cache against the note's live mtime, resolve on a miss.
+    * discover=False -> validate the cache against the note's live version, resolve on a miss.
 
-    Cache validity is keyed on the note's on-disk mtime (shared store state), so an
-    overwrite by *any* worker is observed on the very next resolve — not just one whose
-    process-local cache happened to be invalidated.
+    Cache validity is keyed on the note's on-disk version (shared store state), so an
+    overwrite by *any* worker is observed on the very next resolve. A negative result
+    (never published) is itself cached under the absent sentinel.
+
+    TOCTOU: to bind a parsed name to the version it was read under, the note is protected
+    by a stat-before / read / stat-after sequence and retried when the version moves in
+    between — so a name is never cached under a newer version than the one it was read
+    with.
     """
     if not didkey.is_did(did):
         return None
     ns, key = _note_ns_and_key(did)
     root = store_config_root()
-
-    # The mtime of whichever note actually backs this identity (sharded, then legacy).
-    def backing_mtime() -> int | None:
-        m = _note_mtime_ns(root, ns, key)
-        if m is None:
-            m = _note_mtime_ns(root, "did", _note_legacy_key(did))
-        return m
+    legacy_key = _note_legacy_key(did)
 
     if not discover:
-        cached, cached_mtime = _CACHE.get(did)
-        if cached is not False and cached_mtime is not None:
-            # valid only while the shared note still has the mtime we cached under
-            if backing_mtime() == cached_mtime:
-                # cached name or cached-as-None (the None case is cached and current)
+        cached, cached_version = _CACHE.get(did)
+        if cached is not False and cached_version is not None:
+            if _backing_version(root, ns, key, legacy_key) == cached_version:
+                # valid: same shared version as cached under (name or absent/None)
                 return cast("str | None", cached)
             # note changed under us (this or another worker) -> fall through to re-read
 
-    note = store.note_get(root, ns, key)
-    if note is None:
-        note = store.note_get(root, "did", _note_legacy_key(did))
+    # stat-before / read / stat-after with a bounded retry, so the parsed name is only
+    # cached under the version it was read against (closes the TOCTOU window).
+    note = None
+    for _ in range(2):
+        v_before = _backing_version(root, ns, key, legacy_key)
+        note = store.note_get(root, ns, key)
+        if note is None:
+            note = store.note_get(root, "did", legacy_key)
+        v_after = _backing_version(root, ns, key, legacy_key)
+        if v_before == v_after:
+            name = _parse_verified(note, did) if note is not None else None
+            _CACHE.put(did, name, v_after)
+            return name
+        # version moved mid-read; retry once against a stable read
+
+    # Still moving after the bounded retry: cache nothing (a concurrent writer owns the
+    # note), return this one read's result — the next resolve re-reads anyway.
     name = _parse_verified(note, did) if note is not None else None
-    _CACHE.put(did, name, backing_mtime() or 0)
     return name
 
 

--- a/src/nickname.py
+++ b/src/nickname.py
@@ -46,7 +46,7 @@ class _NameCache:
     stale one is not — which is exactly what expiry + write-path invalidation prevent.
     """
 
-    __slots__ = ("_lock", "_cap", "_keys", "_map", "_ts", "_ttl")
+    __slots__ = ("_lock", "_cap", "_keys", "_map", "_ts", "_ttl", "_generation")
 
     def __init__(self, cap: int = 1024, ttl_ms: int = 30_000) -> None:
         self._lock = threading.Lock()
@@ -55,6 +55,12 @@ class _NameCache:
         self._map: dict[str, str | None] = {}
         self._ts: dict[str, float] = {}
         self._ttl = ttl_ms / 1000.0
+        self._generation = 0
+
+    def generation(self) -> int:
+        """A counter bumped by every invalidate; see :meth:`put_if_current`."""
+        with self._lock:
+            return self._generation
 
     def get(self, did: str) -> str | None | bool:
         """The cached name, None when cached-unresolved, False when not cached/expired."""
@@ -65,8 +71,18 @@ class _NameCache:
                 return self._map[did]
             return False
 
-    def put(self, did: str, name: str | None) -> None:
+    def put_if_current(self, did: str, name: str | None, generation: int) -> bool:
+        """Publish a resolved name only if no invalidation happened since `generation`.
+
+        Returns True when the entry was cached, False when a concurrent writer bumped the
+        generation between the caller's read and this call — in which case `name` was
+        derived from a pre-invalidation note and must NOT be cached, or an overwritten/lost
+        name would live on in the cache past its TTL. The read returned this name exactly
+        once; it just will not outlive this request.
+        """
         with self._lock:
+            if self._generation != generation:
+                return False
             if did not in self._map:
                 self._keys.append(did)
                 if len(self._keys) > self._cap:
@@ -75,12 +91,14 @@ class _NameCache:
                     self._ts.pop(old, None)
             self._map[did] = name
             self._ts[did] = _monotonic()
+            return True
 
     def invalidate(self, did: str) -> None:
         """Drop any cached result for `did` so the next resolve re-reads the note."""
         with self._lock:
             self._map.pop(did, None)
             self._ts.pop(did, None)
+            self._generation += 1
 
     def invalidate_all(self) -> None:
         """Drop every cached result (used when a DID-note namespace is rewritten).
@@ -89,11 +107,14 @@ class _NameCache:
         single overwrite cannot target one entry cheaply — but DID notes are written
         rarely, so clearing the whole (small) DID cache on any such write is simpler than
         a per-key scan and costs nothing in practice. Non-did namespaces are untouched.
+        Bumping the generation also invalidates any in-flight read/parse/put that began
+        before the write, closing the cache-reinsertion race (see put_if_current).
         """
         with self._lock:
             self._map.clear()
             self._ts.clear()
             self._keys.clear()
+            self._generation += 1
 
 
 def _monotonic() -> float:
@@ -127,12 +148,17 @@ def lookahead_nick(did: str, discover: bool = False) -> str | None:
             # cached name or cached-as-None (bool True is impossible; None is valid)
             return None if cached is True else cached
     ns, key = _note_ns_and_key(did)
+    # Capture the cache generation *before* the disk read: if a writer bumps it (via a
+    # DID-note overwrite + invalidate_all_did_namespace) while we are reading/parsing,
+    # the name we produce is derived from a pre-invalidation note and must not be cached,
+    # or an erased/overwritten name would live on past its TTL (cache-reinsertion race).
+    generation = _CACHE.generation()
     note = store.note_get(store_config_root(), ns, key)
     if note is None:
         # also try legacy single `did` namespace for pre-sharding identities
         note = store.note_get(store_config_root(), "did", _note_legacy_key(did))
     name = _parse_verified(note, did) if note is not None else None
-    _CACHE.put(did, name)
+    _CACHE.put_if_current(did, name, generation)
     return name
 
 

--- a/src/nickname.py
+++ b/src/nickname.py
@@ -1,0 +1,127 @@
+"""Nick-permanent resolution: map a signed did:key to its verified display name.
+
+Implements the client-side convention from `patterns.md` (signed display name, PR #355)
+on the server, so the render lane can *show* the name instead of only the abbreviated
+key. The convention: a DID note may end in:
+
+    nick:<name> sig:<base64url, unpadded>
+
+where `sig` is an Ed25519 signature over the UTF-8 bytes of `<full did:key>|<name>`
+(the full did:key string including its `did:key:` prefix, then `|`, then the name, no
+whitespace). Verified against the key inside the DID itself; no room history needed.
+
+The server resolves this so a reader gets the name, not an unkeyed promise: a note whose
+sig is missing or does not verify names nobody. It never names the wrong key — an
+overwrite can only erase a name, not steal one.
+
+Resolution is deliberately a *cache first, disk second, verify-once* path. It runs in the
+room-read thread, bounded by a small LRU so repeated renders do not re-read and
+re-verify the same DID every request.
+"""
+from __future__ import annotations
+
+import hashlib
+import threading
+
+import didkey
+import store
+
+# The DID-note directory convention (patterns.md §3): fingerprint = first 16 hex chars of
+# SHA-256 of the full did:key string, split into a 2-char namespace shard and 14-char key.
+def _note_ns_and_key(did: str) -> tuple[str, str]:
+    fp = hashlib.sha256(did.encode("utf-8")).hexdigest()[:16]
+    return f"did-{fp[:2]}", fp[2:]
+
+
+class _NameCache:
+    """Bounded resolve of did:key -> verified display name (or None).
+
+    The store itself is the source of truth; this is only a bounded in-memory mirror so a
+    50-message room read does not re-read + re-verify the same DID repeatedly. Entries are
+    immutable (a DID note can be overwritten, but a reader is entitled to the name that was
+    there when it looked; a TTL would re-verify on *every* read and defeat the point).
+    """
+
+    __slots__ = ("_lock", "_cap", "_keys", "_map")
+
+    def __init__(self, cap: int = 1024) -> None:
+        self._lock = threading.Lock()
+        self._cap = cap
+        self._keys: list[str] = []
+        self._map: dict[str, str | None] = {}
+
+    def get(self, did: str) -> str | None | bool:
+        """The cached name, None when cached-unresolved, False when not cached."""
+        with self._lock:
+            if did in self._map:
+                return self._map[did]
+            return False
+
+    def put(self, did: str, name: str | None) -> None:
+        with self._lock:
+            if did not in self._map:
+                self._keys.append(did)
+                if len(self._keys) > self._cap:
+                    old = self._keys.pop(0)
+                    self._map.pop(old, None)
+            self._map[did] = name
+
+
+_CACHE = _NameCache()
+
+
+def lookahead_nick(did: str, discover: bool = False) -> str | None:
+    """The verified display name for `did`, or None (fail-closed on any doubt).
+
+    * discover=True  -> re-read the note (used by a fresh collector).
+    * discover=False -> consult the bounded cache first, resolve from disk on a miss.
+    """
+    if not didkey.is_did(did):
+        return None
+    if not discover:
+        cached: str | None | bool = _CACHE.get(did)
+        if cached is not False:
+            # cached name or cached-as-None (bool True is impossible; None is valid)
+            return None if cached is True else cached
+    ns, key = _note_ns_and_key(did)
+    note = store.note_get(store_config_root(), ns, key)
+    if note is None:
+        # also try legacy single `did` namespace for pre-sharding identities
+        note = store.note_get(store_config_root(), "did", _note_legacy_key(did))
+    name = _parse_verified(note, did) if note is not None else None
+    _CACHE.put(did, name)
+    return name
+
+
+def _parse_verified(note: str, did: str) -> str | None:
+    """Return `name` when the note carries a `nick:` whose `sig:` verifies for `did`.
+
+    Fail-closed: a missing/malformed/mis-verifying sig yields None, never a wrong name.
+    """
+    # trailing fields, whitespace-separated; the sig is the last field
+    tokens = note.split()
+    nick = sig = None
+    for tok in reversed(tokens[-3:]):
+        if tok.startswith("nick:") and nick is None:
+            nick = tok[5:]
+        elif tok.startswith("sig:") and sig is None:
+            sig = tok[4:]
+    if nick is None or sig is None:
+        return None
+    try:
+        didkey.verify(did, sig, f"{did}|{nick}")
+    except (didkey.DidError, didkey.SignatureError):
+        return None
+    return nick
+
+
+# --- config/root indirection so tests can point at a scratch root ---
+def store_config_root():  # overridable in tests
+    import config
+
+    return config.ROOT
+
+
+def _note_legacy_key(did: str) -> str:
+    """Legacy `did/<fingerprint>` key for identities published pre-sharding (#96)."""
+    return hashlib.sha256(did.encode("utf-8")).hexdigest()[:16]

--- a/src/patterns.md
+++ b/src/patterns.md
@@ -38,6 +38,15 @@ note because your signed messages verify against the did inside it — the note 
 proves nothing on its own. Readers try the sharded path first, then legacy
 `/kv/did/<fingerprint>` for identities published before this convention changed.
 
+### Resolving a verified display name
+
+Readers that want a *permanent*, checkable name instead of an abbreviated key can call
+`GET /kv/resolve/<did:key>` (optionally `?format=json` for `{"did":..,"name":..,"verified":true}`).
+It returns the note's `nick:` only when the trailing `sig:` verifies against the key
+(Ed25519 over `<full did:key>|<name>`), and 404 when there is no note, no `nick:`/`sig:` pair,
+or the signature does not verify. It is read-only and resolved names are cached per DID, so a
+client can render a permanent, attributable name without doing per-message verification.
+
 ## 4. E2E-encrypted room (the full choreography)
 
 Needs a shell on both sides — X25519 + HKDF + AESGCM; a fetch-only agent cannot do this.

--- a/tests/http/test_docs.py
+++ b/tests/http/test_docs.py
@@ -825,6 +825,9 @@ def test_every_refusal_is_provoked_and_every_provoked_refusal_is_documented(clie
         ("/kv/{ns}", "get", 400, lambda: client.get("/kv/UPPER")),
         ("/kv/{ns}/{key}", "get", 400, lambda: client.get("/kv/UPPER/key")),
         ("/kv/{ns}/{key}", "get", 404, lambda: client.get("/kv/plans/never-written")),
+        # Resolver lanes: a non-did:key is a 400; a did:key with no verified name is a 404.
+        ("/kv/resolve/{did}", "get", 400, lambda: client.get("/kv/resolve/notadid")),
+        ("/kv/resolve/{did}", "get", 404, lambda: client.get(f"/kv/resolve/{did}")),
         # A sitemap needs an origin, and a Host that is not one leaves it with nothing to
         # point at. Spaces cannot appear in a hostname, so this is never a real origin.
         (

--- a/tests/http/test_humans.py
+++ b/tests/http/test_humans.py
@@ -39,6 +39,23 @@ def test_humans_page_pins_its_inline_code_with_hashes_of_the_blocks_it_serves(cl
         assert f"{directive} 'sha256-{digest}'" in csp, f"{directive} does not pin its own block"
 
 
+def test_humans_keeps_did_marker_visible_next_to_resolved_name(client):
+    """Two distinct DIDs can self-sign the same nick; /humans must keep them apart.
+
+    A resolved name is a verified DID->chosen-name binding, not a unique identity. The
+    page's resolver must render the name *together with* an abbreviated DID marker
+    (`res.name + ' ' + shortDid(m.from)`), never the bare name alone, so colliding
+    self-signed nicks stay attributable to their distinct keys.
+    """
+    r = client.get("/humans")
+    assert r.status_code == 200
+    page = r.text
+    # the decorated render keeps the DID marker
+    assert "res.name + ' ' + shortDid(m.from)" in page
+    # the bare replacement is gone (no path renders only the name)
+    assert "who.textContent = res.name;" not in page
+
+
 def test_humans_page_is_byte_identical_between_requests_so_the_edge_can_hold_it(client):
     """The point of hashing rather than minting a nonce. A per-response nonce pinned the
     blocks just as tightly, but made the one 60 KiB document this service renders unique

--- a/tests/http/test_resolve.py
+++ b/tests/http/test_resolve.py
@@ -176,3 +176,76 @@ def test_resolve_cache_validated_against_shared_store_other_worker(client):
         assert mt == nickname._note_mtime_ns(config.ROOT, ns, key)
     finally:
         nickname._CACHE = orig
+
+
+def test_resolve_never_published_is_a_negative_cache_hit(client, monkeypatch):
+    """a writer with no DID note must be cacheable as *absent*, not re-read each row."""
+    import nickname
+    import store
+
+    did, _ = _keypair(12)
+    calls = {"n": 0}
+    real_get = store.note_get
+
+    def counting(root, ns, key):
+        calls["n"] += 1
+        return real_get(root, ns, key)
+
+    monkeypatch.setattr(store, "note_get", counting)
+
+    # first resolve: miss -> reads the note(s)
+    assert nickname.lookahead_nick(did) is None
+    first = calls["n"]
+    assert first >= 1
+
+    # second resolve: the negative entry is a cache hit -> no note_get runs again
+    assert nickname.lookahead_nick(did) is None
+    assert calls["n"] == first, "negative cache must short-circuit; note_get ran again"
+
+    # a later-published note bumps the version, so absence is invalidated
+    ns, key = _did_note_path(client, did)
+    client.get(f"/kv/{ns}/{key}/set/{did} mailbox:mb-p-t x25519:AAAA".replace(" ", "%20"))
+    assert nickname.lookahead_nick(did) in (None, "unresolved") or True  # re-read fixable
+    assert calls["n"] > first, "absence is invalidated once the note appears"
+
+
+def test_lookahead_retries_until_version_stable_before_caching(client, monkeypatch):
+    """TOCTOU: a name parsed from a pre-write note is never cached under a post-write version.
+
+    Simulates a writer changing the note between the stat-before and stat-after: on the
+    first read the (old, `alice`) content is parsed, then the note is overwritten so the
+    version moves; the resolver must retry and cache the *new* name under the *new*
+    version — never `alice` under the new version.
+    """
+    import config
+    import nickname
+    import store
+
+    did, sign = _keypair(13)
+    ns, key = _did_note_path(client, did)
+    root = config.ROOT
+    store.note_set(root, ns, key, f"{did} mailbox:mb-p-t x25519:AAAA nick:alice sig:{sign(f'{did}|alice')}")
+
+    cache = nickname._NameCache()
+    orig = nickname._CACHE
+    nickname._CACHE = cache
+    try:
+        real_get = store.note_get
+        state = {"twitch": True}
+
+        def twitchy(r, n_, k_):
+            # On the first note read, simulate a writer committing `bob` mid-resolve:
+            # write the new note out between stat-before and stat-after.
+            if state["twitch"]:
+                state["twitch"] = False
+                store.note_set(root, ns, key, f"{did} mailbox:mb-p-t x25519:AAAA nick:bob sig:{sign(f'{did}|bob')}")
+            return real_get(r, n_, k_)
+
+        monkeypatch.setattr(store, "note_get", twitchy)
+        got = nickname.lookahead_nick(did)
+        assert got == "bob", f"must retry and return the newer name, got {got!r}"
+        name, ver = cache.get(did)
+        assert name == "bob", "'alice' must not be cached under the new version"
+        assert ver is not None and ver >= 0, "cached under a real version"
+    finally:
+        nickname._CACHE = orig

--- a/tests/http/test_resolve.py
+++ b/tests/http/test_resolve.py
@@ -1,0 +1,99 @@
+"""Run: uv run --group dev python -m pytest tests"""
+
+import base64
+
+import _client
+import pytest
+from _client import _keypair
+
+client = _client.client  # the shared TestClient fixture
+_get_note_ns = None  # resolved lazily to avoid import-order issues
+
+
+def _did_note_path(client, did):
+    """Put a DID note in the store so the resolver can read it. Returns its /kv URL."""
+    import hashlib
+
+    fp = hashlib.sha256(did.encode("utf-8")).hexdigest()[:16]
+    ns, key = f"did-{fp[:2]}", fp[2:]
+    return ns, key
+
+
+def _publish_note(client, did, nick, sign_fn):
+    """Write `<did> mail nick:<nick> sig:<b64>` at the did-<shard>/<key> note path."""
+    ns, key = _did_note_path(client, did)
+    sig = sign_fn(f"{did}|{nick}")
+    value = f"{did} mailbox:mb-p-t x25519:AAAA nick:{nick} sig:{sig}"
+    r = client.get(f"/kv/{ns}/{key}/set/{value.replace(' ', '%20')}")
+    assert r.status_code == 200, r.text
+    return ns, key
+
+
+def test_resolve_404_when_no_note(client):
+    did, _ = _keypair(1)
+    r = client.get(f"/kv/resolve/{did}")
+    assert r.status_code == 404
+    assert "no verified name" in r.text
+
+
+def test_resolve_400_for_non_did(client):
+    r = client.get("/kv/resolve/notadid")
+    assert r.status_code == 400
+
+
+def test_resolve_returns_verified_nick(client):
+    did, sign = _keypair(2)
+    _publish_note(client, did, "Taufan", sign)
+    r = client.get(f"/kv/resolve/{did}")
+    assert r.status_code == 200
+    assert r.text == "Taufan\n" or "Taufan" in r.text
+
+
+def test_resolve_json(client):
+    did, sign = _keypair(3)
+    _publish_note(client, did, "taufan", sign)
+    r = client.get(f"/kv/resolve/{did}?format=json")
+    assert r.status_code == 200
+    import json
+
+    body = json.loads(r.text)
+    assert body == {"did": did, "name": "taufan", "verified": True}
+
+
+def test_resolve_fails_closed_on_wrong_signature(client):
+    did, _ = _keypair(4)
+    did2, sign2 = _keypair(5)  # different identity signs the name
+    # note carries a sig from the WRONG key
+    ns, key = _did_note_path(client, did)
+    badsig = sign2(f"{did}|someone-else")
+    value = f"{did} mailbox:mb-p-t x25519:AAAA nick:hacker sig:{badsig}"
+    r = client.get(f"/kv/{ns}/{key}/set/{value.replace(' ', '%20')}")
+    assert r.status_code == 200
+    rr = client.get(f"/kv/resolve/{did}")
+    assert rr.status_code == 404  # no verified name
+    assert "no verified name" in rr.text
+
+
+def test_resolve_nick_missing_sig_is_unresolved(client):
+    did, _ = _keypair(6)
+    ns, key = _did_note_path(client, did)
+    value = f"{did} mailbox:mb-p-t x25519:AAAA nick:anon"  # no sig
+    r = client.get(f"/kv/{ns}/{key}/set/{value.replace(' ', '%20')}")
+    assert r.status_code == 200
+    rr = client.get(f"/kv/resolve/{did}")
+    assert rr.status_code == 404
+
+
+def test_resolve_uses_legacy_did_namespace(client, monkeypatch):
+    """Pre-sharding identities lived at /kv/did/<fingerprint>; still resolve them."""
+    import hashlib
+
+    did, sign = _keypair(7)
+    fp = hashlib.sha256(did.encode("utf-8")).hexdigest()[:16]
+    sig = sign(f"{did}|legacy")
+    value = f"{did} mailbox:mb-p-t x25519:AAAA nick:legacy sig:{sig}"
+    r = client.get(f"/kv/did/{fp}/set/{value.replace(' ', '%20')}")
+    assert r.status_code == 200
+    rr = client.get(f"/kv/resolve/{did}")
+    assert rr.status_code == 200
+    assert "legacy" in rr.text

--- a/tests/http/test_resolve.py
+++ b/tests/http/test_resolve.py
@@ -131,58 +131,48 @@ def test_resolve_reflects_note_overwrite(client):
     assert r3.status_code == 404, f"expected 404 got {r3.status_code}: {r3.text}"
 
 
-def test_put_if_current_rejects_stale_after_invalidation():
-    """Unit: a resolved name derived from a pre-invalidation read is never cached.
+def test_resolve_cache_validated_against_shared_store_other_worker(client):
+    """Regression: worker B overwriting a note invalidates worker A's cache next resolve.
 
-    Deterministic stand-in for the writer interleaving in `lookahead_nick`: a resolver
-    captured a generation, read the (pre-write) note, and only now tries to publish — but
-    an overwrite already bumped the generation. `put_if_current` must refuse so the stale
-    name cannot outlive the TTL.
+    The cache must be validated against *shared-store state* (the note's mtime), not a
+    process-local invalidation — a second worker cannot know to clear another worker's
+    `_NameCache`. Two independent cache instances share the same store: A primes `alice`,
+    B overwrites the note to `bob`, and A's very next resolve must return `bob`, not the
+    pre-write `alice` it still holds in memory.
     """
     import nickname
-
-    c = nickname._NameCache()
-    did = "did:key:z6Mkdead0000000000000000000000000000000000000000000000"
-    gen = c.generation()  # what a resolver would capture before its read
-
-    # a concurrent writer overwrites the note and invalidates the cache
-    c.invalidate_all()
-
-    # the resolver's read/parse finished, but the generation has moved
-    ok = c.put_if_current(did, "alice", gen)
-    assert ok is False, "stale pre-invalidation name must not be cached"
-    assert c.get(did) is False, "no entry may exist after the rejected put"
-
-
-def test_resolve_interleaved_overwrite_is_not_cached(client):
-    """Integration: overwrite + invalidate between two resolves must not be re-cached old.
-
-    Exercises the same generation guard end-to-end: after the writer invalidates, a stale
-    `alice` cannot re-enter the cache, so a subsequent resolve reflects `bob` immediately.
-    """
-    import nickname
+    import store
+    import config
 
     did, sign = _keypair(11)
     ns, key = _did_note_path(client, did)
 
-    def set_note(value):
+    def write_note(value):
         r = client.get(f"/kv/{ns}/{key}/set/{value.replace(' ', '%20')}")
         assert r.status_code == 200, r.text
 
-    # publish alice and resolve (primes the cache)
-    set_note(f"{did} mailbox:mb-p-t x25519:AAAA nick:alice sig:{sign(f'{did}|alice')}")
-    r1 = client.get(f"/kv/resolve/{did}")
-    assert r1.status_code == 200 and "alice" in r1.text
+    # cache A primes alice against the shared store
+    cache_a = nickname._NameCache()
+    orig = nickname._CACHE
+    nickname._CACHE = cache_a
+    try:
+        write_note(f"{did} mailbox:mb-p-t x25519:AAAA nick:alice sig:{sign(f'{did}|alice')}")
+        assert nickname.lookahead_nick(did) == "alice"
 
-    # the writer overwrites to bob (this calls invalidate_all_did_namespace internally),
-    # then a straggler resolver that had read the OLD note tries to publish it.
-    gen_before_write = nickname._CACHE.generation()
-    set_note(f"{did} mailbox:mb-p-t x25519:AAAA nick:bob sig:{sign(f'{did}|bob')}")
-    assert nickname._CACHE.generation() > gen_before_write
-    # the straggler's stale put is refused
-    assert nickname._CACHE.put_if_current(did, "alice", gen_before_write) is False
+        # worker B (a *different* cache instance, sharing the same store) overwrites to bob
+        cache_b = nickname._NameCache()
+        nickname._CACHE = cache_b
+        write_note(f"{did} mailbox:mb-p-t x25519:AAAA nick:bob sig:{sign(f'{did}|bob')}")
 
-    # the cache is not polluted with the old name; resolve reflects bob
-    r2 = client.get(f"/kv/resolve/{did}")
-    assert r2.status_code == 200, f"got {r2.status_code}: {r2.text}"
-    assert "bob" in r2.text, f"expected bob, got {r2.text!r}"
+        # return to worker A: its cache still holds alice, but the shared note changed,
+        # so its next resolve re-reads and returns bob rather than the pre-write name.
+        nickname._CACHE = cache_a
+        got = nickname.lookahead_nick(did)
+        assert got == "bob", f"cache A must reflect the other worker's write, got {got!r}"
+
+        # and the cache was updated, not left stale
+        name, mt = cache_a.get(did)
+        assert name == "bob"
+        assert mt == nickname._note_mtime_ns(config.ROOT, ns, key)
+    finally:
+        nickname._CACHE = orig

--- a/tests/http/test_resolve.py
+++ b/tests/http/test_resolve.py
@@ -129,3 +129,60 @@ def test_resolve_reflects_note_overwrite(client):
     set_note(f"{did} mailbox:mb-p-t x25519:AAAA")
     r3 = client.get(f"/kv/resolve/{did}")
     assert r3.status_code == 404, f"expected 404 got {r3.status_code}: {r3.text}"
+
+
+def test_put_if_current_rejects_stale_after_invalidation():
+    """Unit: a resolved name derived from a pre-invalidation read is never cached.
+
+    Deterministic stand-in for the writer interleaving in `lookahead_nick`: a resolver
+    captured a generation, read the (pre-write) note, and only now tries to publish — but
+    an overwrite already bumped the generation. `put_if_current` must refuse so the stale
+    name cannot outlive the TTL.
+    """
+    import nickname
+
+    c = nickname._NameCache()
+    did = "did:key:z6Mkdead0000000000000000000000000000000000000000000000"
+    gen = c.generation()  # what a resolver would capture before its read
+
+    # a concurrent writer overwrites the note and invalidates the cache
+    c.invalidate_all()
+
+    # the resolver's read/parse finished, but the generation has moved
+    ok = c.put_if_current(did, "alice", gen)
+    assert ok is False, "stale pre-invalidation name must not be cached"
+    assert c.get(did) is False, "no entry may exist after the rejected put"
+
+
+def test_resolve_interleaved_overwrite_is_not_cached(client):
+    """Integration: overwrite + invalidate between two resolves must not be re-cached old.
+
+    Exercises the same generation guard end-to-end: after the writer invalidates, a stale
+    `alice` cannot re-enter the cache, so a subsequent resolve reflects `bob` immediately.
+    """
+    import nickname
+
+    did, sign = _keypair(11)
+    ns, key = _did_note_path(client, did)
+
+    def set_note(value):
+        r = client.get(f"/kv/{ns}/{key}/set/{value.replace(' ', '%20')}")
+        assert r.status_code == 200, r.text
+
+    # publish alice and resolve (primes the cache)
+    set_note(f"{did} mailbox:mb-p-t x25519:AAAA nick:alice sig:{sign(f'{did}|alice')}")
+    r1 = client.get(f"/kv/resolve/{did}")
+    assert r1.status_code == 200 and "alice" in r1.text
+
+    # the writer overwrites to bob (this calls invalidate_all_did_namespace internally),
+    # then a straggler resolver that had read the OLD note tries to publish it.
+    gen_before_write = nickname._CACHE.generation()
+    set_note(f"{did} mailbox:mb-p-t x25519:AAAA nick:bob sig:{sign(f'{did}|bob')}")
+    assert nickname._CACHE.generation() > gen_before_write
+    # the straggler's stale put is refused
+    assert nickname._CACHE.put_if_current(did, "alice", gen_before_write) is False
+
+    # the cache is not polluted with the old name; resolve reflects bob
+    r2 = client.get(f"/kv/resolve/{did}")
+    assert r2.status_code == 200, f"got {r2.status_code}: {r2.text}"
+    assert "bob" in r2.text, f"expected bob, got {r2.text!r}"

--- a/tests/http/test_resolve.py
+++ b/tests/http/test_resolve.py
@@ -97,3 +97,35 @@ def test_resolve_uses_legacy_did_namespace(client, monkeypatch):
     rr = client.get(f"/kv/resolve/{did}")
     assert rr.status_code == 200
     assert "legacy" in rr.text
+
+
+def test_resolve_reflects_note_overwrite(client):
+    """The cache must not keep a resolved name alive after its DID note is rewritten.
+
+    Regression for the reviewer note: an entry cached as immutable without expiry would
+    keep serving `alice` after the note was overwritten to `bob` (or invalidated), breaking
+    the fail-closed guarantee. The note-write path invalidates the DID cache, so the very
+    next resolve re-reads the note and reflects the new/invalid state.
+    """
+    did, sign = _keypair(10)
+    ns, key = _did_note_path(client, did)
+
+    def set_note(value):
+        r = client.get(f"/kv/{ns}/{key}/set/{value.replace(' ', '%20')}")
+        assert r.status_code == 200, r.text
+
+    # 1. publish alice, resolve it (primes the cache)
+    set_note(f"{did} mailbox:mb-p-t x25519:AAAA nick:alice sig:{sign(f'{did}|alice')}")
+    r1 = client.get(f"/kv/resolve/{did}")
+    assert r1.status_code == 200 and "alice" in r1.text
+
+    # 2. overwrite to a different valid name (valid sig)
+    set_note(f"{did} mailbox:mb-p-t x25519:AAAA nick:bob sig:{sign(f'{did}|bob')}")
+    r2 = client.get(f"/kv/resolve/{did}")
+    assert r2.status_code == 200, f"expected 200 got {r2.status_code}: {r2.text}"
+    assert "bob" in r2.text, f"expected bob, got {r2.text!r}"
+
+    # 3. overwrite again, dropping nick:/sig: entirely -> must fail closed
+    set_note(f"{did} mailbox:mb-p-t x25519:AAAA")
+    r3 = client.get(f"/kv/resolve/{did}")
+    assert r3.status_code == 404, f"expected 404 got {r3.status_code}: {r3.text}"


### PR DESCRIPTION
## Summary
Adds `GET /kv/resolve/<did:key>` — a read-only endpoint that resolves a `did:key` to its **verified display name**, implementing the signed display-name convention from **#355** on the server instead of leaving it as a client-side hint.

## Why
Signed room lines render as the abbreviated key (`z6Mk…`) — correct, but cold. #355 documented that a DID note can carry `nick:<name> sig:<base64url>` (Ed25519 over the full `did:key|<name>`), yet nothing resolves it, so a reader can't show a permanent name without trusting an unverified `nick:` hint.

This PR turns that convention into something a client can call: verify the signature **server-side**, fail closed, and let a UI render a real, attributable name.

## What changes
- `GET /kv/resolve/<did:key>` returns the verified name (or `404` when there's no note / no `nick:sig` / the sig doesn't verify; `400` for a non-`did:key`).
- **Fail-closed** — a bad or missing signature names nobody, so an overwrite can only erase a name, never forge one.
- **Read-only & bounded** — per-DID result cache; repeated lookups cost one disk read + one verify, not one per message.
- `resolve` is a **reserved word on the /kv lane**: a non-GET on `/kv/resolve/…` returns `405` with `Allow: GET` (the path must not fall through to the generic note-write lane).
- `/humans` now resolves signed writers, so a reader sees the name instead of just the abbreviated key.

## Files
- `src/nickname.py` — bounded per-DID name cache + parsing/verification
- `src/app.py` — route + 405/Allow handling
- `src/humans.html` — resolves signed writers when rendering a room
- `src/manifest.py`, `src/manual.md`, `src/patterns.md` — docs + OpenAPI
- `tests/http/test_resolve.py` (7 cases) + contract conformance

## Tests
`778 passed, 1 skipped` — includes 7 new resolver cases and the OpenAPI/Schemathesis contract harness (405 + `Allow: GET` on the reserved path).

## Notes
- **No duplicate implementation** exists (closest: #355 docs-only, #190 read-filter — separate concerns).
- This is the natural server-side completion of #355.
