### PR TITLE
feat(exporter): a packaged Prometheus exporter for /stats (#766)

### DIFF
--- a/exporter/README.md
+++ b/exporter/README.md
@@ -108,8 +108,27 @@ but `increase()` across that window undercounts rather than showing a gap.
 Exporter self-metrics: `technocore_exporter_scrape_success`,
 `technocore_exporter_scrape_duration_seconds`,
 `technocore_exporter_last_success_timestamp_seconds`,
-`technocore_exporter_scrapes_total{outcome="success"|"error"}`. Alert on these first —
-without them a wrong token and a service with no rooms are the same absence of samples.
+`technocore_exporter_scrapes_total{outcome="success"|"error"}`. Without them a wrong token
+and a service with no rooms are the same absence of samples.
+
+#### These do not replace Prometheus's own `up`
+
+Alert on both, and on `up` first. Prometheus synthesizes `up` per scrape, and it answers a
+question the exporter structurally cannot: whether the page arrived at all. Measured
+against Prometheus 3.5.0:
+
+| what happened | `up` | `technocore_exporter_scrape_success` |
+|---|---|---|
+| exporter answers slower than `scrape_timeout` | `0` | no samples stored |
+| exporter is gone | `0` | no samples stored |
+| exporter answering, `/stats` read failing | `1` | `0` |
+
+So `up` covers the whole "we never got the page" half, including the slow case — an
+exporter that eventually answers past the scrape timeout stores nothing of its own no
+matter what it believed it was reporting. The self-metrics uniquely carry the last row,
+where the exporter is healthy and the read behind it is not; a wrong `CHAT_STATS_TOKEN` is
+the common cause and `/stats` answers it with 404, so nothing about it looks like an
+authentication failure. `config/technocore-alerts.yml` ships one alert for each half.
 
 ### Why the room classes are two different shapes
 
@@ -184,9 +203,10 @@ promtool check rules exporter/config/technocore-alerts.yml
 ```
 
 `test rules` is the one that matters of the two: `check rules` only says the file parses,
-while `test rules` unit-tests both alerts in both directions — including the exactly-85%
-boundary that must *not* fire, and the `absent()` case a bare `== 0` rule would miss. It
-runs from `exporter/config` because the test file names its rule file relatively.
+while `test rules` unit-tests all three alerts in both directions — the exactly-85%
+capacity boundary that must *not* fire, one exporter of two going down, a scrape slower
+than `scrape_timeout`, a healthy pair staying quiet, and nothing scraping the job at all.
+It runs from `exporter/config` because the test file names its rule file relatively.
 
 The suite validates the exposition through the client library's own parser on every run, so
 `promtool` is a second opinion rather than the only one.

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -32,7 +32,32 @@ quietly widen this endpoint.
 | `TECHNOCORE_STATS_URL` | `http://127.0.0.1:8080/stats` | |
 | `TECHNOCORE_EXPORTER_HOST` | `127.0.0.1` | |
 | `TECHNOCORE_EXPORTER_PORT` | `9464` | |
-| `TECHNOCORE_STATS_TIMEOUT` | `5` | seconds; must be finite and `0 < t < 10` — **enforced at boot**, not described. Below Prometheus's own default `scrape_timeout` so a slow origin reports a failed scrape instead of the scrape timing out with no samples |
+| `TECHNOCORE_STATS_TIMEOUT` | `5` | seconds; must be finite and `0 < t < 10` — **enforced at boot**, not described. The budget for the whole answer, not one socket operation: see below |
+
+### The timeout is a budget for the answer, not a socket option
+
+`TECHNOCORE_STATS_TIMEOUT` bounds the origin read *and* any time queued behind another
+scrape, so `/metrics` answers within it plus the exporter's own assembly — milliseconds;
+measured at 5.04–5.07s on the 5s default. That is what puts the ceiling below Prometheus's
+own default `scrape_timeout`, so a slow origin reports
+`technocore_exporter_scrape_success 0` while Prometheus is still listening, rather than
+timing out the scrape and storing nothing — which would say nothing about which side is
+unwell.
+
+It reads as an obvious property and was false in two separate ways, both reported by
+reviewers (@Minh3132, @yukkie3276) and both now pinned by regressions:
+
+- `urlopen(timeout=)` bounds each socket operation, not the call, so an origin trickling a
+  byte at a time under the timeout never tripped it — one fetch took **20.01s** on the 5s
+  default and the `GET /metrics` around it answered after **20.18s** reporting
+  `scrape_success 1`, with no concurrency involved. `fetch.py` now reads the body against a
+  deadline.
+- Scrapes serialise on one lock, and the wait was time the timeout never saw: a queued
+  scrape spent a full timeout waiting and another on its own fetch — **17.82s for a 9s
+  timeout**, past a 15s `scrape_timeout`. `collector.py` now spends one deadline on the
+  wait and the fetch together, and publishes the wait in
+  `technocore_exporter_scrape_duration_seconds`, which previously reported 9.01s for that
+  same 17.82s scrape.
 
 ### Configuration is validated at boot, not at first scrape
 
@@ -40,9 +65,17 @@ Every setting above is checked before the server starts, and an unusable one ref
 boot rather than being accepted. That is not tidiness: `collect()` converts any unexpected
 error into `scrape_success 0`, so a timeout of `-1`, `nan` or `inf` — each of which raises
 from `socket.settimeout` on *every* request — would otherwise produce a process that
-starts, stays up, answers `/metrics` forever and never once succeeds. The same applies to a
-port out of range and to a URL whose scheme `urllib` cannot open. Core takes the same
+starts, stays up, answers `/metrics` forever and never once succeeds. Core takes the same
 position for the same reason; see `config._finite_env`.
+
+The same rule covers the rest, and each of these was once accepted at boot: a port out of
+range, a URL whose scheme `urllib` cannot open, a URL whose **port** it cannot
+(`http://host:notaport/stats` booted and then failed every scrape), a URL malformed enough
+that `urlparse` itself raises (`http://[::1/stats` exited with a traceback rather than a
+refusal), and a token that is only whitespace (truthy, so it booted and took 404 forever).
+Every one now refuses with a message naming the variable. The token's value is *not*
+trimmed, only tested — core compares `CHAT_STATS_TOKEN` unstripped, so a token whose
+surrounding whitespace is real has to be sent exactly as configured.
 
 ## Metrics
 
@@ -138,10 +171,22 @@ cache miss is the expensive thing monitoring must not trigger repeatedly.
 
 ```bash
 uv run pytest tests/exporter -q
-uv run --project exporter python -m technocore_exporter > /tmp/m.txt   # or scrape it
+
+# The exporter serves /metrics; it prints nothing. Scrape it from a second shell — the
+# recipe here used to redirect the process's stdout, which is empty, and then hand
+# `promtool check metrics` an empty file that it passes.
+uv run --project exporter technocore-exporter &
+curl -sf 127.0.0.1:9464/metrics > /tmp/m.txt
 promtool check metrics < /tmp/m.txt
+
 promtool check rules exporter/config/technocore-alerts.yml
+(cd exporter/config && promtool test rules technocore-alerts.test.yml)
 ```
+
+`test rules` is the one that matters of the two: `check rules` only says the file parses,
+while `test rules` unit-tests both alerts in both directions — including the exactly-85%
+boundary that must *not* fire, and the `absent()` case a bare `== 0` rule would miss. It
+runs from `exporter/config` because the test file names its rule file relatively.
 
 The suite validates the exposition through the client library's own parser on every run, so
 `promtool` is a second opinion rather than the only one.

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -20,6 +20,12 @@ uv run --project exporter technocore-exporter
 network.** The digest is token-gated at the origin; `/metrics` is not gated at all, and it
 is the same numbers.
 
+It is *only* those numbers. The exporter serves its own `CollectorRegistry`, not the client
+library's global one, so the page carries the families listed below and nothing else — no
+`python_info`, no `process_*`, no GC series. That is asserted on a rendered page in
+`tests/exporter/test_server.py`, so an upstream release adding default collectors cannot
+quietly widen this endpoint.
+
 | Variable | Default | |
 |---|---|---|
 | `TECHNOCORE_STATS_TOKEN` | — | required; read from the environment only, never a flag, because argv is world-readable via `ps` |

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -1,0 +1,141 @@
+# technocore-exporter
+
+Prometheus exporter for a technocore-chat deployment. It reads the token-gated `/stats`
+digest over HTTP and republishes the shared-storage aggregates as metrics. It consumes the
+published HTTP surface and ships nothing back into the service — the same relationship
+`mcp/` has to `src/` — which is why it is its own package rather than a route on the origin.
+
+`/stats` is unchanged by this package, and keeps serving its existing JSON digest and
+history to whatever reads it today.
+
+## Run it
+
+```bash
+export TECHNOCORE_STATS_URL=http://127.0.0.1:8080/stats
+export TECHNOCORE_STATS_TOKEN=...        # must match the service's CHAT_STATS_TOKEN
+uv run --project exporter technocore-exporter
+```
+
+`/metrics` binds to `127.0.0.1:9464` by default. **Keep it there or on the operator's own
+network.** The digest is token-gated at the origin; `/metrics` is not gated at all, and it
+is the same numbers.
+
+| Variable | Default | |
+|---|---|---|
+| `TECHNOCORE_STATS_TOKEN` | — | required; read from the environment only, never a flag, because argv is world-readable via `ps` |
+| `TECHNOCORE_STATS_URL` | `http://127.0.0.1:8080/stats` | |
+| `TECHNOCORE_EXPORTER_HOST` | `127.0.0.1` | |
+| `TECHNOCORE_EXPORTER_PORT` | `9464` | |
+| `TECHNOCORE_STATS_TIMEOUT` | `5` | seconds; must be finite and `0 < t < 10` — **enforced at boot**, not described. Below Prometheus's own default `scrape_timeout` so a slow origin reports a failed scrape instead of the scrape timing out with no samples |
+
+### Configuration is validated at boot, not at first scrape
+
+Every setting above is checked before the server starts, and an unusable one refuses to
+boot rather than being accepted. That is not tidiness: `collect()` converts any unexpected
+error into `scrape_success 0`, so a timeout of `-1`, `nan` or `inf` — each of which raises
+from `socket.settimeout` on *every* request — would otherwise produce a process that
+starts, stays up, answers `/metrics` forever and never once succeeds. The same applies to a
+port out of range and to a URL whose scheme `urllib` cannot open. Core takes the same
+position for the same reason; see `config._finite_env`.
+
+## Metrics
+
+Gauges — current state:
+
+| Metric | |
+|---|---|
+| `technocore_rooms` | rooms that exist, including unlisted; what the room cap bounds |
+| `technocore_rooms_capacity` | `store.MAX_ROOMS` |
+| `technocore_rooms_listing{state="listed"\|"unlisted"}` | **a true partition** — sums to `technocore_rooms` |
+| `technocore_rooms_class{class="mailbox"\|"ownable"\|"ephemeral"}` | **overlapping — never sum** |
+| `technocore_rooms_unclassified` | rooms carrying no class marker |
+| `technocore_room_bytes` / `technocore_room_bytes_capacity` | disk held by rooms, and the enforced budget |
+| `technocore_notes` / `technocore_notes_capacity` | notes across all namespaces |
+| `technocore_notes_capacity_per_namespace` | a namespace can hit this while the global count is far from its cap |
+| `technocore_note_bytes` | |
+| `technocore_stats_sample_age_seconds` | age of the newest **stored sample**, not of the gauges above. Sampling is driven by writes, so this grows without bound on an idle service — context, **not** an availability signal |
+
+Counters — lifetime, best effort:
+
+`technocore_messages_total`, `technocore_rooms_created_total`,
+`technocore_rooms_reaped_total{reason="idle"|"stillborn"}`, `technocore_notes_written_total`,
+`technocore_topics_written_total`.
+
+Best effort on two axes, and the HELP text says so: they are **batched per worker** and
+flushed on an interval or at shutdown, so a hard kill loses the tail; and the counter file
+is rebuilt as zeros if lost, which Prometheus reads as a counter reset — correct handling,
+but `increase()` across that window undercounts rather than showing a gap.
+
+Exporter self-metrics: `technocore_exporter_scrape_success`,
+`technocore_exporter_scrape_duration_seconds`,
+`technocore_exporter_last_success_timestamp_seconds`,
+`technocore_exporter_scrapes_total{outcome="success"|"error"}`. Alert on these first —
+without them a wrong token and a service with no rooms are the same absence of samples.
+
+### Why the room classes are two different shapes
+
+`listed`/`unlisted` partition the room population, so they are label values on one metric
+and summing them is correct. The class markers do not partition anything: `room_classes`
+composes by prefix, so `mb-p-x` is a mailbox *and* unlisted, and a room can carry several
+markers at once. Those are separate metric names — a shape nobody is tempted to add up.
+The test fixture is a real capture in which the class counts genuinely fall short of the
+total, so this is pinned by arithmetic rather than by a comment.
+
+### The token goes to the configured origin and nowhere else
+
+**Ambient proxy configuration is ignored.** `HTTP_PROXY` / `HTTPS_PROXY` in the process
+environment would otherwise route this request — token included — through the proxy rather
+than to the configured origin, so proxy discovery is disabled outright. That is the right
+default for a credential-bearing client whose origin defaults to `127.0.0.1`: proxying
+localhost is almost never intended and the `NO_PROXY` exemption for it is easy to get
+wrong. An operator who genuinely needs an egress proxy needs an explicit trusted setting,
+not an environment variable that happens to be inherited.
+
+Redirects are refused rather than followed. `urllib.request.HTTPRedirectHandler` copies
+every header except `content-length` and `content-type` onto a redirected request, so a
+302 from the configured URL to any host would hand `X-Stats-Token` to that host silently.
+A 3xx is reported as a failed scrape instead.
+
+### A partial digest is refused, not mapped
+
+Every field the mapping reads must be present and a finite, non-negative, non-boolean
+number. Mapping what is there and defaulting the rest would publish `technocore_notes 0`
+beside `scrape_success 1` — a healthy-looking empty service, against which a note-capacity
+alert can never fire. Absent is not zero.
+
+### What this deliberately does not export
+
+- **`requests`** — per *worker*, not per service. `_requests` is a plain module dict, and
+  `src/app.py:1914` records the digest under-reporting by 3x once production moved to
+  `--workers 3`. Consecutive scrapes of a load-balanced URL can land on different
+  processes, so no arrangement of those samples is a monotonic counter, and multiplying by
+  `workers` is an estimate rather than counter aggregation. Capture admission failures at
+  the HTTP server or proxy instead.
+- **`history`** — Prometheus stores what it scrapes; re-exporting the ring as
+  timestamp-labelled series would double-store it and produce a second, disagreeing
+  history. Only the newest sample's timestamp is used, as freshness.
+- **`engagement`** — pooled over the 50 most recently active rooms, so it is a
+  bounded-window sample rather than a service total. Beside real totals it invites an alert
+  on a number that does not mean what its neighbours mean.
+- **Room names, namespaces, DIDs, IP addresses, raw URLs** — never, in any label. An
+  unlisted room name and a note namespace are bearer credentials. A test asserts the label
+  set as an allowlist, because a denylist passes for whatever nobody thought of.
+
+## Scrape interval
+
+**60s**, as shipped in `config/prometheus-scrape.yml`. The service caches the digest for
+`CHAT_STATS_CACHE_SECONDS` (60 by default) because building it is an O(cap) walk. Scraping
+faster buys no freshness — it only spends requests — and on a large store the walk behind a
+cache miss is the expensive thing monitoring must not trigger repeatedly.
+
+## Checks
+
+```bash
+uv run pytest tests/exporter -q
+uv run --project exporter python -m technocore_exporter > /tmp/m.txt   # or scrape it
+promtool check metrics < /tmp/m.txt
+promtool check rules exporter/config/technocore-alerts.yml
+```
+
+The suite validates the exposition through the client library's own parser on every run, so
+`promtool` is a second opinion rather than the only one.

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -36,16 +36,20 @@ quietly widen this endpoint.
 
 ### The timeout is a budget for the answer, not a socket option
 
-`TECHNOCORE_STATS_TIMEOUT` bounds the origin read *and* any time queued behind another
-scrape, so `/metrics` answers within it plus the exporter's own assembly — milliseconds;
-measured at 5.04–5.07s on the 5s default. That is what puts the ceiling below Prometheus's
-own default `scrape_timeout`, so a slow origin reports
+`TECHNOCORE_STATS_TIMEOUT` bounds the whole scrape — name resolution, connect, headers,
+body, and any time queued behind another scrape — so `/metrics` answers within it plus the
+exporter's own assembly, which is milliseconds. That is what puts the ceiling below
+Prometheus's own default `scrape_timeout`, so a slow origin reports
 `technocore_exporter_scrape_success 0` while Prometheus is still listening, rather than
 timing out the scrape and storing nothing — which would say nothing about which side is
 unwell.
 
-It reads as an obvious property and was false in two separate ways, both reported by
-reviewers (@Minh3132, @yukkie3276) and both now pinned by regressions:
+It reads as an obvious property and has now been false in **five** separate ways, none of
+which this package's own tests caught. Two were reported directly by reviewers (@Minh3132,
+@yukkie3276); the other three came out of auditing the phase boundary each report exposed.
+Every one is now pinned by a regression. They share a cause worth
+stating plainly: `urlopen(timeout=)` is a bound on one socket operation, and a scrape is
+made of many.
 
 - `urlopen(timeout=)` bounds each socket operation, not the call, so an origin trickling a
   byte at a time under the timeout never tripped it — one fetch took **20.01s** on the 5s
@@ -58,6 +62,27 @@ reviewers (@Minh3132, @yukkie3276) and both now pinned by regressions:
   wait and the fetch together, and publishes the wait in
   `technocore_exporter_scrape_duration_seconds`, which previously reported 9.01s for that
   same 17.82s scrape.
+- Name resolution runs before there is a socket for the timeout to apply to, so a wedged
+  resolver blocked past it: **20.0s of a 3s budget** at `/metrics` — the scrape
+  answered when the resolver did, which is to say the budget bounded nothing.
+- Connect then tries *every* address the name resolved to, giving each the full timeout, so
+  the budget was spent once per address record rather than once per scrape: **12.0s of a
+  3s budget** across four blackholed A records — four times the budget, with each connect
+  logged at the whole 3.0s rather than a share. Two records is enough to matter, provided both *blackhole* rather
+  than refuse — a refused connection returns at once and costs nothing, while a firewall
+  that drops does not. At the ceiling of just under 10s, two dropping addresses reach ~20s
+  against a 15s `scrape_timeout`.
+- The status line and response headers are read before `urlopen` returns, so the deadline
+  in `_read_within` never saw them. An origin trickling one header byte per 0.5s ran to
+  **22.6s of a 3s budget**, and the exporter was still waiting when the origin stopped
+  trickling — so that figure is the origin's choice, not a bound. This one needs no hostname: it lands on the shipped `127.0.0.1` default,
+  because it is about what the origin sends rather than how it is addressed.
+
+The first two fixes bounded the phases this package could see. The last three are phases it
+could not, which is why the bound moved up a level: `TechnocoreCollector._fetch_within` runs
+the fetch on a worker and stops waiting at the deadline, whatever the transport is doing.
+The worker keeps the fetch lock when it is abandoned, so a wedged origin costs one live
+thread at a time and one in-flight request, no matter how many scrapes arrive.
 
 ### Configuration is validated at boot, not at first scrape
 

--- a/exporter/config/prometheus-scrape.yml
+++ b/exporter/config/prometheus-scrape.yml
@@ -13,6 +13,12 @@ scrape_configs:
     # a slow origin always surfaces as technocore_exporter_scrape_success=0 with telemetry
     # rather than as a scrape timeout with no samples at all — the second tells you nothing
     # about which side is unwell.
+    #
+    # That holds because the exporter treats the timeout as a budget for the origin read
+    # plus any time queued behind another scrape, not as a per-socket-operation timeout. It
+    # did not always: against a trickling origin on the 5s default, GET /metrics answered
+    # after 20.18s reporting success, and a scrape queued behind another took 17.82s on a
+    # 9s timeout — both past this figure. See the exporter README.
     scrape_timeout: 15s
     static_configs:
       - targets: ["127.0.0.1:9464"]

--- a/exporter/config/prometheus-scrape.yml
+++ b/exporter/config/prometheus-scrape.yml
@@ -1,0 +1,16 @@
+# Scrape configuration for technocore-exporter.
+#
+# 60s, matching the service's CHAT_STATS_CACHE_SECONDS default. The digest behind /stats is
+# an O(cap) walk, cached for that long precisely so it is not rebuilt per request; scraping
+# faster returns the same cached bytes and buys no freshness at all. If an operator raises
+# CHAT_STATS_CACHE_SECONDS, raise this with it — a scrape interval below the cache is how
+# monitoring starts paying for a walk it cannot use.
+scrape_configs:
+  - job_name: technocore
+    scrape_interval: 60s
+    # Comfortably above the exporter's own 10s origin timeout, so a slow origin surfaces as
+    # technocore_exporter_scrape_success=0 rather than as a scrape timeout with no samples
+    # at all — the second tells you nothing about which side is unwell.
+    scrape_timeout: 15s
+    static_configs:
+      - targets: ["127.0.0.1:9464"]

--- a/exporter/config/prometheus-scrape.yml
+++ b/exporter/config/prometheus-scrape.yml
@@ -8,9 +8,11 @@
 scrape_configs:
   - job_name: technocore
     scrape_interval: 60s
-    # Comfortably above the exporter's own 10s origin timeout, so a slow origin surfaces as
-    # technocore_exporter_scrape_success=0 rather than as a scrape timeout with no samples
-    # at all — the second tells you nothing about which side is unwell.
+    # Above every origin timeout the exporter will accept: TECHNOCORE_STATS_TIMEOUT
+    # defaults to 5s and is refused at boot unless 0 < t < 10 (SCRAPE_TIMEOUT_CEILING), so
+    # a slow origin always surfaces as technocore_exporter_scrape_success=0 with telemetry
+    # rather than as a scrape timeout with no samples at all — the second tells you nothing
+    # about which side is unwell.
     scrape_timeout: 15s
     static_configs:
       - targets: ["127.0.0.1:9464"]

--- a/exporter/config/prometheus-scrape.yml
+++ b/exporter/config/prometheus-scrape.yml
@@ -14,11 +14,16 @@ scrape_configs:
     # rather than as a scrape timeout with no samples at all — the second tells you nothing
     # about which side is unwell.
     #
-    # That holds because the exporter treats the timeout as a budget for the origin read
-    # plus any time queued behind another scrape, not as a per-socket-operation timeout. It
-    # did not always: against a trickling origin on the 5s default, GET /metrics answered
-    # after 20.18s reporting success, and a scrape queued behind another took 17.82s on a
-    # 9s timeout — both past this figure. See the exporter README.
+    # That holds because the exporter treats the timeout as a budget for the whole scrape —
+    # resolution, connect, headers, body, and any time queued behind another scrape — not as
+    # a per-socket-operation timeout. It did not always, and the gap was not one gap. Two ran
+    # past this figure as measured: a trickling body answered after 20.18s reporting success,
+    # and a scrape queued behind another took 17.82s on a 9s timeout. Three more were
+    # measured on a 3s budget to keep the runs short, so their figures are smaller — a wedged
+    # resolver 20.0s, trickled response headers 22.6s, four address records 12.0s — but
+    # none of the three is bounded by this figure either. The first two last as long as the
+    # other side cares to block; the third is four times the configured timeout, so ~40s at
+    # the accepted ceiling. See the exporter README.
     scrape_timeout: 15s
     static_configs:
       - targets: ["127.0.0.1:9464"]

--- a/exporter/config/technocore-alerts.test.yml
+++ b/exporter/config/technocore-alerts.test.yml
@@ -41,50 +41,140 @@ tests:
                 look emptier than this number.
 
   - interval: 1m
-    name: collection breaks while the service is fine
+    name: the exporter is up and the /stats read is failing
     input_series:
-      # The service is healthy and far from its cap; only the exporter's read fails. The
-      # capacity alert must stay quiet and the staleness alert must fire.
+      # The service is healthy and far from its cap; only the exporter's read fails. `up`
+      # stays 1 — the page arrives, it just reports 0 — so TechnocoreExporterDown must stay
+      # quiet and TechnocoreStatsUnreadable must fire. Pinned in both directions because
+      # collapsing these two into one `or` is what made the description hedge.
       - series: technocore_rooms
         values: "10+0x30"
       - series: technocore_rooms_capacity
         values: "5120+0x30"
