### PR TITLE
test(edge): verify every edge lane path has a wrangler route (#787)

### DIFF
--- a/tests/edge/test_edge_worker.py
+++ b/tests/edge/test_edge_worker.py
@@ -74,6 +74,16 @@ def test_every_routed_path_is_either_snapshotted_or_deliberately_not():
     assert _wrangler_routes() - accounted == set()
 
 
+def test_every_edge_lane_path_is_routed_to_the_worker():
+    """A path in EDGE_CACHED, EDGE_REVALIDATE, or EDGE_ONLY without a matching
+    wrangler route is silently unrouted — every request falls through to the
+    origin, defeating the lane entirely.
+    """
+    snapshot = _snapshot_module()
+    edge_lanes = set(snapshot.EDGE_CACHED) | set(snapshot.EDGE_REVALIDATE) | set(snapshot.EDGE_ONLY)
+    assert edge_lanes - _wrangler_routes() == set()
+
+
 def test_a_liveness_path_is_never_snapshotted():
     """The invariant the third lane exists to hold.
 


### PR DESCRIPTION
Fixes #787

## Summary

Adds a test asserting that every path declared in `EDGE_CACHED`, `EDGE_REVALIDATE`, or `EDGE_ONLY` has a matching route in `wrangler.jsonc`. A path added to any of these lanes without a route passes all existing tests but is silently unrouted — every request falls through to the origin, defeating the lane.

## Existing coverage gap

- `test_every_snapshotted_path_is_routed_to_the_worker` checks PATHS ⊆ routes.
- `test_every_routed_path_is_either_snapshotted_or_deliberately_not` checks routes ⊆ (PATHS ∪ EDGE_*).
- Neither checks that (EDGE_CACHED ∪ EDGE_REVALIDATE ∪ EDGE_ONLY) ⊆ routes.

## Verification

```
26 passed, 1 skipped in 0.42s  (edge tests)
771 passed, 1 skipped         (full suite)
ruff check and format — clean
```

Never edits CHANGELOG.md or sz-baseline.json.