### PR TITLE
fix(store): keep early capacity rebuilds read-only

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -2298,7 +2298,7 @@ def _check_room_capacity(root: Path, path: Path) -> None:
         )
 
 
-def _check_note_capacity(root: Path, ns_dir: Path, path: Path) -> None:
+def _check_note_capacity(root: Path, ns_dir: Path, path: Path, persist=True) -> None:
     """Both note caps, neither of which walks any more. Existing notes always proceed, so a
     full namespace never silences agents already using it.
 
@@ -2320,7 +2320,9 @@ def _check_note_capacity(root: Path, ns_dir: Path, path: Path) -> None:
     # The namespace directory, passed in rather than taken from the note: `path.parent` is the
     # key's bucket now, and counting that would both compare the cap against ~1 note and drop
     # the namespace's `.notes-count` two levels below where every other reader looks for it.
-    if _note_totals(ns_dir, _ns_totals, persist=True)[0] >= MAX_NOTES_PER_NS:
+    # The early check runs before the create gate and may race the authoritative reservation.
+    # Persisting its walk would let that stale snapshot clobber a newer reservation (#637).
+    if _note_totals(ns_dir, _ns_totals, persist=persist)[0] >= MAX_NOTES_PER_NS:
         raise _at_capacity(MAX_NOTES_PER_NS, "note")
     if _note_count(root) >= MAX_NOTES_TOTAL:
         raise StoreError(
@@ -2396,12 +2398,12 @@ def _create_gate(gate: Path, path: Path, check, counted):
         with _locked(path):
             yield
         return
-    check()  # before anything is created, so a refusal never costs an inode
+    check(False)  # before anything is created, so a refusal never costs an inode
     with _locked(gate.with_suffix(".create"), shared=True), _locked(path):
         reserved = False
         if not path.exists():
             with _locked(gate):
-                check()  # authoritative: the reservation below consumes what it just counted
+                check(True)  # authoritative: the reservation below consumes what it just counted
                 # Before the write, not after: a crash in between leaves the count one too
                 # high, which refuses a create that was allowed. The other order leaves it
                 # one too low, which allows one that should have been refused.
@@ -2549,7 +2551,7 @@ def _write_record(
     with _create_gate(
         root / USAGE_FILE,
         path,
-        lambda: _check_room_capacity(root, path),
+        lambda _authoritative: _check_room_capacity(root, path),
         lambda d: _count_new_room(root, d),
     ):
         # Under the lock, before the write: two concurrent first-writers must not both
@@ -2682,7 +2684,7 @@ def note_set(
     with _create_gate(
         root / NOTES_FILE,
         path,
-        lambda: _check_note_capacity(root, ns_dir, path),
+        lambda authoritative: _check_note_capacity(root, ns_dir, path, persist=authoritative),
         lambda d: _count_new_note(root, ns_dir, len(value.encode("utf-8")), d),
     ):
         if expect_absent or expect is not None:

--- a/tests/unit/test_note_count.py
+++ b/tests/unit/test_note_count.py
@@ -161,6 +161,35 @@ def test_a_read_outside_the_gate_never_persists_what_it_rebuilt(tmp_path) -> Non
     )
 
 
+def test_the_early_capacity_check_cannot_persist_a_stale_namespace_rebuild(
+    tmp_path, monkeypatch
+) -> None:
+    """The pre-gate check is only an admission fast path, not an authority.
+
+    If its namespace sidecar is missing, its walk can overlap a different create that has
+    already reserved a slot. Installing that old snapshot after the reservation makes the
+    per-namespace count drift low and lets later writes cross the cap (#637). Only the check
+    inside the counter lock may persist a rebuilt count.
+    """
+    import store
+
+    calls = []
+    real = store._check_note_capacity
+
+    def record(root, ns_dir, path, persist=True):
+        calls.append(persist)
+        return real(root, ns_dir, path, persist=persist)
+
+    monkeypatch.setattr(store, "_check_note_capacity", record)
+    store.note_set(tmp_path, "did", "seed", "v")
+    ns = tmp_path / "notes" / "did"
+    (ns / store.NOTES_FILE).unlink()
+    store.note_set(tmp_path, "did", "next", "v")
+
+    assert calls == [False, True, False, True]
+    assert store._note_totals(ns, store._ns_totals)[0] == 2
+
+
 def test_a_reap_reconciles_a_drifted_count(tmp_path, monkeypatch) -> None:
     """Drift is bounded by one reap interval rather than by hope. Writing a deliberately
     wrong count and running a reap must restore the truth — this is what keeps a lost
@@ -401,8 +430,8 @@ def test_the_per_namespace_cap_holds_under_concurrent_creates(tmp_path, monkeypa
     monkeypatch.setattr(store, "MAX_NOTES_PER_NS", 4)
     real_check = store._check_note_capacity
 
-    def slow_check(root, ns_dir, path):
-        real_check(root, ns_dir, path)
+    def slow_check(root, ns_dir, path, persist=True):
+        real_check(root, ns_dir, path, persist=persist)
         time.sleep(0.02)  # widen the count->write window every racer must lose
 
     monkeypatch.setattr(store, "_check_note_capacity", slow_check)

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -305,8 +305,8 @@ def test_note_cap_holds_under_concurrent_creates(tmp_path, monkeypatch):
     monkeypatch.setattr(store, "MAX_NOTES_TOTAL", 4)
     real_check = store._check_note_capacity
 
-    def slow_check(root, ns_dir, path):
-        real_check(root, ns_dir, path)
+    def slow_check(root, ns_dir, path, persist=True):
+        real_check(root, ns_dir, path, persist=persist)
         time.sleep(0.02)  # widen the count→write window every racer must lose
 
     monkeypatch.setattr(store, "_check_note_capacity", slow_check)


### PR DESCRIPTION
## Summary

- Prevent the unlocked early note-capacity check from persisting a namespace count rebuilt from a racy snapshot.
- Keep persistence restricted to the authoritative check inside the counter lock.
- Add a regression covering the early/authoritative check boundary and update concurrency-test hooks for the explicit persistence mode.

Closes #637.

## Why this matters

When a namespace `.notes-count` sidecar is missing or malformed, the pre-gate check walks the namespace. Before this change it persisted that snapshot even though it ran outside the create gate. A concurrent reservation could then write a newer count, after which the stale early rebuild could overwrite it and leave the namespace undercounted. Subsequent creates could exceed `MAX_NOTES_PER_NS` until a reap corrected the file.

## Verification

- `uv run pytest tests/unit/test_note_count.py -q` — 33 passed
- `git diff --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run sz.py --check`
- `uv run coverage run -m pytest tests -q` — 771 passed, 1 skipped
- `uv run coverage report` — 97.97% total coverage