-      - series: technocore_exporter_scrape_success
+      - series: 'up{job="technocore", instance="a:9464"}'
+        values: "1+0x30"
+      - series: 'technocore_exporter_scrape_success{instance="a:9464"}'
         values: "1 1 1 0+0x27"
     alert_rule_test:
       - eval_time: 4m
-        alertname: TechnocoreMetricsStale
+        alertname: TechnocoreStatsUnreadable
         exp_alerts: []  # failing, but not yet for 5m
       - eval_time: 10m
-        alertname: TechnocoreMetricsStale
+        alertname: TechnocoreStatsUnreadable
         exp_alerts:
           - exp_labels:
               severity: warning
+              instance: "a:9464"
             exp_annotations:
-              summary: "technocore metrics are not being collected"
+              summary: "technocore exporter cannot read /stats"
               description: >-
-                The exporter is down, or it cannot read /stats. Check TECHNOCORE_STATS_TOKEN
-                against the service's CHAT_STATS_TOKEN: a mismatch answers 404, not 401.
+                The exporter is answering but its /stats read is failing. Check
+                TECHNOCORE_STATS_TOKEN against the service's CHAT_STATS_TOKEN: a mismatch
+                answers 404, not 401, so it does not look like an auth failure.
+      - eval_time: 10m
+        alertname: TechnocoreExporterDown
+        exp_alerts: []  # the page arrived; this is not a collection failure
       - eval_time: 10m
         alertname: TechnocoreRoomCapacityPressure
         exp_alerts: []
 
   - interval: 1m
-    name: the exporter disappearing entirely
+    name: one exporter of two goes down
     input_series:
-      # No technocore_exporter_scrape_success series at all — the absent() half. This is
-      # the case a bare `== 0` rule misses, and it is the likelier one: a dead exporter
-      # stops publishing rather than publishing a zero.
+      # The case the previous rule could not see at all. absent() is true only when EVERY
+      # series is gone, so with a second healthy instance a dead exporter fired nothing.
+      # `up` is per instance, so this fires and names the one that is down.
+      - series: 'up{job="technocore", instance="a:9464"}'
+        values: "1+0x30"
+      - series: 'up{job="technocore", instance="b:9464"}'
+        values: "1 1 1 0+0x27"
+      - series: 'technocore_exporter_scrape_success{instance="a:9464"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: TechnocoreExporterDown
+        exp_alerts: []  # down, but not yet for 5m
+      - eval_time: 10m
+        alertname: TechnocoreExporterDown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: technocore
+              instance: "b:9464"
+            exp_annotations:
+              summary: "technocore exporter is not answering"
+              description: >-
+                The exporter is down, unreachable, or answering slower than scrape_timeout —
+                in which case Prometheus stores no exporter samples at all. If no instance is
+                listed, nothing is scraping job "technocore" and the scrape_config is the
+                thing to check.
+
+  - interval: 1m
+    name: the scrape is slower than scrape_timeout
+    input_series:
+      # Measured against Prometheus 3.5.0: a target answering in 8s under a 2s
+      # scrape_timeout yields up=0 and stores no technocore_* samples whatever the exporter
+      # believed it published. Only `up` expresses this, which is why the rule moved to it.
+      - series: 'up{job="technocore", instance="a:9464"}'
+        values: "1 1 1 0+0x27"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: TechnocoreExporterDown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: technocore
+              instance: "a:9464"
+            exp_annotations:
+              summary: "technocore exporter is not answering"
+              description: >-
+                The exporter is down, unreachable, or answering slower than scrape_timeout —
+                in which case Prometheus stores no exporter samples at all. If no instance is
+                listed, nothing is scraping job "technocore" and the scrape_config is the
+                thing to check.
+      - eval_time: 10m
+        alertname: TechnocoreStatsUnreadable
+        exp_alerts: []  # no samples arrived, so the gauge cannot say anything
+
+  - interval: 1m
+    name: a healthy pair stays quiet
+    input_series:
+      # The other direction, so neither rule can pass by firing on everything.
+      - series: 'up{job="technocore", instance="a:9464"}'
+        values: "1+0x30"
+      - series: 'up{job="technocore", instance="b:9464"}'
+        values: "1+0x30"
+      - series: 'technocore_exporter_scrape_success{instance="a:9464"}'
+        values: "1+0x30"
+      - series: 'technocore_exporter_scrape_success{instance="b:9464"}'
+        values: "1+0x30"
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: TechnocoreExporterDown
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: TechnocoreStatsUnreadable
+        exp_alerts: []
+
+  - interval: 1m
+    name: nothing is scraping the job at all
+    input_series:
+      # No `up` for this job anywhere — a dropped scrape_config or a renamed job. No
+      # per-instance expression can see this, which is why absent(up{...}) is kept. The
+      # alert carries no instance label, and the description says so.
       - series: technocore_rooms
         values: "10+0x30"
     alert_rule_test:
       - eval_time: 10m
-        alertname: TechnocoreMetricsStale
+        alertname: TechnocoreExporterDown
         exp_alerts:
           - exp_labels:
               severity: warning
+              job: technocore
             exp_annotations:
-              summary: "technocore metrics are not being collected"
+              summary: "technocore exporter is not answering"
               description: >-
-                The exporter is down, or it cannot read /stats. Check TECHNOCORE_STATS_TOKEN
-                against the service's CHAT_STATS_TOKEN: a mismatch answers 404, not 401.
+                The exporter is down, unreachable, or answering slower than scrape_timeout —
+                in which case Prometheus stores no exporter samples at all. If no instance is
+                listed, nothing is scraping job "technocore" and the scrape_config is the
+                thing to check.

--- a/exporter/config/technocore-alerts.test.yml
+++ b/exporter/config/technocore-alerts.test.yml
@@ -1,0 +1,90 @@
+# promtool unit tests for technocore-alerts.yml.
+#
+# A rules file that parses is not a rules file that fires. These pin both directions for
+# each alert — that it fires on the condition, and that it stays quiet otherwise — because
+# a capacity alert nobody has seen fire is indistinguishable from one that cannot.
+#
+#   promtool test rules exporter/config/technocore-alerts.test.yml
+rule_files:
+  - technocore-alerts.yml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    name: room occupancy crossing the cap threshold
+    input_series:
+      # 4352/5120 = 85%, exactly at the boundary and therefore NOT over it, then 4608 = 90%.
+      - series: technocore_rooms
+        values: "4352+0x20 4608+0x20"
+      - series: technocore_rooms_capacity
+        values: "5120+0x40"
+      - series: technocore_exporter_scrape_success
+        values: "1+0x40"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: TechnocoreRoomCapacityPressure
+        exp_alerts: []  # exactly 85% is not "> 0.85"
+      - eval_time: 21m
+        alertname: TechnocoreRoomCapacityPressure
+        exp_alerts: []  # over the line, but not yet for 15m
+      - eval_time: 37m
+        alertname: TechnocoreRoomCapacityPressure
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "technocore room occupancy above 85% of cap"
+              description: >-
+                90% of the room cap is in use. New rooms are refused at the cap. Note this
+                counts unlisted rooms, which GET /rooms does not show — so the listing will
+                look emptier than this number.
+
+  - interval: 1m
+    name: collection breaks while the service is fine
+    input_series:
+      # The service is healthy and far from its cap; only the exporter's read fails. The
+      # capacity alert must stay quiet and the staleness alert must fire.
+      - series: technocore_rooms
+        values: "10+0x30"
+      - series: technocore_rooms_capacity
+        values: "5120+0x30"
+      - series: technocore_exporter_scrape_success
+        values: "1 1 1 0+0x27"
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: TechnocoreMetricsStale
+        exp_alerts: []  # failing, but not yet for 5m
+      - eval_time: 10m
+        alertname: TechnocoreMetricsStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "technocore metrics are not being collected"
+              description: >-
+                The exporter is down, or it cannot read /stats. Check TECHNOCORE_STATS_TOKEN
+                against the service's CHAT_STATS_TOKEN: a mismatch answers 404, not 401.
+      - eval_time: 10m
+        alertname: TechnocoreRoomCapacityPressure
+        exp_alerts: []
+
+  - interval: 1m
+    name: the exporter disappearing entirely
+    input_series:
+      # No technocore_exporter_scrape_success series at all — the absent() half. This is
+      # the case a bare `== 0` rule misses, and it is the likelier one: a dead exporter
+      # stops publishing rather than publishing a zero.
+      - series: technocore_rooms
+        values: "10+0x30"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: TechnocoreMetricsStale
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              summary: "technocore metrics are not being collected"
+              description: >-
+                The exporter is down, or it cannot read /stats. Check TECHNOCORE_STATS_TOKEN
+                against the service's CHAT_STATS_TOKEN: a mismatch answers 404, not 401.

--- a/exporter/config/technocore-alerts.yml
+++ b/exporter/config/technocore-alerts.yml
@@ -1,24 +1,62 @@
-# One capacity alert, plus the collection alert that has to exist beside it.
+# One capacity alert, plus the two collection alerts that have to exist beside it.
 #
-# The pair is the point: a rule that fires on room pressure is worthless if a broken token
-# silently stops the samples, because "no data" and "no rooms" render identically. So the
-# first rule watches the exporter and the second watches the service.
+# The pairing is the point: a rule that fires on room pressure is worthless if a broken
+# token silently stops the samples, because "no data" and "no rooms" render identically. So
+# the collection rules watch the exporter and the capacity rule watches the service.
+#
+# Two collection rules rather than one, because collection fails in two ways that need
+# different answers — the page never arrived, or it arrived saying the read failed. Only
+# the second is something the exporter can report about itself; see below.
 groups:
   - name: technocore
     rules:
-      - alert: TechnocoreMetricsStale
-        # `absent()` covers the exporter being down; the success gauge covers it being up
-        # and unable to read /stats — a wrong CHAT_STATS_TOKEN is the common cause, and it
-        # answers 404, so nothing about it looks like an authentication failure.
-        expr: absent(technocore_exporter_scrape_success) or technocore_exporter_scrape_success == 0
+      # Two collection alerts, not one, because "we never got the page" and "we got the
+      # page and it says the read failed" are different questions with different fixes,
+      # and an `or` across both produces one alert whose description has to hedge about
+      # which happened. They are mutually exclusive by construction: the second can only
+      # fire when samples exist, which means the first did not.
+      #
+      # Both select `job="technocore"`, the job_name in the prometheus-scrape.yml shipped
+      # beside this file. Rename the job there and these must be renamed with it.
+      - alert: TechnocoreExporterDown
+        # `up` is synthesized by Prometheus per scrape and is the authority on whether the
+        # exporter answered at all. Measured against Prometheus 3.5.0: a target answering
+        # in 8s under a 2s scrape_timeout gives up=0 and stores no technocore_* samples
+        # whatever the exporter believed it was publishing, and a target that is gone gives
+        # the same. Only `up` sees either.
+        #
+        # This replaces absent(technocore_exporter_scrape_success), which was true only
+        # when EVERY series was gone — so with an HA pair, or any second instance, one dead
+        # exporter fired nothing at all. `up` is per instance and labels which one.
+        # absent(up{...}) is kept for the case under that: nothing scraping this job, which
+        # no per-instance expression can see.
+        expr: absent(up{job="technocore"}) or up{job="technocore"} == 0
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: "technocore metrics are not being collected"
+          summary: "technocore exporter is not answering"
           description: >-
-            The exporter is down, or it cannot read /stats. Check TECHNOCORE_STATS_TOKEN
-            against the service's CHAT_STATS_TOKEN: a mismatch answers 404, not 401.
+            The exporter is down, unreachable, or answering slower than scrape_timeout —
+            in which case Prometheus stores no exporter samples at all. If no instance is
+            listed, nothing is scraping job "technocore" and the scrape_config is the
+            thing to check.
+
+      - alert: TechnocoreStatsUnreadable
+        # The case only the exporter can report: it is up and answering promptly, and the
+        # /stats read behind it is failing. `up` stays 1 throughout, so nothing above sees
+        # this. A wrong CHAT_STATS_TOKEN is the common cause, and /stats answers 404 to it
+        # rather than 401, so nothing about the failure looks like authentication.
+        expr: technocore_exporter_scrape_success == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "technocore exporter cannot read /stats"
+          description: >-
+            The exporter is answering but its /stats read is failing. Check
+            TECHNOCORE_STATS_TOKEN against the service's CHAT_STATS_TOKEN: a mismatch
+            answers 404, not 401, so it does not look like an auth failure.
 
       - alert: TechnocoreRoomCapacityPressure
         # Rooms, not bytes: the room cap is the one that refuses creates outright. Bytes

--- a/exporter/config/technocore-alerts.yml
+++ b/exporter/config/technocore-alerts.yml
@@ -1,0 +1,36 @@
+# One capacity alert, plus the collection alert that has to exist beside it.
+#
+# The pair is the point: a rule that fires on room pressure is worthless if a broken token
+# silently stops the samples, because "no data" and "no rooms" render identically. So the
+# first rule watches the exporter and the second watches the service.
+groups:
+  - name: technocore
+    rules:
+      - alert: TechnocoreMetricsStale
+        # `absent()` covers the exporter being down; the success gauge covers it being up
+        # and unable to read /stats — a wrong CHAT_STATS_TOKEN is the common cause, and it
+        # answers 404, so nothing about it looks like an authentication failure.
+        expr: absent(technocore_exporter_scrape_success) or technocore_exporter_scrape_success == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "technocore metrics are not being collected"
+          description: >-
+            The exporter is down, or it cannot read /stats. Check TECHNOCORE_STATS_TOKEN
+            against the service's CHAT_STATS_TOKEN: a mismatch answers 404, not 401.
+
+      - alert: TechnocoreRoomCapacityPressure
+        # Rooms, not bytes: the room cap is the one that refuses creates outright. Bytes
+        # have their own budget and a reaper working against them, so they warrant a
+        # separate, lower-urgency rule an operator can tune to their disk.
+        expr: technocore_rooms / technocore_rooms_capacity > 0.85
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "technocore room occupancy above 85% of cap"
+          description: >-
+            {{ $value | humanizePercentage }} of the room cap is in use. New rooms are
+            refused at the cap. Note this counts unlisted rooms, which GET /rooms does not
+            show — so the listing will look emptier than this number.

--- a/exporter/pyproject.toml
+++ b/exporter/pyproject.toml
@@ -1,0 +1,53 @@
+[project]
+name = "technocore-exporter"
+# Derived from `VERSION` in src/technocore_exporter/__init__.py, for the reason mcp/
+# gives: a literal here can be bumped while the constant the process reports stays
+# behind, publishing a release that identifies itself as the previous one.
+dynamic = ["version"]
+description = "Prometheus exporter for a technocore-chat deployment: shared-storage gauges and lifetime counters, read from the token-gated /stats digest"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.11"
+# One dependency, and it is the exposition format itself. Hand-rolling the text format is
+# where exporters get subtly wrong — HELP escaping, the `_total` suffix rule, the sample
+# ordering OpenMetrics requires — and the client library is also what makes the golden
+# test in tests/test_collector.py a parser round-trip rather than a string compare.
+#
+# Floored on the current major, not pinned: this uses only Collector, the *MetricFamily
+# constructors and start_http_server, which have been stable across the 0.2x line.
+dependencies = [
+    "prometheus-client>=0.20",
+]
+keywords = ["prometheus", "metrics", "exporter", "technocore", "observability"]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Topic :: System :: Monitoring",
+]
+
+[project.urls]
+Homepage = "https://technocore.chat"
+Source = "https://github.com/flop-labs/technocore-chat"
+Documentation = "https://technocore.chat/llms.txt"
+
+[project.scripts]
+technocore-exporter = "technocore_exporter.server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/technocore_exporter/__init__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/technocore_exporter"]
+
+[tool.hatch.build.targets.sdist]
+# An allowlist for the same reason mcp/ uses one: the sdist is this package's source, not
+# a copy of the directory. `config/` is operator material that ships in the repository and
+# is read from there, not installed.
+only-include = ["src/technocore_exporter", "README.md"]
+
+[dependency-groups]
+dev = ["pytest>=8"]

--- a/exporter/src/technocore_exporter/__init__.py
+++ b/exporter/src/technocore_exporter/__init__.py
@@ -1,0 +1,13 @@
+"""Prometheus exporter for a technocore-chat deployment (#766).
+
+Reads the token-gated `/stats` digest and republishes the shared-storage aggregates as
+Prometheus metrics. It consumes the published HTTP surface and ships nothing back into
+the service, which is why it lives beside `mcp/` as its own package rather than in `src/`.
+"""
+
+from .collector import TechnocoreCollector
+from .fetch import StatsUnavailableError, fetch_stats
+
+VERSION = "0.1.0"
+
+__all__ = ["TechnocoreCollector", "StatsUnavailableError", "fetch_stats", "VERSION"]

--- a/exporter/src/technocore_exporter/__main__.py
+++ b/exporter/src/technocore_exporter/__main__.py
@@ -1,5 +1,5 @@
 # The `python -m technocore_exporter` shim. No cover: two lines that only run as a module
-# entrypoint, and main() itself is the serve loop whose parts are tested in test_server.py.
+# entrypoint. main() itself is driven by test_server.py with the serve call stubbed.
 from .server import main  # pragma: no cover
 
 main()  # pragma: no cover

--- a/exporter/src/technocore_exporter/__main__.py
+++ b/exporter/src/technocore_exporter/__main__.py
@@ -1,0 +1,5 @@
+# The `python -m technocore_exporter` shim. No cover: two lines that only run as a module
+# entrypoint, and main() itself is the serve loop whose parts are tested in test_server.py.
+from .server import main  # pragma: no cover
+
+main()  # pragma: no cover

--- a/exporter/src/technocore_exporter/__main__.py
+++ b/exporter/src/technocore_exporter/__main__.py
@@ -1,5 +1,12 @@
-# The `python -m technocore_exporter` shim. No cover: two lines that only run as a module
-# entrypoint. main() itself is driven by test_server.py with the serve call stubbed.
-from .server import main  # pragma: no cover
+"""The `python -m technocore_exporter` shim.
 
-main()  # pragma: no cover
+The guard is not ceremony. Without it `main()` runs on *import* of this module, so
+anything that imports the package's submodules — a docs tool, `pkgutil.walk_packages`, a
+coverage or packaging pass — binds a port and never returns. `mcp/` has no `__main__.py`
+to copy, so this follows the stdlib convention rather than an in-repo precedent.
+"""
+
+from .server import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/exporter/src/technocore_exporter/collector.py
+++ b/exporter/src/technocore_exporter/collector.py
@@ -214,6 +214,10 @@ class TechnocoreCollector(Collector):
         # @Minh3132 and @yukkie3276). `_gather` bounds the wait and the fetch against one
         # deadline instead, so a queued scrape reports failure inside the budget rather than
         # succeeding after nobody is listening.
+        #
+        # `_fetching` is released by the fetch worker, never by the scrape that started it —
+        # see `_fetch_within`. That is what lets a scrape abandon a wedged fetch without
+        # letting the next one open a second request to the same origin.
         self._fetching = threading.Lock()
         self._state = threading.Lock()
 
@@ -231,8 +235,10 @@ class TechnocoreCollector(Collector):
         families inside the guard is what makes "no failure escapes" true of the mapping
         as well as the transport.
 
-        One deadline covers everything after `started`, waiting for the fetch lock
-        included. That is what makes the ceiling in server.py an actual bound: whatever
+        One deadline covers everything after `started`: the wait for the fetch lock, and
+        then the fetch itself in every phase of it — resolution, connect, headers and body
+        — because `_fetch_within` stops waiting at the deadline rather than trusting the
+        transport to. That is what makes the ceiling in server.py an actual bound: whatever
         else happens, this returns within the configured source timeout, so the failure it
         reports arrives while Prometheus is still listening for it.
         """
@@ -244,13 +250,7 @@ class TechnocoreCollector(Collector):
             # in, and an answer after the scrape timeout is worth less than a fast 0.
             return self._failed(started, "timed out waiting for the in-flight scrape")
         try:
-            # Clamped rather than checked for exhaustion: a scrape that wins the lock with
-            # nothing left gets a zero timeout, which is a non-blocking socket, which fails
-            # immediately and is published as scrape_success 0 inside the budget — the same
-            # answer an explicit branch here would produce, without a branch that only the
-            # clock can reach and no test can honestly cover.
-            remaining = max(0.0, deadline - time.monotonic())
-            payload = fetch_stats(self._url, self._token, remaining)
+            payload = self._fetch_within(deadline)
             families = [
                 *_rooms(payload.get("rooms", {})),
                 *_capacity(payload),
@@ -271,12 +271,97 @@ class TechnocoreCollector(Collector):
             # assumption that any such list is complete has been wrong three times.
             log.exception("unexpected error reading %s", self._url)
             return self._failed(started, None)
-        finally:
-            self._fetching.release()
         with self._state:
             self._scrapes["success"] += 1
             self._last_success = time.time()
         return families + list(self._self_metrics(time.monotonic() - started, ok=True))
+
+    def _fetch_within(self, deadline: float) -> dict:
+        """The digest, or refuse at the deadline — whatever the transport is doing.
+
+        `fetch_stats` bounds itself, and for the phase it can see it does so correctly. It
+        cannot see the others. `urlopen(timeout=)` is a *per socket operation* timeout, and
+        three phases run before the body read that `_read_within` guards:
+
+          * name resolution. `socket.create_connection` calls `getaddrinfo()` before it has
+            a socket for the timeout to apply to, so a wedged resolver blocks the whole
+            call — 20.0s of a 3s budget, measured at /metrics (reported by @Minh3132);
+          * connect. That same function then tries *every* address the name resolved to,
+            giving each the full timeout, so a hostname with four blackholed A records cost
+            12.0s of a 3s budget, four times the budget for four records; and
+          * the status line and response headers, read by `http.client` before `open()`
+            returns. An origin trickling one header byte per 0.5s never trips a 3s socket
+            timeout: 22.6s, still waiting when the origin stopped. This one needs no
+            hostname at all — it lands on the shipped `127.0.0.1` default.
+
+        Enumerating those three and bounding each is the move this file has already been
+        wrong about three times over (see the broad handler in `_gather` and the trailing
+        `OSError` in fetch.py). So the bound here is structural: the fetch runs on a worker
+        and the scrape stops waiting at the deadline, whatever the worker is blocked on.
+
+        The lock is the reason this is safe rather than a thread leak. `_fetching` is
+        already held when we get here, and the *worker* releases it — so an abandoned fetch
+        keeps it, the next scrape's bounded `acquire` fails fast and reports
+        `scrape_success 0` inside its own budget, and no second request is ever opened to an
+        origin that has not answered the first. One wedged origin therefore costs one live
+        thread at a time, not one per scrape.
+        """
+        # Clamped rather than checked for exhaustion: a scrape that wins the lock with
+        # nothing left gets a zero timeout, which is a non-blocking socket, which fails
+        # immediately and is published as scrape_success 0 inside the budget — the same
+        # answer an explicit branch here would produce, without a branch that only the
+        # clock can reach and no test can honestly cover.
+        remaining = max(0.0, deadline - time.monotonic())
+        box: dict = {}
+        done = threading.Event()
+        abandoned = threading.Event()
+
+        def run() -> None:
+            try:
+                box["payload"] = fetch_stats(self._url, self._token, remaining)
+            except BaseException as exc:  # noqa: BLE001 - re-raised on the scrape's thread
+                # Re-raised below rather than handled, so `_gather`'s existing handlers see
+                # exactly what they saw when the fetch ran inline.
+                box["error"] = exc
+            finally:
+                # Before `done`, so a scrape that wakes on it finds the lock already free.
+                self._fetching.release()
+                done.set()
+                if abandoned.is_set():
+                    # The scrape that started this has already answered, so nothing above
+                    # will ever look at `box`. Without this the origin's real reason is
+                    # lost: the operator gets "exceeded the scrape budget", which says the
+                    # answer was late but not that the resolver was down. Running the fetch
+                    # inline used to put that reason in the log, and it should still.
+                    #
+                    # Always an error, never a discarded digest. `fetch_stats` is given
+                    # this same deadline, so a worker that outran the scrape has outrun its
+                    # own budget too and `_read_within` refuses before it returns a body.
+                    # The default below is defensive, not a case that happens.
+                    log.warning(
+                        "scrape of %s finished after the budget: %s",
+                        self._url,
+                        box.get("error", "answer discarded"),
+                    )
+
+        worker = threading.Thread(target=run, name="technocore-exporter-fetch", daemon=True)
+        try:
+            worker.start()
+        except BaseException:
+            # Nothing will release `_fetching` if the worker never ran, and a collector
+            # that can no longer take its own lock answers every later scrape with the
+            # queued-behind failure forever.
+            self._fetching.release()
+            raise
+        if not done.wait(max(0.0, deadline - time.monotonic())):
+            # Set before raising, so the worker knows nobody is left to report what it
+            # finds. A worker that finishes inside this window sees it unset and stays
+            # quiet, which is right: the scrape below is about to report for it.
+            abandoned.set()
+            raise StatsUnavailableError("exceeded the scrape budget before the origin answered")
+        if "error" in box:
+            raise box["error"]
+        return box["payload"]
 
     def _failed(self, started: float, reason: str | None) -> list:
         """Failure telemetry alone, and the count that goes with it.

