### PR TITLE
fix(store): stop last_seq rewinding when every visible record has expired

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -889,12 +889,15 @@ def read_messages(
     # advancing past records nobody can read any more, or an expired room would reuse seqs.
     cutoff = _cutoff(room)
     out: list[dict] = []
+    newest_seq: int | None = None  # the room's true high-water mark, even past the cutoff
     if path.exists():
         with path.open("rb") as f:
             for raw in reverse_lines(f):
                 rec = _parse(raw)
                 if rec is None:
                     continue
+                if newest_seq is None:
+                    newest_seq = rec["seq"]
                 if since is not None and rec["seq"] <= since:
                     break
                 if cutoff is not None and _expired(rec, cutoff):
@@ -907,7 +910,7 @@ def read_messages(
         "room": room,
         "count": len(out),
         "first_seq": out[0]["seq"] if out else None,
-        "last_seq": out[-1]["seq"] if out else (since or 0),
+        "last_seq": out[-1]["seq"] if out else (newest_seq if newest_seq is not None else (since or 0)),
         "generation": room_generation(root, room),
         "messages": out,
     }

--- a/src/store.py
+++ b/src/store.py
@@ -910,7 +910,7 @@ def read_messages(
         "room": room,
         "count": len(out),
         "first_seq": out[0]["seq"] if out else None,
-        "last_seq": out[-1]["seq"] if out else (newest_seq if newest_seq is not None else (since or 0)),
+        "last_seq": out[-1]["seq"] if out else max(since or 0, newest_seq or 0),
         "generation": room_generation(root, room),
         "messages": out,
     }

--- a/tests/test_store_stateful.py
+++ b/tests/test_store_stateful.py
@@ -265,7 +265,14 @@ class StoreLifecycle(RuleBasedStateMachine):
         if since is not None:
             assert all(s > since for s in seqs), "`since` returned something already seen"
         assert view["first_seq"] == (seqs[0] if seqs else None)
-        assert view["last_seq"] == (seqs[-1] if seqs else (since or 0))
+        # The empty-read fallback has to preserve both floors: the caller's own cursor,
+        # and the room's surviving high-water mark — but only when the file still holds
+        # one. A reap deletes the file outright, and read_messages does not consult the
+        # floor map there either (out of this fix's scope), so `_on_disk` is the same
+        # check the implementation implicitly makes by way of `path.exists()`.
+        on_disk = _on_disk(self.root, room)
+        floor = on_disk[-1]["seq"] if on_disk else 0
+        assert view["last_seq"] == (seqs[-1] if seqs else max(since or 0, floor))
         for message in view["messages"]:
             assert (message["from"], message["text"]) == self.said[room][message["seq"]]
 

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -951,8 +951,9 @@ def test_an_unparseable_timestamp_counts_as_expired(tmp_path, stamp):
 def test_last_seq_does_not_rewind_when_every_visible_record_expires(tmp_path, monkeypatch):
     """`last_seq` deliberately does NOT filter" is the promise a few lines above it in
     read_messages — a room where every visible record has aged past the TTL must still
-    report its true high-water mark, not fall back to `since` (or 0), or a client reusing
-    the reported last_seq as its next ?since= cursor watches the counter rewind."""
+    report its true high-water mark, not fall back to `since` (or 0). The fallback must
+    not rewind the other way either: a caller whose `since` is already ahead of the room's
+    high-water mark must get its own cursor back, not the smaller discovered seq."""
     import store
 
     real_now = store._now
@@ -964,6 +965,9 @@ def test_last_seq_does_not_rewind_when_every_visible_record_expires(tmp_path, mo
     view = store.read_messages(tmp_path, "e-standup")
     assert view["count"] == 0  # everything really is expired
     assert view["last_seq"] == store.last_seq(tmp_path, "e-standup") == 5
+
+    ahead = store.read_messages(tmp_path, "e-standup", since=10)
+    assert ahead["count"] == 0 and ahead["last_seq"] == 10  # caller's cursor, not rewound
 
 
 def test_ephemeral_ttl_boundary_is_inclusive_then_expires(tmp_path, monkeypatch):

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -948,6 +948,24 @@ def test_an_unparseable_timestamp_counts_as_expired(tmp_path, stamp):
     assert store.read_messages(tmp_path, "keeps-it")["count"] == 0  # a different room, empty
 
 
+def test_last_seq_does_not_rewind_when_every_visible_record_expires(tmp_path, monkeypatch):
+    """`last_seq` deliberately does NOT filter" is the promise a few lines above it in
+    read_messages — a room where every visible record has aged past the TTL must still
+    report its true high-water mark, not fall back to `since` (or 0), or a client reusing
+    the reported last_seq as its next ?since= cursor watches the counter rewind."""
+    import store
+
+    real_now = store._now
+    _at(monkeypatch, store, "2020-01-01T00:00:00.000000Z")
+    for _ in range(5):
+        store.append(tmp_path, "e-standup", "bot", "old")
+    monkeypatch.setattr(store, "_now", real_now)
+
+    view = store.read_messages(tmp_path, "e-standup")
+    assert view["count"] == 0  # everything really is expired
+    assert view["last_seq"] == store.last_seq(tmp_path, "e-standup") == 5
+
+
 def test_ephemeral_ttl_boundary_is_inclusive_then_expires(tmp_path, monkeypatch):
     """At exactly TTL the record is still within the promise; one microsecond older is not.
 


### PR DESCRIPTION
## What
`read_messages()` falls back to `since or 0` for `last_seq` when every record in the
scanned window has expired (an `e-` room whose visible messages have all aged past
`CHAT_EPHEMERAL_TTL_SECONDS`). This contradicts the invariant documented right above it
in the same function — "seq must keep advancing past records nobody can read any more,
or an expired room would reuse seqs" — and the README's "seq keeps counting so no cursor
rewinds" — and disagrees with `store.last_seq()`, which reads the true high-water mark
regardless of expiry.

## Repro
- Write 5 messages to an `e-` room, then let the TTL pass so all 5 expire.
- `read_messages()` returns `count == 0` (correct) but `last_seq == 0` (wrong — the true
  value, also returned by `store.last_seq()`, is 5).
- A client that follows the response's `next: /r/<room>?since=<last_seq>` line would see
  its cursor silently reset to 0.

## Fix
Track the newest parsed record's seq during the same backward scan, before the
`since`/expiry filters run, and use it as the fallback instead of `since or 0` when the
visible window is empty. No extra I/O, no behavior change when `out` is non-empty.

## Test
Added `test_last_seq_does_not_rewind_when_every_visible_record_expires` in
`tests/unit/test_store.py`, which fails on current `main` (asserts `last_seq == 5`,
currently returns `0`) and passes with this fix.