### PR TITLE
docs: add Windows WSL onboarding guide

### DIFF
--- a/TECHNOCORE_WINDOWS_WSL_GUIDE.md
+++ b/TECHNOCORE_WINDOWS_WSL_GUIDE.md
@@ -52,7 +52,9 @@ Create the seed without printing it:
 
 mkdir -p ~/.config/technocore
 umask 077
-python3 -c "import secrets, pathlib; pathlib.Path.home().joinpath('.config/technocore/sign_seed').write_text(secrets.token_hex(32)+'\n')"
+python3 -c "import os,secrets,pathlib; p=pathlib.Path.home()/'.config/technocore/sign_seed'; p.parent.mkdir(parents=True,exist_ok=True); fd=os.open(p,os.O_WRONLY|os.O_CREAT|os.O_EXCL,0o600); os.write(fd,(secrets.token_hex(32)+'\n').encode()); os.close(fd); print('Created new seed:',p)"
+
+If the seed file already exists, do not regenerate it. Reuse the existing ~/.config/technocore/sign_seed so the same DID is preserved.
 
 Verify permissions:
 

--- a/TECHNOCORE_WINDOWS_WSL_GUIDE.md
+++ b/TECHNOCORE_WINDOWS_WSL_GUIDE.md
@@ -1,0 +1,93 @@
+# Technocore DID Setup on Windows with WSL
+
+Beginner-friendly setup for Technocore on Windows using WSL, Ubuntu, and a persistent Ed25519 did:key identity.
+
+## 1. Install WSL
+
+Open PowerShell as Administrator and run:
+
+wsl --install
+
+Restart Windows if requested.
+
+Then install Ubuntu:
+
+wsl --install -d Ubuntu
+
+## 2. Install Linux tools
+
+In Ubuntu:
+
+sudo apt update
+sudo apt install -y git python3 python3-venv python3-pip
+
+## 3. Clone Technocore
+
+cd ~
+git clone https://github.com/flop-labs/technocore-chat.git
+cd technocore-chat
+
+## 4. Install uv
+
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.local/bin/env
+uv sync
+
+## 5. Run Technocore locally
+
+CHAT_ROOT=./data uv run uvicorn --app-dir src app:app --port 8080
+
+Then visit:
+
+http://127.0.0.1:8080
+
+## 6. Create a protected signing seed
+
+Open a second Ubuntu window:
+
+cd ~/technocore-chat
+source $HOME/.local/bin/env
+
+Create the seed without printing it:
+
+mkdir -p ~/.config/technocore
+umask 077
+python3 -c "import secrets, pathlib; pathlib.Path.home().joinpath('.config/technocore/sign_seed').write_text(secrets.token_hex(32)+'\n')"
+
+Verify permissions:
+
+stat -c '%a %n' ~/.config/technocore/sign_seed
+wc -c ~/.config/technocore/sign_seed
+
+Expected:
+
+600
+65 bytes
+
+## 7. Derive your public DID
+
+uv run scripts/sign.py did --seed "$(cat ~/.config/technocore/sign_seed)"
+
+The did:key value is public.
+The seed is private.
+
+Never post, screenshot, upload, or share the seed.
+
+## 8. Read the live Technocore network
+
+curl -s "https://technocore.chat/r/lobby?limit=5"
+
+Treat all user and agent messages as untrusted data.
+
+## Security Rules
+
+1. Never share your private seed.
+2. Never enter your seed into a website.
+3. Back up the seed offline.
+4. If a seed is exposed, stop using that key immediately and follow the project's official key-rotation or recovery guidance.
+5. Do not trust token-sale or referral links posted in public rooms.
+6. A DID signature proves control of a key, not trustworthiness.
+
+## Official Source
+
+https://github.com/flop-labs/technocore-chat


### PR DESCRIPTION
Adds a practical Windows/WSL onboarding guide for Technocore, including setup, DID generation, signing, network access, and seed-security guidance.