--- a/exporter/src/technocore_exporter/collector.py
+++ b/exporter/src/technocore_exporter/collector.py
@@ -1,8 +1,9 @@
 """Map the `/stats` digest onto Prometheus metric families.
 
-Scope is deliberately narrow: only what `store.service_stats` returns. Three things the
-digest carries are left out on purpose, and each omission is a decision rather than an
-oversight — see OMITTED below.
+Scope is deliberately narrow: only what `store.service_stats` returns. `/stats` carries
+five things this exporter does not publish — three from `service_stats` itself and two that
+`app.py` adds to the view — and each omission is a decision rather than an oversight; see
+OMITTED below.
 
 Naming follows the Prometheus conventions: gauges carry no `_total`, counters do (the
 client library appends it), and every byte figure is named `_bytes` because base units
@@ -53,6 +54,19 @@ _COUNTERS = {
 #          bounded-window sample rather than a service total. Publishing it beside real
 #          totals invites an alert on a number that does not mean what its neighbours
 #          mean.
+#
+# The last two are added to the view by `app.py`, not by `service_stats`, so they are
+# outside this package's stated scope by construction — named anyway, because "three
+# omissions" invites the reader to check and find five things in the digest:
+#
+# OMITTED: `capacity_limits` — request-shaping constants (message_chars, read_per_min and
+#          friends), not occupancy. The two that actually bound the aggregates here are
+#          already published from `service_stats`: `room_bytes_total` is the same constant
+#          as `bytes.rooms_capacity` (technocore_room_bytes_capacity) and MAX_ROOMS
+#          arrives as `rooms.capacity` (technocore_rooms_capacity).
+# OMITTED: `client_identity` — `distinct_identities` counts a module-level dict, so it is
+#          per *worker* for exactly the reason `requests` is, and `client_ip_header` is a
+#          configuration string rather than a measurement.
 
 
 def _rooms(rooms: dict) -> Iterable:
@@ -181,8 +195,14 @@ class TechnocoreCollector(Collector):
         # `start_http_server` runs a ThreadingWSGIServer, so two overlapping scrapes call
         # collect() on this one instance concurrently. Without the lock the counter bumps
         # below are an unguarded read-modify-write and one is silently lost — the same
-        # shape as the `_buckets` race in core's limiter. It also stops two scrapes from
-        # each opening their own origin request, which is the more expensive half.
+        # shape as the `_buckets` race in core's limiter.
+        #
+        # It serialises; it does not coalesce. The second scrape still makes its own origin
+        # request once it holds the lock, so the guarantee is at most one request in flight
+        # per process, not one request per pair of overlapping scrapes — and a scrape that
+        # arrives while a slow read is running waits for it, so /metrics can take up to two
+        # timeouts to answer. Deduplicating instead would mean serving one scrape a sample
+        # fetched for another, which is a worse trade for a 60s scrape interval.
         self._lock = threading.Lock()
 
     def collect(self) -> Iterable:

--- a/exporter/src/technocore_exporter/collector.py
+++ b/exporter/src/technocore_exporter/collector.py
@@ -1,0 +1,293 @@
+"""Map the `/stats` digest onto Prometheus metric families.
+
+Scope is deliberately narrow: only what `store.service_stats` returns. Three things the
+digest carries are left out on purpose, and each omission is a decision rather than an
+oversight — see OMITTED below.
+
+Naming follows the Prometheus conventions: gauges carry no `_total`, counters do (the
+client library appends it), and every byte figure is named `_bytes` because base units
+are the convention rather than a preference.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Iterable
+
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
+from prometheus_client.registry import Collector
+
+from .fetch import DEFAULT_TIMEOUT, StatsUnavailableError, fetch_stats
+
+log = logging.getLogger("technocore_exporter")
+
+# The service's own counter names, mapped to (metric, help). `reaped_idle` and
+# `reaped_stillborn` are folded into one family with a `reason` label, which is the only
+# label in the whole exporter whose values come from the service rather than a constant —
+# and it is bounded to exactly these two, because store.COUNTER_KEYS is a fixed tuple.
+_REAP_REASONS = {"reaped_idle": "idle", "reaped_stillborn": "stillborn"}
+
+_COUNTERS = {
+    "messages": ("technocore_messages", "Messages appended to any room, lifetime."),
+    "rooms_created": ("technocore_rooms_created", "Rooms created, lifetime."),
+    "notes_written": ("technocore_notes_written", "Note writes, lifetime."),
+    "topics_written": ("technocore_topics_written", "Room topic writes, lifetime."),
+}
+
+# What this exporter will not publish, and why. Kept as code-adjacent prose because the
+# absences are the part a reviewer has to check.
+#
+# OMITTED: `requests`   — per *worker*, not per service. `_requests` is a plain module
+#          dict, so under `--workers N` the digest reports roughly one worker's share
+#          (src/app.py:1914 records it under-reporting by 3x once production moved to
+#          `--workers 3`). Consecutive scrapes of a load-balanced URL can land on
+#          different processes, so no arrangement of these samples is a monotonic
+#          counter. Multiplying by `workers` is an estimate, not counter aggregation.
+# OMITTED: `history`    — the stored samples. Prometheus stores the samples it scrapes;
+#          re-exporting a ring as timestamp-labelled series would double-store it and
+#          produce a second, disagreeing history. Only the newest sample's timestamp is
+#          used, and only as a freshness gauge.
+# OMITTED: `engagement` — pooled over the 50 most recently active rooms, so it is a
+#          bounded-window sample rather than a service total. Publishing it beside real
+#          totals invites an alert on a number that does not mean what its neighbours
+#          mean.
+
+
+def _rooms(rooms: dict) -> Iterable:
+    """Room occupancy.
+
+    The split between a label and separate metric names is the whole point of this
+    function. `listed`/`unlisted` genuinely partition the room population, so they are
+    label values on one metric and `sum by () (technocore_rooms_listing)` is correct.
+    The class markers do not partition anything: `room_classes` composes by prefix, so
+    `mb-p-x` is both a mailbox and unlisted (its docstring: `mb-p-x -> {mb, p}`), and a
+    room can carry several markers at once. Summing those would double-count, so they
+    are separate metric names — a shape in which nobody is tempted to add them up.
+    """
+    total = rooms.get("total", 0)
+    yield GaugeMetricFamily(
+        "technocore_rooms",
+        "Rooms that exist, including unlisted ones. This is the figure the room cap bounds.",
+        value=total,
+    )
+    yield GaugeMetricFamily(
+        "technocore_rooms_capacity",
+        "Maximum rooms this deployment will hold (store.MAX_ROOMS).",
+        value=rooms.get("capacity", 0),
+    )
+    listing = GaugeMetricFamily(
+        "technocore_rooms_listing",
+        "Rooms by whether GET /rooms enumerates them. A true partition: these sum to technocore_rooms.",
+        labels=["state"],
+    )
+    for state in ("listed", "unlisted"):
+        listing.add_metric([state], rooms.get(state, 0))
+    yield listing
+    classes = GaugeMetricFamily(
+        "technocore_rooms_class",
+        "Rooms carrying each class marker. These OVERLAP and must never be summed: a name "
+        "composes markers by prefix, so mb-p-x counts under mailbox and is also unlisted.",
+        labels=["class"],
+    )
+    for name in ("mailbox", "ownable", "ephemeral"):
+        classes.add_metric([name], rooms.get(name, 0))
+    yield classes
+    yield GaugeMetricFamily(
+        "technocore_rooms_unclassified",
+        "Rooms carrying no class marker at all. Not the complement of technocore_rooms_class, "
+        "because those overlap.",
+        value=rooms.get("open", 0),
+    )
+
+
+def _capacity(payload: dict) -> Iterable:
+    """Byte and note gauges — the pressure an operator actually alerts on."""
+    size = payload.get("bytes", {})
+    notes = payload.get("notes", {})
+    yield GaugeMetricFamily(
+        "technocore_room_bytes",
+        "Bytes held by room files.",
+        value=size.get("rooms", 0),
+    )
+    yield GaugeMetricFamily(
+        "technocore_room_bytes_capacity",
+        "Byte budget rooms are held to (store.MAX_TOTAL_ROOM_BYTES). The enforced bound, "
+        "not MAX_ROOMS * MAX_ROOM_BYTES.",
+        value=size.get("rooms_capacity", 0),
+    )
+    yield GaugeMetricFamily(
+        "technocore_note_bytes",
+        "Bytes held by note files. Refreshed on create and otherwise at most one reap "
+        "interval stale, so it is a gauge to watch rather than a bound a write is refused against.",
+        value=size.get("notes", 0),
+    )
+    yield GaugeMetricFamily(
+        "technocore_notes", "Notes stored across every namespace.", value=notes.get("total", 0)
+    )
+    yield GaugeMetricFamily(
+        "technocore_notes_capacity",
+        "Maximum notes across all namespaces (store.MAX_NOTES_TOTAL).",
+        value=notes.get("capacity", 0),
+    )
+    yield GaugeMetricFamily(
+        "technocore_notes_capacity_per_namespace",
+        "Maximum notes in any one namespace (store.MAX_NOTES_PER_NS). A namespace can hit "
+        "this while technocore_notes is far from its own cap.",
+        value=notes.get("capacity_per_namespace", 0),
+    )
+
+
+def _counters(counters: dict) -> Iterable:
+    """The six lifetime counters (store.COUNTER_KEYS).
+
+    Best effort on both axes, and the HELP text says so because an operator who does not
+    know it will read a flat line as an outage. They lag: message bumps are batched per
+    worker and flushed on an interval or at shutdown, so a hard kill loses the tail. They
+    can also reset: the file is rebuilt as zeros if it is lost, which Prometheus reads as
+    a counter reset and handles, but which makes `increase()` over that window an
+    undercount rather than a gap.
+    """
+    lag = " Best effort: batched per worker, so it lags, and resets to zero if the counter file is lost."
+    for key, (name, help_text) in _COUNTERS.items():
+        yield CounterMetricFamily(name, help_text + lag, value=counters.get(key, 0))
+    reaped = CounterMetricFamily(
+        "technocore_rooms_reaped",
+        "Rooms removed by the reaper, by reason." + lag,
+        labels=["reason"],
+    )
+    for key, reason in _REAP_REASONS.items():
+        reaped.add_metric([reason], counters.get(key, 0))
+    yield reaped
+
+
+class TechnocoreCollector(Collector):
+    """Scrapes /stats once per Prometheus scrape and maps it.
+
+    The service caches that digest for CHAT_STATS_CACHE_SECONDS (60 by default) because
+    building it is an O(cap) walk. Scraping faster than the cache therefore buys no
+    freshness at all — it only spends requests — which is why the shipped scrape config
+    sets 60s and why `technocore_stats_sample_age_seconds` is exported: it lets an
+    operator see the staleness rather than assume it away.
+    """
+
+    def __init__(self, url: str, token: str, timeout: float = DEFAULT_TIMEOUT) -> None:
+        self._url = url
+        self._token = token
+        self._timeout = timeout
+        self._scrapes = {"success": 0, "error": 0}
+        self._last_success = 0.0
+        # `start_http_server` runs a ThreadingWSGIServer, so two overlapping scrapes call
+        # collect() on this one instance concurrently. Without the lock the counter bumps
+        # below are an unguarded read-modify-write and one is silently lost — the same
+        # shape as the `_buckets` race in core's limiter. It also stops two scrapes from
+        # each opening their own origin request, which is the more expensive half.
+        self._lock = threading.Lock()
+
+    def collect(self) -> Iterable:
+        """Yield the page. Never raises — see _gather."""
+        yield from self._gather()
+
+    def _gather(self) -> list:
+        """Build every family for one scrape, or the failure telemetry alone.
+
+        A list rather than a generator, and this is the point rather than a style choice.
+        `collect()` being a generator meant the try/except below only ever guarded the
+        fetch: the mapping ran after the block, on the consumer's iteration, so any error
+        in it escaped and the client library answered /metrics with a 500. Building the
+        families inside the guard is what makes "no failure escapes" true of the mapping
+        as well as the transport.
+        """
+        with self._lock:
+            started = time.monotonic()
+            try:
+                payload = fetch_stats(self._url, self._token, self._timeout)
+                families = [
+                    *_rooms(payload.get("rooms", {})),
+                    *_capacity(payload),
+                    *_counters(payload.get("counters", {})),
+                    *self._sample_age(payload),
+                ]
+            except StatsUnavailableError:
+                # No re-raise and no detail in a metric: a failed scrape is reported as
+                # success=0 and an error count, and the reason goes to the log. Encoding
+                # it as a label value would let the origin's failure mode drive the labels.
+                self._scrapes["error"] += 1
+                return list(self._self_metrics(time.monotonic() - started, ok=False))
+            except Exception:
+                # Deliberately broad, and the narrow handlers in fetch.py are still the
+                # real answer. This is the structural one: a scrape that receives a 500
+                # learns nothing, not even that the exporter is alive. Two transport
+                # families have already escaped a narrow handler here (a bare socket
+                # timeout, and http.client.HTTPException), so the assumption that any such
+                # list is complete has been wrong twice.
+                log.exception("unexpected error reading %s", self._url)
+                self._scrapes["error"] += 1
+                return list(self._self_metrics(time.monotonic() - started, ok=False))
+            self._scrapes["success"] += 1
+            self._last_success = time.time()
+            return families + list(self._self_metrics(time.monotonic() - started, ok=True))
+
+    def _sample_age(self, payload: dict) -> Iterable:
+        """Age of the newest stored sample.
+
+        This is the only thing taken from `history`, and it is not the age of the figures
+        above: those come from a cache at most CHAT_STATS_CACHE_SECONDS old, while the
+        stored samples are written at most every SNAPSHOT_EVERY (300s) and kept for
+        SNAPSHOT_KEEP_SECONDS (30h). It is named for the sample rather than for the scrape
+        because of that gap.
+
+        Do not alert on it. Sampling is driven by writes, not by a timer, so a service
+        nobody is writing to has an unboundedly old newest sample while being perfectly
+        healthy — measured at 300.6s on an idle probe instance moments after the last
+        write. `technocore_exporter_scrape_success` is the availability signal; this is
+        context for reading the history, and a floor under how stale a `history`-derived
+        number can be.
+        """
+        history = payload.get("history")
+        if not isinstance(history, list) or not history:
+            return
+        newest = history[-1]
+        stamp = newest.get("t") if isinstance(newest, dict) else None
+        if not isinstance(stamp, (int, float)) or isinstance(stamp, bool):
+            return
+        yield GaugeMetricFamily(
+            "technocore_stats_sample_age_seconds",
+            "Age of the newest stored aggregate sample. Samples are written by writes, at "
+            "most one per 300s — so this grows without bound on an idle service and is NOT "
+            "an availability signal. Not the age of the gauges above, which come from a "
+            "separate 60s cache.",
+            value=max(0.0, time.time() - float(stamp)),
+        )
+
+    def _self_metrics(self, duration: float, ok: bool) -> Iterable:
+        """Whether the exporter itself is working — the first thing to alert on.
+
+        Without these, a broken token is indistinguishable from a service with no rooms:
+        both render as an absence of samples, and `absent()` alerts are the ones people
+        forget to write.
+        """
+        yield GaugeMetricFamily(
+            "technocore_exporter_scrape_success",
+            "1 if the most recent /stats read succeeded, 0 otherwise.",
+            value=1 if ok else 0,
+        )
+        yield GaugeMetricFamily(
+            "technocore_exporter_scrape_duration_seconds",
+            "Wall time of the most recent /stats read.",
+            value=duration,
+        )
+        yield GaugeMetricFamily(
+            "technocore_exporter_last_success_timestamp_seconds",
+            "Unix time of the last successful /stats read; 0 if there has not been one.",
+            value=self._last_success,
+        )
+        scrapes = CounterMetricFamily(
+            "technocore_exporter_scrapes",
+            "/stats reads attempted by this exporter process, by outcome.",
+            labels=["outcome"],
+        )
+        for outcome in ("success", "error"):
+            scrapes.add_metric([outcome], self._scrapes[outcome])
+        yield scrapes

--- a/exporter/src/technocore_exporter/collector.py
+++ b/exporter/src/technocore_exporter/collector.py
@@ -193,17 +193,29 @@ class TechnocoreCollector(Collector):
         self._scrapes = {"success": 0, "error": 0}
         self._last_success = 0.0
         # `start_http_server` runs a ThreadingWSGIServer, so two overlapping scrapes call
-        # collect() on this one instance concurrently. Without the lock the counter bumps
-        # below are an unguarded read-modify-write and one is silently lost — the same
-        # shape as the `_buckets` race in core's limiter.
+        # collect() on this one instance concurrently.
         #
-        # It serialises; it does not coalesce. The second scrape still makes its own origin
-        # request once it holds the lock, so the guarantee is at most one request in flight
-        # per process, not one request per pair of overlapping scrapes — and a scrape that
-        # arrives while a slow read is running waits for it, so /metrics can take up to two
-        # timeouts to answer. Deduplicating instead would mean serving one scrape a sample
-        # fetched for another, which is a worse trade for a 60s scrape interval.
-        self._lock = threading.Lock()
+        # Two locks, because they are held for wildly different lengths of time. `_fetching`
+        # spans a whole origin read and is acquired with a bound; `_state` guards the
+        # counter bumps and is held for a few instructions. Folding them into one made the
+        # failure path — which has to bump a counter precisely when it could not get the
+        # fetch lock — unable to do so safely.
+        #
+        # `_fetching` serialises; it does not coalesce. The second scrape still makes its
+        # own origin request once it holds the lock, so the guarantee is at most one request
+        # in flight per process, not one request per pair of overlapping scrapes.
+        # Deduplicating instead would mean serving one scrape a sample fetched for another,
+        # which is a worse trade at a 60s scrape interval.
+        #
+        # What it must never do is push a scrape past the budget. Waiting here is time the
+        # source timeout does not see, so an unbounded wait plus a full fetch took a second
+        # scrape to ~2x the timeout — past Prometheus's scrape_timeout, which then stores
+        # neither samples nor the failure telemetry the wait produced (reported by
+        # @Minh3132 and @yukkie3276). `_gather` bounds the wait and the fetch against one
+        # deadline instead, so a queued scrape reports failure inside the budget rather than
+        # succeeding after nobody is listening.
+        self._fetching = threading.Lock()
+        self._state = threading.Lock()
 
     def collect(self) -> Iterable:
         """Yield the page. Never raises — see _gather."""
@@ -218,36 +230,68 @@ class TechnocoreCollector(Collector):
         in it escaped and the client library answered /metrics with a 500. Building the
         families inside the guard is what makes "no failure escapes" true of the mapping
         as well as the transport.
+
+        One deadline covers everything after `started`, waiting for the fetch lock
+        included. That is what makes the ceiling in server.py an actual bound: whatever
+        else happens, this returns within the configured source timeout, so the failure it
+        reports arrives while Prometheus is still listening for it.
         """
-        with self._lock:
-            started = time.monotonic()
-            try:
-                payload = fetch_stats(self._url, self._token, self._timeout)
-                families = [
-                    *_rooms(payload.get("rooms", {})),
-                    *_capacity(payload),
-                    *_counters(payload.get("counters", {})),
-                    *self._sample_age(payload),
-                ]
-            except StatsUnavailableError:
-                # No re-raise and no detail in a metric: a failed scrape is reported as
-                # success=0 and an error count, and the reason goes to the log. Encoding
-                # it as a label value would let the origin's failure mode drive the labels.
-                self._scrapes["error"] += 1
-                return list(self._self_metrics(time.monotonic() - started, ok=False))
-            except Exception:
-                # Deliberately broad, and the narrow handlers in fetch.py are still the
-                # real answer. This is the structural one: a scrape that receives a 500
-                # learns nothing, not even that the exporter is alive. Two transport
-                # families have already escaped a narrow handler here (a bare socket
-                # timeout, and http.client.HTTPException), so the assumption that any such
-                # list is complete has been wrong twice.
-                log.exception("unexpected error reading %s", self._url)
-                self._scrapes["error"] += 1
-                return list(self._self_metrics(time.monotonic() - started, ok=False))
+        started = time.monotonic()
+        deadline = started + self._timeout
+        if not self._fetching.acquire(timeout=self._timeout):
+            # Queued behind a scrape that used the whole budget. Reported as a failure
+            # rather than waited out: past here there is no time left to read the origin
+            # in, and an answer after the scrape timeout is worth less than a fast 0.
+            return self._failed(started, "timed out waiting for the in-flight scrape")
+        try:
+            # Clamped rather than checked for exhaustion: a scrape that wins the lock with
+            # nothing left gets a zero timeout, which is a non-blocking socket, which fails
+            # immediately and is published as scrape_success 0 inside the budget — the same
+            # answer an explicit branch here would produce, without a branch that only the
+            # clock can reach and no test can honestly cover.
+            remaining = max(0.0, deadline - time.monotonic())
+            payload = fetch_stats(self._url, self._token, remaining)
+            families = [
+                *_rooms(payload.get("rooms", {})),
+                *_capacity(payload),
+                *_counters(payload.get("counters", {})),
+                *self._sample_age(payload),
+            ]
+        except StatsUnavailableError as exc:
+            # No re-raise and no detail in a metric: a failed scrape is reported as
+            # success=0 and an error count, and the reason goes to the log. Encoding
+            # it as a label value would let the origin's failure mode drive the labels.
+            return self._failed(started, str(exc))
+        except Exception:
+            # Deliberately broad, and the narrow handlers in fetch.py are still the
+            # real answer. This is the structural one: a scrape that receives a 500
+            # learns nothing, not even that the exporter is alive. Three transport
+            # families have now escaped a narrow handler here (a bare socket timeout,
+            # http.client.HTTPException, and ConnectionResetError mid-body), so the
+            # assumption that any such list is complete has been wrong three times.
+            log.exception("unexpected error reading %s", self._url)
+            return self._failed(started, None)
+        finally:
+            self._fetching.release()
+        with self._state:
             self._scrapes["success"] += 1
             self._last_success = time.time()
-            return families + list(self._self_metrics(time.monotonic() - started, ok=True))
+        return families + list(self._self_metrics(time.monotonic() - started, ok=True))
+
+    def _failed(self, started: float, reason: str | None) -> list:
+        """Failure telemetry alone, and the count that goes with it.
+
+        `started` is taken before the fetch lock, so the duration published here includes
+        any time spent queued. That is deliberate: the queueing is what pushed a scrape
+        past the budget, and a duration measured from the moment the lock was won reported
+        9.01s for a scrape that took 17.82s — the one metric that would have shown the
+        problem was the one metric blind to it.
+        """
+        if reason:
+            log.warning("scrape of %s failed: %s", self._url, reason)
+        with self._state:
+            self._scrapes["error"] += 1
+        return list(self._self_metrics(time.monotonic() - started, ok=False))
 
     def _sample_age(self, payload: dict) -> Iterable:
         """Age of the newest stored sample.
@@ -287,7 +331,14 @@ class TechnocoreCollector(Collector):
         Without these, a broken token is indistinguishable from a service with no rooms:
         both render as an absence of samples, and `absent()` alerts are the ones people
         forget to write.
