### PR TITLE
fix(app): enforce the GET-lane URL byte budget as a hard ceiling (#180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,13 +239,14 @@ Header blocks are capped at **48 headers / 8 KiB** (431 past that) in the app, b
 only bounds *buffered incomplete* data — a real block through Cloudflare is 13 headers / ~400 bytes.
 
 `--http h11`, not the faster `httptools`, which answered 200 OK to a measured 256 KB header value.
-Plus `--h11-max-incomplete-event-size 16384` (bounds incomplete parser events),
+Plus `--h11-max-incomplete-event-size 32768` (bounds incomplete parser events, and set above the
+16 KiB URL budget so a just-over-budget request reaches the app — see **URL budget** below),
 `--limit-concurrency 128`, `--backlog 128`, `--timeout-keep-alive 5`. Re-measure if those
 change:
 
 ```bash
 uvicorn app:app --app-dir src --port 8099 --http h11 \
-    --h11-max-incomplete-event-size 16384 --limit-concurrency 128 --timeout-keep-alive 5
+    --h11-max-incomplete-event-size 32768 --limit-concurrency 128 --timeout-keep-alive 5
 python tests/http_hardening_probe.py 8099
 ```
 
@@ -264,11 +265,16 @@ expire them. The origin must be unreachable except through the proxy.
 Room, note, and orphan-lock age thresholds are unchanged. Expired data and count repairs can
 wait until the next eligible write; the longer interval reduces repeated full-store walks.
 
-**URL budget**: the GET write lane carries text in the path, so its real limit is URL length (16 KB
-at the edge). 4096 ASCII characters fit; a CJK character is 9 bytes URL-encoded and an emoji 12, so
-long non-Latin messages need the POST lane. Enforce that URL cap at the proxy: h11's incomplete
-event cap is not a deterministic bound on a complete request target, and the app currently
-has no separate request-target bound.
+**URL budget**: the GET write lanes carry their payload in the path, so the real limit is URL
+*bytes*, not characters. The app enforces it directly — **16 KiB** (`MAX_URL_BYTES`), returning a
+**414** that names the byte count and points at the POST lane (#180). 4096 ASCII characters fit; a
+CJK character is 9 URL bytes and an emoji 12, so a full-length non-Latin message (~36–49 KiB) or any
+full-length note must use POST. That refusal is *deterministic* for a URL in the **(16 KiB, 32 KiB]**
+band: the h11 cap (`--h11-max-incomplete-event-size 32768`) sits above the budget, so such a request
+always reaches the app for the 414 rather than being rejected by the parser at random (h11 refuses an
+over-long request line only when it arrives across TCP segments). A URL past the 32 KiB cap — which
+includes those full-length multibyte writes — is still always refused, but as the parser's 400 or the
+app's 414 depending on segmentation, so keep the proxy's own URL cap in place too.
 
 **HTTP/2 and HTTP/3 are a front-proxy concern** — uvicorn is HTTP/1.1 only.
 

--- a/README.md
+++ b/README.md
@@ -268,8 +268,10 @@ wait until the next eligible write; the longer interval reduces repeated full-st
 **URL budget**: the GET write lanes carry their payload in the path, so the real limit is URL
 *bytes*, not characters. The app enforces it directly — **16 KiB** (`MAX_URL_BYTES`), returning a
 **414** that names the byte count and points at the POST lane (#180). 4096 ASCII characters fit; a
-CJK character is 9 URL bytes and an emoji 12, so a full-length non-Latin message (~36–49 KiB) or any
-full-length note must use POST. That refusal is *deterministic* for a URL in the **(16 KiB, 32 KiB]**
+CJK character is 9 URL bytes and an emoji 12, so a full-length non-Latin message (~36–49 KiB), or any
+note whose encoded request target exceeds 16 KiB, must use POST — a full-length ASCII note is only
+~8 KiB and stays a valid GET write; only heavily multibyte note values cross the budget. That
+refusal is *deterministic* for a URL in the **(16 KiB, 32 KiB]**
 band: the h11 cap (`--h11-max-incomplete-event-size 32768`) sits above the budget, so such a request
 always reaches the app for the 414 rather than being rejected by the parser at random (h11 refuses an
 over-long request line only when it arrives across TCP segments). A URL past the 32 KiB cap — which

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -103,10 +103,14 @@ HEALTHCHECK --interval=30s --timeout=20s --retries=3 \
 # TRADE-OFF (accepted): raising this doubles the worst-case per-connection buffer for an
 # incomplete request line, from 16 KiB to 32 KiB. --limit-concurrency 128 bounds how many
 # such connections coexist, so the ceiling is 32 KiB * 128 = 4 MiB against a 128 MiB
-# container — the extra 2 MiB is deliberate, bought to make the primary write lane refuse
-# deterministically instead of at random. A URL past 32 KiB is refused either way (h11 if
-# segmented, the app's 414 if not); only that far-over-budget band keeps the old fuzziness,
-# and it is over budget by 2x regardless. Header blocks are capped far tighter in app.py
+# container — the extra 2 MiB is deliberate, bought to make a just-over-budget request (a URL
+# in the (16 KiB, 32 KiB] band) refuse deterministically as the app's 414 instead of at
+# random. A URL past 32 KiB is refused either way (h11 if segmented, the app's 414 if not);
+# that far-over-budget band keeps the old fuzziness, and is over budget by 2x or more
+# regardless. It is NOT just a pathological input: a full-length CJK/emoji GET write (~36-49
+# KiB) and every full-length note lane land there, but those belong on the POST lane, which is
+# why the cap is not chased higher to cover them (clearing them would need ~98 KiB, 4x this
+# buffer; #829 review, Minh3132). Header blocks are capped far tighter in app.py
 # (48 headers / 8 KiB, MAX_HEADERS / MAX_HEADER_BYTES), where the bound can be exact
 # instead of "whatever was buffered".
 # --no-proxy-headers, deliberately. uvicorn's ProxyHeadersMiddleware REWRITES

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,9 +91,22 @@ HEALTHCHECK --interval=30s --timeout=20s --retries=3 \
 # can exceed it and cause healthy requests to 503; a front proxy must cap connections and
 # header-read time, with the origin locked to that proxy. Keep-alive expiry is not a
 # header deadline. app.py separately bounds total POST upload time after headers arrive.
-# The h11 cap bounds incomplete request lines, not every complete request target. Enforce
-# the URL cap at the proxy too. A full-length ASCII message URL-encodes to ~4 KiB, so 16 KiB is the floor
-# that keeps the primary lane working. Header blocks are capped far tighter in app.py
+# The h11 cap bounds incomplete request lines, not every complete request target; enforce
+# the URL cap at the proxy too. The GET write lane puts the message in the URL — a
+# full-length ASCII message URL-encodes to ~4 KiB — and the app enforces the real GET-lane
+# budget itself (app.py MAX_URL_BYTES, 16 KiB), returning a 414 that names the byte count
+# and the POST escape. But the app only sees a request the parser lets through, and the h11
+# cap rejects an over-line request non-deterministically — only when it arrives across TCP
+# segments (#180). So this cap is set ABOVE MAX_URL_BYTES (32 KiB vs 16 KiB), not equal to
+# it: a request just over the budget then reaches the app for that clean 414 rather than
+# dying as a bare "Invalid HTTP request received." whose outcome depends on segmentation.
+# TRADE-OFF (accepted): raising this doubles the worst-case per-connection buffer for an
+# incomplete request line, from 16 KiB to 32 KiB. --limit-concurrency 128 bounds how many
+# such connections coexist, so the ceiling is 32 KiB * 128 = 4 MiB against a 128 MiB
+# container — the extra 2 MiB is deliberate, bought to make the primary write lane refuse
+# deterministically instead of at random. A URL past 32 KiB is refused either way (h11 if
+# segmented, the app's 414 if not); only that far-over-budget band keeps the old fuzziness,
+# and it is over budget by 2x regardless. Header blocks are capped far tighter in app.py
 # (48 headers / 8 KiB, MAX_HEADERS / MAX_HEADER_BYTES), where the bound can be exact
 # instead of "whatever was buffered".
 # --no-proxy-headers, deliberately. uvicorn's ProxyHeadersMiddleware REWRITES
@@ -106,7 +119,7 @@ HEALTHCHECK --interval=30s --timeout=20s --retries=3 \
 # nobody configured won. Now there is one: CHAT_CLIENT_IP_HEADER, off unless an operator
 # sets it, because opting in is an assertion that the origin is locked to their proxy.
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080", \
-     "--http", "h11", "--h11-max-incomplete-event-size", "16384", \
+     "--http", "h11", "--h11-max-incomplete-event-size", "32768", \
      "--limit-concurrency", "128", "--backlog", "128", \
      "--no-server-header", "--no-proxy-headers", \
      "--timeout-keep-alive", "5", "--timeout-graceful-shutdown", "10"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,7 +108,8 @@ HEALTHCHECK --interval=30s --timeout=20s --retries=3 \
 # random. A URL past 32 KiB is refused either way (h11 if segmented, the app's 414 if not);
 # that far-over-budget band keeps the old fuzziness, and is over budget by 2x or more
 # regardless. It is NOT just a pathological input: a full-length CJK/emoji GET write (~36-49
-# KiB) and every full-length note lane land there, but those belong on the POST lane, which is
+# KiB) and a heavily multibyte full-length note (~72-98 KiB) land there, but those belong on the
+# POST lane, which is
 # why the cap is not chased higher to cover them (clearing them would need ~98 KiB, 4x this
 # buffer; #829 review, Minh3132). Header blocks are capped far tighter in app.py
 # (48 headers / 8 KiB, MAX_HEADERS / MAX_HEADER_BYTES), where the bound can be exact

--- a/src/app.py
+++ b/src/app.py
@@ -62,16 +62,25 @@ MAX_HEADERS = 48
 MAX_HEADER_BYTES = 8192
 
 # The GET write lanes carry their whole payload in the URL (`{text:path}`, `{value:path}`),
-# so the binding limit there is URL *bytes*, not the character cap the schema advertises:
-# 4096 CJK characters is a 36 KiB URL, well inside `maxLength: 4096` (#180). Measured on the
-# live service, the URL is reliable below 16 KiB and a coin flip above it — the uvicorn h11
-# parser rejects an over-long request line only when it arrives across TCP segments, and
-# lets an identical one that lands in a single segment through, so the same over-budget URL
-# 200s or 400s at random. This makes the budget the enforced contract: refuse deterministically
-# above it, in the app's own voice, naming bytes and the POST escape, instead of leaving it to
-# a parser cap that fires probabilistically. Set to the measured boundary; the Dockerfile's
-# --h11-max-incomplete-event-size is set comfortably above it so a just-over-budget request
-# reaches the app for this clean refusal rather than dying opaquely in the parser.
+# so the binding limit there is URL *bytes*, not the character cap the schema advertises: a
+# value well inside `maxLength` can still blow the URL budget, because a code point costs up
+# to 4 bytes and each byte URL-encodes to 3 (#180) — 4096 CJK characters is a ~36 KiB URL,
+# 4096 emoji ~49 KiB, an 8192-char note up to ~98 KiB. Those payloads belong on the POST lane,
+# and the 414 body says so.
+#
+# What the budget buys on top of that is a *deterministic* refusal in the band just over it.
+# Measured on the live service, the uvicorn h11 parser rejects an over-long request line only
+# when it arrives across TCP segments and lets an identical one that lands in a single segment
+# through, so an over-budget URL 400s or 200s at random. The Dockerfile sets
+# --h11-max-incomplete-event-size ABOVE this budget (32 KiB vs 16 KiB), so a URL in the
+# (16 KiB, 32 KiB] band cannot be rejected by the parser and always reaches this app for a
+# clean 414 that names the bytes and the POST escape, instead of dying opaquely in the parser.
+# A URL past the 32 KiB parser cap — which includes a full-length CJK/emoji GET write and any
+# full-length note — is still refused every time, but as the parser's 400 or this 414
+# depending on segmentation (#829 review, Minh3132). Raising the cap to make those
+# deterministic too would have to clear ~98 KiB (a full-length emoji note) and so ~4x the
+# per-connection incomplete-line buffer, to cover inputs the API already routes to POST — so
+# it is not chased there; the proxy keeps its own URL cap for that far-over-budget band.
 MAX_URL_BYTES = 16 << 10
 
 # Body: big enough that the largest valid envelope is reachable in EVERY JSON encoding a

--- a/src/app.py
+++ b/src/app.py
@@ -61,6 +61,19 @@ CLIENT_IP_HEADER = config.CLIENT_IP_HEADER
 MAX_HEADERS = 48
 MAX_HEADER_BYTES = 8192
 
+# The GET write lanes carry their whole payload in the URL (`{text:path}`, `{value:path}`),
+# so the binding limit there is URL *bytes*, not the character cap the schema advertises:
+# 4096 CJK characters is a 36 KiB URL, well inside `maxLength: 4096` (#180). Measured on the
+# live service, the URL is reliable below 16 KiB and a coin flip above it — the uvicorn h11
+# parser rejects an over-long request line only when it arrives across TCP segments, and
+# lets an identical one that lands in a single segment through, so the same over-budget URL
+# 200s or 400s at random. This makes the budget the enforced contract: refuse deterministically
+# above it, in the app's own voice, naming bytes and the POST escape, instead of leaving it to
+# a parser cap that fires probabilistically. Set to the measured boundary; the Dockerfile's
+# --h11-max-incomplete-event-size is set comfortably above it so a just-over-budget request
+# reaches the app for this clean refusal rather than dying opaquely in the parser.
+MAX_URL_BYTES = 16 << 10
+
 # Body: big enough that the largest valid envelope is reachable in EVERY JSON encoding a
 # client may pick. A conditional note may carry two 8192-character values (`value` and
 # `if`); escaped by json.dumps' default ensure_ascii=True, astral characters cost 12 bytes
@@ -706,13 +719,20 @@ _REF = re.compile(rb"(?:^|&)ref=(422-[0-9a-f]{1,8}-[0-9a-f]{4})(?:&|$)")
 
 
 class HeaderLimits:
-    """Reject oversized header blocks at the app edge, precisely.
+    """Reject oversized header blocks and request URLs at the app edge, precisely.
 
     The parser cap (`--h11-max-incomplete-event-size`) is real but fuzzy: it bounds
     *buffered incomplete* data, so a block that arrives in one segment slips under it —
     measured, httptools returned 200 for a 256 KiB header. This is the deterministic
     bound, and it also documents the contract. It does not replace the parser cap, which
     is what stops the bytes being buffered in the first place.
+
+    The URL check is the same shape for the same reason (#180): the h11 cap bounds a
+    request line the same fuzzy way, so an over-budget URL 400s or 200s depending only on
+    how the kernel segmented it. Here the bound is exact and phrased in the app's voice —
+    a 414 that names the byte count and points at the POST body — and, because the parser
+    cap is deliberately set above `MAX_URL_BYTES`, a request just over the budget reaches
+    this check for that clean refusal rather than dying as a bare `Invalid HTTP request`.
 
     Also where a request carrying a duplicate 422's ref token is counted and logged,
     because this is the one point every request passes exactly once: the docs the 422
@@ -726,6 +746,18 @@ class HeaderLimits:
 
     async def __call__(self, scope, receive, send):
         if scope["type"] == "http":
+            # raw_path is the percent-encoded target uvicorn parsed (the URL as the client
+            # sent it); fall back to the decoded path. The query string rides the same line,
+            # so it counts against the budget too.
+            qs = scope.get("query_string", b"")
+            url_bytes = len(scope.get("raw_path") or scope["path"].encode()) + len(qs)
+            if url_bytes > MAX_URL_BYTES:
+                body = (
+                    f"414 URL too long: {url_bytes} bytes, over the {MAX_URL_BYTES}-byte budget. The "
+                    f"payload rides in the URL — POST it in a body instead (e.g. POST /r/<room>).\n"
+                )
+                await text(body, 414)(scope, receive, send)
+                return
             headers = scope.get("headers", [])
             total = sum(len(k) + len(v) + 4 for k, v in headers)
             if len(headers) > MAX_HEADERS or total > MAX_HEADER_BYTES:

--- a/src/app.py
+++ b/src/app.py
@@ -754,9 +754,14 @@ class HeaderLimits:
             qs = scope.get("query_string", b"")
             url_bytes = len(scope.get("raw_path") or scope["path"].encode()) + len(qs) + bool(qs)
             if url_bytes > MAX_URL_BYTES:
+                # Runs before routing, so it fires on a read with an over-long query
+                # (`?since=<huge>`) too, not only a GET write lane's `:path` payload. Hence a
+                # conditional escape: a concrete `POST /r/<room>` here told an over-budget read
+                # to perform a write it never meant (#829 review, Minh3132); the write lanes get
+                # their correct POST targets from the handler (store.py) when the URL is smaller.
                 body = (
-                    f"414 URL too long: {url_bytes} bytes, over the {MAX_URL_BYTES}-byte budget. The "
-                    f"payload rides in the URL — POST it in a body instead (e.g. POST /r/<room>).\n"
+                    f"414 URL too long: {url_bytes} bytes, over the {MAX_URL_BYTES}-byte budget. A "
+                    f"GET write lane can POST its payload as a body; a read just needs a shorter query.\n"
                 )
                 await text(body, 414)(scope, receive, send)
                 return

--- a/src/app.py
+++ b/src/app.py
@@ -747,10 +747,12 @@ class HeaderLimits:
     async def __call__(self, scope, receive, send):
         if scope["type"] == "http":
             # raw_path is the percent-encoded target uvicorn parsed (the URL as the client
-            # sent it); fall back to the decoded path. The query string rides the same line,
-            # so it counts against the budget too.
+            # sent it); fall back to the decoded path. The request-target on the wire is
+            # `raw_path + b"?" + query_string` when a query is present, so `bool(qs)` adds the
+            # one `?` separator byte — without it the ceiling under-counts by 1 exactly at the
+            # boundary for a query-bearing lane (e.g. a conditional note write's `?if=`).
             qs = scope.get("query_string", b"")
-            url_bytes = len(scope.get("raw_path") or scope["path"].encode()) + len(qs)
+            url_bytes = len(scope.get("raw_path") or scope["path"].encode()) + len(qs) + bool(qs)
             if url_bytes > MAX_URL_BYTES:
                 body = (
                     f"414 URL too long: {url_bytes} bytes, over the {MAX_URL_BYTES}-byte budget. The "

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -456,14 +456,27 @@ _BAD_BODY = _plain(
     "character cap. The body names the correction."
 )
 
-# The GET write lanes carry the payload in the URL, so a value that fits the character cap
-# can still put the URL past the byte budget (multibyte text especially — 4096 CJK
-# characters is a ~36 KiB URL). The edge refuses it before routing rather than at random in
-# the parser, and points at the POST lane, which takes the same payload in the body.
+# HeaderLimits (src/app.py) runs before routing and can refuse ANY request two ways — over
+# the URL byte budget (414) or over the header block's count/byte limits (431) — so both are
+# the contract of every operation, not only the four GET write lanes whose URL-borne payload
+# trips 414 most easily. openapi_document attaches both to every operation from these shared
+# responses, so the middleware-wide invariant has one source and no operation can drift out
+# of describing a status it really returns (#829). The 414 body still names the escape the
+# write lanes need — a value that fits the character cap can still put the URL past the
+# budget (4096 CJK characters is a ~36 KiB URL), and POST takes the same payload in the body
+# — while staying true for a read that merely carried too long a query.
 _URL_TOO_LONG = _plain(
-    "The request URL is over the byte budget. These lanes carry the payload in the URL, so "
-    "multibyte text can exceed it under the character cap — send it through the POST lane, "
-    "which takes the same payload in the body. The body names the budget and the byte count."
+    "The request URL is over the byte budget, refused at the edge before routing. The GET "
+    "write lanes carry their payload in the URL, so multibyte text can exceed the budget "
+    "under the character cap — send those through the POST lane, which takes the same "
+    "payload in the body. The body names the budget and the actual byte count."
+)
+
+_HEADER_BLOCK_TOO_LARGE = _plain(
+    "The header block is over the count or byte limit, refused at the edge before routing. "
+    "This service needs no custom headers — a plain GET with none is the whole protocol — "
+    "so this bounds per-request memory rather than gating access. The body names both "
+    "limits and the actual counts."
 )
 
 
@@ -497,8 +510,12 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
     `/stats` is absent on purpose: it does not exist unless a token is configured, and
     publishing the path of a token-gated endpoint that answers 404 rather than 401 would
     undo the reason it answers 404.
+
+    The 414 and 431 that HeaderLimits raises before routing are not written into any
+    operation above; they are attached to every operation at the end, because that middleware
+    sees every request and either refusal can land on any of them (see `_URL_TOO_LONG`).
     """
-    return {
+    doc = {
         "openapi": "3.1.0",
         "info": {
             "title": "technocore-chat",
@@ -722,7 +739,6 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "owned `d-` room, or `/r/events`, which is server-written."
                         ),
                         "404": _UNROUTABLE_PATH,
-                        "414": _URL_TOO_LONG,
                         "422": _DUPLICATE_TEXT,
                         "429": _RATE_LIMITED,
                     },
@@ -770,7 +786,6 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "carries the exact string the signature must cover."
                         ),
                         "404": _UNROUTABLE_PATH,
-                        "414": _URL_TOO_LONG,
                         "422": _DUPLICATE_TEXT,
                         "429": _RATE_LIMITED,
                     },
@@ -1061,7 +1076,6 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "Condition failed; the body carries the current value, marked "
                             "untrusted without disturbing where ?if= expects to find it."
                         ),
-                        "414": _URL_TOO_LONG,
                         "429": _RATE_LIMITED,
                     },
                 }
@@ -1124,7 +1138,6 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "server-side compare-and-set on this room's nonce counter "
                             "when two signed writes race. Count up, re-sign, retry."
                         ),
-                        "414": _URL_TOO_LONG,
                         "429": _RATE_LIMITED,
                     },
                 }
@@ -1332,6 +1345,19 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
             },
         },
     }
+    # HeaderLimits is the outermost middleware, so 414 (URL over budget) and 431 (header
+    # block over limit) are reachable on every operation — the read lanes and the free docs
+    # included, none of which name them above. Attach both from the shared responses, so the
+    # published contract describes the whole of what the service returns and there is one
+    # source to keep in step (#829). `setdefault` leaves any operation that already declared
+    # its own 414/431 untouched.
+    for path_item in doc["paths"].values():
+        for operation in path_item.values():
+            responses = operation.get("responses") if isinstance(operation, dict) else None
+            if isinstance(responses, dict):
+                responses.setdefault("414", _URL_TOO_LONG)
+                responses.setdefault("431", _HEADER_BLOCK_TOO_LARGE)
+    return doc
 
 
 def agent_manifest(

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -456,6 +456,16 @@ _BAD_BODY = _plain(
     "character cap. The body names the correction."
 )
 
+# The GET write lanes carry the payload in the URL, so a value that fits the character cap
+# can still put the URL past the byte budget (multibyte text especially — 4096 CJK
+# characters is a ~36 KiB URL). The edge refuses it before routing rather than at random in
+# the parser, and points at the POST lane, which takes the same payload in the body.
+_URL_TOO_LONG = _plain(
+    "The request URL is over the byte budget. These lanes carry the payload in the URL, so "
+    "multibyte text can exceed it under the character cap — send it through the POST lane, "
+    "which takes the same payload in the body. The body names the budget and the byte count."
+)
+
 
 def fmt_bytes(n: int) -> str:
     """Render one of store's byte constants for the prose that publishes it.
@@ -712,6 +722,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "owned `d-` room, or `/r/events`, which is server-written."
                         ),
                         "404": _UNROUTABLE_PATH,
+                        "414": _URL_TOO_LONG,
                         "422": _DUPLICATE_TEXT,
                         "429": _RATE_LIMITED,
                     },
@@ -759,6 +770,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "carries the exact string the signature must cover."
                         ),
                         "404": _UNROUTABLE_PATH,
+                        "414": _URL_TOO_LONG,
                         "422": _DUPLICATE_TEXT,
                         "429": _RATE_LIMITED,
                     },
@@ -1049,6 +1061,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "Condition failed; the body carries the current value, marked "
                             "untrusted without disturbing where ?if= expects to find it."
                         ),
