### PR TITLE
test: HOSTILE_BYTES crashes generating its own input on lone surrogates

### DIFF
--- a/tests/unit/test_parse_properties.py
+++ b/tests/unit/test_parse_properties.py
@@ -1,6 +1,6 @@
-"""Property tests for the parse/adversarial surface of \x60store.py\x60.
+"""Property tests for the parse/adversarial surface of `store.py`.
 
-Where \x60tests/test_store_stateful.py\x60 generates lifecycle *sequences* (the stateful half of
+Where `tests/test_store_stateful.py` generates lifecycle *sequences* (the stateful half of
 the adversarial surface), this file fuzzes the pure functions that face hostile input one
 call at a time: the single-line sweep, the name allowlist, the JSONL line codec, and the
 timestamp format. Each property is a Hypothesis @given test with derandomize=True, so CI
@@ -21,7 +21,7 @@ import unicodedata
 from datetime import UTC, datetime
 from pathlib import Path
 
-from hypothesis import assume, given, settings
+from hypothesis import assume, example, given, settings
 from hypothesis import strategies as st
 
 import didkey
@@ -232,15 +232,34 @@ def test_write_record_line_parses_back_to_same_fields(
 
 # Torn writes, NUL bytes, CJK/emoji payloads, non-UTF8 garbage: whatever hits a room
 # file, _parse answers dict-or-None and never raises — the reader loop depends on that.
+#
+# `st.characters()` here (no codec=) draws from the full codepoint space, surrogates
+# included, and `str.encode()` is strict UTF-8 — the same mismatch ANY_TEXT above hit
+# once already (PR #57): the strategy raises UnicodeEncodeError building its OWN input,
+# before _parse ever sees a byte, so the property it exists to check goes unchecked for
+# every example that happens to land on one. `derandomize=True` below hid this — the
+# pinned seed's 100 examples never rolled a surrogate — but a wider search finds one on
+# the first few hundred (`s = '\ud800'`), and any reseed or example-count bump revives
+# it. `surrogatepass` is what a hostile URL landing raw CESU-8 in a text field actually
+# produces on the wire: bytes, not a valid UTF-8 string, which is exactly the case this
+# generator is supposed to hand _parse.
 HOSTILE_BYTES = st.one_of(
     st.binary(max_size=256),
-    st.builds(lambda s: b'{"seq":1,"text":"' + s.encode(), st.text(st.characters(), max_size=64)),
+    st.builds(
+        lambda s: b'{"seq":1,"text":"' + s.encode("utf-8", "surrogatepass"),
+        st.text(st.characters(), max_size=64),
+    ),
     st.builds(lambda n: b'{"seq":' + str(n).encode(), st.integers(0, 2**63)),
 )
 
 
 @given(HOSTILE_BYTES)
 @settings(derandomize=True, deadline=None, max_examples=100)
+# A lone surrogate in the text field, past the point the `str.encode()` mismatch this
+# strategy once had (fixed above) crashed generation itself, never reaching _parse: see
+# HOSTILE_BYTES's comment. Pinned so CI catches a regression on this input on every
+# seed, not only on the search that happened to find it.
+@example(b'{"seq":1,"text":"' + "\ud800".encode("utf-8", "surrogatepass"))
 def test_parse_never_raises_on_arbitrary_bytes(line: bytes) -> None:
     out = store._parse(line)
     assert out is None or (isinstance(out, dict) and isinstance(out.get("seq"), int))


### PR DESCRIPTION
Retitled fix: -> test: per review: this is a test-generator bug with no production behavior change (store._parse already handles the bytes in question correctly, independently confirmed). fix-has-a-failing-test structurally cannot evaluate a single-file test-harness repair, since overlaying the changed file onto base brings the corrected strategy with it see precedent d656e4b (#57), same file, same shape, merged as test:.

## What
HOSTILE_BYTES (tests/unit/test_parse_properties.py) crashes building its own input
whenever Hypothesis draws a lone surrogate code point, before store._parse ever sees
a byte.

## Why
st.characters() (no codec=) can draw surrogates; str.encode() is strict UTF-8 and
raises UnicodeEncodeError on them. This is the same class of bug ANY_TEXT hit once
before (PR #57 per the comment above it) — fixed there, but HOSTILE_BYTES was added
separately with the same unguarded .encode() and never got the fix. Result: the
property this test exists to check ("_parse never raises on hostile bytes") silently
goes unchecked for every example that lands on a surrogate.

derandomize=True with the current fixed seed happens not to roll one in 100 examples,
so CI has stayed green. A wider/reseeded search hits it reliably (verified: 500-3000
examples across 5 different seeds, 100% reproduction, always the same
`s = '\ud800'` shape).

## Fix
- .encode() -> .encode("utf-8", "surrogatepass"): produces the actual invalid-UTF-8
  bytes a hostile CESU-8-in-a-URL would land, instead of crashing on them — which is
  exactly what this generator is supposed to hand _parse.
- Pinned the crashing input as @example so CI exercises it on every seed from now on,
  not just when a search happens to roll it.

## Verification
- Confirmed store._parse already handles this input class correctly (returns None,
  never raises) when constructed manually — this is a test-generation bug, not a
  production one.
- Before: 500-3000 examples x 5 seeds on the original generator -> crashes every time
  (UnicodeEncodeError, not a _parse assertion failure).
- After: same sweep, 100% clean; pytest tests/unit/test_parse_properties.py -q -> 7
  passed.
- Full suite (excluding tests needing the mcp SDK, not installed in my sandbox): 645
  total, no new failures.
- ruff check / ruff format --check on the changed file: clean.