+
+        The counters are snapshotted under `_state` rather than read field by field while
+        yielding: this runs outside the fetch lock now, so another scrape can bump them
+        between two of the families below and publish a page that disagrees with itself.
         """
+        with self._state:
+            last_success = self._last_success
+            counts = dict(self._scrapes)
         yield GaugeMetricFamily(
             "technocore_exporter_scrape_success",
             "1 if the most recent /stats read succeeded, 0 otherwise.",
@@ -295,13 +346,14 @@ class TechnocoreCollector(Collector):
         )
         yield GaugeMetricFamily(
             "technocore_exporter_scrape_duration_seconds",
-            "Wall time of the most recent /stats read.",
+            "Wall time of the most recent /stats read, including any time queued behind "
+            "another scrape. Bounded by TECHNOCORE_STATS_TIMEOUT.",
             value=duration,
         )
         yield GaugeMetricFamily(
             "technocore_exporter_last_success_timestamp_seconds",
             "Unix time of the last successful /stats read; 0 if there has not been one.",
-            value=self._last_success,
+            value=last_success,
         )
         scrapes = CounterMetricFamily(
             "technocore_exporter_scrapes",
@@ -309,5 +361,5 @@ class TechnocoreCollector(Collector):
             labels=["outcome"],
         )
         for outcome in ("success", "error"):
-            scrapes.add_metric([outcome], self._scrapes[outcome])
+            scrapes.add_metric([outcome], counts[outcome])
         yield scrapes

--- a/exporter/src/technocore_exporter/fetch.py
+++ b/exporter/src/technocore_exporter/fetch.py
@@ -27,10 +27,12 @@ import urllib.request
 # scrape with telemetry rather than as a scrape timeout with no samples at all — the
 # second says nothing about which side is unwell.
 #
-# This is a budget for the whole call, not a socket option. `urlopen(timeout=)` bounds each
-# individual socket operation, so an origin that trickles a byte at a time never trips it:
-# measured at 20.01s for one fetch on this default, with no concurrency at all. The
-# deadline in `_read_within` is what makes the figure above mean what this comment says.
+# This is a budget for the whole scrape, not a socket option. `urlopen(timeout=)` bounds
+# each individual socket operation, so an origin that trickles a byte at a time never trips
+# it: measured at 20.01s for one fetch on this default, with no concurrency at all. The
+# deadline in `_read_within` bounds the body against that, and
+# `TechnocoreCollector._fetch_within` bounds the phases this file cannot see — resolution,
+# connect, and the header read. It takes both for the figure above to mean what it says.
 DEFAULT_TIMEOUT = 5.0
 
 # One `recv` worth of body per iteration of the read loop. `read1` is deliberate: `read`
@@ -193,10 +195,15 @@ def _read_within(response, deadline: float, limit: int) -> bytes:
 def fetch_stats(url: str, token: str, timeout: float = DEFAULT_TIMEOUT) -> dict:
     """Read and validate the JSON digest. Raises StatsUnavailableError for anything else.
 
-    `timeout` is the budget for this whole call — connect, headers and body together —
-    rather than the per-socket-operation timeout `urlopen` understands by itself. The
-    collector's guarantee that a slow origin reports `scrape_success 0` before Prometheus
-    abandons the scrape is only true if this returns within it.
+    `timeout` bounds the body read as a whole — see `_read_within` — rather than as the
+    per-socket-operation timeout `urlopen` understands by itself. It does NOT bound the
+    phases before that: `getaddrinfo` runs before there is a socket to apply it to, connect
+    spends it again on every address a name resolved to, and `http.client` reads the status
+    line and headers under it per operation, so a trickle of header bytes never trips it.
+    Those are bounded a level up, by `TechnocoreCollector._fetch_within`, which stops
+    waiting at the deadline whatever the transport is doing. The collector's guarantee that
+    a slow origin reports `scrape_success 0` before Prometheus abandons the scrape rests on
+    that, not on this.
 
     The token rides in `X-Stats-Token`, never in the URL: a query parameter would land in
     the proxy logs and in the exporter's own error text, and the service does not accept
@@ -246,6 +253,13 @@ def fetch_stats(url: str, token: str, timeout: float = DEFAULT_TIMEOUT) -> dict:
         # The handlers above still run first and still carry the better message; this one
         # only has to make sure nothing socket-shaped leaves as itself.
         raise StatsUnavailableError(f"transport error: {type(exc).__name__}") from None
+    except RecursionError:
+        # Not socket-shaped, so the OSError above does not reach it, and not a ValueError
+        # either: `json.loads` raises this on a deeply nested document, and 40KB of `[`
+        # is enough — two orders of magnitude under MAX_BODY_BYTES. It escaped as itself,
+        # which left the collector's broad handler to log it as an unexpected error with a
+        # traceback rather than as the named refusal every other bad body gets.
+        raise StatsUnavailableError("response nested too deeply to parse") from None
     except ValueError:
         raise StatsUnavailableError("response was not JSON") from None
     if not isinstance(payload, dict):

--- a/exporter/src/technocore_exporter/fetch.py
+++ b/exporter/src/technocore_exporter/fetch.py
@@ -1,0 +1,176 @@
+"""The one call this exporter makes: GET /stats with the operator's token.
+
+Kept separate from the collector so the mapping can be tested against a fixture with no
+socket, which is what makes the golden-output test in tests/exporter/test_collector.py
+exact.
+
+Two rules hold this file together, and both exist because the digest is behind a bearer
+token that is the whole gate on it:
+
+  * the token goes to the configured origin and nowhere else — see _NoRedirect for
+    redirects and _OPENER for ambient proxy configuration; and
+  * nothing raised by the transport escapes as itself. A scrape that fails must reach the
+    collector as StatsUnavailableError so it can be published as success 0. Anything that
+    escapes turns /metrics into a 500, which is the one answer a scrape must never get.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import math
+import urllib.error
+import urllib.request
+
+# Below Prometheus's common 10s scrape_timeout, so a slow origin surfaces as a failed
+# scrape with telemetry rather than as a scrape timeout with no samples at all — the
+# second says nothing about which side is unwell.
+DEFAULT_TIMEOUT = 5.0
+
+# A ceiling on what one scrape will read into memory. The digest is aggregates plus at most
+# 30h of five-minute samples — a few hundred KB at the very top end — so this is orders of
+# magnitude of headroom rather than a tight bound. It exists because `response.read()` with
+# no argument will read whatever the far side sends, and "the far side" is reachable by
+# anything that can occupy the configured address: a wedged origin, a captive portal, or a
+# proxy the operator did not intend. An exporter is monitoring, and monitoring that can be
+# made to exhaust memory takes the observability down with the thing it was watching.
+MAX_BODY_BYTES = 8 * 1024 * 1024
+
+# Fields the mapping reads. A digest missing any of them is refused rather than mapped:
+# absent is not zero, and a note-capacity alert that reads 0 because the field was missing
+# is worse than no sample, because it will never fire.
+REQUIRED = {
+    "rooms": ("total", "listed", "unlisted", "open", "mailbox", "ownable", "ephemeral", "capacity"),
+    "bytes": ("rooms", "notes", "rooms_capacity"),
+    "notes": ("total", "bytes", "capacity", "capacity_per_namespace"),
+    "counters": (
+        "messages",
+        "rooms_created",
+        "reaped_idle",
+        "reaped_stillborn",
+        "notes_written",
+        "topics_written",
+    ),
+}
+
+
+class StatsUnavailableError(Exception):
+    """The digest could not be read, or could not be trusted. Carries no response body.
+
+    The body is deliberately dropped rather than attached: /stats answers 404 with the
+    same bytes an unrouted path gets, so a body here would only ever be that constant or
+    a proxy's error page, and attaching it invites an operator to paste a page that came
+    back from somewhere other than the origin into a log or a ticket.
+    """
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse every redirect, so the token cannot follow one off the configured origin.
+
+    This is not belt-and-braces. `urllib.request.HTTPRedirectHandler.redirect_request`
+    copies every header except `content-length` and `content-type` onto the new request,
+    so a 302 from the configured URL to any host — a misconfiguration, a proxy, a
+    compromised hop — hands `X-Stats-Token` to that host, and `urlopen` follows it
+    silently. Returning None makes urlopen raise the 3xx as an HTTPError instead, which
+    the caller below reports as an unavailable source.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+# ProxyHandler({}) first, and it is not decoration: build_opener() installs a default
+# ProxyHandler that reads HTTP_PROXY/HTTPS_PROXY from the environment, so a process
+# started with either set would send this request — token included — to the proxy rather
+# than to the configured origin. An empty mapping disables that discovery entirely.
+#
+# Disabling rather than honouring it is the right default for a credential-bearing client
+# whose origin defaults to 127.0.0.1: proxying localhost is almost never intended, the
+# NO_PROXY exemption for it is a well-known footgun to get wrong, and the invariant this
+# module states is that the token reaches the configured origin and nowhere else. An
+# operator who genuinely needs an egress proxy needs an explicit, trusted setting for it,
+# not an ambient environment variable.
+_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}), _NoRedirect)
+
+
+def _number(value, where: str) -> float:
+    """A digest field as a metric value, or refuse the sample.
+
+    `bool` is checked before `int` because in Python `True` is an `int`, and a gauge that
+    silently reads 1.0 from a `true` is a wrong number rather than a missing one. NaN and
+    the infinities are refused for the same reason: they parse, they publish, and they
+    poison every rate and ratio computed downstream.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise StatsUnavailableError(f"{where} is not a number")
+    if not math.isfinite(value):
+        raise StatsUnavailableError(f"{where} is not finite")
+    if value < 0:
+        raise StatsUnavailableError(f"{where} is negative")
+    return float(value)
+
+
+def validate(payload: dict) -> dict:
+    """Refuse a structurally incomplete or untrustworthy digest.
+
+    Every field the mapping reads must be present and a finite non-negative number. The
+    alternative — mapping what is there and defaulting the rest to zero — publishes
+    `technocore_notes 0` beside `scrape_success 1`, which reads as a healthy empty service
+    and is indistinguishable from one.
+    """
+    for section, fields in REQUIRED.items():
+        block = payload.get(section)
+        if not isinstance(block, dict):
+            raise StatsUnavailableError(f"digest has no {section} object")
+        for field in fields:
+            if field not in block:
+                raise StatsUnavailableError(f"digest is missing {section}.{field}")
+            _number(block[field], f"{section}.{field}")
+    return payload
+
+
+def fetch_stats(url: str, token: str, timeout: float = DEFAULT_TIMEOUT) -> dict:
+    """Read and validate the JSON digest. Raises StatsUnavailableError for anything else.
+
+    The token rides in `X-Stats-Token`, never in the URL: a query parameter would land in
+    the proxy logs and in the exporter's own error text, and the service does not accept
+    it there anyway.
+    """
+    request = urllib.request.Request(url, headers={"X-Stats-Token": token})
+    try:
+        with _OPENER.open(request, timeout=timeout) as response:
+            if response.status != 200:
+                raise StatsUnavailableError(f"status {response.status}")
+            # One byte over the cap is enough to know it was exceeded, without reading
+            # the rest of whatever is being sent.
+            raw = response.read(MAX_BODY_BYTES + 1)
+            if len(raw) > MAX_BODY_BYTES:
+                raise StatsUnavailableError(f"response exceeded {MAX_BODY_BYTES} bytes")
+            payload = json.loads(raw)
+    except urllib.error.HTTPError as exc:
+        # 404 is what a wrong or unset token looks like — the endpoint reports itself
+        # missing rather than forbidden, so an operator debugging this needs the hint.
+        # A 3xx arrives here too, because _NoRedirect refuses to follow it.
+        if exc.code in (301, 302, 303, 307, 308):
+            raise StatsUnavailableError(
+                f"status {exc.code}: refusing to send the token to a redirect target"
+            ) from None
+        hint = " (wrong or unset CHAT_STATS_TOKEN?)" if exc.code == 404 else ""
+        raise StatsUnavailableError(f"status {exc.code}{hint}") from None
+    except urllib.error.URLError as exc:
+        raise StatsUnavailableError(f"unreachable: {exc.reason}") from None
+    except TimeoutError:
+        # Split from URLError deliberately: a bare socket timeout is *not* a URLError and
+        # has no `.reason`, so folding the two together raised AttributeError from inside
+        # this handler — escaping StatsUnavailableError entirely.
+        raise StatsUnavailableError(f"timed out after {timeout}s") from None
+    except http.client.HTTPException as exc:
+        # The sibling of the TimeoutError case above, and the same lesson: BadStatusLine,
+        # IncompleteRead and RemoteDisconnected are raised while parsing a response and
+        # are neither URLError nor TimeoutError, so without this they escape as themselves.
+        raise StatsUnavailableError(f"protocol error: {type(exc).__name__}") from None
+    except ValueError:
+        raise StatsUnavailableError("response was not JSON") from None
+    if not isinstance(payload, dict):
+        raise StatsUnavailableError("response was not a JSON object")
+    return validate(payload)

--- a/exporter/src/technocore_exporter/fetch.py
+++ b/exporter/src/technocore_exporter/fetch.py
@@ -36,9 +36,11 @@ DEFAULT_TIMEOUT = 5.0
 # made to exhaust memory takes the observability down with the thing it was watching.
 MAX_BODY_BYTES = 8 * 1024 * 1024
 