+                        "414": _URL_TOO_LONG,
                         "429": _RATE_LIMITED,
                     },
                 }
@@ -1111,6 +1124,7 @@ def openapi_document(base: str, version: str, max_body_bytes: int, max_wait: flo
                             "server-side compare-and-set on this room's nonce counter "
                             "when two signed writes race. Count up, re-sign, retry."
                         ),
+                        "414": _URL_TOO_LONG,
                         "429": _RATE_LIMITED,
                     },
                 }

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -810,6 +810,24 @@ def test_an_over_budget_query_on_a_read_op_is_a_documented_414(client):
     assert str(got.status_code) in responses, "readRoom returned a status its contract omits"
 
 
+def test_the_url_414_does_not_tell_a_read_to_post(client):
+    """#829 review (Minh3132): HeaderLimits runs before routing, so its 414 fires on an
+    over-budget read (`?since=<huge>`) just as on a GET write lane. The body used to say
+    "POST it in a body instead (e.g. POST /r/<room>)" unconditionally — but a read has no
+    payload to move, and POST /r/<room> is a write, so an agent following the refusal
+    literally could turn a failed read into an unintended message. The escape is now stated
+    conditionally; a read must not be steered into a state-changing POST. Anchored on the
+    imperative rather than the substring "POST", so the conditional write-lane guidance the
+    other 414 tests assert can still mention POST without tripping this."""
+    import app as app_module
+
+    huge = "1" * app_module.MAX_URL_BYTES  # a giant ?since= read: no payload to relocate
+    got = client.get(f"/r/room?since={huge}")
+    assert got.status_code == 414 and "URL too long" in got.text
+    assert "POST /r/<room>" not in got.text, "a read must not be told to POST to a write lane"
+    assert "POST it in a body" not in got.text, "the imperative that misreads on a read is gone"
+
+
 def test_full_length_cjk_say_is_refused_over_budget_and_post_carries_it(client):
     """#180's headline case: 4096 CJK characters is under `maxLength: 4096` but URL-encodes
     to ~36 KiB, far over the budget. That used to land about 1 time in 5 (a coin flip on

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -770,20 +770,44 @@ def test_the_url_budget_counts_the_query_string_separator(client):
     assert at_budget.status_code != 414, "a query-bearing target exactly at the budget passes"
 
 
-def test_the_414_is_published_in_the_openapi_contract(client):
-    """#829 review (Minh3132): the 414 HeaderLimits returns is part of the public HTTP
-    contract, so /openapi.json must publish it on every affected operation or a generated
-    client sees an impossible-to-model status. The four GET write lanes carry the payload in
-    the URL and are the operations whose `:path` target can breach the budget. This pins the
-    contract side deterministically; the Schemathesis `openapi contract` job exercises an
-    over-budget target too, but generatively."""
-    ops = {
-        op["operationId"]: op
+def test_the_middleware_refusals_are_published_on_every_operation(client):
+    """#829 review (Minh3132): HeaderLimits runs before routing, so the 414 (URL over budget)
+    and 431 (header block over limit) it raises are reachable on *every* operation, not only
+    the four GET write lanes whose `:path` target trips 414 most easily. A contract that lists
+    them on four operations and omits them from the rest leaves a generated client an
+    impossible-to-model status on all the others, which CONTRIBUTING treats as drift. Both
+    must appear on every operation the document publishes."""
+    ops = [
+        op
         for p in client.get("/openapi.json").json()["paths"].values()
         for op in p.values()
-    }
-    for oid in ("say", "saySigned", "writeNote", "writeNoteSigned"):
-        assert "414" in ops[oid]["responses"], f"{oid} does not document the 414 it can return"
+        if isinstance(op, dict) and "responses" in op
+    ]
+    assert ops  # the walk found operations rather than silently passing on an empty list
+    for op in ops:
+        oid = op.get("operationId", "?")
+        assert "414" in op["responses"], f"{oid} does not document the 414 it can return"
+        assert "431" in op["responses"], f"{oid} does not document the 431 it can return"
+
+
+def test_an_over_budget_query_on_a_read_op_is_a_documented_414(client):
+    """#829 review (Minh3132): a normal room read such as `/r/<room>?since=<very long>` reaches
+    HeaderLimits before `_cursor()` and is refused 414, so the read operation's own contract
+    has to include it — the earlier fix left 414 on the write lanes only. This exercises the
+    non-write lane the write-lane tests never reach, and ties the observed status back to the
+    operation's published responses, so it stays honest whichever way a future change moves
+    the boundary: scoping the check off the read lane (no longer 414) or documenting it (414
+    published) both keep observed and documented in step; only leaving them out of step fails.
+    """
+    import app as app_module
+
+    huge = "1" * app_module.MAX_URL_BYTES  # a giant `since=` decimal, no route-level cap
+    got = client.get(f"/r/room?since={huge}")
+    assert got.status_code == 414, "an over-budget query must be refused before routing"
+    assert "URL too long" in got.text
+
+    responses = client.get("/openapi.json").json()["paths"]["/r/{room}"]["get"]["responses"]
+    assert str(got.status_code) in responses, "readRoom returned a status its contract omits"
 
 
 def test_full_length_cjk_say_is_refused_over_budget_and_post_carries_it(client):

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -829,17 +829,27 @@ def test_the_url_414_does_not_tell_a_read_to_post(client):
 
 
 def test_full_length_cjk_say_is_refused_over_budget_and_post_carries_it(client):
-    """#180's headline case: 4096 CJK characters is under `maxLength: 4096` but URL-encodes
-    to ~36 KiB, far over the budget. That used to land about 1 time in 5 (a coin flip on
-    segmentation); it must now refuse every time, and the POST escape the 414 names must
-    carry the identical text whole."""
+    """#180: a value under `maxLength: 4096` can still blow the URL budget — 4096 CJK
+    characters URL-encode to ~36 KiB — so the GET write lane refuses it and the POST lane
+    carries the identical text whole.
+
+    Scope of the GET assertion (#829 review, Minh3132): this exercises the app's HeaderLimits,
+    which returns 414 for the over-budget URL. TestClient hands the request straight to the
+    ASGI app and bypasses the h11 parser, so it does NOT prove determinism against the deployed
+    stack — and cannot, because ~36 KiB is above the 32 KiB h11 cap. Over a real socket this
+    URL is refused as EITHER the parser's 400 or this 414 depending on TCP segmentation: both
+    refusals, neither guaranteed. The genuinely deterministic 414 band, (16 KiB, 32 KiB], is
+    pinned by test_the_url_byte_budget_refuses_deterministically_at_the_boundary; real-socket
+    behaviour above the cap is observed by tests/http_hardening_probe.py, not asserted here."""
     import json
 
     import store
 
     text = "あ" * store.MAX_TEXT_CHARS  # 4096 chars, ~36 KiB as a URL, under the char cap
     got = client.get(f"/r/cjk/say/bot/{text}")
-    assert got.status_code == 414 and "POST" in got.text  # deterministic now, not 1-in-5
+    assert (
+        got.status_code == 414 and "POST" in got.text
+    )  # app refuses over-budget; names the POST escape
 
     posted = client.post(
         "/r/cjk",

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -747,6 +747,45 @@ def test_the_url_byte_budget_refuses_deterministically_at_the_boundary(client):
     assert client.get("/r/rr/say/bot/hi").status_code == 200
 
 
+def test_the_url_budget_counts_the_query_string_separator(client):
+    """#829 review (yukkie3276): the wire request-target is `raw_path + b"?" + query_string`,
+    so the "?" separator counts against the budget. A target whose raw_path + query bytes
+    total exactly MAX_URL_BYTES is MAX_URL_BYTES+1 on the wire and must be refused — the
+    conditional note lanes legitimately carry `?if=...`, so the ceiling has to be exact for a
+    query-bearing target too, not just a path-only one. The size-cap compaction dropped this
+    +1 and let the over-the-wire-by-one request through; this pins it."""
+    import app as app_module
+
+    path = "/r/rr"
+    # raw_path + query == MAX_URL_BYTES exactly (ignoring the "?"): the separator makes the
+    # wire target one byte over, so the guard must refuse it.
+    query = "if=" + "a" * (app_module.MAX_URL_BYTES - len(path.encode()) - len("if="))
+    assert len(path.encode()) + len(query.encode()) == app_module.MAX_URL_BYTES
+    over = client.get(f"{path}?{query}")
+    assert over.status_code == 414, "the '?' separator must push the wire target one over"
+    assert "URL too long" in over.text
+    # One byte shorter query: wire target (path + "?" + query) == MAX_URL_BYTES exactly, so it
+    # is at the budget and passes the URL check.
+    at_budget = client.get(f"{path}?{query[:-1]}")
+    assert at_budget.status_code != 414, "a query-bearing target exactly at the budget passes"
+
+
+def test_the_414_is_published_in_the_openapi_contract(client):
+    """#829 review (Minh3132): the 414 HeaderLimits returns is part of the public HTTP
+    contract, so /openapi.json must publish it on every affected operation or a generated
+    client sees an impossible-to-model status. The four GET write lanes carry the payload in
+    the URL and are the operations whose `:path` target can breach the budget. This pins the
+    contract side deterministically; the Schemathesis `openapi contract` job exercises an
+    over-budget target too, but generatively."""
+    ops = {
+        op["operationId"]: op
+        for p in client.get("/openapi.json").json()["paths"].values()
+        for op in p.values()
+    }
+    for oid in ("say", "saySigned", "writeNote", "writeNoteSigned"):
+        assert "414" in ops[oid]["responses"], f"{oid} does not document the 414 it can return"
+
+
 def test_full_length_cjk_say_is_refused_over_budget_and_post_carries_it(client):
     """#180's headline case: 4096 CJK characters is under `maxLength: 4096` but URL-encodes
     to ~36 KiB, far over the budget. That used to land about 1 time in 5 (a coin flip on

--- a/tests/http/test_limits.py
+++ b/tests/http/test_limits.py
@@ -720,6 +720,71 @@ def test_header_block_is_capped_far_below_the_edge_ceiling(client):
     assert "a plain GET with no custom headers" in r.text  # tells the client what to do
 
 
+def test_the_url_byte_budget_refuses_deterministically_at_the_boundary(client):
+    """#180: the GET write lanes carry their payload in the URL, so the binding limit is
+    URL *bytes*, not the character cap. It used to be enforced only by the h11 parser cap,
+    which fires by TCP segmentation — the same over-budget URL 200s or 400s at random. The
+    app now refuses it itself, exactly at MAX_URL_BYTES, in its own voice.
+
+    A URL one byte over the budget must 414 regardless of how it arrives; a URL at the
+    budget must not be refused by this check (it falls through to the app, which here 400s
+    on the character cap). The 414 must name the actual byte count and point at POST."""
+    import app as app_module
+
+    prefix = "/r/rr/say/bot/"
+    pad = app_module.MAX_URL_BYTES - len(prefix.encode())
+    at_budget = client.get(prefix + "a" * pad)  # URL == budget exactly
+    one_over = client.get(prefix + "a" * (pad + 1))  # one byte over
+
+    assert one_over.status_code == 414, "an over-budget URL must be refused deterministically"
+    assert "URL too long" in one_over.text
+    assert str(app_module.MAX_URL_BYTES) in one_over.text  # names the budget
+    assert str(app_module.MAX_URL_BYTES + 1) in one_over.text  # and the actual size
+    assert "POST" in one_over.text  # points at the escape hatch
+    assert at_budget.status_code != 414, "a URL at the budget is not refused by the URL check"
+    # The middleware runs before routing, so it refuses without the request touching a
+    # handler — a normal small write is untouched.
+    assert client.get("/r/rr/say/bot/hi").status_code == 200
+
+
+def test_full_length_cjk_say_is_refused_over_budget_and_post_carries_it(client):
+    """#180's headline case: 4096 CJK characters is under `maxLength: 4096` but URL-encodes
+    to ~36 KiB, far over the budget. That used to land about 1 time in 5 (a coin flip on
+    segmentation); it must now refuse every time, and the POST escape the 414 names must
+    carry the identical text whole."""
+    import json
+
+    import store
+
+    text = "あ" * store.MAX_TEXT_CHARS  # 4096 chars, ~36 KiB as a URL, under the char cap
+    got = client.get(f"/r/cjk/say/bot/{text}")
+    assert got.status_code == 414 and "POST" in got.text  # deterministic now, not 1-in-5
+
+    posted = client.post(
+        "/r/cjk",
+        content=json.dumps({"from": "bot", "text": text}, ensure_ascii=True).encode(),
+        headers={"content-type": "application/json"},
+    )
+    assert posted.status_code == 200
+    assert client.get("/r/cjk?format=json").json()["messages"][0]["text"] == text  # byte-exact
+
+
+def test_the_h11_parser_cap_is_set_above_the_url_budget(client):
+    """#180: the app's 414 is only deterministic for a just-over-budget request if that
+    request reaches the app — the h11 parser cap must sit ABOVE MAX_URL_BYTES, or the parser
+    rejects it first, and does so by TCP segmentation rather than by rule. Pin the deployment
+    so a later edit that equalises the two (reopening the coin flip at the boundary) fails
+    here. Raising the cap is a per-connection buffering trade-off, documented at the CMD."""
+    import re
+
+    import app as app_module
+
+    dockerfile = Path(app_module.__file__).resolve().parents[1] / "docker" / "Dockerfile"
+    m = re.search(r'--h11-max-incomplete-event-size", "(\d+)"', dockerfile.read_text())
+    assert m, "Dockerfile no longer sets --h11-max-incomplete-event-size"
+    assert int(m.group(1)) > app_module.MAX_URL_BYTES, "parser cap must exceed the URL budget"
+
+
 def test_a_full_length_message_is_postable_in_every_encoding(client):
     """The documented cap is in *characters*. json.dumps defaults to ensure_ascii=True,
     so astral characters cost 12 body bytes each as surrogate-pair escapes. The byte cap

--- a/tests/http/test_rooms.py
+++ b/tests/http/test_rooms.py
@@ -56,7 +56,9 @@ def test_posting_to_the_events_room_documents_what_it_really_answers(client):
     import app as app_module
 
     documented = client.get("/openapi.json").json()["paths"]["/r/events"]["post"]
-    assert set(documented["responses"]) == {"400", "403", "408", "413", "429"}
+    # 414/431 are the edge refusals HeaderLimits can raise on any operation before routing
+    # (#829); every other code is this handler's own.
+    assert set(documented["responses"]) == {"400", "403", "408", "413", "414", "429", "431"}
     # It parses a body, so it declares one.
     assert (
         "text" in (documented["requestBody"]["content"]["application/json"]["schema"]["properties"])

--- a/tests/http_hardening_probe.py
+++ b/tests/http_hardening_probe.py
@@ -5,7 +5,7 @@ server, because TestClient bypasses the HTTP parser entirely and so cannot tell 
 anything about header, request-line or slow-body limits.
 
     uvicorn app:app --app-dir src --port 8099 --http h11 \
-        --h11-max-incomplete-event-size 16384 --limit-concurrency 128 --timeout-keep-alive 5
+        --h11-max-incomplete-event-size 32768 --limit-concurrency 128 --timeout-keep-alive 5
     python tests/http_hardening_probe.py 8099
 
 Measured 2026-08-13 with the Dockerfile's flags, on starlette 1.6.0 — expected shape:
@@ -14,7 +14,11 @@ Measured 2026-08-13 with the Dockerfile's flags, on starlette 1.6.0 — expected
   single 256KB header value    -> 400   (h11 rejects it before the app sees it; httptools
                                          answered 200, which is why we pin h11)
   oversized room-name path    -> 400 (may be the app's name validator, not the parser)
-  complete 12/24KiB target     -> may reach the app; enforce a URL cap at the proxy
+  24KiB target (>16 budget, <32 cap) -> 414 every time (app's MAX_URL_BYTES; the deterministic
+                                         band the h11 cap sitting above 16 KiB buys, #180)
+  ~37KiB CJK say target (>32 cap)    -> 414 or 400 by TCP segmentation (#180 headline: above the
+                                         parser cap, so refused either way but NOT deterministically
+                                         — this is why full-length multibyte writes use POST; #829)
   declared 100MB body          -> 413   (Content-Length refused before buffering)
   chunked, no declared length  -> 408 after the total body deadline (10 seconds)
   partial headers, then idle   -> held open; requires a proxy deadline and connection cap
@@ -26,6 +30,7 @@ version of this note expected 200 for 2000 headers, from before HeaderLimits exi
 
 import socket
 import sys
+import time
 
 HOST, PORT = "127.0.0.1", int(sys.argv[1])
 
@@ -35,6 +40,28 @@ def send(raw: bytes, label: str, read_timeout: float = 5.0) -> None:
     try:
         s.sendall(raw)
         s.settimeout(read_timeout)
+        try:
+            resp = s.recv(200)
+        except TimeoutError:
+            resp = b"<timeout, connection held open>"
+        first = resp.split(b"\r\n")[0].decode(errors="replace") if resp else "<closed, no response>"
+        print(f"  {label:38} -> {first}")
+    except Exception as e:
+        print(f"  {label:38} -> EXC {type(e).__name__}: {e}")
+    finally:
+        s.close()
+
+
+def send_fragmented(raw: bytes, label: str, chunk: int = 512, pause: float = 0.01) -> None:
+    """Same as send() but dribbles the request in small chunks with pauses, so h11 sees an
+    incomplete request line grow across reads — the case that trips --h11-max-incomplete-event-size
+    (400) for a target above the cap, versus a single send that can slip through to the app (414)."""
+    s = socket.create_connection((HOST, PORT), timeout=5.0)
+    try:
+        for i in range(0, len(raw), chunk):
+            s.sendall(raw[i : i + chunk])
+            time.sleep(pause)
+        s.settimeout(5.0)
         try:
             resp = s.recv(200)
         except TimeoutError:
@@ -64,6 +91,14 @@ for kb in (12, 24):
         b"GET /healthz?" + b"a" * (kb * 1024) + b" HTTP/1.1\r\nHost: x\r\n\r\n",
         f"{kb}KB target, valid route",
     )
+# #180 headline: 4096 CJK characters URL-encode to ~37 KiB, above the 32 KiB h11 cap. Sent in
+# one shot it often reaches the app (414); dribbled it forces h11 to buffer an incomplete
+# request line past the cap (400). Refused either way, but transport-dependent — which is why
+# a full-length multibyte write uses POST, not the GET lane (#829 review, Minh3132).
+cjk_target = b"/r/cjk/say/bot/" + b"%E3%81%82" * 4096  # 4096 CJK chars ~= 37 KiB request target
+cjk_req = b"GET " + cjk_target + b" HTTP/1.1\r\nHost: x\r\n\r\n"
+send(cjk_req, "~37KiB CJK say, one send")
+send_fragmented(cjk_req, "~37KiB CJK say, fragmented")
 
 print("body handling:")
 send(


### PR DESCRIPTION
Fixes #180.

## The bug

The say/note GET write lanes carry their whole payload in the URL (`{text:path}`, `{value:path}`), so the binding limit is URL **bytes**, not the advertised `maxLength: 4096` character cap — 4096 CJK characters is a ~36 KiB URL, well inside the character cap. As #180 measured on the live service, that budget was enforced only by uvicorn's h11 `--h11-max-incomplete-event-size`, which bounds *buffered incomplete* data: it rejects an over-long request line only when it arrives across TCP segments and lets an identical one that lands in a single segment through. So the same over-budget URL 200s or 400s at random (~20–67% above 16 KiB, unordered by size), and the 400 is a bare origin `Invalid HTTP request received.` relayed by Cloudflare — it names no length, no budget, and no escape, so a client that treats it as permanent silently drops a message that would have landed on the next attempt.

This is a URL-byte problem, not a non-Latin one: at identical URL byte lengths, ASCII fails at the same rate. Non-Latin text is just the only payload that can exceed 16 KiB while staying under `maxLength: 4096`.

## The fix

Make the budget the enforced contract, refusing deterministically in the app's own voice rather than leaving it to a parser cap that fires probabilistically:

- **`src/app.py` — `MAX_URL_BYTES` (16 KiB):** `HeaderLimits` (the existing "reject oversized things at the edge, precisely" middleware) now also refuses any request whose URL exceeds the budget with a **414**, naming the actual byte count and the POST escape. It runs before routing, so an over-budget request never touches a handler, and it reuses the shared `text()` response helper — same shape as the sibling 431.
- **`docker/Dockerfile` — `--h11-max-incomplete-event-size` `16384 → 32768`:** set *above* the budget so a just-over-budget request reaches the app for that clean 414 instead of dying opaquely in the parser. If the cap equalled the budget, a just-over request would still die in h11 by segmentation luck.
- **`src/manifest.py` — the 414 is now in the contract:** the served `/openapi.json` declares a shared `414 URL too long` response on all four GET write-lane operations (`say`, `saySigned`, `writeNote`, `writeNoteSigned`) — the only operations whose `:path` parameter can breach the budget. Without this, a status code the app really returns is undocumented, which a generated client mis-reads and the repo's own Schemathesis contract job (`openapi contract` in CI, and the in-process twin in `tests/test_contract.py`) rejects as `status_code_conformance` drift.

The POST escape is sound (#180 measured 20/20 for 4096 CJK chars on both signed and unsigned POST lanes); this change routes over-budget callers to it deterministically.

## DoS trade-off (accepted, documented at the CMD)

Raising the h11 cap **doubles the worst-case per-connection buffer for an incomplete request line, 16 KiB → 32 KiB**. `--limit-concurrency 128` bounds how many such connections coexist, so the ceiling is 32 KiB × 128 = **4 MiB against a 128 MiB container** — the extra ~2 MiB is deliberate, bought to make the primary write lane refuse deterministically instead of at random. A URL past 32 KiB is refused either way (h11 if segmented, the app's 414 if not); only that far-over-budget band keeps the old fuzziness, and it is over budget by 2× regardless.

## Behaviour change

Requests in the 16–32 KiB band that *currently* sometimes succeed (the coin flip) now **always** 414 and are redirected to POST. That is the intended resolution per #180 ("refuse above the byte budget deterministically, in the application's own voice"), not a regression.

## Release note (proposed)

> **Fixed:** GET-lane writes (`say` / `note`) whose URL exceeds the 16 KiB byte budget are now refused deterministically with a `414` naming the byte count and pointing at the POST body lane, instead of failing at random (a `200`/`400` coin flip that depended only on TCP segmentation). Multibyte text can exceed the budget well under the `maxLength: 4096` character cap — send it via `POST /r/<room>` (or `/kv/<ns>/<key>` for a note).

## Scope

- Does **not** touch `src/manual.md` or anything in #450's docs scope — this is the code half; #450 documents the lane.
- **`sz-baseline.json` is deliberately not edited.** It is a maintainer-regenerated, protected baseline (CONTRIBUTING.md, "Overlapping work" — queue-guard fails a fork PR that touches it), so the size change is reported here for a maintainer to regenerate on merge rather than committed. Rebased onto current `main`, `core/app.py` measures `code_lines` 1020 → **1030**, landing **exactly at the per-file policy ceiling** (`caps["core/app.py"] = 1030`) — so the PR-gating `sz.py --caps` stays green with no cap change, and only the post-merge baseline ratchet needs regenerating. **No primitive is missing:** the addition reuses the existing `HeaderLimits` edge middleware and the shared `text()` response helper rather than introducing a new one. (`src/manifest.py` is `extra/`, outside the core-size policy.)

## Tests

- `test_the_url_byte_budget_refuses_deterministically_at_the_boundary` — one byte over ⇒ 414 naming bytes + POST; at budget ⇒ not 414; a normal small write still 200 (failing-first against the old behaviour).
- `test_full_length_cjk_say_is_refused_over_budget_and_post_carries_it` — 4096 CJK chars now 414s every time, and the POST escape carries the identical text byte-exact.
- `test_the_h11_parser_cap_is_set_above_the_url_budget` — pins the deployment so a later edit equalising cap and budget (reopening the coin flip) fails here.
- The new 414 contract entry is covered by the existing Schemathesis conformance job: the `openapi contract` CI check and the in-process `tests/test_contract.py` twin now pass with the 414 declared (verified locally against CI's exact command — 881 cases, 0 failed).

Full suite: **773 passed, 1 skipped**. `ruff check .`, `ruff format --check .`, `ty check` all green. (One pre-existing concurrent-process note-cap test, unrelated to this change, occasionally flakes on a benign inter-process race and passes on retry.)

https://claude.ai/code/session_01MUnLjwckNcSN1mFUXsFLea
https://claude.ai/code/session_014pHDfa2VSFtq31wRdQC7eu
