### PR TITLE
fix(humans): widen the DID marker to 8 trailing characters

### DIFF
--- a/src/humans.html
+++ b/src/humans.html
@@ -1096,7 +1096,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
       // is a screenshot that carries its own provenance.
       var who = document.createElement('span'); who.className = 'who';
       who.textContent = m.from.indexOf('did:key:z') === 0
-        ? m.from.slice(8, 12) + '…' + m.from.slice(-4)
+        ? m.from.slice(8, 12) + '…' + m.from.slice(-8)
         : '~' + m.from;
       var body = document.createElement('span'); body.className = 'body'; body.textContent = m.text;
       // `ts` is the server's, so it is the one field in the row nobody could have forged by
@@ -1325,7 +1325,7 @@ GET /kv/topic/&lt;room&gt;/set/&lt;text&gt;    what a room is for — shown abov
 
   // The same abbreviation didkey.abbreviate() and render() above use, so one identity reads
   // the same in the composer, in the log, and in `?format=text`.
-  function shortDid(did) { return did.slice(8, 12) + '…' + did.slice(-4); }
+  function shortDid(did) { return did.slice(8, 12) + '…' + did.slice(-8); }
 
   // seed -> { did, key }. The public half comes back out of the JWK export rather than being
   // computed here: WebCrypto already derived it during the import, and RFC 8037 requires an

--- a/tests/humans_ui_probe.mjs
+++ b/tests/humans_ui_probe.mjs
@@ -643,6 +643,75 @@ const browser = await chromium.launch({
   await context.close();
 }
 
+
+// ---------------------------------------------------------------- did marker collision
+// shortDid() used to keep only the last 4 base58 characters after the constant `z6Mk`
+// prefix every Ed25519 did:key starts with, so two different keys whose DIDs happened to
+// share their last 4 characters rendered as the exact same marker — nothing in the log
+// told the two identities apart. SEED_A/SEED_B are a real collision under the old scheme
+// and a real distinction under the fixed one, found against didkey.py's own encoding (not
+// reimplemented here) rather than picked by hand.
+{
+  const context = await browser.newContext({ viewport: { width: 900, height: 900 } });
+  const page = await context.newPage();
+  const errors = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+  await page.goto(`${BASE}/humans`, { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#identity:not([hidden])", { timeout: 5000 });
+
+  const SEED_A = "de7cb2f01a67d8b196738e995ffe362d4ea1099301d852e4ccecd17f4c6c0f1f";
+  const DID_A  = "did:key:z6MkrpxBFhfQSjQhhWZJRb9xW2NCy1ayDy16cznvz9tN9DtS";
+  const SEED_B = "0f14584b84e5f0a0cf2b16a1367f26e14d06df8a00876590b9b49a4d09480a9d";
+  const DID_B  = "did:key:z6MkjTvbjitn32Czwguyvqe5dGb5oF6Z17taijbtn4wk9DtS";
+  if (DID_A.slice(-4) !== DID_B.slice(-4) || DID_A.slice(-8) === DID_B.slice(-8)) {
+    throw new Error("did-marker-collision fixture no longer collides — regenerate SEED_A/SEED_B");
+  }
+
+  const room = `didmarker${Date.now().toString(36)}`;
+  const TOKEN_A = `marker-a-${Date.now().toString(36)}`;
+  const TOKEN_B = `marker-b-${Date.now().toString(36)}`;
+
+  await page.click("#keymore summary");
+  await page.fill("#seed", SEED_A);
+  await page.click("#keyuse");
+  await page.waitForFunction((did) => document.getElementById("me")?.getAttribute("title") === did, DID_A);
+  check("did marker: SEED_A signs in as the expected DID",
+        (await page.getAttribute("#me", "title")) === DID_A);
+  await page.fill("#room", room);
+  await page.click("#join");
+  await page.fill("#text", TOKEN_A);
+  await page.click("#send");
+  const rowA = page.locator(`#log .msg:has(.body:text-is("${TOKEN_A}"))`);
+  await rowA.waitFor({ timeout: 8000 });
+
+  await page.click("#keyout");
+  if (!(await page.locator("#seed").isVisible())) {
+    await page.click("#keymore summary");
+  }
+  await page.fill("#seed", SEED_B);
+  await page.click("#keyuse");
+  await page.waitForFunction((did) => document.getElementById("me")?.getAttribute("title") === did, DID_B);
+  check("did marker: SEED_B signs in as the expected DID",
+        (await page.getAttribute("#me", "title")) === DID_B);
+  await page.fill("#room", room);
+  await page.click("#join");
+  await page.fill("#text", TOKEN_B);
+  await page.click("#send");
+  const rowB = page.locator(`#log .msg:has(.body:text-is("${TOKEN_B}"))`);
+  await rowB.waitFor({ timeout: 8000 });
+
+  const markerA = (await rowA.locator(".who").textContent()).trim();
+  const markerB = (await rowB.locator(".who").textContent()).trim();
+  check("did marker: two different signers render two different markers",
+        markerA !== markerB, `${markerA} vs ${markerB}`);
+  check("did marker: each marker keeps the 8 trailing characters the fix widened to",
+        markerA.endsWith(DID_A.slice(-8)) && markerB.endsWith(DID_B.slice(-8)),
+        `${markerA} / ${markerB}`);
+
+  check("did marker: no page errors throughout", errors.length === 0, errors.join("; "));
+  await context.close();
+}
+
 // -------------------------------------------------------------------- passkey + delegation
 // Two things a Python test cannot reach at all: whether an authenticator's PRF output can
 // actually stand in as an Ed25519 seed, and whether the identity comes back on a browser


### PR DESCRIPTION
## What
Widens the did:key marker shown in `/humans` from 4 to 8 trailing base58
characters, in both `shortDid()` and the message-row render path. A caller
of `/humans` sees a more distinguishing marker; no HTTP-level behavior
changes.

## Why
Every Ed25519 `did:key` on this server begins `z6Mk`, so the marker's only
distinguishing power was its last 4 characters — two different identities
could render with the exact same marker. This is the same class of issue
#300 tracks for `didkey.abbreviate()` (PR #305), but in `/humans`'s own JS
truncation, which #305 does not touch.

## Checks
- [x] `uv run coverage run -m pytest tests -q && uv run coverage report`
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] Docs: no doc describes this marker's character count, nothing to update
- [x] New surface: nothing new — existing render path, no new route/parameter/
      persistent state