-# Fields the mapping reads. A digest missing any of them is refused rather than mapped:
-# absent is not zero, and a note-capacity alert that reads 0 because the field was missing
-# is worse than no sample, because it will never fire.
+# Every field the mapping reads, plus `notes.bytes`, which it does not: the digest carries
+# the same number twice (`bytes.notes` is `note_stats()["bytes"]`) and a digest that has
+# only one of them is not the shape this was written against. A digest missing any of these
+# is refused rather than mapped: absent is not zero, and a note-capacity alert that reads 0
+# because the field was missing is worse than no sample, because it will never fire.
 REQUIRED = {
     "rooms": ("total", "listed", "unlisted", "open", "mailbox", "ownable", "ephemeral", "capacity"),
     "bytes": ("rooms", "notes", "rooms_capacity"),

--- a/exporter/src/technocore_exporter/fetch.py
+++ b/exporter/src/technocore_exporter/fetch.py
@@ -19,13 +19,25 @@ from __future__ import annotations
 import http.client
 import json
 import math
+import time
 import urllib.error
 import urllib.request
 
 # Below Prometheus's common 10s scrape_timeout, so a slow origin surfaces as a failed
 # scrape with telemetry rather than as a scrape timeout with no samples at all — the
 # second says nothing about which side is unwell.
+#
+# This is a budget for the whole call, not a socket option. `urlopen(timeout=)` bounds each
+# individual socket operation, so an origin that trickles a byte at a time never trips it:
+# measured at 20.01s for one fetch on this default, with no concurrency at all. The
+# deadline in `_read_within` is what makes the figure above mean what this comment says.
 DEFAULT_TIMEOUT = 5.0
+
+# One `recv` worth of body per iteration of the read loop. `read1` is deliberate: `read`
+# blocks until it has the full count, which collapses the deadline check below into a
+# single unbounded wait, while `read1` returns whatever one socket read produced and hands
+# control back to the loop.
+CHUNK_BYTES = 64 * 1024
 
 # A ceiling on what one scrape will read into memory. The digest is aggregates plus at most
 # 30h of five-minute samples — a few hundred KB at the very top end — so this is orders of
@@ -131,24 +143,72 @@ def validate(payload: dict) -> dict:
     return payload
 
 
+def _rearm(response, remaining: float) -> None:
+    """Point the response's socket timeout at what is left of the budget.
+
+    Re-derived from the response every call rather than cached: `HTTPResponse.fp` is set to
+    None the moment the body is fully consumed, so a handle taken once raises AttributeError
+    on the last iteration of the loop below.
+
+    Best effort by design. The chain is private (`fp.raw._sock`), so if a future CPython
+    reshapes it this silently does nothing and the deadline check in `_read_within` still
+    bounds the read to one socket operation's overshoot — far better than the unbounded
+    read this replaces, and a great deal better than raising from inside the recovery path.
+    """
+    sock = getattr(getattr(getattr(response, "fp", None), "raw", None), "_sock", None)
+    if sock is not None:
+        sock.settimeout(max(0.0, remaining))
+
+
+def _read_within(response, deadline: float, limit: int) -> bytes:
+    """The body, or refuse — under a wall-clock deadline and a byte cap.
+
+    Two bounds, and they fail differently on purpose. The cap is about memory: an exporter
+    that can be made to exhaust it takes the observability down with the thing it was
+    watching. The deadline is about the scrape contract: `urlopen(timeout=)` bounds each
+    socket operation, not the call, so an origin sending one byte per second under the
+    timeout keeps this alive indefinitely while Prometheus gives up at `scrape_timeout` and
+    stores nothing — no samples, and no failure telemetry either, which is the one outcome
+    the exporter exists to prevent.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    while total <= limit:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise StatsUnavailableError("exceeded the scrape budget while reading")
+        _rearm(response, remaining)
+        # One byte over the cap is enough to know it was exceeded, without reading the
+        # rest of whatever is being sent.
+        chunk = response.read1(min(CHUNK_BYTES, limit + 1 - total))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+    if total > limit:
+        raise StatsUnavailableError(f"response exceeded {limit} bytes")
+    return b"".join(chunks)
+
+
 def fetch_stats(url: str, token: str, timeout: float = DEFAULT_TIMEOUT) -> dict:
     """Read and validate the JSON digest. Raises StatsUnavailableError for anything else.
+
+    `timeout` is the budget for this whole call — connect, headers and body together —
+    rather than the per-socket-operation timeout `urlopen` understands by itself. The
+    collector's guarantee that a slow origin reports `scrape_success 0` before Prometheus
+    abandons the scrape is only true if this returns within it.
 
     The token rides in `X-Stats-Token`, never in the URL: a query parameter would land in
     the proxy logs and in the exporter's own error text, and the service does not accept
     it there anyway.
     """
+    deadline = time.monotonic() + timeout
     request = urllib.request.Request(url, headers={"X-Stats-Token": token})
     try:
         with _OPENER.open(request, timeout=timeout) as response:
             if response.status != 200:
                 raise StatsUnavailableError(f"status {response.status}")
-            # One byte over the cap is enough to know it was exceeded, without reading
-            # the rest of whatever is being sent.
-            raw = response.read(MAX_BODY_BYTES + 1)
-            if len(raw) > MAX_BODY_BYTES:
-                raise StatsUnavailableError(f"response exceeded {MAX_BODY_BYTES} bytes")
-            payload = json.loads(raw)
+            payload = json.loads(_read_within(response, deadline, MAX_BODY_BYTES))
     except urllib.error.HTTPError as exc:
         # 404 is what a wrong or unset token looks like — the endpoint reports itself
         # missing rather than forbidden, so an operator debugging this needs the hint.
@@ -165,12 +225,27 @@ def fetch_stats(url: str, token: str, timeout: float = DEFAULT_TIMEOUT) -> dict:
         # Split from URLError deliberately: a bare socket timeout is *not* a URLError and
         # has no `.reason`, so folding the two together raised AttributeError from inside
         # this handler — escaping StatsUnavailableError entirely.
-        raise StatsUnavailableError(f"timed out after {timeout}s") from None
+        # Formatted, because `timeout` is no longer the configured figure: the collector
+        # passes what is left of the budget after any queueing, so an unformatted float
+        # put `timed out after 8.99998889499966s` in the operator's log.
+        raise StatsUnavailableError(f"timed out after {timeout:.2f}s") from None
     except http.client.HTTPException as exc:
         # The sibling of the TimeoutError case above, and the same lesson: BadStatusLine,
         # IncompleteRead and RemoteDisconnected are raised while parsing a response and
         # are neither URLError nor TimeoutError, so without this they escape as themselves.
         raise StatsUnavailableError(f"protocol error: {type(exc).__name__}") from None
+    except OSError as exc:
+        # Last, and it is the point rather than a fourth guess. The three handlers above
+        # were each added after a specific class escaped as itself, and a third did anyway:
+        # `urllib` wraps what is raised while *opening* into URLError, but a socket that
+        # fails mid-body — ConnectionResetError on an RST — is raised raw, is not a
+        # URLError, not a TimeoutError and not an HTTPException.
+        #
+        # URLError and TimeoutError are both OSError subclasses, so this catches whatever
+        # the next one turns out to be without anyone having to have thought of it first.
+        # The handlers above still run first and still carry the better message; this one
+        # only has to make sure nothing socket-shaped leaves as itself.
+        raise StatsUnavailableError(f"transport error: {type(exc).__name__}") from None
     except ValueError:
         raise StatsUnavailableError("response was not JSON") from None
     if not isinstance(payload, dict):

--- a/exporter/src/technocore_exporter/server.py
+++ b/exporter/src/technocore_exporter/server.py
@@ -18,7 +18,7 @@ import time
 import urllib.parse
 from typing import NamedTuple
 
-from prometheus_client import REGISTRY, start_http_server
+from prometheus_client import CollectorRegistry, start_http_server
 
 from .collector import TechnocoreCollector
 from .fetch import DEFAULT_TIMEOUT
@@ -137,11 +137,35 @@ def settings(env: dict[str, str] | None = None) -> Settings:
     )
 
 
-def build(config: Settings, registry=REGISTRY) -> TechnocoreCollector:
-    """Register the collector. Separate from main() so a test can assert what was wired."""
+def build(config: Settings, registry: CollectorRegistry) -> TechnocoreCollector:
+    """Register the collector. Separate from main() so a test can assert what was wired.
+
+    `registry` has no default on purpose. It used to default to the client library's global
+    `REGISTRY`, which is not empty: importing `prometheus_client` pre-registers the process,
+    platform and GC collectors, so whatever this exporter served carried `python_info`,
+    `process_resident_memory_bytes`, `process_cpu_seconds`, `process_open_fds` and the GC
+    families beside ours (reported by @Minh3132). A default that quietly widens an
+    unauthenticated endpoint is the wrong default, so there is none.
+    """
     collector = TechnocoreCollector(config.url, config.token, config.timeout)
     registry.register(collector)
     return collector
+
+
+def build_registry(config: Settings) -> CollectorRegistry:
+    """The registry `/metrics` serves: this exporter's families and nothing else.
+
+    This is the call `main()` makes, so the boundary is decided in one testable place rather
+    than in the serve loop. Two claims depend on it and both are checkable from here: the
+    first-wave scope is what `store.service_stats` returns plus exporter self-metrics, and
+    the README tells operators that the ungated `/metrics` page carries the same numbers as
+    the token-gated digest. A process/runtime surface arriving from the library's global
+    default would contradict both, and would change with an upstream release rather than
+    with a change here.
+    """
+    registry = CollectorRegistry()
+    build(config, registry)
+    return registry
 
 
 def describe(config: Settings) -> str:
@@ -153,11 +177,14 @@ def describe(config: Settings) -> str:
     return f"serving /metrics on {config.host}:{config.port}, reading {config.url}"
 
 
-def main() -> None:  # pragma: no cover - the serve loop; its parts are tested above
+# no cover: the `while True` never completes, so the line after it can never be reached.
+# main() itself is exercised by test_main_serves_the_registry_it_built, which stubs the
+# serve call and the sleep — the pragma is about the loop, not about the wiring above it.
+def main() -> None:  # pragma: no cover
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     config = settings()
-    build(config)
-    start_http_server(config.port, addr=config.host)
+    registry = build_registry(config)
+    start_http_server(config.port, addr=config.host, registry=registry)
     log.info("%s", describe(config))
     while True:
         time.sleep(3600)

--- a/exporter/src/technocore_exporter/server.py
+++ b/exporter/src/technocore_exporter/server.py
@@ -1,0 +1,163 @@
+"""Serve /metrics.
+
+`start_http_server` from the client library rather than a hand-rolled handler: it already
+answers with the right Content-Type, handles the OpenMetrics negotiation Prometheus does,
+and is the surface the library's own tests cover.
+
+Split into `settings()` / `build()` / `main()` so the configuration rules — which are where
+the security properties live — are testable without binding a socket or entering the
+serve loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import time
+import urllib.parse
+from typing import NamedTuple
+
+from prometheus_client import REGISTRY, start_http_server
+
+from .collector import TechnocoreCollector
+from .fetch import DEFAULT_TIMEOUT
+
+log = logging.getLogger("technocore_exporter")
+
+DEFAULT_URL = "http://127.0.0.1:8080/stats"
+DEFAULT_PORT = 9464
+DEFAULT_HOST = "127.0.0.1"
+
+
+class Settings(NamedTuple):
+    url: str
+    token: str
+    host: str
+    port: int
+    timeout: float
+
+
+# The scrape timeout this source timeout must stay under. Prometheus's own default, and
+# the figure the README's headroom argument is written against: a source timeout at or
+# above it cannot fail before the scrape does, so the failure lands as a scrape timeout
+# with no samples instead of as scrape_success 0 with telemetry.
+SCRAPE_TIMEOUT_CEILING = 10.0
+
+
+def _refuse(message: str):
+    return SystemExit(f"technocore-exporter: {message}")
+
+
+def _seconds(raw: str) -> float:
+    """A timeout from the environment, or refuse to start.
+
+    Same reasoning core states for `config._finite_env`: `int()` raises on junk and takes
+    the process down, which is the loudest way to report bad configuration, while
+    `float()` accepts `inf` and `nan` happily. Here the consequence is specific and worse
+    than a wrong number. A negative or NaN value raises ValueError from `socket.settimeout`
+    and `inf` raises OverflowError — on *every* scrape, not at boot — and `collect()` now
+    deliberately converts any unexpected exception into `scrape_success 0`. So a typo in
+    this knob would produce a process that starts, stays up, answers /metrics forever and
+    can never once succeed. Refusing at boot is the difference between a visible
+    misconfiguration and an exporter that looks alive and is not.
+    """
+    try:
+        value = float(raw)
+    except ValueError:
+        raise _refuse(f"TECHNOCORE_STATS_TIMEOUT must be a number, got {raw!r}") from None
+    if not math.isfinite(value):
+        raise _refuse(f"TECHNOCORE_STATS_TIMEOUT must be finite, got {raw!r}")
+    if value <= 0:
+        # 0 is refused too: socket.settimeout accepts it, but it means non-blocking, so
+        # every scrape fails instantly. Accepted-but-always-failing is the case this
+        # function exists to prevent.
+        raise _refuse(f"TECHNOCORE_STATS_TIMEOUT must be greater than 0, got {raw!r}")
+    if value >= SCRAPE_TIMEOUT_CEILING:
+        raise _refuse(
+            f"TECHNOCORE_STATS_TIMEOUT must be below {SCRAPE_TIMEOUT_CEILING}s so a slow "
+            f"origin reports a failed scrape rather than timing out the scrape, got {raw!r}"
+        )
+    return value
+
+
+def _port(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError:
+        raise _refuse(f"TECHNOCORE_EXPORTER_PORT must be an integer, got {raw!r}") from None
+    if not 1 <= value <= 65535:
+        raise _refuse(f"TECHNOCORE_EXPORTER_PORT must be 1-65535, got {raw!r}")
+    return value
+
+
+def _url(raw: str) -> str:
+    """Refuse a URL the fetch could only fail on, for the same reason as the timeout.
+
+    `urllib.request.Request` raises ValueError for an unknown scheme at *request* time,
+    which the broad catch in collect() would render as a permanently failing scrape.
+    """
+    parsed = urllib.parse.urlparse(raw)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise _refuse(f"TECHNOCORE_STATS_URL must be an http(s) URL, got {raw!r}")
+    if parsed.username or parsed.password:
+        # Refused rather than stripped, and the value is not echoed. `describe()` puts this
+        # URL in the startup log, so `http://user:secret@host/stats` would write a second
+        # credential to the very place the stats token is kept out of. /stats authenticates
+        # with X-Stats-Token and nothing else, so URL credentials could only ever be a
+        # mistake — and one worth naming rather than silently discarding.
+        raise _refuse("TECHNOCORE_STATS_URL must not embed credentials; use the token")
+    return raw
+
+
+def settings(env: dict[str, str] | None = None) -> Settings:
+    """Read configuration, refusing anything that could only fail later.
+
+    Every value here is checked at boot rather than at first use. The token comes from the
+    environment only: there is no `--token` flag on purpose, because an argv token is
+    readable from `ps` by every other user on the host, and this token is the whole gate on
+    the digest.
+
+    The host defaults to loopback for the other half of that: the digest is token-gated at
+    the origin, but /metrics is not gated at all and carries the same numbers.
+    """
+    source = os.environ if env is None else env
+    token = source.get("TECHNOCORE_STATS_TOKEN", "")
+    if not token:
+        raise _refuse(
+            "TECHNOCORE_STATS_TOKEN is not set. It must match the service's "
+            "CHAT_STATS_TOKEN; without it /stats answers 404."
+        )
+    return Settings(
+        url=_url(source.get("TECHNOCORE_STATS_URL", DEFAULT_URL)),
+        token=token,
+        host=source.get("TECHNOCORE_EXPORTER_HOST", DEFAULT_HOST),
+        port=_port(source.get("TECHNOCORE_EXPORTER_PORT", str(DEFAULT_PORT))),
+        timeout=_seconds(source.get("TECHNOCORE_STATS_TIMEOUT", str(DEFAULT_TIMEOUT))),
+    )
+
+
+def build(config: Settings, registry=REGISTRY) -> TechnocoreCollector:
+    """Register the collector. Separate from main() so a test can assert what was wired."""
+    collector = TechnocoreCollector(config.url, config.token, config.timeout)
+    registry.register(collector)
+    return collector
+
+
+def describe(config: Settings) -> str:
+    """The startup log line. Its own function because what it must NOT contain is a rule.
+
+    The URL is logged and the token never is, at any level — so this is asserted rather
+    than left to a reviewer noticing a future `%s` gaining an argument.
+    """
+    return f"serving /metrics on {config.host}:{config.port}, reading {config.url}"
+
+
+def main() -> None:  # pragma: no cover - the serve loop; its parts are tested above
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    config = settings()
+    build(config)
+    start_http_server(config.port, addr=config.host)
+    log.info("%s", describe(config))
+    while True:
+        time.sleep(3600)

--- a/exporter/src/technocore_exporter/server.py
+++ b/exporter/src/technocore_exporter/server.py
@@ -42,6 +42,13 @@ class Settings(NamedTuple):
 # the figure the README's headroom argument is written against: a source timeout at or
 # above it cannot fail before the scrape does, so the failure lands as a scrape timeout
 # with no samples instead of as scrape_success 0 with telemetry.
+#
+# This bounds the origin read, not one socket operation, and only because two other things
+# now hold: `_gather` spends one deadline on the lock wait and the fetch together, and
+# `_read_within` enforces it across a trickling body. Before those, this number bounded
+# nothing — against a trickling origin on the 5s default, one fetch took 20.01s and the
+# `GET /metrics` around it answered after 20.18s, reporting success — and the arithmetic
+# here was describing a guarantee the code did not make.
 SCRAPE_TIMEOUT_CEILING = 10.0
 
 
@@ -96,10 +103,24 @@ def _url(raw: str) -> str:
 
     `urllib.request.Request` raises ValueError for an unknown scheme at *request* time,
     which the broad catch in collect() would render as a permanently failing scrape.
+
+    Both the parse and the port are inside the guard, and each closed a hole of exactly the
+    kind this function exists to close. `urlparse` itself raises on a malformed IPv6 literal
+    (`http://[::1/stats`), so this took the process down with a traceback rather than the
+    stated refusal every other setting here gets. And a non-numeric or out-of-range port —
+    `http://127.0.0.1:notaport/stats` — parsed fine, booted fine, and then failed *every*
+    scrape with `protocol error: InvalidURL`: accepted at boot and permanently unable to
+    work, which is the one outcome validating configuration here is for.
     """
-    parsed = urllib.parse.urlparse(raw)
+    try:
+        parsed = urllib.parse.urlparse(raw)
+        port = parsed.port
+    except ValueError:
+        raise _refuse(f"TECHNOCORE_STATS_URL is not a usable URL, got {raw!r}") from None
     if parsed.scheme not in ("http", "https") or not parsed.netloc:
         raise _refuse(f"TECHNOCORE_STATS_URL must be an http(s) URL, got {raw!r}")
+    if port is not None and not 1 <= port <= 65535:
+        raise _refuse(f"TECHNOCORE_STATS_URL port must be 1-65535, got {raw!r}")
     if parsed.username or parsed.password:
         # Refused rather than stripped, and the value is not echoed. `describe()` puts this
         # URL in the startup log, so `http://user:secret@host/stats` would write a second
@@ -122,10 +143,23 @@ def settings(env: dict[str, str] | None = None) -> Settings:
     the origin, but /metrics is not gated at all and carries the same numbers.
     """
     source = os.environ if env is None else env
+    # Tested stripped, used raw. `TECHNOCORE_STATS_TOKEN=" "` is what a stray space in a
+    # unit file or a `.env` line looks like; it is truthy, so it booted, sent a space and
+    # took 404 from /stats forever — accepted at boot and permanently unable to work, the
+    # same shape as an unusable URL or timeout.
+    #
+    # The value itself is *not* stripped, deliberately. `config.STATS_TOKEN` in core reads
+    # CHAT_STATS_TOKEN without stripping and compares with `secrets.compare_digest`, so a
+    # token whose surrounding whitespace is real is a token this must send unchanged.
+    # Trimming here would turn one operator's working configuration into a silent 404.
     token = source.get("TECHNOCORE_STATS_TOKEN", "")
-    if not token:
+    if not token.strip():
+        # Two messages, because they send the operator to different places. "Is not set"
+        # is wrong for `TOKEN=" "` — the variable is set, and being told it is not sends
+        # someone to check the thing they can already see is there.
+        what = "is not set" if not token else "is only whitespace"
         raise _refuse(
-            "TECHNOCORE_STATS_TOKEN is not set. It must match the service's "
+            f"TECHNOCORE_STATS_TOKEN {what}. It must match the service's "
             "CHAT_STATS_TOKEN; without it /stats answers 404."
         )
     return Settings(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,12 @@ dev = [
     # the SDK has to be importable *here* for those tests to run — it is not a runtime
     # dependency of technocore-chat and must never become one.
     "mcp>=2.1,<3",
+    # Dev-only for the same reason and on the same terms: the exporter in exporter/
+    # declares this itself (exporter/pyproject.toml), and nothing in src/ imports or ships
+    # it. It is here so `ty` can check exporter/ and so its suite runs from a plain
+    # `uv sync --frozen`. Not a runtime dependency of technocore-chat, and must not become
+    # one — the exporter reads the published /stats over HTTP, never the store.
+    "prometheus-client>=0.20",
     # In `dev` rather than its own group since tests/test_contract.py — the generative half
     # of the input doctrine (docs/design.md §3.5) — runs inside pytest, so the ordinary
     # `uv sync --frozen` has to be enough to run the suite. Pinned exactly, not `>=` like
@@ -77,18 +83,18 @@ known-first-party = ["app", "didkey", "store"]
 [tool.ty.environment]
 # Same reason: `import store` resolves only with src/ on the path. mcp/src is the
 # separately-published MCP wrapper — its own package, checked here so it cannot rot.
-extra-paths = ["./src", "./mcp/src"]
+extra-paths = ["./src", "./mcp/src", "./exporter/src"]
 
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 # The single source of path bootstrap for the suite — src for import app/store/didkey,
 # tests for _client — so no test file needs its own sys.path.insert.
-pythonpath = ["src", "tests"]
+pythonpath = ["src", "tests", "exporter/src"]
 
 [tool.coverage.run]
 branch = true
-source = ["src", "mcp/src"]
+source = ["src", "mcp/src", "exporter/src"]
 
 [tool.coverage.report]
 # Combined statement + branch coverage. A branch-aware floor keeps a PR from improving the

--- a/tests/exporter/conftest.py
+++ b/tests/exporter/conftest.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+import pytest
+
+# No sys.path insert: [tool.pytest.ini_options] pythonpath carries exporter/src, the same
+# way it carries src/ for `import app`. This directory tests exporter/ the way tests/edge
+# tests edge/ — CI runs `pytest tests` with an explicit path, so a suite outside tests/
+# is silently never collected while its files still count against coverage.
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def stats() -> dict:
+    """A real `/stats` body, captured from a live service rather than written by hand.
+
+    See fixtures/README.md for the exact traffic behind it. The numbers matter: this
+    deployment holds a room that is both a mailbox and unlisted, and another that is
+    unlisted and nothing else, which is what makes the class counts genuinely fail to
+    partition rather than failing to partition only in principle.
+    """
+    return json.loads((FIXTURES / "stats.json").read_text())

--- a/tests/exporter/fixtures/README.md
+++ b/tests/exporter/fixtures/README.md
@@ -1,0 +1,30 @@
+# fixtures/stats.json
+
+Captured from a real service, not hand-written, so the mapping is tested against bytes the
+origin actually produced.
+
+Built on `20a4457` with `CHAT_STATS_CACHE_SECONDS=0` (the default 60s cache otherwise
+serves the empty digest taken before the writes landed — which is worth knowing, and is why
+`technocore_stats_sample_age_seconds` exists):
+
+```
+uv run uvicorn --app-dir src app:app --port 8099     # CHAT_STATS_TOKEN set
+GET /r/lobby/say/prober/<text>                x5     # an open room
+GET /r/d-probeownable/say/prober/...                 # ownable
+GET /r/e-probeeph/say/prober/...                     # ephemeral
+GET /r/p-probeprivate/say/prober/...                 # unlisted, no other marker
+GET /r/mb-p-probemailbox/say-signed/...              # mailbox AND unlisted (signed: mb- refuses unsigned)
+GET /kv/probe-ns/key-{one,two}/set/<value>           # notes
+GET /kv/topic/{lobby,e-probeeph}/set/<text>          # topic notes
+GET /stats                                           # captured here
+```
+
+`/r/events` is in the totals because the service creates it itself to announce room
+creations; that is real behaviour and belongs in the fixture.
+
+The two properties the tests lean on, from these exact numbers:
+
+- `listed 4 + unlisted 2 = 6 = total` — a real partition.
+- `open 2 + mailbox 1 + ownable 1 + ephemeral 1 = 5 != 6` — not a partition. The mailbox
+  room counts under both `mailbox` and `unlisted`, and `p-probeprivate` carries no class
+  marker that any of the four names, so the class counts fall short of the total.

--- a/tests/exporter/fixtures/stats.json
+++ b/tests/exporter/fixtures/stats.json
@@ -1,0 +1,102 @@
+{
+ "rooms": {
+  "total": 6,
+  "listed": 4,
+  "unlisted": 2,
+  "open": 2,
+  "mailbox": 1,
+  "ownable": 1,
+  "ephemeral": 1,
+  "capacity": 5120
+ },
+ "bytes": {
+  "rooms": 1200,
+  "notes": 63,
+  "rooms_capacity": 5368709120
+ },
+ "notes": {
+  "total": 4,
+  "bytes": 63,
+  "capacity": 163840,
+  "capacity_per_namespace": 5120
+ },
+ "counters": {
+  "messages": 9,
+  "rooms_created": 5,
+  "reaped_idle": 0,
+  "reaped_stillborn": 0,
+  "notes_written": 5,
+  "topics_written": 3
+ },
+ "engagement": {
+  "window_cap": 200,
+  "windowed_messages": 10,
+  "zero_response_share": 1.0,
+  "nick_diversity": 0.2
+ },
+ "history": [
+  {
+   "t": 1788977170,
+   "rooms": {
+    "total": 2,
+    "listed": 2,
+    "unlisted": 0,
+    "open": 2,
+    "mailbox": 0,
+    "ownable": 0,
+    "ephemeral": 0,
+    "capacity": 5120
+   },
+   "bytes": {
+    "rooms": 175,
+    "notes": 0,
+    "rooms_capacity": 5368709120
+   },
+   "notes": {
+    "total": 0,
+    "bytes": 0,
+    "capacity": 163840,
+    "capacity_per_namespace": 5120
+   },
+   "counters": {
+    "messages": 1,
+    "rooms_created": 1,
+    "reaped_idle": 0,
+    "reaped_stillborn": 0,
+    "notes_written": 0,
+    "topics_written": 0
+   },
+   "engagement": {
+    "window_cap": 200,
+    "windowed_messages": 2,
+    "zero_response_share": 1.0,
+    "nick_diversity": 1.0
+   }
+  }
+ ],
+ "requests": {
+  "read": 2,
+  "write": 5,
+  "rate_limited": 0,
+  "duplicate": 0,
+  "followed": 0,
+  "create": 1,
+  "uptime_seconds": 83,
+  "scope": "per_worker",
+  "workers": 1
+ },
+ "capacity_limits": {
+  "message_chars": 4096,
+  "note_chars": 8192,
+  "room_bytes": 10485760,
+  "read_per_min": 120,
+  "write_per_min": 30,
+  "new_rooms_per_day": 20,
+  "room_bytes_total": 5368709120
+ },
+ "client_identity": {
+  "client_ip_header": null,
+  "distinct_identities": 1,
+  "proxied_requests_ignored": 0
+ }
+}

--- a/tests/exporter/test_collector.py
+++ b/tests/exporter/test_collector.py
@@ -168,6 +168,19 @@ def test_the_reap_reason_label_carries_both_values(render, stats):
     assert stats["counters"]["reaped_idle"] == 0
 
 
+def test_the_reap_reasons_are_not_transposed(render, stats):
+    """The fixture has both reap counters at 0, so no other test can tell them apart.
+
+    With `reaped_idle == reaped_stillborn == 0`, swapping the two values in `_REAP_REASONS`
+    passes every other assertion in this file — including the one above, which checks both
+    samples are 0. The mapping direction is pinned here against distinct numbers instead.
+    """
+    counters = {**stats["counters"], "reaped_idle": 7, "reaped_stillborn": 3}
+    text = render(payload={**stats, "counters": counters})
+    assert _sample(text, "technocore_rooms_reaped_total", reason="idle") == 7
+    assert _sample(text, "technocore_rooms_reaped_total", reason="stillborn") == 3
+
+
 def test_the_real_values_are_carried_through(render, stats):
     """The mapping itself, against the captured digest."""
     text = render()
@@ -260,8 +273,9 @@ def test_overlapping_scrapes_are_serialised(stats, monkeypatch):
     threads to interleave on exactly that bytecode. Depth is deterministic: if any two
     bodies ever overlap, the maximum observed depth is 2 and the test fails every time.
 
-    Serialising is wanted for its own sake too. It stops two overlapping scrapes each
-    opening their own origin request, which is the more expensive half of the race.
+    Serialising is not deduplicating, and the last assertion below is what says so: eight
+    threads produce eight successful reads, one after another. The lock bounds how many
+    origin requests are in flight at once, not how many are made.
     """
     import technocore_exporter.collector as module
 

--- a/tests/exporter/test_collector.py
+++ b/tests/exporter/test_collector.py
@@ -1,0 +1,291 @@
+"""What the exporter publishes, and — more of the file than usual — what it does not.
+
+The omissions are the reviewable part of this package: an exporter that ships a misleading
+metric is worse than one that ships nothing, because an alert gets written against it.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+from prometheus_client import CollectorRegistry, generate_latest
+from prometheus_client.parser import text_string_to_metric_families
+from technocore_exporter.collector import TechnocoreCollector
+from technocore_exporter.fetch import StatsUnavailableError
+
+
+class _Collector(TechnocoreCollector):
+    """The collector with the network replaced by a value, or an exception."""
+
+    def __init__(self, payload=None, error=None):
+        super().__init__("http://origin.invalid/stats", "token")
+        self._payload = payload
+        self._error = error
+
+    def _read(self):
+        if self._error is not None:
+            raise self._error
+        return self._payload
+
+
+@pytest.fixture
+def render(stats, monkeypatch):
+    """Render the exposition page for a given digest, or for a failed read.
+
+    The module-level `fetch_stats` is what gets replaced, not a method on the collector, so
+    every test drives `collect()` by the same path production does.
+    """
+
+    def _render(payload=None, error=None):
+        collector = _Collector(payload if error is None else None, error)
+        monkeypatch.setattr(
+            "technocore_exporter.collector.fetch_stats",
+            lambda *a, **k: collector._read(),
+        )
+        registry = CollectorRegistry()
+        registry.register(collector)
+        return generate_latest(registry).decode()
+
+    return lambda payload=stats, error=None: _render(payload, error)
+
+
+def _families(text: str) -> dict:
+    return {f.name: f for f in text_string_to_metric_families(text)}
+
+
+def _sample(text: str, name: str, **labels) -> float:
+    for family in text_string_to_metric_families(text):
+        for s in family.samples:
+            if s.name == name and all(s.labels.get(k) == v for k, v in labels.items()):
+                return s.value
+    raise AssertionError(f"no sample {name}{labels or ''} in output")
+
+
+def test_the_output_is_valid_prometheus_exposition(render):
+    """A parser round-trip, not a string compare: this is the check promtool also makes."""
+    text = render()
+    families = _families(text)
+    assert families, "nothing parsed"
+    for family in families.values():
+        assert family.documentation, f"{family.name} has no HELP"
+        assert family.type in {"gauge", "counter", "unknown"}
+
+
+def test_the_listing_labels_partition_the_room_total(render, stats):
+    """listed + unlisted == total, on real numbers. Summing this label is correct."""
+    text = render()
+    listed = _sample(text, "technocore_rooms_listing", state="listed")
+    unlisted = _sample(text, "technocore_rooms_listing", state="unlisted")
+    total = _sample(text, "technocore_rooms")
+    assert listed == stats["rooms"]["listed"] == 4
+    assert unlisted == stats["rooms"]["unlisted"] == 2
+    assert listed + unlisted == total == 6
+
+
+def test_the_class_counts_do_not_partition_and_say_so(render, stats):
+    """The trap this exporter exists to not fall into.
+
+    The fixture holds a room that is both a mailbox and unlisted, and one that is unlisted
+    with no other marker — so the class counts fall short of the total, and a dashboard
+    that summed them would under-report occupancy while looking arithmetically tidy.
+    """
+    text = render()
+    classes = sum(
+        _sample(text, "technocore_rooms_class", **{"class": name})
+        for name in ("mailbox", "ownable", "ephemeral")
+    )
+    unclassified = _sample(text, "technocore_rooms_unclassified")
+    total = _sample(text, "technocore_rooms")
+    assert classes + unclassified == 5
+    assert total == 6
+    assert classes + unclassified < total, "fixture no longer exercises the overlap"
+    help_text = _families(text)["technocore_rooms_class"].documentation
+    assert "OVERLAP" in help_text and "never be summed" in help_text
+
+
+def test_every_label_value_is_from_a_fixed_set(render):
+    """No room name, namespace, DID, IP or URL may ever become a label value.
+
+    Asserted as an allowlist rather than a denylist: a denylist passes for whatever nobody
+    thought of, and the whole point is that this label set is closed.
+    """
+    allowed = {
+        "state": {"listed", "unlisted"},
+        "class": {"mailbox", "ownable", "ephemeral"},
+        "reason": {"idle", "stillborn"},
+        "outcome": {"success", "error"},
+    }
+    for family in text_string_to_metric_families(render()):
+        for s in family.samples:
+            for key, value in s.labels.items():
+                assert key in allowed, f"unexpected label {key!r} on {s.name}"
+                assert value in allowed[key], f"unexpected value {value!r} for {key}"
+
+
+def test_per_worker_request_counters_are_not_exported(render, stats):
+    """`requests` is per worker; consecutive scrapes of a load-balanced URL can land on
+    different processes, so no arrangement of those samples is a monotonic counter."""
+    assert "requests" in stats, "fixture should still carry the field being refused"
+    text = render()
+    for forbidden in ("technocore_requests", "technocore_read", "technocore_rate_limited"):
+        assert forbidden not in text
+    assert "uptime_seconds" not in text
+    assert "per_worker" not in text
+
+
+def test_history_is_not_republished_as_series(render, stats):
+    """Only the newest sample's timestamp is used, and only as freshness."""
+    assert stats["history"], "fixture should carry at least one stored sample"
+    text = render()
+    assert "technocore_history" not in text
+    assert _sample(text, "technocore_stats_sample_age_seconds") >= 0
+
+
+def test_engagement_is_not_exported(render, stats):
+    """A bounded-window sample, not a service total — it must not sit beside real ones."""
+    assert "engagement" in stats
+    text = render()
+    for forbidden in ("engagement", "zero_response", "nick_diversity", "windowed_messages"):
+        assert forbidden not in text
+
+
+def test_counters_are_counters_and_gauges_are_gauges(render):
+    """`_total` on counters and not on gauges is the convention promtool enforces."""
+    families = _families(render())
+    assert families["technocore_messages"].type == "counter"
+    assert families["technocore_rooms"].type == "gauge"
+    text = render()
+    assert "technocore_messages_total" in text
+    assert "technocore_rooms_total" not in text
+
+
+def test_the_reap_reason_label_carries_both_values(render, stats):
+    text = render()
+    assert _sample(text, "technocore_rooms_reaped_total", reason="idle") == 0
+    assert _sample(text, "technocore_rooms_reaped_total", reason="stillborn") == 0
+    assert stats["counters"]["reaped_idle"] == 0
+
+
+def test_the_real_values_are_carried_through(render, stats):
+    """The mapping itself, against the captured digest."""
+    text = render()
+    assert _sample(text, "technocore_messages_total") == stats["counters"]["messages"] == 9
+    assert _sample(text, "technocore_rooms_created_total") == 5
+    assert _sample(text, "technocore_notes_written_total") == 5
+    assert _sample(text, "technocore_topics_written_total") == 3
+    assert _sample(text, "technocore_room_bytes") == stats["bytes"]["rooms"] == 1200
+    assert _sample(text, "technocore_note_bytes") == 63
+    assert _sample(text, "technocore_notes") == 4
+    assert _sample(text, "technocore_notes_capacity") == 163840
+    assert _sample(text, "technocore_notes_capacity_per_namespace") == 5120
+    assert _sample(text, "technocore_rooms_capacity") == 5120
+    assert _sample(text, "technocore_room_bytes_capacity") == 5368709120
+
+
+def test_counter_help_states_the_lag_and_reset_behaviour(render):
+    """An operator who does not know these are batched reads a flat line as an outage."""
+    doc = _families(render())["technocore_messages"].documentation
+    assert "Best effort" in doc and "lags" in doc and "resets to zero" in doc
+
+
+def test_a_failed_scrape_reports_zero_and_still_serves_self_metrics(render):
+    """The failure mode that must not look like an empty service.
+
+    Without these, a wrong token and a service with no rooms are the same absence of
+    samples — and `absent()` alerts are the ones people forget to write.
+    """
+    text = render(error=StatsUnavailableError("status 404 (wrong or unset CHAT_STATS_TOKEN?)"))
+    assert _sample(text, "technocore_exporter_scrape_success") == 0
+    assert _sample(text, "technocore_exporter_scrapes_total", outcome="error") == 1
+    assert "technocore_rooms " not in text, "no stale storage gauges on a failed scrape"
+
+
+def test_the_failure_reason_never_reaches_a_metric(render):
+    """The origin's failure text must not drive the label set."""
+    text = render(error=StatsUnavailableError("unreachable: [Errno -2] Name or service not known"))
+    assert "Errno" not in text and "not known" not in text
+
+
+def test_an_unexpected_error_still_publishes_a_failed_scrape(render):
+    """`collect()` must never propagate, whatever the cause.
+
+    An exception escaping here makes the client library answer /metrics with a 500, so the
+    scrape learns nothing — not even that the exporter is alive. Two transport families
+    have already escaped a narrow handler in fetch.py (a bare socket timeout, and
+    http.client.HTTPException), so the broad catch is the structural answer rather than a
+    third guess at a complete list.
+    """
+    text = render(error=RuntimeError("something nobody predicted"))
+    assert _sample(text, "technocore_exporter_scrape_success") == 0
+    assert _sample(text, "technocore_exporter_scrapes_total", outcome="error") == 1
+    assert "technocore_rooms " not in text
+    assert "nobody predicted" not in text, "the cause goes to the log, never to a metric"
+
+
+def test_a_bool_timestamp_is_not_read_as_a_number(render, stats):
+    """`True` is an int in Python; a sample age of 'now minus True' would be nonsense."""
+    payload = {**stats, "history": [{"t": True}]}
+    assert "technocore_stats_sample_age_seconds" not in render(payload=payload)
+
+
+# ------------------------------------------------------- found in self-review, not by CI
+
+
+def test_a_mapping_error_cannot_escape_collect(render, stats, monkeypatch):
+    """The guard has to cover the mapping, not only the fetch.
+
+    `collect()` was a generator whose try/except wrapped `fetch_stats` alone, so the
+    mapping ran later, on the consumer's iteration, and any error in it escaped — leaving
+    /metrics answering 500, which is exactly what the broad catch exists to prevent. The
+    families are built inside the guard now. Reproduced before the fix by making one
+    mapping function raise.
+    """
+    import technocore_exporter.collector as module
+
+    monkeypatch.setattr(module, "_capacity", lambda p: (_ for _ in ()).throw(KeyError("bug")))
+    text = render()
+    assert _sample(text, "technocore_exporter_scrape_success") == 0
+    assert "technocore_rooms " not in text, "a partial page is worse than a failed one"
+    assert "bug" not in text, "the cause goes to the log, never to a metric"
+
+
+def test_overlapping_scrapes_are_serialised(stats, monkeypatch):
+    """`start_http_server` is threaded, so collect() runs concurrently on one instance.
+
+    Asserted as non-overlap rather than as a final count: `self._scrapes[...] += 1` is an
+    unguarded read-modify-write without the lock — the same shape as the `_buckets` race in
+    core's limiter — but a count assertion can pass by luck, since losing a bump needs the
+    threads to interleave on exactly that bytecode. Depth is deterministic: if any two
+    bodies ever overlap, the maximum observed depth is 2 and the test fails every time.
+
+    Serialising is wanted for its own sake too. It stops two overlapping scrapes each
+    opening their own origin request, which is the more expensive half of the race.
+    """
+    import technocore_exporter.collector as module
+
+    depth = 0
+    peak = 0
+    seen = threading.Lock()
+
+    def tracked_fetch(*a, **k):
+        nonlocal depth, peak
+        with seen:
+            depth += 1
+            peak = max(peak, depth)
+        time.sleep(0.01)
+        with seen:
+            depth -= 1
+        return stats
+
+    monkeypatch.setattr(module, "fetch_stats", tracked_fetch)
+    collector = TechnocoreCollector("http://origin.invalid/stats", "token")
+    threads = [threading.Thread(target=lambda: list(collector.collect())) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert not any(t.is_alive() for t in threads), "a scrape deadlocked"
+    assert peak == 1, f"{peak} scrapes overlapped; the collector lock is not holding"
+    assert collector._scrapes["success"] == 8

--- a/tests/exporter/test_collector.py
+++ b/tests/exporter/test_collector.py
@@ -6,6 +6,7 @@ metric is worse than one that ships nothing, because an alert gets written again
 
 from __future__ import annotations
 
+import json
 import socket
 import threading
 import time
@@ -432,3 +433,289 @@ def test_a_scrape_that_never_wins_the_lock_still_reports_inside_the_budget():
     assert _value(families, "technocore_exporter_scrape_success") == 0
     assert _value(families, "technocore_exporter_scrapes_total", "error") == 1
     assert elapsed < 1.0, f"a 0.5s budget took {elapsed:.2f}s waiting for the lock"
+
+
+def _trickling_header_origin(seconds=4.0, every=0.5):
+    """An origin that sends a status line and then header bytes, slowly. Returns its port.
+
+    The half of the trickle the body-read fix does not reach: `http.client` reads the status
+    line and headers inside `urlopen`, under the per-socket-operation timeout, so a byte
+    every 0.5s under a 1.0s budget never trips anything. It stops after `seconds` rather
+    than running forever, for the reason the body-trickle test gives: without the fix this
+    has to fail rather than wedge CI.
+
+    `every` must stay comfortably under the caller's budget — that is the whole mechanism.
+    A gap wider than the budget is trapped by the per-socket timeout like any other slow
+    read, and demonstrates nothing.
+    """
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(8)
+    connections = []
+
+    def serve():
+        while True:
+            try:
+                conn, _ = listener.accept()
+            except OSError:  # pragma: no cover - the test finished first
+                return
+            connections.append(conn)
+            threading.Thread(target=trickle, args=(conn,), daemon=True).start()
+
+    def trickle(conn):
+        try:
+            conn.recv(65536)
+            conn.sendall(b"HTTP/1.1 200 OK\r\n")
+            # A header line that never reaches the blank line ending the headers.
+            pad = b"X-Padding: " + b"a" * 4096 + b"\r\n"
+            started = time.monotonic()
+            i = 0
+            while time.monotonic() - started < seconds:
+                conn.sendall(pad[i % len(pad) : i % len(pad) + 1])
+                i += 1
+                time.sleep(every)
+        except OSError:  # pragma: no cover - the scrape gave up first, which is the point
+            pass
+
+    threading.Thread(target=serve, daemon=True).start()
+    return listener.getsockname()[1], connections
+
+
+def test_a_trickling_header_cannot_outrun_the_budget():
+    """The body deadline guards the body. Headers are read before it ever runs.
+
+    `_read_within` bounds `response.read1`, but `urlopen` has already returned by then —
+    `http.client` consumed the status line and every header under the per-socket timeout,
+    which one byte per 0.5s never trips. Measured at 22.6s of a 3s budget at `/metrics`,
+    and it was still going when the origin gave up rather than the exporter.
+
+    This is the one of the three that needs no hostname: it lands on the shipped
+    `127.0.0.1` default, because it is about what the origin sends rather than how it is
+    addressed.
+    """
+    port, _ = _trickling_header_origin()
+    collector = TechnocoreCollector(f"http://127.0.0.1:{port}/stats", "token", timeout=1.0)
+    started = time.monotonic()
+    families = list(collector.collect())
+    elapsed = time.monotonic() - started
+    assert _value(families, "technocore_exporter_scrape_success") == 0
+    assert elapsed < 1.5, f"a 1.0s budget took {elapsed:.2f}s reading headers"
+
+
+def test_a_wedged_resolver_cannot_outrun_the_budget(monkeypatch):
+    """Reported by @Minh3132 on `0deacdf`.
+
+    `socket.create_connection` calls `getaddrinfo()` before it has a socket for
+    `urlopen(timeout=)` to apply to, so name resolution is outside every bound this package
+    had. Measured at 20.0s of a 3s budget at `/metrics`, with no sample stored by
+    Prometheus at all: past `scrape_timeout: 15s`, the failure telemetry arrives after
+    nobody is listening for it.
+
+    The resolver is stubbed rather than pointed at a real wedged one because a test cannot
+    depend on the host's DNS being broken in a particular way; what it blocks in is real
+    time, on the thread CPython would really block.
+    """
+    real = socket.getaddrinfo
+
+    def wedged(host, *args, **kwargs):
+        if host == "origin.invalid":
+            time.sleep(4.0)
+            raise socket.gaierror(socket.EAI_AGAIN, "Temporary failure in name resolution")
+        return real(host, *args, **kwargs)  # pragma: no cover - only the stub host is used
+
+    monkeypatch.setattr(socket, "getaddrinfo", wedged)
+    collector = TechnocoreCollector("http://origin.invalid:8080/stats", "token", timeout=1.0)
+    started = time.monotonic()
+    families = list(collector.collect())
+    elapsed = time.monotonic() - started
+    assert _value(families, "technocore_exporter_scrape_success") == 0
+    assert elapsed < 1.5, f"a 1.0s budget took {elapsed:.2f}s resolving"
+
+
+def test_every_address_of_a_name_cannot_each_spend_the_whole_budget(monkeypatch):
+    """`create_connection` tries every address a name resolved to, with the full timeout each.
+
+    So the budget is spent once per address record, not once per scrape: four blackholed A
+    records cost 12.0s of a 3s budget, each connect logged with the whole 3.0s rather than
+    a share. Two records is enough to break the shipped arithmetic, provided both blackhole
+    rather than refuse — a refusal returns at once, a dropping firewall does not. At the
+    accepted ceiling of just under 10s, two such addresses reach ~20s against
+    `scrape_timeout: 15s`.
+
+    Connect is stubbed because no address is portably guaranteed to blackhole rather than
+    refuse in CI. What is *not* stubbed is the part being pinned: the addresses come out of
+    the real `create_connection` loop, and the timeout recorded on each socket is the one it
+    really set. The assertion on `attempts` is that fact; the assertion on elapsed is that
+    the collector no longer pays for it.
+    """
+    addresses = [f"198.51.100.{n}" for n in (1, 2, 3, 4)]
+    attempts = []
+
+    def resolves_to_all(host, port, *args, **kwargs):
+        assert host == "origin.invalid"
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, port)) for ip in addresses]
+
+    def blackhole(self, address):
+        attempts.append((address[0], self.gettimeout()))
+        time.sleep(self.gettimeout())
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(socket, "getaddrinfo", resolves_to_all)
+    monkeypatch.setattr(socket.socket, "connect", blackhole)
+    collector = TechnocoreCollector("http://origin.invalid:8080/stats", "token", timeout=0.5)
+    started = time.monotonic()
+    families = list(collector.collect())
+    elapsed = time.monotonic() - started
+    assert _value(families, "technocore_exporter_scrape_success") == 0
+    assert elapsed < 1.0, f"a 0.5s budget took {elapsed:.2f}s connecting"
+    # Wait for the abandoned worker to walk the rest of the addresses, polling the fact
+    # rather than sleeping a guessed duration: a fixed sleep that expires early lets
+    # monkeypatch restore the real `connect`, and the worker then makes a genuine outbound
+    # attempt to a TEST-NET address from CI.
+    until = time.monotonic() + 10.0
+    while len(attempts) < len(addresses) and time.monotonic() < until:
+        time.sleep(0.02)
+    # What CPython actually did with the budget: every address, each with the whole of what
+    # was left of it rather than a share — which is what makes four addresses cost four.
+    assert [ip for ip, _ in attempts] == addresses
+    assert min(timeout for _, timeout in attempts) > 0.45, (
+        f"expected the whole budget on each address, got {attempts}"
+    )
+
+
+def test_an_abandoned_fetch_keeps_the_lock_so_no_second_request_is_opened():
+    """The thread bound, stated as a property rather than left to the reader.
+
+    `_fetching` is released by the worker, not by the scrape that started it. A scrape that
+    abandons a wedged fetch therefore leaves the lock held, and every later scrape fails on
+    the bounded acquire instead of opening a second request to an origin that has not
+    answered the first. Without that, a wedged origin would collect one live thread and one
+    in-flight request per scrape, for as long as it stayed wedged.
+
+    This guards the fix's own hazard rather than a pre-existing bug, so it is written
+    against a blocker the worker cannot escape on its own: the trickling headers, which are
+    outside every timeout `fetch_stats` can set. An origin that merely hangs is no good
+    here — the worker's socket timeout fires at about the same instant the scrape abandons
+    it, and the lock is then released a few microseconds either side of the assertion.
+    """
+    port, connections = _trickling_header_origin(seconds=3.0, every=0.1)
+    collector = TechnocoreCollector(f"http://127.0.0.1:{port}/stats", "token", timeout=0.3)
+    for _ in range(5):
+        families = list(collector.collect())
+        assert _value(families, "technocore_exporter_scrape_success") == 0
+    # Counted at the origin rather than as live threads. A thread count is a count over the
+    # whole process, and the other tests in this file deliberately leave wedged fetches
+    # behind them — so it measures the neighbours, not this collector. Connections accepted
+    # by *this* origin are the invariant in the docstring, stated directly.
+    assert len(connections) == 1, f"five scrapes opened {len(connections)} requests"
+    assert collector._fetching.locked(), "the abandoned fetch released the lock"
+
+
+def test_a_fetch_thread_that_cannot_start_does_not_strand_the_lock(monkeypatch):
+    """The one path where the worker cannot be the one to release `_fetching`.
+
+    Handing the release to the worker is what bounds a wedged origin to a single in-flight
+    request. It also means that if the thread never starts — `RuntimeError: can't start new
+    thread`, which is what thread exhaustion looks like — nobody releases, and a collector
+    that cannot take its own lock answers *every* later scrape with the queued-behind
+    failure, permanently, from one transient failure to spawn.
+    """
+
+    def cannot_start(self):
+        raise RuntimeError("can't start new thread")
+
+    monkeypatch.setattr(threading.Thread, "start", cannot_start)
+    collector = TechnocoreCollector("http://origin.invalid/stats", "token", timeout=1.0)
+    families = list(collector.collect())
+    assert _value(families, "technocore_exporter_scrape_success") == 0
+    assert not collector._fetching.locked(), "a failed spawn stranded the fetch lock"
+
+
+def test_an_abandoned_fetch_still_reports_what_the_origin_finally_did(caplog, monkeypatch):
+    """Running the fetch on a worker takes the transport's real reason out of the log.
+
+    The scrape answers at the deadline with "exceeded the scrape budget", which says the
+    answer was late but not *why* — and the worker that eventually learns the reason has no
+    one left to tell. Inline, `_failed` put `unreachable: [Errno -3] Temporary failure in
+    name resolution` in front of the operator. That is a diagnostic this change would
+    otherwise have removed, so the worker logs it once it knows.
+    """
+    real = socket.getaddrinfo
+
+    def wedged(host, *args, **kwargs):
+        if host == "origin.invalid":
+            time.sleep(1.0)
+            raise socket.gaierror(socket.EAI_AGAIN, "Temporary failure in name resolution")
+        return real(host, *args, **kwargs)  # pragma: no cover - only the stub host is used
+
+    monkeypatch.setattr(socket, "getaddrinfo", wedged)
+    collector = TechnocoreCollector("http://origin.invalid:8080/stats", "token", timeout=0.2)
+    with caplog.at_level("WARNING", logger="technocore_exporter"):
+        families = list(collector.collect())
+        assert _value(families, "technocore_exporter_scrape_success") == 0
+        # The scrape is already back; wait for the worker to reach its own conclusion.
+        # Waited out inside the patch rather than after it, so the worker never sees the
+        # real resolver restored underneath it.
+        until = time.monotonic() + 10.0
+        while collector._fetching.locked() and time.monotonic() < until:
+            time.sleep(0.02)
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("after the budget" in m and "name resolution" in m for m in messages), messages
+
+
+def test_an_origin_that_answers_late_is_still_an_error_not_a_discarded_digest(caplog, monkeypatch):
+    """An abandoned worker cannot come back with a usable digest, and that is worth pinning.
+
+    `fetch_stats` is handed the same deadline the scrape waits on, so a worker that outran
+    the scrape has outrun its own budget too: `_read_within` refuses before the body is
+    returned. That is why the abandoned-worker log has one arm rather than two, and it is
+    the kind of claim that rots silently — a later change giving the fetch its own longer
+    budget would make a late success reachable, and this test is what would notice.
+
+    The origin here is entirely healthy. Only the resolution is slow, and it is slow in the
+    one phase `fetch_stats` cannot bound for itself, so the fetch really does go on to
+    connect and read a valid digest before the deadline check refuses it.
+    """
+    body = json.dumps({"rooms": {}, "bytes": {}, "notes": {}, "counters": {}}).encode()
+
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(2)
+
+    def serve():
+        try:
+            conn, _ = listener.accept()
+            conn.recv(65536)
+            conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n" % len(body))
+            conn.sendall(body)
+            conn.close()
+        except OSError:  # pragma: no cover - the test finished first
+            pass
+
+    threading.Thread(target=serve, daemon=True).start()
+    port = listener.getsockname()[1]
+    real = socket.getaddrinfo
+
+    def slow_then_fine(host, requested_port, *args, **kwargs):
+        if host == "origin.invalid":
+            time.sleep(0.8)
+            return real("127.0.0.1", port, *args, **kwargs)
+        return real(host, requested_port, *args, **kwargs)  # pragma: no cover - stub only
+
+    monkeypatch.setattr(socket, "getaddrinfo", slow_then_fine)
+    collector = TechnocoreCollector("http://origin.invalid:8080/stats", "token", timeout=0.2)
+    with caplog.at_level("WARNING", logger="technocore_exporter"):
+        families = list(collector.collect())
+        assert _value(families, "technocore_exporter_scrape_success") == 0
+        until = time.monotonic() + 10.0
+        while collector._fetching.locked() and time.monotonic() < until:
+            time.sleep(0.02)
+    assert not collector._fetching.locked(), "the worker never finished"
+    late = [
+        record.getMessage()
+        for record in caplog.records
+        if "origin.invalid" in record.getMessage() and "after the budget" in record.getMessage()
+    ]
+    assert late, [record.getMessage() for record in caplog.records]
+    assert "exceeded the scrape budget while reading" in late[0], late
+    assert "answer discarded" not in late[0], late

--- a/tests/exporter/test_collector.py
+++ b/tests/exporter/test_collector.py
@@ -6,6 +6,7 @@ metric is worse than one that ships nothing, because an alert gets written again
 
 from __future__ import annotations
 
+import socket
 import threading
 import time
 
@@ -303,3 +304,131 @@ def test_overlapping_scrapes_are_serialised(stats, monkeypatch):
     assert not any(t.is_alive() for t in threads), "a scrape deadlocked"
     assert peak == 1, f"{peak} scrapes overlapped; the collector lock is not holding"
     assert collector._scrapes["success"] == 8
+
+
+def test_a_digest_with_no_stored_samples_publishes_no_sample_age(render, stats):
+    """A service that has never written a snapshot, which is every service on day one.
+
+    `app.py` builds the view as `{**service_stats, "history": store.snapshots(root)}` and
+    `snapshots()` returns [] until the first one is written, so this is the ordinary
+    fresh-deployment shape rather than a malformed digest. `history` is deliberately not in
+    REQUIRED — its absence is a fact about the service, not a broken read — so the scrape
+    must succeed and simply omit the age.
+
+    It was the one branch in the package no test drove; the storage gauges beside it are
+    what make the omission safe to leave silent.
+    """
+    text = render(payload={**stats, "history": []})
+    assert "technocore_stats_sample_age_seconds" not in text
+    assert _sample(text, "technocore_exporter_scrape_success") == 1
+    assert _sample(text, "technocore_rooms") == stats["rooms"]["total"]
+
+
+# --------------------------------------------------- the scrape budget, under contention
+
+
+def _hanging_origin():
+    """An origin that accepts and then says nothing at all. Returns its port.
+
+    A real socket, not a patched `fetch_stats`: the property under test is how long the
+    collector takes to answer, and a stub that sleeps proves only that a sleep sleeps.
+    """
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(4)
+    held = []
+
+    def serve():
+        while True:
+            try:
+                conn, _ = listener.accept()
+            except OSError:  # pragma: no cover - the test finished first
+                return
+            held.append(conn)  # kept open and unanswered
+
+    threading.Thread(target=serve, daemon=True).start()
+    return listener.getsockname()[1]
+
+
+def _race(collector, count=2):
+    """Drive `count` overlapping scrapes, returning (elapsed, families) for each in order."""
+    results = {}
+
+    def scrape(name, delay):
+        time.sleep(delay)
+        started = time.monotonic()
+        families = list(collector.collect())
+        results[name] = (time.monotonic() - started, families)
+
+    threads = [threading.Thread(target=scrape, args=(i, i * 0.05)) for i in range(count)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    return [results[i] for i in range(count)]
+
+
+def _value(families, name, *labels):
+    """A sample by its exposed name — `technocore_exporter_scrapes_total`, not the family
+    name `technocore_exporter_scrapes` the client library derives it from."""
+    for family in families:
+        for sample in family.samples:
+            if sample.name == name and tuple(sample.labels.values()) == labels:
+                return sample.value
+    raise AssertionError(f"no sample {name}{labels or ''}")
+
+
+def test_a_queued_scrape_still_answers_inside_the_budget():
+    """Reported by @Minh3132 and @yukkie3276, on the same head, half an hour apart.
+
+    `_gather` serialises scrapes, and the wait was time the source timeout never saw: a
+    second scrape waited a full timeout for the lock and then spent another one on its own
+    fetch. Measured at 17.82s for a 9s timeout — past the shipped `scrape_timeout: 15s`, so
+    Prometheus abandoned it and stored neither samples nor the `scrape_success 0` the wait
+    had just produced. One deadline now covers the wait and the fetch together.
+    """
+    collector = TechnocoreCollector(
+        f"http://127.0.0.1:{_hanging_origin()}/stats", "token", timeout=1.0
+    )
+    for elapsed, families in _race(collector):
+        assert _value(families, "technocore_exporter_scrape_success") == 0
+        assert elapsed < 1.5, f"a 1.0s budget took {elapsed:.2f}s"
+
+
+def test_the_published_duration_is_the_time_the_scrape_actually_took():
+    """The metric that would have shown the queueing was the metric blind to it.
+
+    `started` was taken after the fetch lock was won, so the queued scrape published
+    `scrape_duration_seconds 9.01` for a scrape that took 17.82s to answer. An operator
+    watching the duration could not see the wait that was busting their scrape timeout.
+    Taking `started` before the acquire is what makes this number the answer time.
+    """
+    collector = TechnocoreCollector(
+        f"http://127.0.0.1:{_hanging_origin()}/stats", "token", timeout=1.0
+    )
+    for elapsed, families in _race(collector):
+        published = _value(families, "technocore_exporter_scrape_duration_seconds")
+        assert abs(published - elapsed) < 0.25, (
+            f"published {published:.2f}s for a scrape that took {elapsed:.2f}s"
+        )
+
+
+def test_a_scrape_that_never_wins_the_lock_still_reports_inside_the_budget():
+    """The far end of the queue: a scrape that cannot get the lock at all.
+
+    Driven by holding `_fetching` outright rather than by racing two slow origins, because
+    the property is "the wait is bounded" and a race can only ever demonstrate the waits it
+    happened to produce. Without the bound this call blocks for as long as the holder does
+    — indefinitely — and Prometheus abandons it long before it answers.
+    """
+    collector = TechnocoreCollector("http://origin.invalid/stats", "token", timeout=0.5)
+    collector._fetching.acquire()
+    try:
+        started = time.monotonic()
+        families = list(collector.collect())
+        elapsed = time.monotonic() - started
+    finally:
+        collector._fetching.release()
+    assert _value(families, "technocore_exporter_scrape_success") == 0
+    assert _value(families, "technocore_exporter_scrapes_total", "error") == 1
+    assert elapsed < 1.0, f"a 0.5s budget took {elapsed:.2f}s waiting for the lock"

--- a/tests/exporter/test_fetch.py
+++ b/tests/exporter/test_fetch.py
@@ -6,9 +6,12 @@ import http.client
 import http.server
 import io
 import json
+import socket
+import struct
 import subprocess
 import sys
 import threading
+import time
 import urllib.error
 import urllib.request
 from email.message import Message
@@ -390,3 +393,122 @@ def test_the_token_never_reaches_a_redirect_target_end_to_end():
         for server in (sink, source):
             server.shutdown()
             server.server_close()
+
+
+# ---------------------------------------------- the budget, and what escapes a narrow catch
+
+
+def _raw_origin(respond):
+    """A socket server that answers exactly once, over a socket the test controls.
+
+    `http.server` cannot express either case below: one trickles a body slowly enough that
+    no single socket operation ever times out, and the other resets the connection
+    mid-body. Both need the socket itself, which is the whole point — a stub opener raising
+    a chosen exception can only ever prove that the exception someone already thought of is
+    handled.
+
+    Returns the port; the thread is a daemon and the listener closes with it.
+    """
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+
+    def serve():
+        try:
+            conn, _ = listener.accept()
+            conn.recv(65536)
+            respond(conn)
+        except OSError:  # pragma: no cover - the test finished first
+            pass
+
+    threading.Thread(target=serve, daemon=True).start()
+    return listener.getsockname()[1]
+
+
+def test_a_trickling_origin_cannot_outrun_the_scrape_budget():
+    """`urlopen(timeout=)` bounds one socket operation, not the call.
+
+    Reported as an overlapping-scrape problem by @Minh3132 and @yukkie3276; this is the
+    half that needs no concurrency at all. An origin sending one byte at a time, each
+    comfortably inside the timeout, never trips it — measured at 20.01s on the shipped 5s
+    default before the fix, against a Prometheus scrape_timeout of 15s. The scrape is
+    abandoned with no samples *and* no failure telemetry, which is the one outcome the
+    self-metrics exist to prevent.
+
+    Asserted as wall time rather than as the exception: the old code raised
+    StatsUnavailableError here too — eventually, and far too late for anyone to read it.
+    """
+    body = json.dumps(_valid()).encode()
+
+    def trickle(conn):
+        conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n" % len(body))
+        # Ten pauses of 0.4s, each far inside the 1.0s budget so no single socket
+        # operation ever times out, then the remainder. Bounded on purpose: without the
+        # fix this test has to *fail*, not hang, or a regression wedges CI instead of
+        # reporting. Pre-fix it returned the whole body after ~4s against a 1.0s budget.
+        for i in range(10):
+            time.sleep(0.4)
+            conn.sendall(body[i : i + 1])
+        conn.sendall(body[10:])
+
+    port = _raw_origin(trickle)
+    started = time.monotonic()
+    with pytest.raises(StatsUnavailableError):
+        fetch_stats(f"http://127.0.0.1:{port}/stats", "token", timeout=1.0)
+    elapsed = time.monotonic() - started
+    assert elapsed < 1.5, f"a 1.0s budget took {elapsed:.2f}s"
+
+
+def test_a_connection_reset_mid_body_is_reported_not_raised_raw():
+    """The third transport family to escape a narrow handler, and the reason for `OSError`.
+
+    `urllib` wraps what is raised while *opening* into URLError, but an RST during the body
+    read surfaces as a bare ConnectionResetError: not a URLError, not a TimeoutError, not
+    an HTTPException. It escaped `fetch_stats` as itself, and only the collector's broad
+    catch kept /metrics off a 500 — at the cost of a traceback logged as "unexpected"
+    instead of a named failure.
+    """
+    body = json.dumps(_valid()).encode()
+
+    def reset(conn):
+        conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n" % (len(body) + 4096))
+        conn.sendall(body[:64])
+        time.sleep(0.05)
+        # SO_LINGER with a zero timeout makes close() send RST rather than FIN, which is
+        # what raises in the peer's recv. A clean FIN is a different case: it truncates the
+        # body, and JSON refuses it on its own.
+        conn.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+        conn.close()
+
+    port = _raw_origin(reset)
+    with pytest.raises(StatsUnavailableError, match="transport error: ConnectionResetError"):
+        fetch_stats(f"http://127.0.0.1:{port}/stats", "token", timeout=5.0)
+
+
+def test_the_budget_holds_even_if_the_socket_cannot_be_re_armed(monkeypatch):
+    """`_rearm` reaches through a private chain (`fp.raw._sock`), so it may stop working.
+
+    When it works, the socket itself raises at the deadline and the loop's own check never
+    runs — which would leave the fallback untested and free to rot until the CPython
+    release that needs it. Neutering `_rearm` is what drives it: the deadline check in
+    `_read_within` still has to bound the read, to one socket operation's overshoot rather
+    than to nothing at all.
+    """
+    monkeypatch.setattr("technocore_exporter.fetch._rearm", lambda response, remaining: None)
+    body = json.dumps(_valid()).encode()
+
+    def trickle(conn):
+        conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n" % len(body))
+        for i in range(10):
+            time.sleep(0.3)
+            conn.sendall(body[i : i + 1])
+        conn.sendall(body[10:])
+
+    port = _raw_origin(trickle)
+    started = time.monotonic()
+    with pytest.raises(StatsUnavailableError, match="exceeded the scrape budget"):
+        fetch_stats(f"http://127.0.0.1:{port}/stats", "token", timeout=0.5)
+    elapsed = time.monotonic() - started
+    # One overshoot is the documented cost of losing the re-arm: the read in flight when
+    # the deadline passes still carries the full socket timeout. Bounded, not unbounded.
+    assert elapsed < 1.5, f"a 0.5s budget took {elapsed:.2f}s with no re-arm"

--- a/tests/exporter/test_fetch.py
+++ b/tests/exporter/test_fetch.py
@@ -1,0 +1,373 @@
+"""The one call, and the three ways it goes wrong."""
+
+from __future__ import annotations
+
+import http.client
+import http.server
+import io
+import json
+import subprocess
+import sys
+import threading
+import urllib.error
+import urllib.request
+from email.message import Message
+from pathlib import Path
+
+import pytest
+from technocore_exporter.fetch import REQUIRED, StatsUnavailableError, fetch_stats
+
+URL = "http://origin.invalid/stats"
+
+
+def _valid() -> dict:
+    """The smallest digest validate() accepts: every required field, all zero."""
+    return {section: dict.fromkeys(fields, 0) for section, fields in REQUIRED.items()}
+
+
+class _Response(io.BytesIO):
+    """Enough of an HTTPResponse for the one `with urlopen(...)` in fetch_stats.
+
+    io.BytesIO is already a context manager that closes itself, so this only adds the
+    `.status` the code reads — overriding __enter__/__exit__ would narrow the inherited
+    signature for nothing.
+    """
+
+    def __init__(self, body: bytes, status: int = 200):
+        super().__init__(body)
+        self.status = status
+
+
+class _Opener:
+    """Stands in for urlopen, recording the request so the header assertions can read it."""
+
+    def __init__(self, result):
+        self.result = result
+        self.seen: urllib.request.Request | None = None
+
+    def __call__(self, request, timeout=None):
+        if isinstance(self.result, Exception):
+            raise self.result
+        self.seen = request
+        return self.result
+
+
+class _StubOpener:
+    """Stands in for the module's opener — the transport boundary, and the only thing a
+    unit test should replace. Patching `urllib.request.urlopen` would no longer intercept:
+    fetch_stats goes through a build_opener() instance so redirects can be refused."""
+
+    def __init__(self, result):
+        self.inner = _Opener(result)
+
+    def open(self, request, timeout=None):
+        return self.inner(request, timeout)
+
+    @property
+    def seen(self):
+        return self.inner.seen
+
+
+def _patch(monkeypatch, result) -> _StubOpener:
+    opener = _StubOpener(result)
+    monkeypatch.setattr("technocore_exporter.fetch._OPENER", opener)
+    return opener
+
+
+def test_the_token_rides_in_a_header_never_the_url(monkeypatch):
+    """A query parameter would land in the proxy logs, and the service ignores it there."""
+    opener = _patch(monkeypatch, _Response(json.dumps(_valid()).encode()))
+    fetch_stats(URL, "s3cret")
+    assert opener.seen is not None
+    assert opener.seen.get_full_url() == URL
+    assert "s3cret" not in opener.seen.get_full_url()
+    assert opener.seen.get_header("X-stats-token") == "s3cret"
+
+
+def test_a_404_hints_at_the_token(monkeypatch):
+    """The endpoint reports itself missing rather than forbidden, so the hint is the fix."""
+    _patch(monkeypatch, urllib.error.HTTPError(URL, 404, "Not Found", Message(), None))
+    with pytest.raises(StatsUnavailableError, match="wrong or unset CHAT_STATS_TOKEN"):
+        fetch_stats(URL, "wrong")
+
+
+def test_no_response_body_reaches_the_error(monkeypatch):
+    """/stats answers 404 with the same bytes an unrouted path gets; a proxy answers with
+    its own page. Neither belongs in a log line an operator will paste somewhere."""
+    body = io.BytesIO(b"<html>upstream said something quotable</html>")
+    _patch(monkeypatch, urllib.error.HTTPError(URL, 502, "Bad Gateway", Message(), body))
+    with pytest.raises(StatsUnavailableError) as caught:
+        fetch_stats(URL, "token")
+    assert "quotable" not in str(caught.value)
+    assert "502" in str(caught.value)
+
+
+def test_a_non_json_body_is_refused(monkeypatch):
+    _patch(monkeypatch, _Response(b"not json at all"))
+    with pytest.raises(StatsUnavailableError, match="not JSON"):
+        fetch_stats(URL, "token")
+
+
+def test_a_json_array_is_refused(monkeypatch):
+    """Valid JSON, wrong shape — `.get` on a list is an AttributeError at scrape time."""
+    _patch(monkeypatch, _Response(b"[1, 2, 3]"))
+    with pytest.raises(StatsUnavailableError, match="not a JSON object"):
+        fetch_stats(URL, "token")
+
+
+def test_an_unreachable_origin_is_reported_not_raised_raw(monkeypatch):
+    _patch(monkeypatch, urllib.error.URLError("connection refused"))
+    with pytest.raises(StatsUnavailableError, match="unreachable"):
+        fetch_stats(URL, "token")
+
+
+def test_a_timeout_is_reported_rather_than_escaping(monkeypatch):
+    """The regression behind splitting TimeoutError out of the URLError handler.
+
+    `urlopen` raises a bare socket timeout, which is a TimeoutError and not a URLError, so
+    it has no `.reason`. Handled together, the f-string raised AttributeError from inside
+    the handler — past StatsUnavailableError, out of `collect()`, and into a 500 on
+    /metrics. A slow origin has to read as a failed scrape, not as a broken exporter.
+    """
+    _patch(monkeypatch, TimeoutError())
+    with pytest.raises(StatsUnavailableError, match="timed out after"):
+        fetch_stats(URL, "token", timeout=2.5)
+
+
+def test_a_2xx_that_is_not_200_is_refused(monkeypatch):
+    """Defensive, and cheap to hold: urlopen raises HTTPError for 4xx/5xx, so this branch
+    is for the odd success — a 204, or a redirect the opener followed to an empty body.
+    Falling through would hand `json.loads` an empty string and report it as 'not JSON',
+    which sends an operator looking at the wrong thing."""
+    _patch(monkeypatch, _Response(b"", status=204))
+    with pytest.raises(StatsUnavailableError, match="status 204"):
+        fetch_stats(URL, "token")
+
+
+# --------------------------------------------------------------- reported by @osr21
+
+
+def test_the_token_never_follows_a_redirect(monkeypatch):
+    """A real credential leak, and not a theoretical one.
+
+    `urllib.request.HTTPRedirectHandler.redirect_request` copies every header except
+    `content-length` and `content-type` onto the redirected request, so a 302 from the
+    configured URL to any host hands `X-Stats-Token` to that host and `urlopen` follows it
+    silently. Reproduced end to end against two loopback servers before the fix: the sink
+    received the sentinel token and `fetch_stats` accepted the sink's reply.
+    """
+    for code in (301, 302, 303, 307, 308):
+        _patch(monkeypatch, urllib.error.HTTPError(URL, code, "Found", Message(), None))
+        with pytest.raises(StatsUnavailableError, match="refusing to send the token"):
+            fetch_stats(URL, "sentinel-token")
+
+
+def test_the_redirect_handler_refuses_rather_than_rewrites():
+    """Pinned on the handler itself, because the behaviour above is one `return None`."""
+    from technocore_exporter.fetch import _NoRedirect
+
+    assert _NoRedirect().redirect_request(None, None, 302, "Found", Message(), URL) is None
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        http.client.BadStatusLine("broken"),
+        http.client.IncompleteRead(b"half"),
+        http.client.LineTooLong("header line"),
+    ],
+)
+def test_a_protocol_error_is_reported_not_raised_raw(monkeypatch, exc):
+    """The sibling of the TimeoutError case, and the same lesson twice.
+
+    `http.client.HTTPException` subclasses are raised while parsing a response and are
+    neither `URLError` nor `TimeoutError`, so a narrow handler lets them escape as
+    themselves — out of `collect()` and into a 500 on /metrics, which reports nothing at
+    all rather than reporting a failed scrape.
+    """
+    _patch(monkeypatch, exc)
+    with pytest.raises(StatsUnavailableError, match="protocol error"):
+        fetch_stats(URL, "token")
+
+
+def test_a_digest_missing_a_required_field_is_refused(monkeypatch):
+    """Absent is not zero.
+
+    Mapping a partial digest and defaulting the rest publishes `technocore_notes 0` beside
+    `scrape_success 1` — a healthy-looking empty service, indistinguishable from a real
+    one, against which a note-capacity alert can never fire.
+    """
+    _patch(monkeypatch, _Response(json.dumps({"rooms": {"total": 7}}).encode()))
+    with pytest.raises(StatsUnavailableError, match="missing rooms."):
+        fetch_stats(URL, "token")
+
+
+def test_a_missing_section_is_refused(monkeypatch):
+    payload = _valid()
+    del payload["counters"]
+    _patch(monkeypatch, _Response(json.dumps(payload).encode()))
+    with pytest.raises(StatsUnavailableError, match="no counters object"):
+        fetch_stats(URL, "token")
+
+
+@pytest.mark.parametrize(
+    ("value", "match"),
+    [
+        (True, "not a number"),
+        (False, "not a number"),
+        ("12", "not a number"),
+        (None, "not a number"),
+        (-1, "negative"),
+        (float("nan"), "not finite"),
+        (float("inf"), "not finite"),
+    ],
+)
+def test_an_untrustworthy_field_value_is_refused(monkeypatch, value, match):
+    """`True` is an `int` in Python, so a bool would publish as 1.0 — a wrong number rather
+    than a missing one. NaN and the infinities parse and publish, then poison every rate
+    and ratio computed from them downstream."""
+    payload = _valid()
+    payload["rooms"]["total"] = value
+    _patch(monkeypatch, _Response(json.dumps(payload).encode()))
+    with pytest.raises(StatsUnavailableError, match=match):
+        fetch_stats(URL, "token")
+
+
+def test_a_complete_digest_is_accepted(monkeypatch):
+    """The other direction, so the validator cannot pass by refusing everything."""
+    _patch(monkeypatch, _Response(json.dumps(_valid()).encode()))
+    assert fetch_stats(URL, "token")["rooms"]["total"] == 0
+
+
+def test_the_opener_ignores_ambient_proxy_configuration():
+    """The direct half: no proxy handler in the module's opener carries any mapping.
+
+    `build_opener()` installs a default `ProxyHandler` that reads HTTP_PROXY/HTTPS_PROXY
+    from the environment, so without `ProxyHandler({})` the token goes to whatever those
+    name. Asserted on the opener itself rather than on behaviour, because the handler is
+    constructed once at import and a behavioural test in this process would pass for the
+    wrong reason — the environment having been read before the test set it.
+    """
+    from technocore_exporter.fetch import _OPENER
+
+    # `ProxyHandler({})` registers no per-scheme `<type>_open` method, so OpenerDirector
+    # keeps none of it — the absence *is* the property, and it is stronger than an empty
+    # mapping being present. Verified against the contrast: with HTTP_PROXY set, a plain
+    # `build_opener()` carries a ProxyHandler holding {'http': 'http://...'}, while
+    # `build_opener(ProxyHandler({}))` carries none.
+    # getattr because `OpenerDirector.handlers` is real at runtime but absent from the
+    # typeshed stubs, and a suppression comment would hide a genuine future error here.
+    handlers = getattr(_OPENER, "handlers", None)
+    assert handlers, "opener exposes no handlers to inspect"
+    assert not [h for h in handlers if isinstance(h, urllib.request.ProxyHandler)]
+
+
+def test_a_configured_proxy_never_receives_the_token(tmp_path):
+    """The end-to-end half, in a subprocess because the opener is built at import.
+
+    Reported by @yukkie3276: with HTTP_PROXY set and no NO_PROXY, urllib routed the whole
+    request — `X-Stats-Token` included — through the proxy. Reproduced before the fix; the
+    sink received the sentinel token and the absolute URL as its request path.
+    """
+    script = tmp_path / "probe.py"
+    script.write_text(
+        "import http.server, os, sys, threading, json\n"
+        "seen = {}\n"
+        "class P(http.server.BaseHTTPRequestHandler):\n"
+        "    def do_GET(self):\n"
+        "        seen['t'] = self.headers.get('X-Stats-Token')\n"
+        "        b = b'{}'\n"
+        "        self.send_response(200); self.send_header('Content-Length', str(len(b)))\n"
+        "        self.end_headers(); self.wfile.write(b)\n"
+        "    def log_message(self, *a): pass\n"
+        "srv = http.server.HTTPServer(('127.0.0.1', 0), P)\n"
+        "threading.Thread(target=srv.serve_forever, daemon=True).start()\n"
+        "os.environ['HTTP_PROXY'] = 'http://127.0.0.1:%d' % srv.server_port\n"
+        "os.environ.pop('NO_PROXY', None); os.environ.pop('no_proxy', None)\n"
+        "sys.path.insert(0, sys.argv[1])\n"
+        "from technocore_exporter.fetch import fetch_stats, StatsUnavailableError\n"
+        "try:\n"
+        "    fetch_stats('http://stats.example.invalid/stats', 'sentinel-token', timeout=3)\n"
+        "except StatsUnavailableError:\n"
+        "    pass\n"
+        "print(json.dumps(seen.get('t')))\n"
+    )
+    src = Path(__file__).resolve().parents[2] / "exporter" / "src"
+    result = subprocess.run(
+        [sys.executable, str(script), str(src)], capture_output=True, text=True, timeout=60
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout.strip()) is None, "the proxy received the stats token"
+
+
+def test_an_oversized_body_is_refused_without_reading_it_all(monkeypatch):
+    """`response.read()` with no argument reads whatever the far side sends.
+
+    Monitoring that can be made to exhaust memory takes the observability down with the
+    thing it was watching, so the read is capped and one byte over the cap is enough to
+    refuse.
+    """
+    from technocore_exporter.fetch import MAX_BODY_BYTES
+
+    _patch(monkeypatch, _Response(b"x" * (MAX_BODY_BYTES + 10)))
+    with pytest.raises(StatsUnavailableError, match="exceeded"):
+        fetch_stats(URL, "token")
+
+
+def test_a_body_at_the_cap_is_still_read(monkeypatch):
+    """The boundary in the other direction, so the cap cannot pass by refusing everything."""
+    payload = json.dumps(_valid()).encode()
+    assert len(payload) < 4096
+    _patch(monkeypatch, _Response(payload))
+    assert fetch_stats(URL, "token")["rooms"]["total"] == 0
+
+
+def test_the_token_never_reaches_a_redirect_target_end_to_end():
+    """The same property as the parametrised test above, proved against real sockets.
+
+    The unit test asserts the message for each 3xx; this asserts the thing that actually
+    matters — that the sink never sees the credential. Kept alongside rather than instead:
+    the unit test would still pass if `_NoRedirect` were removed and something else began
+    raising, and this one would not.
+    """
+    received = {}
+
+    class Sink(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            received["token"] = self.headers.get("X-Stats-Token")
+            body = b"{}"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        # Name matches BaseHTTPRequestHandler.log_message exactly; renaming the first
+        # parameter would break a keyword call through the base signature.
+        def log_message(self, format, *args):  # noqa: A002 - see above
+            pass
+
+    sink = http.server.HTTPServer(("127.0.0.1", 0), Sink)
+
+    class Redirector(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(302)
+            self.send_header("Location", f"http://127.0.0.1:{sink.server_port}/stats")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        # Name matches BaseHTTPRequestHandler.log_message exactly; renaming the first
+        # parameter would break a keyword call through the base signature.
+        def log_message(self, format, *args):  # noqa: A002 - see above
+            pass
+
+    source = http.server.HTTPServer(("127.0.0.1", 0), Redirector)
+    for server in (sink, source):
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        with pytest.raises(StatsUnavailableError, match="refusing to send the token"):
+            fetch_stats(f"http://127.0.0.1:{source.server_port}/stats", "sentinel-token", 5)
+        assert received.get("token") is None, "the redirect target received the stats token"
+    finally:
+        for server in (sink, source):
+            server.shutdown()
+            server.server_close()

--- a/tests/exporter/test_fetch.py
+++ b/tests/exporter/test_fetch.py
@@ -314,12 +314,31 @@ def test_an_oversized_body_is_refused_without_reading_it_all(monkeypatch):
         fetch_stats(URL, "token")
 
 
-def test_a_body_at_the_cap_is_still_read(monkeypatch):
-    """The boundary in the other direction, so the cap cannot pass by refusing everything."""
+def test_an_ordinary_digest_is_still_read(monkeypatch):
+    """The cap must not pass by refusing everything. A real digest is nowhere near it."""
     payload = json.dumps(_valid()).encode()
     assert len(payload) < 4096
     _patch(monkeypatch, _Response(payload))
     assert fetch_stats(URL, "token")["rooms"]["total"] == 0
+
+
+@pytest.mark.parametrize(("cap_delta", "refused"), [(0, False), (-1, True)])
+def test_the_body_cap_is_exact_at_its_boundary(monkeypatch, cap_delta, refused):
+    """Exactly at the cap is read; one byte over is refused.
+
+    Against a cap moved to the fixture's own length rather than against an 8 MiB body: the
+    boundary is what `read(MAX_BODY_BYTES + 1)` plus `len(raw) > MAX_BODY_BYTES` gets wrong
+    by one in either direction, and the previous pair of tests only covered "far under" and
+    "far over", where an off-by-one is invisible.
+    """
+    payload = json.dumps(_valid()).encode()
+    monkeypatch.setattr("technocore_exporter.fetch.MAX_BODY_BYTES", len(payload) + cap_delta)
+    _patch(monkeypatch, _Response(payload))
+    if refused:
+        with pytest.raises(StatsUnavailableError, match="exceeded"):
+            fetch_stats(URL, "token")
+    else:
+        assert fetch_stats(URL, "token")["rooms"]["total"] == 0
 
 
 def test_the_token_never_reaches_a_redirect_target_end_to_end():

--- a/tests/exporter/test_fetch.py
+++ b/tests/exporter/test_fetch.py
@@ -512,3 +512,27 @@ def test_the_budget_holds_even_if_the_socket_cannot_be_re_armed(monkeypatch):
     # One overshoot is the documented cost of losing the re-arm: the read in flight when
     # the deadline passes still carries the full socket timeout. Bounded, not unbounded.
     assert elapsed < 1.5, f"a 0.5s budget took {elapsed:.2f}s with no re-arm"
+
+
+def test_a_deeply_nested_body_is_reported_not_raised_raw():
+    """The fourth family to escape as itself, and the first that is not socket-shaped.
+
+    `json.loads` raises `RecursionError` on a deeply nested document — 40KB of `[` does it,
+    two orders of magnitude under MAX_BODY_BYTES — and it is a `RuntimeError`, so neither
+    the `ValueError` handler nor the trailing `OSError` one reaches it. It escaped
+    `fetch_stats`, which left the collector's broad handler to log it as an *unexpected*
+    error with a traceback, rather than as the named refusal every other unusable body gets.
+
+    The body is reachable by anything that can occupy the configured address, which is the
+    same argument MAX_BODY_BYTES is there for.
+    """
+    depth = 20_000
+    body = (b"[" * depth) + (b"]" * depth)
+
+    def nested(conn):
+        conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n" % len(body))
+        conn.sendall(body)
+
+    port = _raw_origin(nested)
+    with pytest.raises(StatsUnavailableError, match="nested too deeply"):
+        fetch_stats(f"http://127.0.0.1:{port}/stats", "token", timeout=5.0)

--- a/tests/exporter/test_server.py
+++ b/tests/exporter/test_server.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from prometheus_client import CollectorRegistry
+from prometheus_client import CollectorRegistry, generate_latest
+from prometheus_client.parser import text_string_to_metric_families
 from technocore_exporter.fetch import DEFAULT_TIMEOUT
 from technocore_exporter.server import (
     DEFAULT_HOST,
@@ -11,7 +12,9 @@ from technocore_exporter.server import (
     DEFAULT_URL,
     SCRAPE_TIMEOUT_CEILING,
     build,
+    build_registry,
     describe,
+    main,
     settings,
 )
 
@@ -156,3 +159,66 @@ def test_the_refusal_does_not_echo_the_credential():
         assert "s3cret" not in str(exc)
     else:
         raise AssertionError("expected a refusal")
+
+
+# ------------------------------------ what the ungated page exposes, reported by @Minh3132
+
+
+def _served_names(body: str) -> set:
+    return {family.name for family in text_string_to_metric_families(body)}
+
+
+def test_the_served_registry_carries_only_our_families(monkeypatch, stats):
+    """The boundary, asserted on a rendered page rather than on the registration call.
+
+    `build` used to default to the client library's global `REGISTRY`, which arrives
+    pre-populated with the process, platform and GC collectors — so the ungated `/metrics`
+    page published `python_info`, `process_resident_memory_bytes` and friends alongside the
+    digest. Rendering the page is what makes that visible; asserting on what was registered
+    is not, because those families are registered by an import, not by this package.
+    """
+    monkeypatch.setattr("technocore_exporter.collector.fetch_stats", lambda *a, **k: stats)
+    config = settings(env={**TOKEN, "TECHNOCORE_STATS_URL": "https://chat.example/stats"})
+
+    body = generate_latest(build_registry(config)).decode()
+
+    names = _served_names(body)
+    assert names, "the served page is empty"
+    assert all(name.startswith("technocore_") for name in names), sorted(names)
+
+
+def test_main_serves_the_registry_it_built(monkeypatch, stats):
+    """The production wiring, not a stand-in for it.
+
+    A test that only renders `build_registry(config)` still passes if `main()` goes back to
+    calling `start_http_server` without a registry, because the library then serves its own
+    default and never consults ours. So this drives `main()` itself and asserts on the
+    registry the serve call actually received.
+    """
+    captured = {}
+
+    def fake_start(port, addr, registry):
+        captured.update(port=port, addr=addr, registry=registry)
+
+    def stop(*_args):
+        raise SystemExit
+
+    monkeypatch.setattr("technocore_exporter.server.start_http_server", fake_start)
+    monkeypatch.setattr("technocore_exporter.server.time.sleep", stop)
+    monkeypatch.setattr("technocore_exporter.collector.fetch_stats", lambda *a, **k: stats)
+    monkeypatch.setenv("TECHNOCORE_STATS_TOKEN", "s3cret-token")
+    monkeypatch.setenv("TECHNOCORE_STATS_URL", "https://chat.example/stats")
+    monkeypatch.setenv("TECHNOCORE_EXPORTER_PORT", "9999")
+    # main() reads the real environment. Cleared rather than trusted, so a developer who
+    # exports one of these for a live exporter does not get a failure from this file.
+    monkeypatch.delenv("TECHNOCORE_STATS_TIMEOUT", raising=False)
+    monkeypatch.delenv("TECHNOCORE_EXPORTER_HOST", raising=False)
+
+    with pytest.raises(SystemExit):
+        main()
+
+    assert (captured["port"], captured["addr"]) == (9999, DEFAULT_HOST)
+    body = generate_latest(captured["registry"]).decode()
+    assert all(name.startswith("technocore_") for name in _served_names(body))
+    for upstream in ("python_info", "process_resident_memory_bytes", "python_gc_objects"):
+        assert upstream not in body, f"{upstream} reached the ungated page"

--- a/tests/exporter/test_server.py
+++ b/tests/exporter/test_server.py
@@ -29,7 +29,7 @@ def test_a_missing_token_stops_the_process_with_the_reason():
 
 
 def test_an_empty_token_counts_as_missing():
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit, match="TECHNOCORE_STATS_TOKEN is not set"):
         settings(env={"TECHNOCORE_STATS_TOKEN": ""})
 
 
@@ -112,14 +112,58 @@ def test_an_unusable_port_is_refused_at_boot(raw):
 
 @pytest.mark.parametrize(
     "raw",
-    ["", "not a url", "ftp://host/stats", "file:///etc/passwd", "/stats", "http:///stats"],
+    [
+        "",
+        "not a url",
+        "ftp://host/stats",
+        "file:///etc/passwd",
+        "/stats",
+        "http:///stats",
+        # The port, which the scheme check does not see. `http://127.0.0.1:notaport/stats`
+        # parsed clean, booted clean, and then failed every scrape with `protocol error:
+        # InvalidURL` — accepted at boot and permanently unable to work, which is the exact
+        # outcome this validator exists to prevent.
+        "http://127.0.0.1:notaport/stats",
+        "http://127.0.0.1:99999/stats",
+        "http://127.0.0.1:0/stats",
+        # `urlparse` raises on this one before any check runs, so the process died with a
+        # traceback instead of the refusal every other setting here gets.
+        "http://[::1/stats",
+    ],
 )
 def test_an_unusable_stats_url_is_refused_at_boot(raw):
     """Same class as the timeout: `urllib.request.Request` raises for an unknown scheme at
     *request* time, which the broad catch in collect() would render as a permanently
-    failing scrape rather than as the configuration error it is."""
+    failing scrape rather than as the configuration error it is.
+
+    Every case here must reach `SystemExit` with the variable named. A traceback is not a
+    refusal: it is the same "unusable configuration" outcome reported in a way that does
+    not tell the operator which knob to fix.
+    """
     with pytest.raises(SystemExit, match="TECHNOCORE_STATS_URL"):
         settings(env={**TOKEN, "TECHNOCORE_STATS_URL": raw})
+
+
+@pytest.mark.parametrize("raw", [" ", "\t", "\n", "   "])
+def test_a_whitespace_only_token_counts_as_missing(raw):
+    """`TECHNOCORE_STATS_TOKEN=" "` is truthy, so it booted and 404ed forever.
+
+    Same shape as an unusable URL or timeout: accepted at boot, permanently unable to work.
+    A stray space in a unit file or a `.env` line is how it happens.
+    """
+    with pytest.raises(SystemExit, match="TECHNOCORE_STATS_TOKEN is only whitespace"):
+        settings(env={"TECHNOCORE_STATS_TOKEN": raw})
+
+
+def test_a_token_whose_whitespace_is_real_is_sent_unchanged():
+    """The other direction, and the reason the value is tested stripped but used raw.
+
+    Core reads CHAT_STATS_TOKEN without stripping and compares with `compare_digest`, so a
+    token with surrounding whitespace is one this must send exactly as configured.
+    Trimming it here would turn a working deployment into a silent 404.
+    """
+    config = settings(env={"TECHNOCORE_STATS_TOKEN": " padded "})
+    assert config.token == " padded "
 
 
 def test_the_usable_configuration_is_still_accepted():
@@ -222,3 +266,27 @@ def test_main_serves_the_registry_it_built(monkeypatch, stats):
     assert all(name.startswith("technocore_") for name in _served_names(body))
     for upstream in ("python_info", "process_resident_memory_bytes", "python_gc_objects"):
         assert upstream not in body, f"{upstream} reached the ungated page"
+
+
+def test_importing_the_module_entrypoint_does_not_start_the_server(monkeypatch):
+    """`__main__.py` ran `main()` at import, with no `if __name__` guard.
+
+    Anything that imports the package's submodules — a docs tool, `pkgutil.walk_packages`,
+    a packaging or coverage pass — therefore bound a port and never returned. The guard is
+    the stdlib convention; `mcp/` has no `__main__.py` to copy, so there was no in-repo
+    precedent to follow either.
+
+    Asserted through a real import rather than by reading the source for the guard, because
+    a source scan passes for a file that has the words in a comment.
+    """
+    import importlib
+
+    called = []
+    monkeypatch.setattr(
+        "technocore_exporter.server.main", lambda: called.append(True), raising=True
+    )
+    # Reloaded rather than merely imported: the module may already be in sys.modules from
+    # an earlier test, and a cached import executes nothing at all — which would make this
+    # pass whether or not the guard is there.
+    importlib.reload(importlib.import_module("technocore_exporter.__main__"))
+    assert called == [], "importing __main__ ran main()"

--- a/tests/exporter/test_server.py
+++ b/tests/exporter/test_server.py
@@ -1,0 +1,158 @@
+"""Configuration rules, which is where this package's security properties live."""
+
+from __future__ import annotations
+
+import pytest
+from prometheus_client import CollectorRegistry
+from technocore_exporter.fetch import DEFAULT_TIMEOUT
+from technocore_exporter.server import (
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    DEFAULT_URL,
+    SCRAPE_TIMEOUT_CEILING,
+    build,
+    describe,
+    settings,
+)
+
+TOKEN = {"TECHNOCORE_STATS_TOKEN": "s3cret-token"}
+
+
+def test_a_missing_token_stops_the_process_with_the_reason():
+    """Not a warning and not a 404 loop: without the token there is nothing to export, and
+    the failure mode at the origin (404, not 401) is the one an operator misreads."""
+    with pytest.raises(SystemExit, match="CHAT_STATS_TOKEN"):
+        settings(env={})
+
+
+def test_an_empty_token_counts_as_missing():
+    with pytest.raises(SystemExit):
+        settings(env={"TECHNOCORE_STATS_TOKEN": ""})
+
+
+def test_the_defaults_are_loopback_and_the_local_origin():
+    """Loopback by default because /metrics is not gated at all."""
+    config = settings(env=TOKEN)
+    assert config.host == DEFAULT_HOST == "127.0.0.1"
+    assert config.port == DEFAULT_PORT == 9464
+    assert config.url == DEFAULT_URL
+    # Below Prometheus's common 10s scrape_timeout, so a slow origin is reported as a
+    # failed scrape rather than swallowed by the scrape timing out with no samples.
+    assert config.timeout == DEFAULT_TIMEOUT < 10.0
+
+
+def test_every_setting_is_overridable():
+    config = settings(
+        env={
+            **TOKEN,
+            "TECHNOCORE_STATS_URL": "https://chat.example/stats",
+            "TECHNOCORE_EXPORTER_HOST": "0.0.0.0",
+            "TECHNOCORE_EXPORTER_PORT": "9999",
+            "TECHNOCORE_STATS_TIMEOUT": "2.5",
+        }
+    )
+    assert config.url == "https://chat.example/stats"
+    assert (config.host, config.port, config.timeout) == ("0.0.0.0", 9999, 2.5)
+
+
+def test_the_token_never_reaches_the_startup_log():
+    """Asserted rather than left to a reviewer noticing a future format string change."""
+    config = settings(env={**TOKEN, "TECHNOCORE_STATS_URL": "https://chat.example/stats"})
+    line = describe(config)
+    assert "s3cret-token" not in line
+    assert "chat.example" in line and "9464" in line
+
+
+def test_the_collector_is_wired_with_the_configured_values():
+    registry = CollectorRegistry()
+    config = settings(env={**TOKEN, "TECHNOCORE_STATS_URL": "https://chat.example/stats"})
+    collector = build(config, registry=registry)
+    assert collector._url == "https://chat.example/stats"
+    assert collector._token == "s3cret-token"
+    assert collector._timeout == DEFAULT_TIMEOUT
+
+
+# ------------------------------------------------- boot validation, reported by @Minh3132
+
+
+@pytest.mark.parametrize(
+    "raw", ["-1", "-0.5", "nan", "NaN", "inf", "-inf", "Infinity", "0", "abc", ""]
+)
+def test_an_unusable_timeout_is_refused_at_boot(raw):
+    """The failure mode this closes is worse than a wrong number.
+
+    A negative or NaN timeout raises ValueError from socket.settimeout and inf raises
+    OverflowError — on every scrape, not at boot. Since collect() deliberately converts any
+    unexpected exception into scrape_success 0, an unvalidated typo here produces a process
+    that starts, stays up, answers /metrics forever and can never once succeed. Refusing at
+    boot is the difference between a visible misconfiguration and an exporter that looks
+    alive and is not.
+    """
+    with pytest.raises(SystemExit, match="TECHNOCORE_STATS_TIMEOUT"):
+        settings(env={**TOKEN, "TECHNOCORE_STATS_TIMEOUT": raw})
+
+
+def test_a_timeout_at_or_above_the_scrape_ceiling_is_refused():
+    """The headroom in the README is part of the contract, so it is enforced rather than
+    described: at or above Prometheus's own default scrape_timeout the source can no longer
+    fail first, and the failure lands as a scrape timeout with no samples."""
+    with pytest.raises(SystemExit, match="must be below"):
+        settings(env={**TOKEN, "TECHNOCORE_STATS_TIMEOUT": str(SCRAPE_TIMEOUT_CEILING)})
+    assert settings(env={**TOKEN, "TECHNOCORE_STATS_TIMEOUT": "9.9"}).timeout == 9.9
+
+
+@pytest.mark.parametrize("raw", ["0", "-1", "65536", "99999", "abc", "8.5", ""])
+def test_an_unusable_port_is_refused_at_boot(raw):
+    with pytest.raises(SystemExit, match="TECHNOCORE_EXPORTER_PORT"):
+        settings(env={**TOKEN, "TECHNOCORE_EXPORTER_PORT": raw})
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "not a url", "ftp://host/stats", "file:///etc/passwd", "/stats", "http:///stats"],
+)
+def test_an_unusable_stats_url_is_refused_at_boot(raw):
+    """Same class as the timeout: `urllib.request.Request` raises for an unknown scheme at
+    *request* time, which the broad catch in collect() would render as a permanently
+    failing scrape rather than as the configuration error it is."""
+    with pytest.raises(SystemExit, match="TECHNOCORE_STATS_URL"):
+        settings(env={**TOKEN, "TECHNOCORE_STATS_URL": raw})
+
+
+def test_the_usable_configuration_is_still_accepted():
+    """The other direction, so the validators cannot pass by refusing everything."""
+    config = settings(
+        env={
+            **TOKEN,
+            "TECHNOCORE_STATS_URL": "https://chat.example/stats",
+            "TECHNOCORE_EXPORTER_PORT": "9999",
+            "TECHNOCORE_STATS_TIMEOUT": "2.5",
+        }
+    )
+    assert (config.url, config.port, config.timeout) == ("https://chat.example/stats", 9999, 2.5)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "http://user:s3cret@host/stats",
+        "http://user@host/stats",
+        "https://admin:hunter2@chat.example/stats",
+    ],
+)
+def test_a_url_embedding_credentials_is_refused(raw):
+    """`describe()` writes this URL to the startup log, so URL credentials would put a
+    second secret in the one place the stats token is deliberately kept out of. /stats
+    authenticates with X-Stats-Token and nothing else, so these can only be a mistake."""
+    with pytest.raises(SystemExit, match="must not embed credentials"):
+        settings(env={**TOKEN, "TECHNOCORE_STATS_URL": raw})
+
+
+def test_the_refusal_does_not_echo_the_credential():
+    """A refusal that quotes the value would write the secret to stderr instead."""
+    try:
+        settings(env={**TOKEN, "TECHNOCORE_STATS_URL": "http://user:s3cret@host/stats"})
+    except SystemExit as exc:
+        assert "s3cret" not in str(exc)
+    else:
+        raise AssertionError("expected a refusal")

