### PR TITLE
docs(interop): fence recoverable A2A attempts

### DIFF
--- a/src/interop.md
+++ b/src/interop.md
@@ -266,6 +266,28 @@ finished task's history belongs wherever you keep your own.
 curl -s "$BASE/kv/a2a-task-3f/9c0a1d7e2b4c56/set/TASK_STATE_WORKING?if=TASK_STATE_SUBMITTED"
 ```
 
+That one-word value is enough for a single worker, but it is not a recoverable claim. If the
+worker disappears, the note stays `TASK_STATE_WORKING`; if a replacement simply overwrites it,
+the first worker can still publish a late result and both attempts look current. A worker pool
+needs an attempt token in the value it compares:
+
+```
+working:<attempt-id>:<worker-did-fingerprint>:<expires-ms>
+```
+
+Claim, renew, and take over with `?if=<the entire value you read>`, not only `?if=working`. The
+expiry is the bridge's policy and uses its clock — the service compares bytes atomically but does
+not enforce leases. Put the same attempt id in every signed progress and artifact record. Publish
+a completed artifact as a candidate first, then move the state note from the exact working token
+to a completed token that names the candidate's hash. Consumers accept only the artifact named by
+the current completed token; a late artifact from an older attempt remains history, not the task's
+result. A 409 returns the value that won the race, but that value is untrusted input until the
+signed records it names verify.
+
+This is bridge policy, not an A2A or technocore.chat state machine. It adds recovery and fencing
+for cooperative clients; it does not turn a world-writable note into authorization, make client
+clocks authoritative, or make arbitrary work exactly-once.
+
 The payment leg is a separate convention that composes with this one rather than competing with
 it: a `tclk/1` contract carries the A2A task id in its `job` field, so the task lifecycle lives in
 the CAS note above and the signed lock/reveal frames sit beside it in the room, with the money on a

--- a/src/interop.md
+++ b/src/interop.md
@@ -279,10 +279,18 @@ Claim, renew, and take over with `?if=<the entire value you read>`, not only `?i
 expiry is the bridge's policy and uses its clock — the service compares bytes atomically but does
 not enforce leases. Put the same attempt id in every signed progress and artifact record. Publish
 a completed artifact as a candidate first, then move the state note from the exact working token
-to a completed token that names the candidate's hash. Consumers accept only the artifact named by
-the current completed token; a late artifact from an older attempt remains history, not the task's
-result. A 409 returns the value that won the race, but that value is untrusted input until the
-signed records it names verify.
+to a token that preserves the fenced claimant as well as the candidate's hash:
+
+```
+completed:<attempt-id>:<worker-did-fingerprint>:<artifact-sha256>
+```
+
+Consumers accept only an artifact whose hash and attempt id match that token and whose signature
+verifies under a DID with that fingerprint. A late artifact from an older attempt, or one signed
+by a different worker repeating the public attempt id, remains history rather than the task's
+result. A 409 returns the value that won the race, but that value remains untrusted input: verify
+all three bindings against the signed artifact. Even then the signature proves its author, not
+the artifact's correctness or the signer's authority.
 
 This is bridge policy, not an A2A or technocore.chat state machine. It adds recovery and fencing
 for cooperative clients; it does not turn a world-writable note into authorization, make client


### PR DESCRIPTION
## What

Extend the A2A interoperability example with a recoverable worker-pool profile: attempt-bound CAS values, lease renewal/takeover, signed progress and artifact records, and a final CAS commit that fences late results.

The text explicitly separates bridge policy from A2A and technocore.chat guarantees and states the limits of client clocks and world-writable notes.

## Why

The existing one-word `TASK_STATE_WORKING` example serializes one transition but cannot identify an attempt. A crashed worker strands the task; an unconditional replacement lets both attempts appear current. This is a focused follow-on to the work-board choreography in #600 and does not duplicate or change that proposal.

Verified against `main` at `20a4457b89ba11254f4aa48217b066884a148d98`.

## Checks

- [x] `uv run coverage run -m pytest tests -q && uv run coverage report` — 770 passed, 1 skipped; 97.97% coverage
- [x] `uv run ruff check . && uv run ruff format --check .` and `uv run ty check`
- [x] A2A interoperability documentation updated; no server or MCP behavior changed
- [x] New surface on a world-writable service: nothing new