--- a/uv.lock
+++ b/uv.lock
@@ -1010,6 +1010,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/73/f1334c29c2af4cd9dba6c7817e61b611bd0215e2eb5565c6064a4de18802/prometheus_client-0.26.0.tar.gz", hash = "sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b", size = 92910, upload-time = "2026-07-24T19:36:41.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl", hash = "sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6", size = 64494, upload-time = "2026-07-24T19:36:40.854Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1633,6 +1642,7 @@ dev = [
     { name = "httpx2" },
     { name = "hypothesis" },
     { name = "mcp" },
+    { name = "prometheus-client" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "rust-just" },
@@ -1658,6 +1668,7 @@ dev = [
     { name = "httpx2", specifier = ">=2.10.0" },
     { name = "hypothesis", specifier = ">=6.165.10" },
     { name = "mcp", specifier = ">=2.1,<3" },
+    { name = "prometheus-client", specifier = ">=0.20" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.16.1" },
     { name = "rust-just", specifier = ">=1.58.0" },


### PR DESCRIPTION
Closes nothing on its own; implements the first wave of #766.

## What changes for a caller

Nothing on the service. `/stats` keeps its existing JSON digest, history and token gate byte for byte, and no route, response or core module is touched. This adds a new package under `exporter/` that an operator runs beside the service: it reads the token-gated `/stats` over HTTP and republishes the shared-storage aggregates as Prometheus metrics on its own `/metrics`.

The relationship to core is the one `mcp/` already has — its own `pyproject.toml`, its own declared dependencies, no import from `src/` — so `sz.py --caps` is unaffected and no size cap moves.

## Scope

Only what `store.service_stats` returns:

- **Gauges** — `rooms` (`total`, `listed`, `unlisted`, `open`, `mailbox`, `ownable`, `ephemeral`) and `capacity`; `bytes.rooms`, `bytes.notes`, `bytes.rooms_capacity`; note count and byte total.
- **Counters** — the six in `COUNTER_KEYS` (`store.py:248`), with `reaped_idle`/`reaped_stillborn` folded into `technocore_rooms_reaped_total{reason=...}`. HELP text states the best-effort lag and reset behaviour, because a reader who does not know these are batched per worker will read a flat line as an outage.
- **Exporter self-metrics** — scrape success, duration, last-success timestamp, and a scrapes counter by outcome. Without these a wrong token and a service with no rooms are the same absence of samples.

### Room classes are exported in two shapes, deliberately

`listed`/`unlisted` partition the population, so they are label values on one metric and summing them is correct. The class markers do not partition anything — `room_classes` composes by prefix, so `mb-p-x` is a mailbox *and* unlisted — so those are separate metric names, a shape nobody is tempted to add up. The fixture is a real capture in which `listed 4 + unlisted 2 = 6 = total` while `open 2 + mailbox 1 + ownable 1 + ephemeral 1 = 5`, so the distinction is pinned by arithmetic rather than by a comment.

### Not exported, each for a reason

- **`requests`** — per *worker*, not per service. `app.py:1914` records the digest under-reporting by 3x once production moved to `--workers 3`, and consecutive scrapes of a load-balanced URL can land on different processes, so no arrangement of those samples is a monotonic counter. Admission failures belong to the HTTP server or proxy.
- **`history`** — Prometheus stores what it scrapes. Re-exporting the ring as timestamp-labelled series would double-store it and produce a second, disagreeing history. Only the newest sample's timestamp is used, as freshness.
- **`engagement`** — pooled over the 50 most recently active rooms, so it is a bounded-window sample rather than a service total, and misleading beside real totals.

## Abuse impact

No new public surface on the service; it makes no writes and adds no route. The exporter's own `/metrics` is **not** authenticated and carries the same numbers as the token-gated digest, so it binds to `127.0.0.1` by default and the README says to keep it on the operator's network. The token is read from the environment only — never a flag, because argv is readable via `ps` — and a test asserts it never reaches the startup log line. No room name, namespace, DID, IP address or raw URL can become a label value: the label set is asserted as an allowlist, because a denylist passes for whatever nobody thought of.

## Two defects found while building it

- `fetch.py` caught `(URLError, TimeoutError)` together and read `exc.reason`. A bare socket timeout is not a `URLError` and has no `.reason`, so a slow origin raised `AttributeError` from inside the handler, escaped the module's own exception, and would have turned `/metrics` into a 500. Split, with a regression test.
- `technocore_stats_sample_age_seconds` was documented as sitting below ~300s on a healthy service. Sampling is driven by writes, not a timer, so it grows without bound on an idle service — measured at 300.6s on an idle probe instance moments after the last write. It is now documented as context and explicitly not an availability signal, so nobody alerts on it.

## Verification

Verified against `main` `20a4457` (fresh `git fetch origin`).

```
uv run ruff check .            All checks passed
uv run ruff format --check .   102 files already formatted
uv run ty check                All checks passed
uv run sz.py --caps            pass (core untouched: app.py 1020/1030, store.py 992/1010)
uv run coverage run -m pytest  799 passed, 1 skipped
uv run coverage report         98.01%  (main is 97.97%; exporter/src is 100%)
```

`promtool` 3.5.0: `check metrics` over live exporter output (no findings), `check rules`, `check config`, and `test rules` — the last unit-tests both alerts in both directions, including the exactly-85% boundary that must *not* fire and the `absent()` case a bare `== 0` rule would miss.

The fixture is captured from a real service rather than hand-written; `exporter/tests/fixtures/README.md` records the exact traffic behind it. End to end, the exporter was run against a live instance, and then against a killed one to confirm a failed scrape reports `success 0` and serves no stale storage gauges.

## Documentation and compatibility

`exporter/README.md` carries the metric table, the omissions above, and the scrape guidance. No served document changes, because nothing about the service's HTTP surface changes.

Root `pyproject.toml` gains `prometheus-client` as a **dev-only** dependency and `exporter/src` in `ty` extra-paths, coverage source and testpaths — the same wiring `mcp/src` has, and for the same reason: so the package is checked here and cannot rot against a `/stats` change it does not import. It is not a runtime dependency of technocore-chat and must not become one.

### Release note

> A packaged Prometheus exporter (`exporter/`) reads the token-gated `/stats` digest and republishes the shared-storage gauges and lifetime counters. `/stats` is unchanged.

## Scrape interval

60s, as shipped in `exporter/config/prometheus-scrape.yml`, matching `CHAT_STATS_CACHE_SECONDS`. The digest is an O(cap) walk cached for that long precisely so it is not rebuilt per request; scraping faster returns the same cached bytes and buys no freshness.

## On overlap

#766 asks whether the exporter belongs in this repository or in an external companion package. This PR is the in-repo answer with the reasoning in the issue thread; if the call goes the other way, the layout is what changes, not the mapping.

@luch91 raised the boundary question on 2026-09-07 and I said I would review theirs rather than compete if they proceeded — that offer stands. @osr21 has since said they are proceeding with the same scope. I am not asking anyone to stop, and per CONTRIBUTING's "Overlapping work", a collision that is not clear-cut is the maintainers' call. This is filed because the work was already complete and validated; take whichever is more useful.
